### PR TITLE
Fix problem with defaults.nh not being found when debugging within VS IDE

### DIFF
--- a/win/win32/vs2015/default.props
+++ b/win/win32/vs2015/default.props
@@ -5,6 +5,7 @@
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v140</PlatformToolset>
+    <LocalDebuggerWorkingDirectory>$(BinDir)</LocalDebuggerWorkingDirectory>
   </PropertyGroup> 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" >
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/win/win32/vs2017/default.props
+++ b/win/win32/vs2017/default.props
@@ -5,6 +5,7 @@
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
+    <LocalDebuggerWorkingDirectory>$(BinDir)</LocalDebuggerWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" >
     <UseDebugLibraries>true</UseDebugLibraries>


### PR DESCRIPTION
When debugging using the Visual Studio IDE, by default the working directory is the project directory.
Because of this, both NetHack and NetHackW will fail to find defaults.nh.  This change simply changes
the default working directory to $BinDir allowing defaults.nh to be found along side the executable.