### PR TITLE
Improve the handling of rawprint messages

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -924,6 +924,11 @@ E int NDECL(phase_of_the_moon);
 E boolean NDECL(friday_13th);
 E int NDECL(night);
 E int NDECL(midnight);
+E void FDECL(strbuf_init, (strbuf_t *));
+E void FDECL(strbuf_append, (strbuf_t *, const char *));
+E void FDECL(strbuf_reserve, (strbuf_t *, int));
+E void FDECL(strbuf_empty, (strbuf_t *));
+E void FDECL(strbuf_nl_to_crlf, (strbuf_t *));
 
 /* ### invent.c ### */
 

--- a/include/hack.h
+++ b/include/hack.h
@@ -151,6 +151,12 @@ enum game_end_types {
     ASCENDED
 };
 
+typedef struct strbuf {
+    int    len;
+    char * str;
+    char   buf[256];
+} strbuf_t;
+
 #include "align.h"
 #include "dungeon.h"
 #include "monsym.h"

--- a/src/hacklib.c
+++ b/src/hacklib.c
@@ -1105,12 +1105,14 @@ midnight()
     return (getlt()->tm_hour == 0);
 }
 
+/* strbuf_init() inittializes strbuf state for use */
 void strbuf_init(strbuf_t * strbuf)
 {
     strbuf->str = NULL;
     strbuf->len = 0;
 }
 
+/* strbuf_append() appends given str to strbuf->str */
 void strbuf_append(strbuf_t * strbuf, const char * str)
 {
     if (strbuf->str == NULL)
@@ -1121,6 +1123,7 @@ void strbuf_append(strbuf_t * strbuf, const char * str)
     strcat(strbuf->str, str);
 }
 
+/* strbuf_reserve() ensure strbuf->str has storage for len characters */
 void strbuf_reserve(strbuf_t * strbuf, int len)
 {
     if (strbuf->str == NULL) {
@@ -1132,13 +1135,13 @@ void strbuf_reserve(strbuf_t * strbuf, int len)
     if (len > strbuf->len) {
         char * oldbuf = strbuf->str;
         strbuf->len = len + sizeof(strbuf->buf);
-        strbuf->str = (char *) malloc(len);
-        if (strbuf->str == NULL) panic("Failed allocating %u bytes", len);
+        strbuf->str = (char *) alloc(len);
         strcpy(strbuf->str, oldbuf);
         if (oldbuf != strbuf->buf) free(oldbuf);
     }
 }
 
+/* strbuf_empty() frees allocated memory and set strbuf to initial state */
 void strbuf_empty(strbuf_t * strbuf)
 {
     if (strbuf->str != strbuf->buf)
@@ -1146,6 +1149,7 @@ void strbuf_empty(strbuf_t * strbuf)
     strbuf_init(strbuf);
 }
 
+/* strbuf_nl_to_crlf() converts all occurences of \n to \r\n */
 void strbuf_nl_to_crlf(strbuf_t * strbuf)
 {
     if (strbuf->str) {

--- a/src/hacklib.c
+++ b/src/hacklib.c
@@ -61,6 +61,10 @@
         boolean         friday_13th     (void)
         int             night           (void)
         int             midnight        (void)
+        void            strbuf_int      (strbuf *, const char *)
+        void            strbuf_append   (strbuf *, const char *)
+        void            strbuf_reserve  (strbuf *, int)
+        void            strbuf_empty    (strbuf *)
 =*/
 #ifdef LINT
 #define Static /* pacify lint */
@@ -183,7 +187,7 @@ char *
 strip_newline(str)
 char *str;
 {
-    char *p = index(str, '\n');
+    char *p = rindex(str, '\n');
 
     if (p) {
         if (p > str && *(p - 1) == '\r')
@@ -1099,6 +1103,67 @@ int
 midnight()
 {
     return (getlt()->tm_hour == 0);
+}
+
+void strbuf_init(strbuf_t * strbuf)
+{
+    strbuf->str = NULL;
+    strbuf->len = 0;
+}
+
+void strbuf_append(strbuf_t * strbuf, const char * str)
+{
+    if (strbuf->str == NULL)
+        strbuf_reserve(strbuf, strlen(str) + 1);
+    else
+        strbuf_reserve(strbuf, strlen(strbuf->str) + strlen(str) + 1);
+
+    strcat(strbuf->str, str);
+}
+
+void strbuf_reserve(strbuf_t * strbuf, int len)
+{
+    if (strbuf->str == NULL) {
+        strbuf->str = strbuf->buf;
+        strbuf->str[0] = '\0';
+        strbuf->len = sizeof(strbuf->buf);
+    }
+
+    if (len > strbuf->len) {
+        char * oldbuf = strbuf->str;
+        strbuf->len = len + sizeof(strbuf->buf);
+        strbuf->str = (char *) malloc(len);
+        if (strbuf->str == NULL) panic("Failed allocating %u bytes", len);
+        strcpy(strbuf->str, oldbuf);
+        if (oldbuf != strbuf->buf) free(oldbuf);
+    }
+}
+
+void strbuf_empty(strbuf_t * strbuf)
+{
+    if (strbuf->str != strbuf->buf)
+        free(strbuf->str);
+    strbuf_init(strbuf);
+}
+
+void strbuf_nl_to_crlf(strbuf_t * strbuf)
+{
+    if (strbuf->str) {
+        int len = strlen(strbuf->str);
+        int count = 0;
+        char * cp = strbuf->str;
+        while (*cp) if (*cp++ == '\n') count++;
+        if (count) {
+            strbuf_reserve(strbuf, len + count + 1);
+            cp = strbuf->str + len + count;
+            while (count) {
+                if ((*cp-- = cp[-count]) == '\n') {
+                    *cp-- = '\r';
+                    count--;
+                }
+            }
+        }
+    }
 }
 
 /*hacklib.c*/

--- a/src/hacklib.c
+++ b/src/hacklib.c
@@ -1135,7 +1135,7 @@ void strbuf_reserve(strbuf_t * strbuf, int len)
     if (len > strbuf->len) {
         char * oldbuf = strbuf->str;
         strbuf->len = len + sizeof(strbuf->buf);
-        strbuf->str = (char *) alloc(len);
+        strbuf->str = (char *) alloc(strbuf->len);
         strcpy(strbuf->str, oldbuf);
         if (oldbuf != strbuf->buf) free(oldbuf);
     }

--- a/sys/share/pcmain.c
+++ b/sys/share/pcmain.c
@@ -139,6 +139,15 @@ char *argv[];
 /* use STDERR by default
 _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
 _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);*/
+/* Heap Debugging
+    _CrtSetDbgFlag( _CrtSetDbgFlag(_CRTDBG_REPORT_FLAG)
+        | _CRTDBG_ALLOC_MEM_DF
+        | _CRTDBG_CHECK_ALWAYS_DF
+        | _CRTDBG_CHECK_CRT_DF
+        | _CRTDBG_DELAY_FREE_MEM_DF
+        | _CRTDBG_LEAK_CHECK_DF);
+    _CrtSetBreakAlloc(1423);
+*/
 # endif
 #endif
 

--- a/sys/share/pcsys.c
+++ b/sys/share/pcsys.c
@@ -546,6 +546,8 @@ msexit()
         getreturn("to end");
     synch_cursor();
 #endif
+    getreturn_enabled = TRUE;
+    wait_synch();
     return;
 }
 #endif /* MICRO || WIN32 || OS2 */

--- a/win/win32/mhmsgwnd.c
+++ b/win/win32/mhmsgwnd.c
@@ -245,6 +245,25 @@ onMSNHCommand(HWND hWnd, WPARAM wParam, LPARAM lParam)
     data = (PNHMessageWindow) GetWindowLongPtr(hWnd, GWLP_USERDATA);
     switch (wParam) {
     case MSNH_MSG_PUTSTR: {
+        /* Add the passed in message to the existing text.  Support the
+         * adding of text that ends in newline.  A newline in text
+         * will force any subsequent text that is added to be added on
+         * a new output line.
+         *
+         * TODO: Text can be added with newlines occuring within the text not
+         *       just at the end.  As currently implemented, this can causes
+         *       the text to be rendered such that the text following the
+         *       newline is rendered on a new line.  This can cause a poor
+         *       user experience when the user has set only a single text line
+         *       for the message window.  In this case, the user will not see
+         *       any line other then the last line of text and the --MORE--
+         *       message thus missing any text that appears before the last
+         *       embedded newling.  This does not meet the requirements of the
+         *       message window.
+         *       This code should be changed to do the right thing and split
+         *       the text so that only lines that end in newlines are added to
+         *       the stored window text.
+         */
         PMSNHMsgPutstr msg_data = (PMSNHMsgPutstr) lParam;
         SCROLLINFO si;
         char *p;

--- a/win/win32/mhmsgwnd.c
+++ b/win/win32/mhmsgwnd.c
@@ -271,8 +271,15 @@ onMSNHCommand(HWND hWnd, WPARAM wParam, LPARAM lParam)
                 /* check for "--more--" */
                 if (!data->nevermore && more_prompt_check(hWnd)) {
                     int okkey = 0;
-                    int chop;
+                    char tmptext[MAXWINDOWTEXT + 1];
+
                     // @@@ Ok respnses
+
+                    /* save original text */
+                    strcpy(tmptext, data->window_text[MSG_LINES - 1].text);
+
+                    /* text could end newline so strip it*/
+                    strip_newline(data->window_text[MSG_LINES - 1].text);
 
                     /* append more prompt and inticate the update */
                     strncat(
@@ -301,10 +308,9 @@ onMSNHCommand(HWND hWnd, WPARAM wParam, LPARAM lParam)
                         }
                     }
 
-                    /* erase the "--more--" prompt */
-                    chop = strlen(data->window_text[MSG_LINES - 1].text)
-                           - strlen(MORE);
-                    data->window_text[MSG_LINES - 1].text[chop] = '\0';
+                    /* restore original text */
+                    strcpy(data->window_text[MSG_LINES - 1].text, tmptext);
+
                     data->lines_not_seen = 0;
                 }
 
@@ -601,6 +607,7 @@ onPaint(HWND hWnd)
                     - (client_rt.bottom - ps.rcPaint.bottom) / data->yChar);
         y = min(ps.rcPaint.bottom, client_rt.bottom);
         for (i = LastLine; i >= FirstLine; i--) {
+            char tmptext[MAXWINDOWTEXT + 1];
             x = data->xChar * (2 - data->xPos);
 
             draw_rt.left = x;
@@ -612,8 +619,10 @@ onPaint(HWND hWnd)
                 hdc, mswin_get_font(NHW_MESSAGE, data->window_text[i].attr,
                                     hdc, FALSE));
 
-            /* convert to UNICODE */
-            NH_A2W(data->window_text[i].text, wbuf, sizeof(wbuf));
+            /* convert to UNICODE stripping newline */
+            strcpy(tmptext, data->window_text[i].text);
+            strip_newline(tmptext);
+            NH_A2W(tmptext, wbuf, sizeof(wbuf));
             wlen = _tcslen(wbuf);
             setMsgTextColor(hdc, i < (MSG_LINES - data->lines_last_turn));
 #ifdef MSG_WRAP_TEXT
@@ -765,6 +774,10 @@ can_append_text(HWND hWnd, int attr, const char *text)
     if (data->window_text[MSG_LINES - 1].attr != attr)
         return FALSE;
 
+    /* cannot append if current line ends in newline */
+    if (str_end_is(data->window_text[MSG_LINES - 1].text, "\n"))
+        return FALSE;
+
     /* check if the maximum string langth will be exceeded */
     if (strlen(data->window_text[MSG_LINES - 1].text) + 2
             + /* space characters */
@@ -772,10 +785,11 @@ can_append_text(HWND hWnd, int attr, const char *text)
         >= MAXWINDOWTEXT)
         return FALSE;
 
-    /* check if the text is goinf to fin into a single line */
+    /* check if the text is going to fit into a single line */
     strcpy(tmptext, data->window_text[MSG_LINES - 1].text);
     strcat(tmptext, "  ");
     strcat(tmptext, text);
+    strip_newline(tmptext);
     strcat(tmptext, MORE);
 
     hdc = GetDC(hWnd);
@@ -836,6 +850,8 @@ more_prompt_check(HWND hWnd)
                                     hdc, FALSE));
 
         strcpy(tmptext, data->window_text[MSG_LINES - i - 1].text);
+        strip_newline(tmptext);
+
         if (i == 0)
             strcat(tmptext, MORE);
 

--- a/win/win32/mswproc.c
+++ b/win/win32/mswproc.c
@@ -1296,7 +1296,8 @@ mswin_print_glyph(winid wid, XCHAR_P x, XCHAR_P y, int glyph, int bkglyph)
 }
 
 /*
- * mswin_raw_print_accumulate()
+ * mswin_raw_print_accumulate() accumulate the given text into
+ *   raw_print_strbuf.
  */
 void
 mswin_raw_print_accumulate(const char * str, boolean bold)
@@ -1308,14 +1309,15 @@ mswin_raw_print_accumulate(const char * str, boolean bold)
 }
 
 /*
- * mswin_raw_print_flush()
+ * mswin_raw_print_flush() - display any text found in raw_print_strbuf in a
+ *   dialog box and clear raw_print_strbuf.
  */
 void
 mswin_raw_print_flush()
 {
     if (raw_print_strbuf.str != NULL) {
         int wlen = strlen(raw_print_strbuf.str) + 1;
-        TCHAR * wbuf = (TCHAR *) malloc(wlen * sizeof(TCHAR));
+        TCHAR * wbuf = (TCHAR *) alloc(wlen * sizeof(TCHAR));
         if (wbuf != NULL) {
             NHMessageBox(GetNHApp()->hMainWnd,
                             NH_A2W(raw_print_strbuf.str, wbuf, wlen),

--- a/win/win32/mswproc.c
+++ b/win/win32/mswproc.c
@@ -75,6 +75,8 @@ COLORREF status_fg_color = RGB(0xFF, 0xFF, 0xFF);
 COLORREF message_bg_color = RGB(0, 0, 0);
 COLORREF message_fg_color = RGB(0xFF, 0xFF, 0xFF);
 
+strbuf_t raw_print_strbuf = { 0 };
+
 /* Interface definition, for windows.c */
 struct window_procs mswin_procs = {
     "MSWIN",
@@ -717,8 +719,7 @@ mswin_exit_nhwindows(const char *str)
 
     /* Write Window settings to the registry */
     mswin_write_reg();
-    while (max_brush)
-        DeleteObject(brush_table[--max_brush]);
+
 }
 
 /* Prepare the window to be suspended. */
@@ -1238,6 +1239,7 @@ void
 mswin_wait_synch()
 {
     logDebug("mswin_wait_synch()\n");
+    mswin_raw_print_flush();
 }
 
 /*
@@ -1294,6 +1296,38 @@ mswin_print_glyph(winid wid, XCHAR_P x, XCHAR_P y, int glyph, int bkglyph)
 }
 
 /*
+ * mswin_raw_print_accumulate()
+ */
+void
+mswin_raw_print_accumulate(const char * str, boolean bold)
+{
+    bold; // ignored for now
+
+    if (raw_print_strbuf.str != NULL) strbuf_append(&raw_print_strbuf, "\n");
+    strbuf_append(&raw_print_strbuf, str);
+}
+
+/*
+ * mswin_raw_print_flush()
+ */
+void
+mswin_raw_print_flush()
+{
+    if (raw_print_strbuf.str != NULL) {
+        int wlen = strlen(raw_print_strbuf.str) + 1;
+        TCHAR * wbuf = (TCHAR *) malloc(wlen * sizeof(TCHAR));
+        if (wbuf != NULL) {
+            NHMessageBox(GetNHApp()->hMainWnd,
+                            NH_A2W(raw_print_strbuf.str, wbuf, wlen),
+                            MB_ICONINFORMATION | MB_OK);
+            free(wbuf);
+        }
+        strbuf_empty(&raw_print_strbuf);
+    }
+}
+
+
+/*
 raw_print(str)  -- Print directly to a screen, or otherwise guarantee that
                    the user sees str.  raw_print() appends a newline to str.
                    It need not recognize ASCII control characters.  This is
@@ -1305,14 +1339,12 @@ raw_print(str)  -- Print directly to a screen, or otherwise guarantee that
 void
 mswin_raw_print(const char *str)
 {
-    TCHAR wbuf[255];
     logDebug("mswin_raw_print(%s)\n", str);
+
     if (str && *str) {
         extern int redirect_stdout;
         if (!redirect_stdout)
-            NHMessageBox(GetNHApp()->hMainWnd,
-                         NH_A2W(str, wbuf, sizeof(wbuf)),
-                         MB_ICONINFORMATION | MB_OK);
+            mswin_raw_print_accumulate(str, FALSE);
         else
             fprintf(stdout, "%s", str);
     }
@@ -1326,11 +1358,14 @@ possible).
 void
 mswin_raw_print_bold(const char *str)
 {
-    TCHAR wbuf[255];
     logDebug("mswin_raw_print_bold(%s)\n", str);
-    if (str && *str)
-        NHMessageBox(GetNHApp()->hMainWnd, NH_A2W(str, wbuf, sizeof(wbuf)),
-                     MB_ICONINFORMATION | MB_OK);
+    if (str && *str) {
+        extern int redirect_stdout;
+        if (!redirect_stdout)
+            mswin_raw_print_accumulate(str, TRUE);
+        else
+            fprintf(stdout, "%s", str);
+    }
 }
 
 /*

--- a/win/win32/vs2015/NetHack.vcxproj
+++ b/win/win32/vs2015/NetHack.vcxproj
@@ -24,7 +24,7 @@
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalIncludeDirectories>$(WinWin32Dir);$(IncDir);$(SysWinntDir);$(SysShareDir);$(WinShareDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>TILES;WIN32CON;DLB;MSWIN_GRAPHICS;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>TILES;WIN32CON;DLB;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;winmm.lib;Winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/win/win32/vs2017/NetHack.vcxproj
+++ b/win/win32/vs2017/NetHack.vcxproj
@@ -24,7 +24,7 @@
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalIncludeDirectories>$(WinWin32Dir);$(IncDir);$(SysWinntDir);$(SysShareDir);$(WinShareDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>TILES;WIN32CON;DLB;MSWIN_GRAPHICS;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>TILES;WIN32CON;DLB;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;winmm.lib;Winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/win/win32/winMS.h
+++ b/win/win32/winMS.h
@@ -164,6 +164,7 @@ void mswin_cliparound(int x, int y);
 void mswin_print_glyph(winid wid, XCHAR_P x, XCHAR_P y, int glyph, int bkglyph);
 void mswin_raw_print(const char *str);
 void mswin_raw_print_bold(const char *str);
+void mswin_raw_print_flush();
 int mswin_nhgetch(void);
 int mswin_nh_poskey(int *x, int *y, int *mod);
 void mswin_nhbell(void);


### PR DESCRIPTION
There are several improvements in this pull request.  In particular if during program initialization you encounter problems causing multiple raw_print messages, all the messages will be displayed in a single dialog instead of getting a series of individual message dialogs for each raw_print message.

Fixed an undetected problem with building NetHack where we were defining MSWIN_GRAPHICS.

Implemented a mechanism for dynamically growing a string.  Leveraged this mechanism to reduce code complexity of splash window code.
