### PR TITLE
Change flag::sortloot to xchar

### DIFF
--- a/include/flag.h
+++ b/include/flag.h
@@ -48,7 +48,7 @@ struct flag {
     boolean showexp;         /* show experience points */
     boolean showscore;       /* show score */
     boolean silent;          /* whether the bell rings or not */
-    boolean sortloot;        /* sort items alphabetically when looting */
+    xchar sortloot;          /* sort items alphabetically when looting */
     boolean sortpack;        /* sorted inventory */
     boolean sparkle;         /* show "resisting" special FX (Scott Bigham) */
     boolean standout;        /* use standout for --More-- */


### PR DESCRIPTION
When typedefed to C99's bool type, Clang complains in container_contents about "comparison of constant 108 with expression of type 'boolean' (aka 'bool') is always false".
