### PR TITLE
Return computed result instead of constant.

### DIFF
--- a/src/trap.c
+++ b/src/trap.c
@@ -4524,7 +4524,7 @@ boolean *noticed; /* set to true iff hero notices the effect; */
         --force_mintrap;
         /* mon might now be on the migrating monsters list */
     }
-    return TRUE;
+    return result;
 }
 
 /* only called when the player is doing something to the chest directly */


### PR DESCRIPTION
I did not tested the change (do not know how) but either "result" is unused or it should be returned. The patch tackles the latter case.
