### PR TITLE
Fix permanent inventory window going away after pick item(s) operations.

### DIFF
--- a/win/win32/mhmenu.c
+++ b/win/win32/mhmenu.c
@@ -246,7 +246,18 @@ mswin_menu_window_select_menu(HWND hWnd, int how, MENU_ITEM_P **_selected,
         data->is_active = FALSE;
         LayoutMenu(hWnd); // hide dialog buttons
         mswin_popup_destroy(hWnd);
+
+        /* If we just used the permanent inventory window to pick something,
+         * set the menu back to its display inventory state.
+         */
+        if (flags.perm_invent && mswin_winid_from_handle(hWnd) == WIN_INVEN
+            && how != PICK_NONE) {
+            data->menu.prompt[0] = '\0';
+            SetMenuListType(hWnd, PICK_NONE);
+            LayoutMenu(hWnd);
+        }
     }
+
     return ret_val;
 }
 /*-----------------------------------------------------------------------------*/

--- a/win/win32/mswproc.c
+++ b/win/win32/mswproc.c
@@ -2202,7 +2202,10 @@ mswin_popup_destroy(HWND hWnd)
     }
     DrawMenuBar(GetNHApp()->hMainWnd);
 
-    ShowWindow(hWnd, SW_HIDE);
+    /* Don't hide the permanent inventory window ... leave it showing */
+    if(!flags.perm_invent || mswin_winid_from_handle(hWnd) != WIN_INVEN)
+        ShowWindow(hWnd, SW_HIDE);
+
     GetNHApp()->hPopupWnd = NULL;
 
     mswin_layout_main_window(hWnd);


### PR DESCRIPTION
In the windows GUI when permanent inventory is being used, there is an annoying bug where any command that uses the inventory window to pick an item (or items) will cause the inventory window to become hidden requiring the user to use 'i' to redisplay the inventory.

Another side effect of this problem is that a jarring white empty space is created if the user happens to be using window backgrounds other then white (such as black).

This fix is in two parts.  First, we don't hide the permanent inventory window when destroying its as a popup.  Second, after a pick operation where we just used the permanent inventory window we restore the proper display state of the inventory window (pick type NONE and no prompt).
