### PR TITLE
Allow #exploremode to still be used by player name even if pw is null.

### DIFF
--- a/sys/unix/unixmain.c
+++ b/sys/unix/unixmain.c
@@ -624,12 +624,13 @@ char *optstr;
     char *pwname;
     if (optstr[0] == '*')
         return TRUE; /* allow any user */
-    if (!pw)
-        return FALSE;
     if (sysopt.check_plname)
         pwname = plname;
-    else
+    else {
+        if (!pw)
+            return FALSE;
         pwname = pw->pw_name;
+    }
     pwlen = strlen(pwname);
     eop = eos(optstr);
     w = optstr;


### PR DESCRIPTION
I hit a problem using explore mode on my private server. For whatever reason (possibly my configuration) pw was always null and so I could never activate explore mode after starting a game. This moves the check for using the player name to be before the check for if pw is null.