### PR TITLE
Achievement recording fixes

### DIFF
--- a/src/bones.c
+++ b/src/bones.c
@@ -175,7 +175,14 @@ boolean restore;
             } else if (otmp->otyp == SPE_BOOK_OF_THE_DEAD) {
                 otmp->otyp = SPE_BLANK_PAPER;
                 curse(otmp);
+            /* these might still be flagged as prizes if the late
+               hero did not pick them up */
+            } else if (otmp->otyp == AMULET_OF_REFLECTION
+                       || otmp->otyp == BAG_OF_HOLDING
+                       || otmp->otyp == LUCKSTONE) {
+                otmp->record_achieve_special = 0;
             }
+                
         }
     }
 }

--- a/src/invent.c
+++ b/src/invent.c
@@ -506,10 +506,12 @@ struct obj *obj;
         }
         set_artifact_intrinsic(obj, 1, W_ART);
     }
-    if (is_mines_prize(obj) && obj->record_achieve_special) {
+    if (obj->otyp == LUCKSTONE && obj->record_achieve_special == 1) {
         u.uachieve.mines_luckstone = 1;
         obj->record_achieve_special = 0;
-    } else if (is_soko_prize(obj) && obj->record_achieve_special) {
+    } else if ((obj->otyp == AMULET_OF_REFLECTION
+                || obj->otyp == BAG_OF_HOLDING)
+               && obj->record_achieve_special == 1) {
         u.uachieve.finish_sokoban = 1;
         obj->record_achieve_special = 0;
     }

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -1759,6 +1759,7 @@ struct mkroom *croom;
     schar x, y;
     char c;
     boolean named; /* has a name been supplied in level description? */
+    boolean rndobj = TRUE; /* object is randomly generated */
 
     named = o->name.str ? TRUE : FALSE;
 
@@ -1771,9 +1772,10 @@ struct mkroom *croom;
 
     if (!c)
         otmp = mkobj_at(RANDOM_CLASS, x, y, !named);
-    else if (o->id != -1)
+    else if (o->id != -1) {
+        rndobj = FALSE;
         otmp = mksobj_at(o->id, x, y, TRUE, !named);
-    else {
+    } else {
         /*
          * The special levels are compiled with the default "text" object
          * class characters.  We must convert them to the internal format.
@@ -1951,7 +1953,9 @@ struct mkroom *croom;
      * "prize" and then set record_achieve_special (maps to corpsenm)
      * for the object.  That field will later be checked to find out if
      * the player obtained the prize. */
-    if (is_mines_prize(otmp) || is_soko_prize(otmp)) {
+    /* if object is on the prize level and not randomly generated,
+     * it must be the one */
+    if ((is_mines_prize(otmp) || is_soko_prize(otmp)) && !rndobj) {
         otmp->record_achieve_special = 1;
     }
 


### PR DESCRIPTION
This properly fixes the issues with mines and soko achievement recording, as follows:
1. record_achieve_special is mapped to corpsenm, which has a default value of -1.  Setting to 1 on the prize item and then checking for nonzero will always mark the achievement (current workaround is to also check the level at pickup time, but this has other issues outlined below).
2. only checking level and otyp when setting record_achieve_special opens the possibility that a random luckstone may be generated at mine-end, and this may be interpreted as the prize (this has possibly happened though it's hard to be conclusive as monsters pick things up and move them)
3. checking the level at pickup time is problematic if a monster picks up the prize and takes it to another level before the hero gets his hands on it (cases of this have been recorded).