### PR TITLE
TTY menu enhancements

### DIFF
--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -360,9 +360,6 @@ char **argv UNUSED;
     (void) signal(SIGWINCH, (SIG_RET_TYPE) winch_handler);
 #endif
 
-    /* add one a space forward menu command alias */
-    add_menu_cmd_alias(' ', MENU_NEXT_PAGE);
-
     tty_clear_nhwindow(BASE_WINDOW);
 
     tty_putstr(BASE_WINDOW, 0, "");
@@ -1863,6 +1860,7 @@ struct WinDesc *cw;
 
             /* set extra chars.. */
             Strcat(resp, default_menu_cmds);
+            Strcat(resp, " ");                  /* next page or end */
             Strcat(resp, "0123456789\033\n\r"); /* counts, quit */
             Strcat(resp, gacc);                 /* group accelerators */
             Strcat(resp, mapped_menu_cmds);
@@ -1946,12 +1944,15 @@ struct WinDesc *cw;
                 break;
             }
         /* else fall through */
+        case ' ':
         case MENU_NEXT_PAGE:
             if (cw->npages > 0 && curr_page != cw->npages - 1) {
                 curr_page++;
                 page_start = 0;
-            } else
-                finished = TRUE; /* questionable behavior */
+            } else if (morc == ' ') {
+                /* ' ' finishes menus here, but stop '>' doing the same. */
+                finished = TRUE;
+            }
             break;
         case MENU_PREVIOUS_PAGE:
             if (cw->npages > 0 && curr_page != 0) {

--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -1777,6 +1777,15 @@ struct WinDesc *cw;
                      page_lines++, curr = curr->next) {
                     int color = NO_COLOR, attr = ATR_NONE;
                     boolean menucolr = FALSE;
+                    int select_pos = -1; /* -/+/# position for selectables */
+                    int format_start_pos = 0; /* menu color/attr start pos */
+
+                    if (curr->identifier.a_void != 0) {
+                        /* "a - whatever" */
+                        select_pos = 2; /* '-' */
+                        format_start_pos = 4; /* start of "whatever" */
+                    }
+
                     if (curr->selector)
                         *rp++ = curr->selector;
 
@@ -1793,27 +1802,31 @@ struct WinDesc *cw;
                      * actually output the character.  We're faster doing
                      * this.
                      */
-                    if (iflags.use_menu_color
-                        && (menucolr = get_menu_coloring(curr->str, &color,
-                                                         &attr))) {
-                        term_start_attr(attr);
-#ifdef TEXTCOLOR
-                        if (color != NO_COLOR)
-                            term_start_color(color);
-#endif
-                    } else
-                        term_start_attr(curr->attr);
                     for (n = 0, cp = curr->str;
 #ifndef WIN32CON
                          *cp
                          && (int) ++ttyDisplay->curx < (int) ttyDisplay->cols;
-                         cp++, n++)
+                         cp++, n++
 #else
                          *cp
                          && (int) ttyDisplay->curx < (int) ttyDisplay->cols;
-                         cp++, n++, ttyDisplay->curx++)
+                         cp++, n++, ttyDisplay->curx++
 #endif
-                        if (n == 2 && curr->identifier.a_void != 0
+                        ) {
+                        if (n == format_start_pos) {
+                            if (iflags.use_menu_color
+                                && (menucolr = get_menu_coloring(curr->str,
+                                                                 &color,
+                                                                 &attr))) {
+                                term_start_attr(attr);
+#ifdef TEXTCOLOR
+                                if (color != NO_COLOR)
+                                    term_start_color(color);
+#endif
+                            } else
+                                term_start_attr(curr->attr);
+                        }
+                        if (n == select_pos && curr->identifier.a_void != 0
                             && curr->selected) {
                             if (curr->count == -1L)
                                 (void) putchar('+'); /* all selected */
@@ -1821,6 +1834,7 @@ struct WinDesc *cw;
                                 (void) putchar('#'); /* count selected */
                         } else
                             (void) putchar(*cp);
+                    }
                     if (iflags.use_menu_color && menucolr) {
 #ifdef TEXTCOLOR
                         if (color != NO_COLOR)


### PR DESCRIPTION
Two minor improvements to TTY menus:
1. Stop `>` from closing TTY menus if the menu is scrolled to the last page (it can still be dismissed like this if space is used). This makes scrolling with `<` and `>` safe from the risk of accidentally closing menus.
2. Omit the "a - " part of "a - whatever" from menu coloring, to match NAO343.
