### PR TITLE
attack_mode: enhanced alternative to confirm option

### DIFF
--- a/dat/opthelp
+++ b/dat/opthelp
@@ -99,6 +99,11 @@ Compound options are written as option_name:option_value.
 
 Compound options which can be set during the game are:
 
+attack_mode   attack, refrain or ask to attack monsters [chat]
+              pacifist -- don't fight anything
+              chat     -- chat with peacefuls, fight hostiles
+              ask      -- ask to fight peacefuls
+              fightall -- fight peacefuls and hostiles
 boulder       override the default boulder symbol with another default: [`]
 disclose      the types of information you want offered at the end of the
               game  [ni na nv ng nc no]

--- a/doc/Guidebook.mn
+++ b/doc/Guidebook.mn
@@ -2049,6 +2049,17 @@ The default is to randomly pick an appropriate alignment.
 If you prefix the value with `!' or ``no'', you will
 exclude that alignment from being picked randomly.
 Cannot be set with the `O' command.  Persistent.
+.lp attack_mode
+This option controls what happens when attempting to attack monsters.
+The possible values are:
+.sd
+.si
+.CC p "pacifist: don't fight anything;"
+.CC c "chat: chat with peaceful monsters, fight hostiles (default);"
+.CC a "ask: ask to fight peaceful monsters, fight hostiles;"
+.CC f "fightall: fight peaceful and hostile monsters without asking."
+.ei
+.ed
 .lp autodescribe
 Automatically describe the terrain under cursor when asked to get a location
 on the map.  The

--- a/doc/Guidebook.tex
+++ b/doc/Guidebook.tex
@@ -2464,6 +2464,20 @@ If you prefix the value with `{\tt !}' or ``{\tt no}'', you will
 exclude that alignment from being picked randomly.
 Cannot be set with the `{\tt O}' command.  Persistent.
 %.lp
+\item[\ib{attack\verb+_+mode}]
+This option controls what happens when attempting to attack monsters.
+The possible values are:
+
+%.sd
+%.si
+{\tt p} --- pacifist: don't fight anything;\\
+{\tt c} --- chat: chat with peaceful monsters, fight hostiles (default);\\
+{\tt a} --- ask: ask to fight peaceful monsters, fight hostiles;\\
+{\tt f} --- fightall: fight peaceful and hostile monsters without asking.
+%.ei
+%.ed
+%.lp
+
 \item[\ib{autodescribe}]
 Automatically describe the terrain under cursor when asked to get a location
 on the map.  The

--- a/include/extern.h
+++ b/include/extern.h
@@ -2384,7 +2384,7 @@ E void NDECL(u_init);
 /* ### uhitm.c ### */
 
 E void FDECL(erode_armor, (struct monst *, int));
-E boolean FDECL(attack_checks, (struct monst *, struct obj *));
+E boolean FDECL(attack_checks, (struct monst *, struct obj *, int));
 E void FDECL(check_caitiff, (struct monst *));
 E int FDECL(find_roll_to_hit,
             (struct monst *, UCHAR_P, struct obj *, int *, int *));

--- a/include/extern.h
+++ b/include/extern.h
@@ -2171,6 +2171,7 @@ E void FDECL(yelp, (struct monst *));
 E void FDECL(whimper, (struct monst *));
 E void FDECL(beg, (struct monst *));
 E int NDECL(dotalk);
+E int FDECL(dochat, (BOOLEAN_P, int, int, int));
 #ifdef USER_SOUNDS
 E int FDECL(add_sound_mapping, (const char *));
 E void FDECL(play_sound_for_message, (const char *));

--- a/include/flag.h
+++ b/include/flag.h
@@ -22,7 +22,7 @@ struct flag {
     boolean beginner;
     boolean biff;      /* enable checking for mail */
     boolean bones;     /* allow saving/loading bones */
-    boolean confirm;   /* confirm before hitting tame monsters */
+    boolean confirm;   /* TODO: Unused, remove on next savebreak. */
     boolean dark_room; /* show shadows in lit rooms */
     boolean debug;     /* in debugging mode */
 #define wizard flags.debug
@@ -173,6 +173,12 @@ struct sysflag {
 #define GPCOORDS_COMPASS 'c'
 #define GPCOORDS_SCREEN  's'
 
+/* values for iflags.attack_mode */
+#define ATTACK_MODE_PACIFIST  'p'
+#define ATTACK_MODE_CHAT      'c'
+#define ATTACK_MODE_ASK       'a'
+#define ATTACK_MODE_FIGHT_ALL 'f'
+
 struct instance_flags {
     /* stuff that really isn't option or platform related. They are
      * set and cleared during the game to control the internal
@@ -198,6 +204,7 @@ struct instance_flags {
 #ifdef ALTMETA
     boolean altmeta; /* Alt-c sends ESC c rather than M-c */
 #endif
+    char attack_mode;         /* attack, refrain or ask to attack monsters */
     boolean cbreak;           /* in cbreak mode, rogue format */
     boolean deferred_X;       /* deferred entry into explore mode */
     boolean num_pad;          /* use numbers for movement commands */

--- a/src/apply.c
+++ b/src/apply.c
@@ -2874,7 +2874,7 @@ struct obj *obj;
     /* Attack the monster there */
     bhitpos = cc;
     if ((mtmp = m_at(bhitpos.x, bhitpos.y)) != (struct monst *) 0) {
-        if (attack_checks(mtmp, uwep))
+        if (attack_checks(mtmp, uwep, 0))
             return res;
         if (overexertion())
             return 1; /* burn nutrition; maybe pass out */
@@ -3053,12 +3053,9 @@ struct obj *obj;
         if ((mtmp = m_at(cc.x, cc.y)) == (struct monst *) 0)
             break;
         notonhead = (bhitpos.x != mtmp->mx || bhitpos.y != mtmp->my);
-        save_confirm = flags.confirm;
         if (verysmall(mtmp->data) && !rn2(4)
             && enexto(&cc, u.ux, u.uy, (struct permonst *) 0)) {
-            flags.confirm = FALSE;
-            (void) attack_checks(mtmp, uwep);
-            flags.confirm = save_confirm;
+            (void) attack_checks(mtmp, uwep, 1);
             check_caitiff(mtmp); /* despite fact there's no damage */
             You("pull in %s!", mon_nam(mtmp));
             mtmp->mundetected = 0;
@@ -3066,9 +3063,7 @@ struct obj *obj;
             return 1;
         } else if ((!bigmonst(mtmp->data) && !strongmonst(mtmp->data))
                    || rn2(4)) {
-            flags.confirm = FALSE;
-            (void) attack_checks(mtmp, uwep);
-            flags.confirm = save_confirm;
+            (void) attack_checks(mtmp, uwep, 1);
             check_caitiff(mtmp);
             (void) thitmonst(mtmp, uwep);
             return 1;

--- a/src/dokick.c
+++ b/src/dokick.c
@@ -131,18 +131,17 @@ struct monst *mon;
 xchar x, y;
 {
     if (mon) {
-        boolean save_forcefight = context.forcefight;
+        int mode = 0;
 
         bhitpos.x = x;
         bhitpos.y = y;
         if (!mon->mpeaceful || !canspotmon(mon))
-            context.forcefight = TRUE; /* attack even if invisible */
+            mode = 2; /* attack even if invisible */
         /* kicking might be halted by discovery of hidden monster,
            by player declining to attack peaceful monster,
            or by passing out due to encumbrance */
-        if (attack_checks(mon, (struct obj *) 0) || overexertion())
+        if (attack_checks(mon, (struct obj *) 0, mode) || overexertion())
             mon = 0; /* don't kick after all */
-        context.forcefight = save_forcefight;
     }
     return (boolean) (mon != 0);
 }

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -1304,12 +1304,18 @@ dogaze()
             } else if (flags.safe_dog && mtmp->mtame && !Confusion) {
                 You("avoid gazing at %s.", y_monnam(mtmp));
             } else {
-                if (flags.confirm && mtmp->mpeaceful && !Confusion) {
-                    Sprintf(qbuf, "Really %s %s?",
-                            (adtyp == AD_CONF) ? "confuse" : "attack",
-                            mon_nam(mtmp));
-                    if (yn(qbuf) != 'y')
+                if (mtmp->mpeaceful && !Confusion) {
+                    if (iflags.attack_mode == ATTACK_MODE_PACIFIST
+                        || iflags.attack_mode == ATTACK_MODE_CHAT) {
+                        You("avoid gazing at %s.", mon_nam(mtmp));
                         continue;
+                    } else if (iflags.attack_mode == ATTACK_MODE_ASK) {
+                        Sprintf(qbuf, "Really %s %s?",
+                                (adtyp == AD_CONF) ? "confuse" : "attack",
+                                mon_nam(mtmp));
+                        if (yn(qbuf) != 'y')
+                            continue;
+                    }
                     setmangry(mtmp);
                 }
                 if (!mtmp->mcanmove || mtmp->mstun || mtmp->msleeping

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -96,9 +96,10 @@ int hurt;
 
 /* FALSE means it's OK to attack */
 boolean
-attack_checks(mtmp, wep)
+attack_checks(mtmp, wep, mode)
 register struct monst *mtmp;
 struct obj *wep; /* uwep for attack(), null for kick_monster() */
+int mode; /* 0 = normal checks; 1 = pre-confirmed; 2 = force fight */
 {
     char qbuf[QBUFSZ];
 
@@ -108,7 +109,7 @@ struct obj *wep; /* uwep for attack(), null for kick_monster() */
     if (u.uswallow && mtmp == u.ustuck)
         return FALSE;
 
-    if (context.forcefight) {
+    if (mode == 2 || context.forcefight) {
         /* Do this in the caller, after we checked that the monster
          * didn't die from the blow.  Reason: putting the 'I' there
          * causes the hero to forget the square's contents since
@@ -202,7 +203,7 @@ struct obj *wep; /* uwep for attack(), null for kick_monster() */
         }
         if (canspotmon(mtmp)) {
             Sprintf(qbuf, "Really attack %s?", mon_nam(mtmp));
-            if (!paranoid_query(ParanoidHit, qbuf)) {
+            if (mode == 0 && !paranoid_query(ParanoidHit, qbuf)) {
                 context.move = 0;
                 return TRUE;
             }
@@ -369,7 +370,7 @@ register struct monst *mtmp;
        it uses bhitpos instead; it might map an invisible monster there */
     bhitpos.x = u.ux + u.dx;
     bhitpos.y = u.uy + u.dy;
-    if (attack_checks(mtmp, uwep))
+    if (attack_checks(mtmp, uwep, 0))
         return TRUE;
 
     if (Upolyd && noattacks(youmonst.data)) {


### PR DESCRIPTION
This option controls what happens when attempting to attack monsters.  The possible values are:
- p - `pacifist`: don't fight anything
- c - `chat`: chat with peaceful monsters, fight hostiles (default)
- a - `ask`: ask to fight peaceful monsters, fight hostiles
- f - `fightall`: fight peaceful and hostile monsters without asking

`attack_mode` replaces the old `confirm` option; `attack_mode:a` is equivalent to `confirm`, while `attack_mode:f` is equivalent to `noconfirm`.

`attack_mode:c` essentially waits a turn when the player bumps into a peaceful monster.  Note that it does NOT trigger the donation prompt of aligned priests.  Players can still accidentally hit peaceful monsters if they move into an 'I' and a peaceful monster is hiding underneath.

`attack_mode:p` avoids attacking any monsters knowingly.

Both pacifist and chat are overridden by stunning / confusion / hallucination, and by Stormbringer, correctly accounting for its override flag in the attack logic.

`attack_mode:c` should cut down on annoying prompt spam near peacefuls for most players, while `attack_mode:p` should be especially welcome to pacifist conduct players.
