### PR TITLE
Proper form of "cannot" with "thou"

### DIFF
--- a/src/pray.c
+++ b/src/pray.c
@@ -594,7 +594,7 @@ aligntyp resp_god;
         }
         if (Is_astralevel(&u.uz) || Is_sanctum(&u.uz)) {
             /* one more try for high altars */
-            verbalize("Thou cannot escape my wrath, mortal!");
+            verbalize("Thou canst not escape my wrath, mortal!");
             summon_minion(resp_god, FALSE);
             summon_minion(resp_god, FALSE);
             summon_minion(resp_god, FALSE);


### PR DESCRIPTION
When angered in sanctum or astral plane, your deity booms out:
**Thou cannot escape my wrath, mortal!** 
This is not in line with other god messages. They all use the 2nd singular except this one.

I suggest replacing it with
**Thou canst not escape my wrath, mortal!**


Shakespearean examples:
"Thou canst not speak of that thou dost not feel." - Romeo and Juliet 3:3
"Thou canst not say I did it" - Macbeth 3:4

This has bugged me since I first ~~reached the astral plane and angered my god~~ read the code.