### PR TITLE
Fix C343-415: Mail daemons can be created when populating special levels with demons

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1088,7 +1088,7 @@ E struct monst *FDECL(makemon, (struct permonst *, int, int, int));
 E boolean FDECL(create_critters, (int, struct permonst *, BOOLEAN_P));
 E struct permonst *NDECL(rndmonst);
 E void FDECL(reset_rndmonst, (int));
-E struct permonst *FDECL(mkclass, (CHAR_P, int));
+E struct permonst *FDECL(mkclass, (CHAR_P));
 E int FDECL(mkclass_poly, (int));
 E int FDECL(adj_lev, (struct permonst *));
 E struct permonst *FDECL(grow_up, (struct monst *, struct monst *));

--- a/src/apply.c
+++ b/src/apply.c
@@ -979,7 +979,7 @@ struct obj **optr;
             && !(mvitals[PM_WOOD_NYMPH].mvflags & G_GONE)
             && !(mvitals[PM_WATER_NYMPH].mvflags & G_GONE)
             && !(mvitals[PM_MOUNTAIN_NYMPH].mvflags & G_GONE)
-            && (mtmp = makemon(mkclass(S_NYMPH, 0), u.ux, u.uy, NO_MINVENT))
+            && (mtmp = makemon(mkclass(S_NYMPH), u.ux, u.uy, NO_MINVENT))
                    != 0) {
             You("summon %s!", a_monnam(mtmp));
             if (!obj_resists(obj, 93, 100)) {

--- a/src/dig.c
+++ b/src/dig.c
@@ -922,13 +922,13 @@ coord *cc;
         if (!Blind)
             pline(Hallucination ? "Dude!  The living dead!"
                                 : "The grave's owner is very upset!");
-        (void) makemon(mkclass(S_ZOMBIE, 0), dig_x, dig_y, NO_MM_FLAGS);
+        (void) makemon(mkclass(S_ZOMBIE), dig_x, dig_y, NO_MM_FLAGS);
         break;
     case 3:
         if (!Blind)
             pline(Hallucination ? "I want my mummy!"
                                 : "You've disturbed a tomb!");
-        (void) makemon(mkclass(S_MUMMY, 0), dig_x, dig_y, NO_MM_FLAGS);
+        (void) makemon(mkclass(S_MUMMY), dig_x, dig_y, NO_MM_FLAGS);
         break;
     default:
         /* No corpse */

--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -567,7 +567,7 @@ int spellnum;
     case CLC_INSECTS: {
         /* Try for insects, and if there are none
            left, go for (sticks to) snakes.  -3. */
-        struct permonst *pm = mkclass(S_ANT, 0);
+        struct permonst *pm = mkclass(S_ANT);
         struct monst *mtmp2 = (struct monst *) 0;
         char let = (pm ? S_ANT : S_SNAKE);
         boolean success = FALSE, seecaster;
@@ -582,7 +582,7 @@ int spellnum;
         for (i = 0; i <= quan; i++) {
             if (!enexto(&bypos, mtmp->mux, mtmp->muy, mtmp->data))
                 break;
-            if ((pm = mkclass(let, 0)) != 0
+            if ((pm = mkclass(let)) != 0
                 && (mtmp2 = makemon(pm, bypos.x, bypos.y, MM_ANGRY)) != 0) {
                 success = TRUE;
                 mtmp2->msleeping = mtmp2->mpeaceful = mtmp2->mtame = 0;

--- a/src/minion.c
+++ b/src/minion.c
@@ -364,7 +364,7 @@ lminion()
     struct permonst *ptr;
 
     for (tryct = 0; tryct < 20; tryct++) {
-        ptr = mkclass(S_ANGEL, 0);
+        ptr = mkclass(S_ANGEL);
         if (ptr && !is_lord(ptr))
             return (monsndx(ptr));
     }
@@ -380,7 +380,7 @@ aligntyp atyp;
     struct permonst *ptr;
 
     for (tryct = 0; tryct < 20; tryct++) {
-        ptr = mkclass(S_DEMON, 0);
+        ptr = mkclass(S_DEMON);
         if (ptr && is_ndemon(ptr)
             && (atyp == A_NONE || sgn(ptr->maligntyp) == sgn(atyp)))
             return (monsndx(ptr));

--- a/src/mklev.c
+++ b/src/mklev.c
@@ -426,7 +426,7 @@ int type;
                      && (mvitals[PM_GIANT_MIMIC].mvflags & G_GONE))) {
                 /* make a mimic instead */
                 levl[x][y].doormask = D_NODOOR;
-                mtmp = makemon(mkclass(S_MIMIC, 0), x, y, NO_MM_FLAGS);
+                mtmp = makemon(mkclass(S_MIMIC), x, y, NO_MM_FLAGS);
                 if (mtmp)
                     set_mimic_sym(mtmp);
             }
@@ -529,7 +529,7 @@ int trap_type;
                         levl[xx][yy].typ = IRONBARS;
                         if (rn2(3))
                             (void) mkcorpstat(CORPSE, (struct monst *) 0,
-                                              mkclass(S_HUMAN, 0), xx,
+                                              mkclass(S_HUMAN), xx,
                                               yy + dy, TRUE);
                     }
                     if (!level.flags.noteleport)

--- a/src/mkroom.c
+++ b/src/mkroom.c
@@ -438,7 +438,7 @@ morguemon()
 
     if (hd > 10 && i < 10) {
         if (Inhell || In_endgame(&u.uz)) {
-            return mkclass(S_DEMON, 0);
+            return mkclass(S_DEMON);
         } else {
             int ndemon_res = ndemon(A_NONE);
             if (ndemon_res != NON_PM)
@@ -448,11 +448,11 @@ morguemon()
     }
 
     if (hd > 8 && i > 85)
-        return mkclass(S_VAMPIRE, 0);
+        return mkclass(S_VAMPIRE);
 
     return ((i < 20) ? &mons[PM_GHOST]
                      : (i < 40) ? &mons[PM_WRAITH]
-                                : mkclass(S_ZOMBIE, 0));
+                                : mkclass(S_ZOMBIE));
 }
 
 struct permonst *
@@ -514,7 +514,7 @@ mkswamp() /* Michiel Huisjes & Fred de Wilde */
                             eelct++;
                         }
                     } else if (!rn2(4)) /* swamps tend to be moldy */
-                        (void) makemon(mkclass(S_FUNGUS, 0), sx, sy,
+                        (void) makemon(mkclass(S_FUNGUS), sx, sy,
                                        NO_MM_FLAGS);
                 }
         level.flags.has_swamp = 1;
@@ -713,23 +713,23 @@ courtmon()
     int i = rn2(60) + rn2(3 * level_difficulty());
 
     if (i > 100)
-        return mkclass(S_DRAGON, 0);
+        return mkclass(S_DRAGON);
     else if (i > 95)
-        return mkclass(S_GIANT, 0);
+        return mkclass(S_GIANT);
     else if (i > 85)
-        return mkclass(S_TROLL, 0);
+        return mkclass(S_TROLL);
     else if (i > 75)
-        return mkclass(S_CENTAUR, 0);
+        return mkclass(S_CENTAUR);
     else if (i > 60)
-        return mkclass(S_ORC, 0);
+        return mkclass(S_ORC);
     else if (i > 45)
         return &mons[PM_BUGBEAR];
     else if (i > 30)
         return &mons[PM_HOBGOBLIN];
     else if (i > 15)
-        return mkclass(S_GNOME, 0);
+        return mkclass(S_GNOME);
     else
-        return mkclass(S_KOBOLD, 0);
+        return mkclass(S_KOBOLD);
 }
 
 #define NSTYPES (PM_CAPTAIN - PM_SOLDIER + 1)

--- a/src/questpgr.c
+++ b/src/questpgr.c
@@ -595,12 +595,12 @@ qt_montype()
         qpm = urole.enemy1num;
         if (qpm != NON_PM && rn2(5) && !(mvitals[qpm].mvflags & G_GENOD))
             return &mons[qpm];
-        return mkclass(urole.enemy1sym, 0);
+        return mkclass(urole.enemy1sym);
     }
     qpm = urole.enemy2num;
     if (qpm != NON_PM && rn2(5) && !(mvitals[qpm].mvflags & G_GENOD))
         return &mons[qpm];
-    return mkclass(urole.enemy2sym, 0);
+    return mkclass(urole.enemy2sym);
 }
 
 /* special levels can include a custom arrival message; display it */

--- a/src/read.c
+++ b/src/read.c
@@ -2441,7 +2441,7 @@ create_particular()
         }
         for (i = 0; i <= multi; i++) {
             if (monclass != MAXMCLASSES)
-                whichpm = mkclass(monclass, 0);
+                whichpm = mkclass(monclass);
             else if (randmonst)
                 whichpm = rndmonst();
             mtmp = makemon(whichpm, u.ux, u.uy, NO_MM_FLAGS);

--- a/src/shknam.c
+++ b/src/shknam.c
@@ -466,7 +466,7 @@ boolean mkspecl;
     }
 
     if (rn2(100) < depth(&u.uz) && !MON_AT(sx, sy)
-        && (ptr = mkclass(S_MIMIC, 0)) != 0
+        && (ptr = mkclass(S_MIMIC)) != 0
         && (mtmp = makemon(ptr, sx, sy, NO_MM_FLAGS)) != 0) {
         /* note: makemon will set the mimic symbol to a shop item */
         if (rn2(10) >= depth(&u.uz)) {

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -1534,7 +1534,7 @@ struct mkroom *croom;
         else if (g_mvflags & G_GONE)    /* genocided or extinct */
             pm = (struct permonst *) 0; /* make random monster */
     } else {
-        pm = mkclass(class, G_NOGEN);
+        pm = mkclass(class);
         /* if we can't get a specific monster type (pm == 0) then the
            class has been genocided, so settle for a random monster */
     }
@@ -3058,7 +3058,7 @@ struct sp_coder *coder;
                 } else {
                     struct permonst *pm = (struct permonst *) 0;
                     if (def_char_to_monclass(monclass) != MAXMCLASSES) {
-                        pm = mkclass(def_char_to_monclass(monclass), G_NOGEN);
+                        pm = mkclass(def_char_to_monclass(monclass));
                     } else {
                         pm = rndmonst();
                     }


### PR DESCRIPTION
The root cause of this was that special level creation was deliberately ignoring the `G_NOGEN` flag when making monsters by class, so a random `&` could create a mail daemon.

The mail daemon case had already been patched by commit 9e7df53b (spurious mail daemons (trunk only)), but further testing revealed that this bug also caused:
- `r` monsters creating wererats (animal form) in the Healer quest
- `S` monsters creating water moccasins in the Archaeologist quest and Medusa's Island levels
- `&` monsters creating water demons

... all of which are flagged `G_NOGEN` and thus were not supposed to be generated randomly.

The only reason that the special level system was ignoring `G_NOGEN` was to allow creation of random `;` (eel class) monsters which are all flagged `G_NOGEN`.  This fix replaces both that approach and the previous mail-daemon-only work-around patch by auto-detecting this condition and only relaxing the `G_NOGEN` restriction if it applies to the whole class of monsters requested; currently, only `S_EEL` and `S_KOP` fulfill this condition.

Incidentally, this is the same fix that prevents random chromatic dragons from spawning when special levels request random 'D' monsters in DynaHack (chromatic dragons are regular monsters in that variant).

Based on DynaHack commit b1532ff (Fix C343-415: Mail daemons can be created when populating special levels with demons) by me.
