### PR TITLE
Fix Wizard of Yendor stealing quest artifacts

### DIFF
--- a/doc/fixes36.1
+++ b/doc/fixes36.1
@@ -169,7 +169,7 @@ if a long worm inherited inventory from a previous shape, and if an egg or
 	figurine in that inventory hatched or auto-activated, messages were
 	given when hero could see any tail segment even if head was unseen,
 	making it seem as if worm's inventory was kept in the visible segment
-Wizard will now steal any quest artifact from hero, not just own role's
+Wizard of Yendor will no longer steal your quest artifact
 prevent a hostile renegade Angel of <lawful god> from delivering taunt
 	messages which mention threats of retribution from that god
 a few types of monster (barrow wight, Nazgul, erinys) have weapon attacks that

--- a/include/extern.h
+++ b/include/extern.h
@@ -2227,7 +2227,7 @@ E void FDECL(stealgold, (struct monst *));
 E void FDECL(remove_worn_item, (struct obj *, BOOLEAN_P));
 E int FDECL(steal, (struct monst *, char *));
 E int FDECL(mpickobj, (struct monst *, struct obj *));
-E void FDECL(stealamulet, (struct monst *));
+E void FDECL(stealamulet, (struct monst *, BOOLEAN_P));
 E void FDECL(maybe_absorb_item, (struct monst *, struct obj *, int, int));
 E void FDECL(mdrop_obj, (struct monst *, struct obj *, BOOLEAN_P));
 E void FDECL(mdrop_special_objs, (struct monst *));

--- a/include/obj.h
+++ b/include/obj.h
@@ -200,8 +200,6 @@ struct obj {
      && objects[otmp->otyp].oc_skill >= -P_SHURIKEN \
      && objects[otmp->otyp].oc_skill <= -P_BOW)
 #define uslinging() (uwep && objects[uwep->otyp].oc_skill == P_SLING)
-/* 'is_quest_artifact()' only applies to the current role's artifact */
-#define any_quest_artifact(o) ((o)->oartifact >= ART_ORB_OF_DETECTION)
 
 /* Armor */
 #define is_shield(otmp)          \

--- a/src/mhitu.c
+++ b/src/mhitu.c
@@ -1342,11 +1342,13 @@ register struct attack *mattk;
 
     case AD_SAMU:
         hitmsg(mtmp, mattk);
-        /* when the Wizard or quest nemesis hits, there's a 1/20 chance
-           to steal a quest artifact (any, not just the one for the hero's
-           own role) or the Amulet or one of the invocation tools */
-        if (!rn2(20))
-            stealamulet(mtmp);
+        /* when the Wiz hits, 1/20 steals the amulet */
+        /* Quest artifact may be stolen by the quest nemesis. */
+        if (u.uhave.amulet || u.uhave.bell || u.uhave.book || u.uhave.menorah
+            || (u.uhave.questart && mtmp->data->msound == MS_NEMESIS)) {
+            if (!rn2(20))
+                stealamulet(mtmp, mtmp->data->msound == MS_NEMESIS);
+        }
         break;
 
     case AD_TLPT:

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -119,8 +119,7 @@ register struct monst *mtmp;
     register struct obj *otmp;
 
     for (otmp = mtmp->minvent; otmp; otmp = otmp->nobj)
-        if (otmp->otyp == AMULET_OF_YENDOR
-            || any_quest_artifact(otmp)
+        if (otmp->otyp == AMULET_OF_YENDOR || is_quest_artifact(otmp)
             || otmp->otyp == BELL_OF_OPENING
             || otmp->otyp == CANDELABRUM_OF_INVOCATION
             || otmp->otyp == SPE_BOOK_OF_THE_DEAD)
@@ -176,7 +175,7 @@ register short otyp;
         if (otyp) {
             if (otmp->otyp == otyp)
                 return 1;
-        } else if (any_quest_artifact(otmp))
+        } else if (is_quest_artifact(otmp))
             return 1;
     }
     return 0;
@@ -208,7 +207,7 @@ register short otyp;
         if (otyp) {
             if (otmp->otyp == otyp)
                 return otmp;
-        } else if (any_quest_artifact(otmp))
+        } else if (is_quest_artifact(otmp))
             return otmp;
     return (struct obj *) 0;
 }


### PR DESCRIPTION
This removes the biggest reason that players neglect to use their role's quest artifact.  Players can now take advantage of their quest artifact's unique properties and abilities without the downside of losing it after waking Rodney, increasing the uniqueness of different roles.

Quest nemeses are still able to steal quest artifacts.
