### PR TITLE
Fix crash with MAIL env variable

### DIFF
--- a/src/mail.c
+++ b/src/mail.c
@@ -90,7 +90,12 @@ free_maildata()
 void
 getmailstatus()
 {
-    if (!mailbox && !(mailbox = nh_getenv("MAIL"))) {
+    char *emailbox;
+    if (emailbox = nh_getenv("MAIL")) {
+        mailbox = (char *) alloc((unsigned) strlen(emailbox));
+        Strcpy(mailbox, emailbox);
+    }
+    if (!mailbox) {
 #ifdef MAILPATH
 #ifdef AMS
         struct passwd ppasswd;


### PR DESCRIPTION
This fix to mail.c prevents a core dump in free_maildata. I had the MAIL environment variable set to the path for my mailbox and whenever nethack exited it coredumped in free_maildata. Evidently the pointer being passed to free was not pointing to memory allocated in the heap. So, I modified the code to allocate a string off the heap for the mailbox path if this path came from an environment variable.

This issue was probably caused by the free mailbox at exit commit 3b38c75517846742000082f1f465d405f79c3983. This commit added code to free the mailbox memory but introduced a core dump because when an environment variable is set nh doesn't allocate memory off the heap.
