### PR TITLE
map_coloring: L's Coloured Walls and Floor v1 patch (adapted)

### DIFF
--- a/dat/mines.des
+++ b/dat/mines.des
@@ -84,6 +84,12 @@ REGION:(00,00,36,16),lit,"ordinary"
 STAIR:levregion(01,03,20,19),(00,00,36,15),up
 STAIR:levregion(61,03,75,19),(00,00,36,15),down
 
+# Define the town area so that it can be colored separately from the
+# surrounding mines.
+#
+# unfilled forces it to be added to the level's rooms list.
+REGION:(02,02,34,16),lit,"ordinary",unfilled
+
 # shame we can't make polluted fountains
 FOUNTAIN:(16,09)
 FOUNTAIN:(25,09)
@@ -576,6 +582,23 @@ REGION:(37,13,39,17),lit,"ordinary"
 REGION:(36,14,40,17),lit,"ordinary"
 REGION:(59,02,72,10),lit,"ordinary"
 
+# Define gnomes' homes so that they can be colored separately from the
+# surrounding mines.
+#
+# unfilled forces them to be added to the level's rooms list.
+REGION:(02,13,03,14),lit,"ordinary",unfilled
+REGION:(01,18,03,19),lit,"ordinary",unfilled
+REGION:(21,12,25,13),lit,"ordinary",unfilled
+REGION:(19,17,21,18),lit,"ordinary",unfilled
+REGION:(38,05,39,07),lit,"ordinary",unfilled
+REGION:(43,08,44,10),lit,"ordinary",unfilled
+REGION:(58,04,59,05),lit,"ordinary",unfilled
+REGION:(61,04,63,04),lit,"ordinary",unfilled
+REGION:(68,04,68,04),lit,"ordinary",unfilled
+REGION:(70,04,71,05),lit,"ordinary",unfilled
+REGION:(66,14,68,15),lit,"ordinary",unfilled
+REGION:(70,17,73,19),lit,"ordinary",unfilled
+
 MONSTER: ('@', "watchman"), random, peaceful
 MONSTER: ('@', "watchman"), random, peaceful
 MONSTER: ('@', "watchman"), random, peaceful
@@ -673,6 +696,22 @@ REGION:(23,1,25,3),lit,"shop"
 REGION:(22,12,24,13),lit,"food shop"
 REGION:(31,12,36,14),lit,"temple"
 ALTAR:(35,13),align[0],shrine
+
+# Define gnomes' homes so that they can be colored separately from the
+# surrounding mines.
+#
+# unfilled forces them to be added to the level's rooms list.
+REGION:(02,01,04,03),lit,"ordinary",unfilled
+REGION:(02,08,03,09),lit,"ordinary",unfilled
+REGION:(09,03,11,05),lit,"ordinary",unfilled
+REGION:(13,05,14,06),lit,"ordinary",unfilled
+REGION:(13,10,14,11),lit,"ordinary",unfilled
+REGION:(19,11,20,13),lit,"ordinary",unfilled
+REGION:(21,09,31,09),lit,"ordinary",unfilled
+REGION:(27,01,28,03),lit,"ordinary",unfilled
+REGION:(27,07,28,08),lit,"ordinary",unfilled
+REGION:(30,01,36,02),lit,"ordinary",unfilled
+REGION:(34,06,36,08),lit,"ordinary",unfilled
 
 DOOR:closed,(5,2)
 DOOR:locked,(4,8)

--- a/dat/opthelp
+++ b/dat/opthelp
@@ -24,6 +24,7 @@ lit_corridor   show a dark corridor as lit if in sight            [FALSE]
 lootabc        use a/b/c rather than o/i/b when looting           [FALSE]
 menu_overlay   overlay menus on the screen and align to right     [TRUE]
 mail           enable the mail daemon                             [TRUE]
+map_coloring   recolor terrain of special dungeon regions         [TRUE]
 null           allow nulls to be sent to your terminal            [TRUE]
                try turning this option off (forcing NetHack to use its own
                delay code) if moving objects seem to teleport across rooms

--- a/doc/Guidebook.mn
+++ b/doc/Guidebook.mn
@@ -2227,6 +2227,8 @@ Enable mail delivery during the game (default on).  Persistent.
 .lp "male    "
 An obsolete synonym for ``gender:male''.
 Cannot be set with the `O' command.
+.lp map_coloring
+Recolor terrain of special dungeon regions (default on).
 .lp mention_walls
 Give feedback when walking against a wall (default off).
 .lp menucolors

--- a/doc/Guidebook.tex
+++ b/doc/Guidebook.tex
@@ -2671,6 +2671,9 @@ Enable mail delivery during the game (default on).  Persistent.
 An obsolete synonym for ``{\tt gender:male}''.  Cannot be set with the
 `{\tt O}' command.
 %.lp
+\item[\ib{map\_coloring}]
+Recolor terrain of special dungeon regions (default on).
+%.lp
 \item[\ib{mention\verb+_+walls}]
 Give feedback when walking against a wall (default off).
 %.lp

--- a/include/flag.h
+++ b/include/flag.h
@@ -220,6 +220,7 @@ struct instance_flags {
     boolean use_status_hilites;   /* use color in status line */
     boolean use_background_glyph; /* use background glyph when appropriate */
     boolean hilite_pile;          /* mark piles of objects with a hilite */
+    boolean map_coloring;     /* recolor terrain of special dungeon regions */
     boolean autodescribe;     /* autodescribe mode in getpos() */
 #if 0
 	boolean  DECgraphics;	/* use DEC VT-xxx extended character set */

--- a/src/mapglyph.c
+++ b/src/mapglyph.c
@@ -130,7 +130,37 @@ unsigned *ospecial;
             color = CLR_WHITE;
 #endif
         } else {
-            cmap_color(offset);
+            if (iflags.use_color && iflags.map_coloring) {
+                /* Special colors for special dungeon areas. */
+                if (offset >= S_vwall && offset <= S_trwall) {
+                    if (In_W_tower(x, y, &u.uz))
+                        color = CLR_MAGENTA;
+                    else if (In_mines(&u.uz) && !*in_rooms(x, y, 0))
+                        color = CLR_BROWN;
+                    else if (In_sokoban(&u.uz))
+                        color = CLR_BRIGHT_BLUE;
+                    else if (In_hell(&u.uz) && !Is_valley(&u.uz))
+                        color = CLR_RED;
+                    else if (Is_astralevel(&u.uz))
+                        color = CLR_WHITE;
+                } else if (offset == S_altar) {
+                    if (Is_astralevel(&u.uz)) {
+                        color = CLR_BRIGHT_MAGENTA;
+                    } else {
+                        aligntyp a = Amask2align(levl[x][y].altarmask & AM_MASK);
+                        if (a == A_LAWFUL)
+                            color = CLR_BRIGHT_BLUE;
+                        else if (a == A_NEUTRAL)
+                            color = CLR_GRAY;
+                        else if (a == A_CHAOTIC)
+                            color = CLR_BLACK;
+                        else
+                            color = CLR_RED;
+                    }
+                }
+            }
+            if (color == NO_COLOR)
+                cmap_color(offset);
         }
     } else if ((offset = (glyph - GLYPH_OBJ_OFF)) >= 0) { /* object */
         idx = objects[offset].oc_class + SYM_OFF_O;

--- a/src/options.c
+++ b/src/options.c
@@ -144,6 +144,7 @@ static struct Bool_Opt {
 #else
     { "mail", (boolean *) 0, TRUE, SET_IN_FILE },
 #endif
+    { "map_coloring", &iflags.map_coloring, TRUE, SET_IN_GAME },
     { "mention_walls", &iflags.mention_walls, FALSE, SET_IN_GAME },
     { "menucolors", &iflags.use_menu_color, FALSE, SET_IN_GAME },
     /* for menu debugging only*/
@@ -3450,7 +3451,8 @@ boolean tinitial, tfrom_file;
                        || boolopt[i].addr == &flags.showrace
                        || boolopt[i].addr == &iflags.use_inverse
                        || boolopt[i].addr == &iflags.hilite_pile
-                       || boolopt[i].addr == &iflags.hilite_pet) {
+                       || boolopt[i].addr == &iflags.hilite_pet
+                       || boolopt[i].addr == &iflags.map_coloring) {
                 need_redraw = TRUE;
 #ifdef TEXTCOLOR
             } else if (boolopt[i].addr == &iflags.use_color) {


### PR DESCRIPTION
This implements the Coloured Walls and Floor v1 patch by L (Leon Arnott):
- http://bilious.alt.org/?296
- http://l.j-factor.com/nethack/glyphcolor.diff

This recolors various features of the dungeon:
- Walls of the Wizard's Tower are magenta.
- Other walls in Gehennom (except the Valley) are red.
- Walls of the Gnomish Mines are brown, except for room walls.
- Walls of the Astral Plane are white.
- Altars are bright blue / gray / black / red depending on alignment, except on the Astral Plane, where they are all bright magenta.

This new feature can be toggled with the new `map_coloring` option (default on).

Compared to the original patch:
- The original patch had no option and was thus unconditional.
- Floors are no longer colored, since it looks ugly.
- Walls of Sokoban are bright blue.
- The Valley of the Dead is no longer grayscale, since it would be an interface screw.
- Beehives are not colored, since it interacts poorly with the way special rooms are handled.
- Lawful altars were white in the patch, but bright blue here, since white and gray are hard to distinguish.
- Room preservation has been adapted for the new level compiler.
- One of the tiny closets in Grotto Town is fixed to be colored as room wall instead of mine wall.
- Orc Town area is considered rooms instead of mine wall.
