### PR TITLE
Use rn2() instead of Rand() for selection_do_randline()

### DIFF
--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -4089,8 +4089,8 @@ struct opvar *ov;
         my = ((y1 + y2) / 2);
     } else {
         do {
-            dx = (Rand() % rough) - (rough / 2);
-            dy = (Rand() % rough) - (rough / 2);
+            dx = rn2(rough) - (rough / 2);
+            dy = rn2(rough) - (rough / 2);
             mx = ((x1 + x2) / 2) + dx;
             my = ((y1 + y2) / 2) + dy;
         } while ((mx > COLNO - 1 || mx < 0 || my < 0 || my > ROWNO - 1));


### PR DESCRIPTION
That is, use NetHack's RNG instead of the direct system RNG.  This fixes maps generated with randlines to interact correctly with potential future RNG system changes e.g. switching PRNG algorithms, supporting NAO343's RNG reseeding, and even supporting replays like NetHack 4.

Based on DynaHack commit e464f63 (lev_comp: Fix system RNG use in randline) by me.
