### PR TITLE
Fix screen resize with Linux tty

### DIFF
--- a/sys/share/ioctl.c
+++ b/sys/share/ioctl.c
@@ -65,7 +65,8 @@ struct termio termio;
 
 #if defined(TIOCGWINSZ)                                    \
     && (defined(BSD) || defined(ULTRIX) || defined(AIX_31) \
-        || defined(_BULL_SOURCE) || defined(SVR4))
+        || defined(_BULL_SOURCE) || defined(SVR4) ||       \
+        defined(LINUX))
 #define USE_WIN_IOCTL
 #include "tcap.h" /* for LI and CO */
 #endif


### PR DESCRIPTION
This fixes the issue that I emailed the devteam about where the screen does not resize properly on NAO. In my own Linux environment I found that the screen resize worked if the SVR4 flag was set in unixconf.h and did not without it. I tracked this down to line 68 of ioctl.c. If SVR4 is set then USE_WIN_IOCTL is set and this enables the resize of the screen. My fix was just to add LINUX as one of the flags checked so you don't have to rely on SVR4 being set when it wouldn't really make sense. I tested this on Oracle Enterprise Linux 6.8 (Redhat 6.8) 32 bit.
