### PR TITLE
Fix billing/credit when hero nests their containers on a shop floor

### DIFF
--- a/src/pickup.c
+++ b/src/pickup.c
@@ -2025,15 +2025,14 @@ register struct obj *obj;
         (void) snuff_lit(obj);
 
     if (floor_container && costly_spot(u.ux, u.uy)) {
-        if (obj->oclass == COIN_CLASS) {
-            ; /* defer gold until after put-in message */
-        } else if (current_container->no_charge && !obj->unpaid) {
-            /* don't sell when putting the item into your own container */
-            obj->no_charge = 1;
-        } else {
+        /* defer gold until after put-in message */
+        if (obj->oclass != COIN_CLASS) {
             /* sellobj() will take an unpaid item off the shop bill */
             was_unpaid = obj->unpaid ? TRUE : FALSE;
-            sellobj_state(SELL_DELIBERATE);
+            /* don't sell when putting the item into your own container,
+             * but handle billing correctly */
+            sellobj_state(current_container->no_charge
+                          ? SELL_DONTSELL : SELL_DELIBERATE);
             sellobj(obj, u.ux, u.uy);
             sellobj_state(SELL_NORMAL);
         }

--- a/src/shk.c
+++ b/src/shk.c
@@ -2885,7 +2885,7 @@ xchar x, y;
 
         if (container) {
             dropped_container(obj, shkp, FALSE);
-            if (!obj->unpaid && !saleitem)
+            if (!obj->unpaid)
                 obj->no_charge = 1;
             if (unpaid)
                 subfrombill(obj, shkp);
@@ -2960,7 +2960,7 @@ xchar x, y;
             if (!isgold) {
                 if (container)
                     dropped_container(obj, shkp, FALSE);
-                if (!obj->unpaid && !saleitem)
+                if (!obj->unpaid)
                     obj->no_charge = 1;
                 subfrombill(obj, shkp);
             }

--- a/src/shk.c
+++ b/src/shk.c
@@ -2880,7 +2880,8 @@ xchar x, y;
     offer = ltmp + cltmp;
 
     /* get one case out of the way: nothing to sell, and no gold */
-    if (!isgold && ((offer + gltmp) == 0L || sell_how == SELL_DONTSELL)) {
+    if (!(isgold || cgold)
+        && ((offer + gltmp) == 0L || sell_how == SELL_DONTSELL)) {
         boolean unpaid = is_unpaid(obj);
 
         if (container) {
@@ -2956,7 +2957,7 @@ xchar x, y;
                       currency(eshkp->credit));
         }
 
-        if (!offer) {
+        if (!offer || sell_how == SELL_DONTSELL) {
             if (!isgold) {
                 if (container)
                     dropped_container(obj, shkp, FALSE);


### PR DESCRIPTION
This fixes a bug where the hero could accidentally donate the contents of their bag to a shopkeeper if they put it in another bag on the shop floor that also belonged to the hero.  To reproduce:
1. Drop a sack on the floor, but don't sell it.
2. Get another sack and put in hero-owned objects.
3. Put the sack with objects into the sack on the shop floor.
4. Take out the sack with the objects from the sack on the shop floor.

The shopkeeper will claim you owe them for the objects in the sack, and view the contents of the sack will show them as belonging to the shopkeeper.

In fixing this, this also fixes `SELL_DONTSELL` to do what it's supposed to for containers and contained gold.
