### PR TITLE
Fix memory error by adding byte for null string terminator.

### DIFF
--- a/src/mail.c
+++ b/src/mail.c
@@ -92,7 +92,7 @@ getmailstatus()
 {
     char *emailbox;
     if ((emailbox = nh_getenv("MAIL")) != 0) {
-        mailbox = (char *) alloc((unsigned) strlen(emailbox));
+        mailbox = (char *) alloc((unsigned) strlen(emailbox) + 1);
         Strcpy(mailbox, emailbox);
     }
     if (!mailbox) {


### PR DESCRIPTION
Line 95 in mail.c introduced a bug by allocating one byte less than was needed.
The call to alloc was supposed to get enough bytes to hold a string but it
used strlen() to get the number of bytes. We should have allocated strlen()+1.
This didn't cause an error on Linux on x86-64 but it showed up on the
Raspberry Pi platform.