### PR TITLE
Add configuration for Qt 5

### DIFF
--- a/sys/unix/Makefile.src
+++ b/sys/unix/Makefile.src
@@ -273,7 +273,7 @@ WINX11LIB = -lXaw -lXmu -lXext -lXt -lX11
 WINQTLIB = -L$(QTDIR)/lib -lqt
 #
 # libraries for Qt 4
-WINQT4LIB = `pkg-config QtGui --libs`
+WINQT4LIB = `pkg-config $(QTGUI) --libs`
 #
 # libraries for KDE (with Qt)
 WINKDELIB = -lkdecore -lkdeui -lXext
@@ -548,25 +548,25 @@ qttableview.moc: ../include/qttableview.h
 
 # Qt 4 windowport meta-object-compiler output
 qt4kde0.moc : ../win/Qt4/qt4kde0.h
-	$(QTDIR)/bin/moc -o qt4kde0.moc ../win/Qt4/qt4kde0.h
+	$(MOC) -o qt4kde0.moc ../win/Qt4/qt4kde0.h
 qt4main.moc : ../win/Qt4/qt4main.h
-	$(QTDIR)/bin/moc -o qt4main.moc ../win/Qt4/qt4main.h
+	$(MOC) -o qt4main.moc ../win/Qt4/qt4main.h
 qt4map.moc : ../win/Qt4/qt4map.h
-	$(QTDIR)/bin/moc -o qt4map.moc ../win/Qt4/qt4map.h
+	$(MOC) -o qt4map.moc ../win/Qt4/qt4map.h
 qt4menu.moc : ../win/Qt4/qt4menu.h
-	$(QTDIR)/bin/moc -o qt4menu.moc ../win/Qt4/qt4menu.h
+	$(MOC) -o qt4menu.moc ../win/Qt4/qt4menu.h
 qt4msg.moc : ../win/Qt4/qt4msg.h
-	$(QTDIR)/bin/moc -o qt4msg.moc ../win/Qt4/qt4msg.h
+	$(MOC) -o qt4msg.moc ../win/Qt4/qt4msg.h
 qt4plsel.moc : ../win/Qt4/qt4plsel.h
-	$(QTDIR)/bin/moc -o qt4plsel.moc ../win/Qt4/qt4plsel.h
+	$(MOC) -o qt4plsel.moc ../win/Qt4/qt4plsel.h
 qt4set.moc : ../win/Qt4/qt4set.h
-	$(QTDIR)/bin/moc -o qt4set.moc ../win/Qt4/qt4set.h
+	$(MOC) -o qt4set.moc ../win/Qt4/qt4set.h
 qt4stat.moc : ../win/Qt4/qt4stat.h
-	$(QTDIR)/bin/moc -o qt4stat.moc ../win/Qt4/qt4stat.h
+	$(MOC) -o qt4stat.moc ../win/Qt4/qt4stat.h
 qt4xcmd.moc : ../win/Qt4/qt4xcmd.h
-	$(QTDIR)/bin/moc -o qt4xcmd.moc ../win/Qt4/qt4xcmd.h
+	$(MOC) -o qt4xcmd.moc ../win/Qt4/qt4xcmd.h
 qt4yndlg.moc : ../win/Qt4/qt4yndlg.h
-	$(QTDIR)/bin/moc -o qt4yndlg.moc ../win/Qt4/qt4yndlg.h
+	$(MOC) -o qt4yndlg.moc ../win/Qt4/qt4yndlg.h
 
 #	build monst.o and objects.o before executing '$(MAKE) makedefs'
 $(MAKEDEFS): $(FIRSTOBJ) \

--- a/sys/unix/hints/linux-qt4
+++ b/sys/unix/hints/linux-qt4
@@ -16,6 +16,12 @@ SHELLDIR = $(PREFIX)/games
 INSTDIR=$(HACKDIR)
 VARDIR = $(HACKDIR)
 
+# For Qt 4:
+QTGUI=QtGui
+MOC=$(QTDIR)/bin/moc
+# For Qt 5:
+#QTGUI=Qt5Gui Qt5Widgets Qt5Multimedia
+#MOC=$(QTDIR)/bin/moc-qt5
 
 POSTINSTALL= cp -n sys/unix/sysconf $(INSTDIR)/sysconf; $(CHOWN) $(GAMEUID) $(INSTDIR)/sysconf; $(CHGRP) $(GAMEGRP) $(INSTDIR)/sysconf; chmod $(VARFILEPERM) $(INSTDIR)/sysconf;
 POSTINSTALL+= bdftopcf win/X11/nh10.bdf > $(INSTDIR)/nh10.pcf; (cd $(INSTDIR); mkfontdir);
@@ -28,7 +34,8 @@ CFLAGS+=-DTIMED_DELAY
 CFLAGS+=-DDUMPLOG
 CFLAGS+=-DCONFIG_ERROR_SECURE=FALSE
 CFLAGS+=-DQT_GRAPHICS -DDEFAULT_WINDOW_SYS=\"Qt\" -DNOTTYGRAPHICS
-CFLAGS+=`pkg-config QtGui --cflags`
+CFLAGS+=`pkg-config $(QTGUI) --cflags`
+CFLAGS+=-fPIC
 
 LINK=g++
 CXX=g++


### PR DESCRIPTION
I called the directory Qt4, but the source code also compiles with Qt 5, with a little help from the preprocessor.

With Qt 5, at least on Fedora 26, the needed packages are Qt5Gui Qt5Widgets Qt5Multimedia, the MOC is moc-qt5 and the source must be compiled with -fPIC. The linker complains if you don't use -fPIC.

This change adjusts sys/unix/hints/linux-qt4 to provide the variables QTGUI and MOC, with an alternate configuration for Qt 5, and adjusts sys/unix/Makefile.src to accept these variables.