### PR TITLE
Fix paid object on bill when angering another shopkeeper

### DIFF
--- a/src/shk.c
+++ b/src/shk.c
@@ -859,7 +859,7 @@ boolean silent;
             } else
                 bp++;
     }
-    if (obj->unpaid & !silent)
+    if (obj->unpaid && !silent)
         pline("onbill: unpaid obj not on bill?");
     return (struct bill_x *) 0;
 }


### PR DESCRIPTION
To test:
1. Get a level layout with two shops facing each other, e.g. minetn-4.
2. Sell a fragile object to one of the shops.
3. Dig a pit in the other shop's door space so its shopkeeper stays out of the way.
4. Pick up an object in that other shop so it appears on your bill.
5. Zap a wand of striking at the first shop to break the fragile object.
6. 'p'ay for the object picked up.

Expected result: Object gets the standard prompt to pay for it.

Actual result: "Paid object on bill??" followed by "Program in disorder perhaps you'd better #quit." followed by the object being given to the player for free.

The cause?  This comment going all the way back to 2002:

```
/* FIXME: object handling should be limited to
   items which are on this particular shk's bill */
```

Originally reported by PaRaD0xx in FreeNode's #NetHack IRC channel whilst playing NAO343.

Based on DynaHack commit d995ed1 (Fix paid object on bill when angering another shkp) by me.
