### PR TITLE
Fix bug with handling of hilite color NO_COLOR

### DIFF
--- a/win/win32/mhmain.c
+++ b/win/win32/mhmain.c
@@ -104,7 +104,7 @@ register_main_window_class()
     wcex.hInstance = GetNHApp()->hApp;
     wcex.hIcon = LoadIcon(GetNHApp()->hApp, (LPCTSTR) IDI_NETHACKW);
     wcex.hCursor = LoadCursor(NULL, IDC_ARROW);
-    wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
+    wcex.hbrBackground = CreateSolidBrush(RGB(0, 0, 0));
     wcex.lpszMenuName = (TCHAR *) IDC_NETHACKW;
     wcex.lpszClassName = szMainWindowClass;
 

--- a/win/win32/mhstatus.c
+++ b/win/win32/mhstatus.c
@@ -275,7 +275,8 @@ onWMPaint(HWND hWnd, WPARAM wParam, LPARAM lParam)
             else if (atr & HL_DIM)
                 fntatr = ATR_DIM;
             fnt = mswin_get_font(NHW_STATUS, fntatr, hdc, FALSE);
-            nFg = (clr >= 0 && clr < CLR_MAX) ? nhcolor_to_RGB(clr) : Fg;
+            nFg = (clr == NO_COLOR ? Fg :
+                   ((clr >= 0 && clr < CLR_MAX) ? nhcolor_to_RGB(clr) : Fg));
             nBg = Bg;
 
             GetTextExtentPoint32(hdc, wbuf, vlen, &sz);


### PR DESCRIPTION
If a status hilite color is set to NO_COLOR, we will map this color to white (0xffffff) instead of using default foreground color of status window.  This can cause the unexpected result of drawing white text on white in the case that the user has set their status window background to white.

Made a change to the background brush of the main window to be black.  The main window background color is used when we are hiding/showing child windows.  This is a better choice given that the map window's background brush is black.  In the case that all window backgrounds have been set to black, this gives a pleasing consistent user experience without any flashes of white.