### PR TITLE
Add several missing entries to the encyclopedia

### DIFF
--- a/dat/data.base
+++ b/dat/data.base
@@ -422,9 +422,6 @@ barbarian
 	things.  He excelled them even in lithe economy of motion.
 	They were wolves, but he was a tiger.
 		[ Conan - The Warrior, by Robert E. Howard ]
-barbed devil
-	Barbed devils lack any real special abilities, though they
-	are quite difficult to kill.
 # takes "bat or bird" when specifying 'B'
 ~combat
 ~wombat
@@ -532,6 +529,7 @@ ooze
 	kind had swept so evilly free of all litter.
 		[ At the Mountains of Madness, by H.P. Lovecraft ]
 blue jelly
+spotted jelly
 	I'd planned how to prevent the lock from sealing behind me; it
 	required a temporary sacrifice, not cleverness.  I used the door
 	itself to help me cut off a portion of my body, after shunting all
@@ -890,6 +888,20 @@ tiamat
 	extremely vain.
 citrine*
 	A pale yellow variety of crystalline quartz resembling topaz.
+clay golem
+        It was a warm spring night when a fist knocked at the door so
+        hard that the hinges bent.
+        A man opened it and peered out into the street. There was
+        mist coming off the river and it was a cloudy night. He might
+        as well have tried to see through white velvet.
+        But he thought afterwards that there had been shapes out
+        there, just beyond the light spilling out into the road. A
+        lot of shapes, watching him carefully. He thought maybe
+        there’d been very faint points of light...
+        There was no mistaking the shape right in front of him,
+        though. It was big and dark red and looked like a child’s
+        clay model of a man. Its eyes were two embers.
+                [ Feet of Clay, by Terry Pratchett ]
 cleaver
 	Hither came Conan, the Cimmerian, black-haired, sullen-eyed,
 	sword in hand, a thief, a reaver, a slayer, with gigantic
@@ -1248,7 +1260,7 @@ dingo
 		[ Webster's Encyclopedic Unabridged Dictionary
 		    of the English Language ]
 disenchanter
-	Ask not, what your magic can do to it.  Ask what it can do
+	Ask not what your magic can do to it.  Ask what it can do
 	to your magic.
 dispater
 	The Roman ruler of the underworld and fortune, similar to the
@@ -1992,6 +2004,7 @@ gold golem
 ~gold golem
 ~straw golem
 ~wood golem
+~clay golem
 *golem
 	"The original story harks back, so they say, to the sixteenth
 	century.  Using long-lost formulas from the Kabbala, a rabbi is
@@ -2303,7 +2316,8 @@ cornucopia
 	And scatters corn and wine, and fruits and flowers.
 		[ Os Lusiadas, by Luis Vaz de Camoes ]
 horned devil
-	Horned devils lack any real special abilities, though they
+barbed devil
+	These devils lack any real special abilities, though they
 	are quite difficult to kill.
 ~horsem*
 *horse
@@ -3630,6 +3644,14 @@ obsidian*
 	favored by primitive peoples for knives, arrowheads, spearheads,
 	and other weapons and tools.
 		[ The Columbia Encyclopedia, Sixth Edition ]
+ochre jelly
+	Ochre jellies are yellowish blobs that can slide under doors and
+	through narrow cracks in pursuit of creatures to devour. They
+	have enough bestial cunning to avoid large groups of enemies.
+	An ochre jelly follows at a safe distance as it pursues its meal.
+	Its digestive enzymes dissolve flesh quickly but have no effect
+	on other substances such as bone, wood, and metal.
+		[ Dungeons & Dragons 5th Edition Monster Manual ]
 odin
 	Also called Sigtyr (god of Victory), Val-father (father of
 	the slain), One-Eyed, Hanga-god (god of the hanged), Farma-
@@ -3966,6 +3988,7 @@ pony
 	continent and to and from our own world.  The precise manner
 	of their working is a Management secret.
 	  [ The Tough Guide to Fantasyland, by Diana Wynne Jones ]
+trident
 poseido*n
 	Poseido(o)n, lord of the seas and father of rivers and
 	fountains, was the son of Chronos and Rhea, brother of Zeus,
@@ -4809,6 +4832,17 @@ stair*
 	Dr. Peter Venkman:  They go up.
 		[ Ghostbusters, directed by Ivan Reitman,
 		  written by Dan Ackroyd and Harold Ramis ]
+*stalker
+	An invisible stalker is an air elemental that has been
+	summoned from its native plane and transformed by powerful
+	magic. Its sole purpose is to hunt down creatures and
+	retrieve objects for its summoner. [...] Invisible stalkers are
+	composed of air and are naturally invisible. A creature might
+	hear and feel an invisible stalker in passing, but the
+	elemental remains invisible even when it attacks. A spell
+	that allows someone to see the invisible reveals only the
+	invisible stalker's vague outline.
+		[ Dungeons & Dragons 5th Edition Monster Manual ]
 ~statue trap
 statue*
 	Then at last he began to wonder why the lion was standing so
@@ -5115,6 +5149,7 @@ tripe ration
 	often, alas, because the heat has not been kept low enough,
 	it has the consistency of wet shoe leather.
 		[ Joy of Cooking, by I Rombauer and M Becker ]
+~water troll
 *troll
 	The troll shambled closer.  He was perhaps eight feet tall,
 	perhaps more.  His forward stoop, with arms dangling past
@@ -5383,6 +5418,21 @@ water demon
 	and drink, I will enjoy eating you, the biggest monkey, most
 	of all!"  He grinned, and saliva dripped down his hairy chin.
 		[ Buddhist Tales for Young and Old, Vol. 1 ]
+water troll
+	It wasn’t that the troll was _horrifying_. Instead of the
+	rotting, betentacled monstrosity he had been expecting
+	Rincewind found himself looking at a rather squat but not
+	particularly ugly old man who would quite easily have passed
+	for normal on any city street, always provided that other
+	people on the street were used to seeing old men who were
+	apparently composed of water and very little else. It was as
+	if the ocean had decided to create life without going through
+	all that tedious business of evolution, and had simply formed
+	a part of itself into a biped and sent it walking squishily up
+	the beach. The troll was a pleasant translucent blue color.
+	As Rincewind stared a small shoal of silver fish flashed
+	across its chest.
+	    [ The Colour of Magic, by Terry Pratchett ]
 weapon
 	A weapon is a device for making your enemy change his mind.
 		[ The Vor Game, by Lois McMaster Bujold ]
@@ -5391,17 +5441,17 @@ web
 	When first we practise to deceive!
 		[ Marmion, by Sir Walter Scott ]
 whistle
-	There were legends both on the front and on the back of the 
+	There were legends both on the front and on the back of the
 	whistle. The one read thus:
 
-	FLA FUR BIS FLE The other: QUIS EST ISTE QUI VENIT 
-	'I ought to be able to make it out,' he thought; 
-	'but I suppose I am a little rusty in my Latin. 
-	When I come to think of it, I don't believe I even 
-	know the word for a whistle. The long one does seem 
-	simple enough. It ought to mean, "Who is this who is coming?" 
+	FLA FUR BIS FLE The other: QUIS EST ISTE QUI VENIT
+	'I ought to be able to make it out,' he thought;
+	'but I suppose I am a little rusty in my Latin.
+	When I come to think of it, I don't believe I even
+	know the word for a whistle. The long one does seem
+	simple enough. It ought to mean, "Who is this who is coming?"
 
-	Well, the best way to find out is evidently to whistle 
+	Well, the best way to find out is evidently to whistle
 	for him.'
 
 		[Ghost Stories of an Antiquary, by Montague Rhodes James


### PR DESCRIPTION
This makes several edits to the encyclopedia, mostly for some entries that aren't already in there.
* Horned and barbed devils are merged since the descriptions are the same.
* Spotted jelly is the same passage as blue jelly, since the passage is more about their immobility than blue jelly specifically.
* Clay golem is the opening passage from Feet of Clay rather than the generic golem text.
* Ochre jelly and invisible stalker are given descriptions from D&D.
* Trident is the same passage as Poseidon.
* Water troll is given the paragraph from The Colour of Magic describing a water troll.