### PR TITLE
Refactor getobj and add the ability to handle floor items/features to it

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -633,7 +633,7 @@ E int NDECL(opentin);
 E int NDECL(unfaint);
 #endif
 E void NDECL(eatmupdate);
-E boolean FDECL(is_edible, (struct obj *));
+E int FDECL(is_edible, (struct obj *));
 E void NDECL(init_uhunger);
 E int NDECL(Hear_again);
 E void NDECL(reset_eat);
@@ -962,7 +962,11 @@ E boolean NDECL(wearing_armor);
 E boolean FDECL(is_worn, (struct obj *));
 E struct obj *FDECL(g_at, (int, int));
 E boolean FDECL(splittable, (struct obj *));
-E struct obj *FDECL(getobj, (const char *, const char *));
+E int FDECL(allow_floor, (struct obj *));
+E int FDECL(allow_any_obj, (struct obj *));
+E int FDECL(allow_any, (struct obj *));
+E struct obj *FDECL(getobj, (const char *, int (*)(OBJ_P), BOOLEAN_P,
+                             BOOLEAN_P));
 E int FDECL(ggetobj, (const char *, int (*)(OBJ_P), int,
                       BOOLEAN_P, unsigned *));
 E int FDECL(askchain, (struct obj **, const char *, int, int (*)(OBJ_P),
@@ -1654,7 +1658,7 @@ E boolean FDECL(erosion_matters, (struct obj *));
 E char *FDECL(doname, (struct obj *));
 E char *FDECL(doname_with_price, (struct obj *));
 E char *FDECL(doname_vague_quan, (struct obj *));
-E boolean FDECL(not_fully_identified, (struct obj *));
+E int FDECL(not_fully_identified, (struct obj *));
 E char *FDECL(corpse_xname, (struct obj *, const char *, unsigned));
 E char *FDECL(cxname, (struct obj *));
 E char *FDECL(cxname_singular, (struct obj *));
@@ -1812,8 +1816,7 @@ E int FDECL(collect_obj_classes, (char *, struct obj *, BOOLEAN_P,
 E boolean FDECL(rider_corpse_revival, (struct obj *, BOOLEAN_P));
 E boolean FDECL(menu_class_present, (int));
 E void FDECL(add_valid_menu_class, (int));
-E boolean FDECL(allow_all, (struct obj *));
-E boolean FDECL(allow_category, (struct obj *));
+E int FDECL(allow_category, (struct obj *));
 E boolean FDECL(is_worn_by_type, (struct obj *));
 E int FDECL(ck_bag, (struct obj *));
 #ifdef USE_TRAMPOLI
@@ -1825,7 +1828,7 @@ E int FDECL(pickup_object, (struct obj *, long, BOOLEAN_P));
 E int FDECL(query_category, (const char *, struct obj *, int,
                              menu_item **, int));
 E int FDECL(query_objlist, (const char *, struct obj **, int,
-                            menu_item **, int, boolean (*)(OBJ_P)));
+                            menu_item **, int, int (*)(OBJ_P)));
 E struct obj *FDECL(pick_obj, (struct obj *));
 E int NDECL(encumber_msg);
 E int FDECL(container_at, (int, int, BOOLEAN_P));
@@ -2000,7 +2003,7 @@ E long NDECL(random);
 E void FDECL(learnscroll, (struct obj *));
 E char *FDECL(tshirt_text, (struct obj *, char *));
 E int NDECL(doread);
-E boolean FDECL(is_chargeable, (struct obj *));
+E int FDECL(is_chargeable, (struct obj *));
 E void FDECL(recharge, (struct obj *, int));
 E void FDECL(forget_objects, (int));
 E void FDECL(forget_levels, (int));

--- a/include/extern.h
+++ b/include/extern.h
@@ -959,7 +959,7 @@ E struct obj *NDECL(u_have_novel);
 E struct obj *FDECL(o_on, (unsigned int, struct obj *));
 E boolean FDECL(obj_here, (struct obj *, int, int));
 E boolean NDECL(wearing_armor);
-E boolean FDECL(is_worn, (struct obj *));
+E int FDECL(is_worn, (struct obj *));
 E struct obj *FDECL(g_at, (int, int));
 E boolean FDECL(splittable, (struct obj *));
 E int FDECL(allow_floor, (struct obj *));
@@ -1005,7 +1005,7 @@ E void NDECL(reassign);
 E int NDECL(doorganize);
 E void NDECL(free_pickinv_cache);
 E int FDECL(count_unpaid, (struct obj *));
-E int FDECL(count_buc, (struct obj *, int, boolean (*)(OBJ_P)));
+E int FDECL(count_buc, (struct obj *, int, int (*)(OBJ_P)));
 E void FDECL(tally_BUCX, (struct obj *, BOOLEAN_P,
                           int *, int *, int *, int *, int *));
 E long FDECL(count_contents, (struct obj *, BOOLEAN_P, BOOLEAN_P, BOOLEAN_P));
@@ -1812,12 +1812,12 @@ E void NDECL(getlock);
 /* ### pickup.c ### */
 
 E int FDECL(collect_obj_classes, (char *, struct obj *, BOOLEAN_P,
-                                  boolean FDECL((*), (OBJ_P)), int *));
+                                  int FDECL((*), (OBJ_P)), int *));
 E boolean FDECL(rider_corpse_revival, (struct obj *, BOOLEAN_P));
 E boolean FDECL(menu_class_present, (int));
 E void FDECL(add_valid_menu_class, (int));
 E int FDECL(allow_category, (struct obj *));
-E boolean FDECL(is_worn_by_type, (struct obj *));
+E int FDECL(is_worn_by_type, (struct obj *));
 E int FDECL(ck_bag, (struct obj *));
 #ifdef USE_TRAMPOLI
 E int FDECL(in_container, (struct obj *));

--- a/include/extern.h
+++ b/include/extern.h
@@ -1832,6 +1832,7 @@ E int FDECL(query_objlist, (const char *, struct obj **, int,
 E struct obj *FDECL(pick_obj, (struct obj *));
 E int NDECL(encumber_msg);
 E int FDECL(container_at, (int, int, BOOLEAN_P));
+E int FDECL(floor_loot_ok, (struct obj *));
 E int NDECL(doloot);
 E boolean FDECL(container_gone, (int (*)(OBJ_P)));
 E boolean NDECL(u_handsy);

--- a/include/extern.h
+++ b/include/extern.h
@@ -351,6 +351,7 @@ E void FDECL(row_refresh, (int, int, int));
 E void NDECL(cls);
 E void FDECL(flush_screen, (int));
 E int FDECL(back_to_glyph, (XCHAR_P, XCHAR_P));
+E int FDECL(back_to_defsym, (XCHAR_P, XCHAR_P));
 E int FDECL(zapdir_to_glyph, (int, int, int));
 E int FDECL(glyph_at, (XCHAR_P, XCHAR_P));
 E void NDECL(set_wall_state);

--- a/include/extern.h
+++ b/include/extern.h
@@ -1833,7 +1833,6 @@ E int FDECL(query_objlist, (const char *, struct obj **, int,
 E struct obj *FDECL(pick_obj, (struct obj *));
 E int NDECL(encumber_msg);
 E int FDECL(container_at, (int, int, BOOLEAN_P));
-E int FDECL(floor_loot_ok, (struct obj *));
 E int NDECL(doloot);
 E boolean FDECL(container_gone, (int (*)(OBJ_P)));
 E boolean NDECL(u_handsy);

--- a/include/hack.h
+++ b/include/hack.h
@@ -273,14 +273,16 @@ enum hmon_atkmode_types {
 #define ALL_FINISHED 0x01 /* called routine already finished the job */
 
 /* flags to control query_objlist() */
-#define BY_NEXTHERE 0x1       /* follow objlist by nexthere field */
-#define AUTOSELECT_SINGLE 0x2 /* if only 1 object, don't ask */
-#define USE_INVLET 0x4        /* use object's invlet */
-#define INVORDER_SORT 0x8     /* sort objects by packorder */
-#define SIGNAL_NOMENU 0x10    /* return -1 rather than 0 if none allowed */
-#define SIGNAL_ESCAPE 0x20    /* return -2 rather than 0 for ESC */
-#define FEEL_COCKATRICE 0x40  /* engage cockatrice checks and react */
-#define INCLUDE_HERO 0x80     /* show hero among engulfer's inventory */
+#define BY_NEXTHERE 0x1        /* follow objlist by nexthere field */
+#define AUTOSELECT_SINGLE 0x2  /* if only 1 object, don't ask */
+#define USE_INVLET 0x4         /* use object's invlet */
+#define INVORDER_SORT 0x8      /* sort objects by packorder */
+#define SIGNAL_NOMENU 0x10     /* return -1 rather than 0 if none allowed */
+#define SIGNAL_ESCAPE 0x20     /* return -2 rather than 0 for ESC */
+#define FEEL_COCKATRICE 0x40   /* engage cockatrice checks and react */
+#define INCLUDE_HERO 0x80      /* show hero among engulfer's inventory */
+#define HIDE_DISCOURAGED 0x100 /* only show objects where allow() returns 2 */
+#define INCLUDE_FEATURE  0x200 /* include dungeon features */
 
 /* Flags to control query_category() */
 /* BY_NEXTHERE used by query_category() too, so skip 0x01 */

--- a/src/apply.c
+++ b/src/apply.c
@@ -3526,10 +3526,6 @@ struct obj *obj;
     if (!obj || obj == &zeroobj)
         return 0;
 
-    /* allow lootables to be applied everywhere */
-    if (obj->where != OBJ_INVENT)
-        return floor_loot_ok(obj);
-
     if (obj->oclass == TOOL_CLASS || is_pole(obj) || is_axe(obj))
         return 2;
 
@@ -3563,7 +3559,7 @@ doapply()
         return 0;
 
     setapplyclasses(class_list); /* tools[] */
-    obj = getobj("use or apply", apply_ok, TRUE, TRUE);
+    obj = getobj("use or apply", apply_ok, TRUE, FALSE);
     if (!obj)
         return 0;
 

--- a/src/apply.c
+++ b/src/apply.c
@@ -3527,11 +3527,8 @@ struct obj *obj;
         return 0;
 
     /* allow lootables to be applied everywhere */
-    if (Is_container(obj))
-        return 2;
-
     if (obj->where != OBJ_INVENT)
-        return 0;
+        return floor_loot_ok(obj);
 
     if (obj->oclass == TOOL_CLASS || is_pole(obj) || is_axe(obj))
         return 2;

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -1385,9 +1385,25 @@ int dieroll; /* needed for Magicbane and vorpal blades */
     return FALSE;
 }
 
-static NEARDATA const char recharge_type[] = { ALLOW_COUNT, ALL_CLASSES, 0 };
-static NEARDATA const char invoke_types[] = { ALL_CLASSES, 0 };
-/* #invoke: an "ugly check" filters out most objects */
+STATIC_OVL int
+invocable(obj)
+struct obj *obj;
+{
+    if (!obj)
+        return 0;
+
+    if (obj->oartifact || objects[obj->otyp].oc_unique ||
+        (obj->otyp == FAKE_AMULET_OF_YENDOR && !obj->known) ||
+        obj->otyp == CRYSTAL_BALL || obj->otyp == MIRROR ||
+        obj->otyp == MAGIC_LAMP ||
+        (obj->otyp == OIL_LAMP && !objects[OIL_LAMP].oc_name_known))
+        return 2;
+
+    if (obj->otyp == FAKE_AMULET_OF_YENDOR || obj->otyp == OIL_LAMP)
+        return 1;
+
+    return 0;
+}
 
 /* the #invoke command */
 int
@@ -1395,7 +1411,7 @@ doinvoke()
 {
     struct obj *obj;
 
-    obj = getobj(invoke_types, "invoke");
+    obj = getobj("invoke", invocable, FALSE, FALSE);
     if (!obj)
         return 0;
     if (!retouch_object(&obj, FALSE))
@@ -1489,7 +1505,7 @@ struct obj *obj;
             break;
         }
         case CHARGE_OBJ: {
-            struct obj *otmp = getobj(recharge_type, "charge");
+            struct obj *otmp = getobj("charge", is_chargeable, TRUE, FALSE);
             boolean b_effect;
 
             if (!otmp) {

--- a/src/display.c
+++ b/src/display.c
@@ -1566,6 +1566,13 @@ int
 back_to_glyph(x, y)
 xchar x, y;
 {
+    return cmap_to_glyph(back_to_defsym(x, y));
+}
+
+int
+back_to_defsym(x, y)
+xchar x, y;
+{
     int idx;
     struct rm *ptr = &(levl[x][y]);
 
@@ -1684,7 +1691,7 @@ xchar x, y;
         break;
     }
 
-    return cmap_to_glyph(idx);
+    return idx;
 }
 
 /*

--- a/src/do.c
+++ b/src/do.c
@@ -20,18 +20,15 @@ STATIC_DCL void NDECL(final_level);
 
 extern int n_dgns; /* number of dungeons, from dungeon.c */
 
-static NEARDATA const char drop_types[] = { ALLOW_COUNT, COIN_CLASS,
-                                            ALL_CLASSES, 0 };
-
 /* 'd' command: drop one inventory item */
 int
 dodrop()
 {
-    int result, i = (invent) ? 0 : (SIZE(drop_types) - 1);
+    int result;
 
     if (*u.ushops)
         sellobj_state(SELL_DELIBERATE);
-    result = drop(getobj(&drop_types[i], "drop"));
+    result = drop(getobj("drop", allow_any_obj, TRUE, FALSE));
     if (*u.ushops)
         sellobj_state(SELL_NORMAL);
     if (result)
@@ -526,10 +523,6 @@ const char *word;
         /* getobj() kludge sets corpsenm to user's specified count
            when refusing to split a stack of cursed loadstones */
         if (*word) {
-            /* getobj() ignores a count for throwing since that is
-               implicitly forced to be 1; replicate its kludge... */
-            if (!strcmp(word, "throw") && obj->quan > 1L)
-                obj->corpsenm = 1;
             pline("For some reason, you cannot %s%s the stone%s!", word,
                   obj->corpsenm ? " any of" : "", plur(obj->quan));
         }
@@ -837,7 +830,7 @@ int retry;
         /* should coordinate with perm invent, maybe not show worn items */
         n = query_objlist("What would you like to drop?", &invent,
                           (USE_INVLET | INVORDER_SORT), &pick_list, PICK_ANY,
-                          all_categories ? allow_all : allow_category);
+                          all_categories ? allow_any_obj : allow_category);
         if (n > 0) {
             /*
              * picklist[] contains a set of pointers into inventory, but

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -1301,6 +1301,19 @@ static NEARDATA const char callable[] = {
     GEM_CLASS,    SPBOOK_CLASS, ARMOR_CLASS, TOOL_CLASS, 0
 };
 
+STATIC_OVL int
+call_ok(obj)
+struct obj *obj;
+{
+    if (!obj || obj == &zeroobj)
+        return 0;
+
+    if (objtyp_is_callable(obj->otyp))
+        return 2;
+
+    return 1;
+}
+
 boolean
 objtyp_is_callable(i)
 int i;
@@ -1318,7 +1331,7 @@ docallcmd()
     winid win;
     anything any;
     menu_item *pick_list = 0;
-    char ch, allowall[2];
+    char ch;
     /* if player wants a,b,c instead of i,o when looting, do that here too */
     boolean abc = flags.lootabc;
 
@@ -1363,14 +1376,12 @@ docallcmd()
         do_mname();
         break;
     case 'i': /* name an individual object in inventory */
-        allowall[0] = ALL_CLASSES;
-        allowall[1] = '\0';
-        obj = getobj(allowall, "name");
+        obj = getobj("name", allow_any_obj, FALSE, FALSE);
         if (obj)
             do_oname(obj);
         break;
     case 'o': /* name a type of object in inventory */
-        obj = getobj(callable, "call");
+        obj = getobj("call", call_ok, FALSE, FALSE);
         if (obj) {
             /* behave as if examining it in inventory;
                this might set dknown if it was picked up

--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -1354,6 +1354,85 @@ struct obj *stolenobj; /* no message if stolenobj is already being doffing */
     return result;
 }
 
+STATIC_OVL int
+equip_ok(obj, removing, accessory)
+struct obj *obj;
+boolean removing;
+boolean accessory;
+{
+    if (!obj || obj == &zeroobj)
+        return 0;
+
+    /* meat rings aren't encouraged for putting on */
+    if (!removing && obj->otyp == MEAT_RING)
+        return 1;
+
+    /* allow, but don't list, accessories for W/T or vice versa */
+    if (obj->oclass == ARMOR_CLASS) {
+        if (accessory)
+            return 1;
+    } else if (obj->oclass == AMULET_CLASS || obj->oclass == RING_CLASS ||
+               obj->otyp == BLINDFOLD || obj->otyp == TOWEL ||
+               obj->otyp == LENSES || obj->otyp == MEAT_RING) {
+        if (!accessory)
+            return 1;
+    } else
+        return 0;
+
+    /* removing non-worn equipment */
+    if (removing && !obj->owornmask)
+        return 1;
+
+    long mask = 0;
+    if (obj->oclass == ARMOR_CLASS && !removing &&
+        !canwearobj(obj, &mask, FALSE))
+        return 1;
+
+    /* check for putting on accessories in already filled slots */
+    if (!removing &&
+        (((obj->oclass == RING_CLASS || obj->otyp == MEAT_RING) &&
+          uleft && uright) ||
+         (obj->oclass == AMULET_CLASS && uamul) ||
+         (obj->oclass == TOOL_CLASS && ublindf)))
+        return 1;
+
+    /* removing inaccessible equipment */
+    if (removing &&
+        inaccessible_equipment(obj, NULL, (obj->oclass == RING_CLASS)))
+        return 1;
+
+    /* all good to go */
+    return 2;
+}
+
+STATIC_OVL int
+puton_ok(obj)
+struct obj *obj;
+{
+    return equip_ok(obj, FALSE, TRUE);
+}
+
+STATIC_OVL int
+remove_ok(obj)
+struct obj *obj;
+{
+    return equip_ok(obj, TRUE, TRUE);
+}
+
+STATIC_OVL int
+wear_ok(obj)
+struct obj *obj;
+{
+    return equip_ok(obj, FALSE, FALSE);
+}
+
+STATIC_OVL int
+takeoff_ok(obj)
+struct obj *obj;
+{
+    return equip_ok(obj, TRUE, FALSE);
+}
+
 /* both 'clothes' and 'accessories' now include both armor and accessories;
    TOOL_CLASS is for eyewear, FOOD_CLASS is for MEAT_RING */
 static NEARDATA const char clothes[] = {
@@ -1483,7 +1562,7 @@ dotakeoff()
         return 0;
     }
     if (Narmorpieces != 1 || ParanoidRemove)
-        otmp = getobj(clothes, "take off");
+        otmp = getobj("take off", takeoff_ok, FALSE, FALSE);
     if (!otmp)
         return 0;
 
@@ -1502,7 +1581,7 @@ doremring()
         return 0;
     }
     if (Naccessories != 1 || ParanoidRemove)
-        otmp = getobj(accessories, "remove");
+        otmp = getobj("remove", remove_ok, FALSE, FALSE);
     if (!otmp)
         return 0;
 
@@ -1765,9 +1844,6 @@ boolean noisy;
         } else
             *mask = W_ARM;
     } else {
-        /* getobj can't do this after setting its allow_all flag; that
-           happens if you have armor for slots that are covered up or
-           extra armor for slots that are filled */
         if (noisy)
             silly_thing("wear", otmp);
         err++;
@@ -1982,7 +2058,7 @@ dowear()
         You("are already wearing a full complement of armor.");
         return 0;
     }
-    otmp = getobj(clothes, "wear");
+    otmp = getobj("wear", wear_ok, FALSE, FALSE);
     return otmp ? accessory_or_armor_on(otmp) : 0;
 }
 
@@ -2001,7 +2077,7 @@ doputon()
              (ublindf->otyp == LENSES) ? "some lenses" : "a blindfold");
         return 0;
     }
-    otmp = getobj(accessories, "put on");
+    otmp = getobj("put on", puton_ok, FALSE, FALSE);
     return otmp ? accessory_or_armor_on(otmp) : 0;
 }
 

--- a/src/engrave.c
+++ b/src/engrave.c
@@ -426,10 +426,19 @@ freehand()
             || (!bimanual(uwep) && (!uarms || !uarms->cursed)));
 }
 
-static NEARDATA const char styluses[] = { ALL_CLASSES, ALLOW_NONE,
-                                          TOOL_CLASS,  WEAPON_CLASS,
-                                          WAND_CLASS,  GEM_CLASS,
-                                          RING_CLASS,  0 };
+STATIC_OVL int
+stylus(obj)
+struct obj *obj;
+{
+    if (!obj || obj->oclass == TOOL_CLASS || obj->oclass == WEAPON_CLASS ||
+        obj->oclass == WAND_CLASS || obj->oclass == GEM_CLASS ||
+        obj->oclass == RING_CLASS)
+        return 2;
+
+    if (obj != &zeroobj)
+        return 1;
+    return 0;
+}
 
 /* Mohs' Hardness Scale:
  *  1 - Talc             6 - Orthoclase
@@ -533,7 +542,7 @@ doengrave()
      * Edited by GAN 10/20/86 so as not to change weapon wielded.
      */
 
-    otmp = getobj(styluses, "write with");
+    otmp = getobj("write with", stylus, FALSE, FALSE);
     if (!otmp) /* otmp == zeroobj if fingers */
         return 0;
 

--- a/src/invent.c
+++ b/src/invent.c
@@ -1390,6 +1390,9 @@ boolean allow_floor;
         }
 
         if (ilet == ',' || ilet == '?' || ilet == '*') {
+            if (ilet == ',' && !floor)
+                return &zeroobj; /* dungeon feature */
+
             boolean show_discouraged = FALSE;
             int qflags = (INVORDER_SORT | SIGNAL_ESCAPE);
             menu_item *selection = NULL;

--- a/src/invent.c
+++ b/src/invent.c
@@ -1342,6 +1342,7 @@ boolean allow_floor;
                     ilet = '?';
                 else
                     ilet = '*';
+                first = FALSE;
             }
         } else {
             Sprintf(eos(qbuf), " [%s]", buf);

--- a/src/invent.c
+++ b/src/invent.c
@@ -1403,8 +1403,6 @@ boolean allow_floor;
             struct obj **objchain = &invent;
             if (ilet == ',') {
                 qflags |= (BY_NEXTHERE | FEEL_COCKATRICE);
-                if (!floor || !feature)
-                    qflags |= AUTOSELECT_SINGLE;
                 if (feature)
                     qflags |= INCLUDE_FEATURE;
 

--- a/src/invent.c
+++ b/src/invent.c
@@ -1222,37 +1222,12 @@ boolean allow_floor;
         }
     }
 
-    /* add the " or ?*" part */
-    if (!*buf) {
-        if (!altinv) { /* nothing at all */
-            pline("You don't have anything to %s.", what);
-            return NULL;
-        }
-    }
-
-    if (!*buf) /* no encouraged selections */
-        Strcpy(buf, "*");
-    else if (inv) { /* encouraged inventory objects */
-        lets['?'] = TRUE;
-        Sprintf(eos(buf), " or ?*", buf);
-    } else if (altinv) /* valid (but not encouraged) inventory objects */
-        Sprintf(eos(buf), " or *", buf);
-
-    /* Yes, allow this even if !inv && !altinv. This allows use to give
-       feedback to the player as to how nothing in the inventory is a
-       valid choice. */
-    lets['*'] = TRUE;
-
-    /* Done with letter selections. */
-
     /* create an uppercase version of what, for menustyle:non-full with floor
        prompts */
     int whatlen = strlen(what);
     char upperwhat[whatlen + 1];
     Strcpy(upperwhat, what);
     *upperwhat = highc(*upperwhat);
-
-    /* done with preparing, now do the actual prompt */
 
     /* things on the floor for old-style prompts */
     if (feature && oldstyle) {
@@ -1309,6 +1284,32 @@ boolean allow_floor;
             }
         }
     }
+
+    /* add the " or ?*" part */
+    if (!*buf) {
+        if (!altinv) { /* nothing at all */
+            pline("You don't have anything%s to %s.",
+                  floor || feature ? " else" : "", what);
+            return NULL;
+        }
+    }
+
+    if (!*buf) /* no encouraged selections */
+        Strcpy(buf, "*");
+    else if (inv) { /* encouraged inventory objects */
+        lets['?'] = TRUE;
+        Sprintf(eos(buf), " or ?*", buf);
+    } else if (altinv) /* valid (but not encouraged) inventory objects */
+        Sprintf(eos(buf), " or *", buf);
+
+    /* Yes, allow this even if !inv && !altinv. This allows use to give
+       feedback to the player as to how nothing in the inventory is a
+       valid choice. */
+    lets['*'] = TRUE;
+
+    /* Done with letter selections. */
+
+    /* done with preparing, now do the actual prompt */
 
     boolean first = TRUE;
     for (;;) {

--- a/src/invent.c
+++ b/src/invent.c
@@ -1257,12 +1257,12 @@ boolean allow_floor;
     /* things on the floor for old-style prompts */
     if (feature && oldstyle) {
         struct trap *trap = t_at(u.ux, u.uy);
-        int sym = back_to_glyph(u.ux, u.uy);
+        int sym = back_to_defsym(u.ux, u.uy);
         if (trap)
-            sym = trap_to_glyph(trap);
+            sym = trap_to_defsym(what_trap(trap->ttyp));
 
         Sprintf(qbuf, "%s the %s?", upperwhat,
-                an(defsyms[sym].explanation));
+                defsyms[sym].explanation);
 
         c = ynq(qbuf);
         if (c == 'y')

--- a/src/invent.c
+++ b/src/invent.c
@@ -1393,8 +1393,11 @@ boolean allow_floor;
         }
 
         if (ilet == ',' || ilet == '?' || ilet == '*') {
-            if (ilet == ',' && !floor)
-                return &zeroobj; /* dungeon feature */
+            if (ilet == ',' && !floor) {
+                /* dungeon feature */
+                res = &zeroobj;
+                continue;
+            }
 
             boolean show_discouraged = FALSE;
             int qflags = (INVORDER_SORT | SIGNAL_ESCAPE);

--- a/src/invent.c
+++ b/src/invent.c
@@ -1209,11 +1209,14 @@ boolean allow_floor;
     if (feature && oldstyle) {
         struct trap *trap = t_at(u.ux, u.uy);
         int sym = back_to_defsym(u.ux, u.uy);
+        char fbuf[BUFSZ];
+
         if (trap)
             sym = trap_to_defsym(what_trap(trap->ttyp));
 
         Sprintf(qbuf, "%s the %s?", upperwhat,
-                defsyms[sym].explanation);
+                trap ? defsyms[sym].explanation :
+                dfeature_at(u.ux, u.uy, fbuf));
 
         c = ynq(qbuf);
         if (c == 'y')

--- a/src/invent.c
+++ b/src/invent.c
@@ -1293,14 +1293,20 @@ boolean allow_floor;
             obj = res;
             res = NULL;
 
+            ilet = ',';
+            if (obj != &zeroobj && obj->where == OBJ_INVENT)
+                ilet = obj->invlet;
+
             if (!cnt) { /* picked 0 of something */
                 if (flags.verbose)
                     pline1(Never_mind);
                 return NULL;
             }
 
-            if (obj == &zeroobj || cnt < 0 || cnt == obj->quan)
+            if (obj == &zeroobj || cnt < 0 || cnt == obj->quan) {
+                savech(ilet);
                 return obj;
+            }
 
             if (cnt > obj->quan) {
                 You("don't have that many!  You only have %ld.", obj->quan);
@@ -1316,6 +1322,7 @@ boolean allow_floor;
                 /* kludge for canletgo()'s can't-drop-this message */
                 obj->corpsenm = (int) cnt;
 
+            savech(ilet);
             return obj;
         }
 
@@ -1323,8 +1330,10 @@ boolean allow_floor;
         ilet = 0;
 
         Sprintf(qbuf, "What do you want to %s?", what);
-        if (in_doagain)
+        if (in_doagain) {
             ilet = readchar();
+            pline("ilet:%c", ilet);
+        }
         else if (iflags.force_invmenu) {
             if (!first) /* if we're still here, we escaped */
                 ilet = quitchars[0];
@@ -1366,6 +1375,7 @@ boolean allow_floor;
                 return NULL;
             }
 
+            savech(ilet);
             return &zeroobj;
         }
 

--- a/src/invent.c
+++ b/src/invent.c
@@ -1330,10 +1330,8 @@ boolean allow_floor;
         ilet = 0;
 
         Sprintf(qbuf, "What do you want to %s?", what);
-        if (in_doagain) {
+        if (in_doagain)
             ilet = readchar();
-            pline("ilet:%c", ilet);
-        }
         else if (iflags.force_invmenu) {
             if (!first) /* if we're still here, we escaped */
                 ilet = quitchars[0];
@@ -1394,9 +1392,6 @@ boolean allow_floor;
         }
 
         if (ilet == ',' || ilet == '?' || ilet == '*') {
-            if (ilet == ',' && !floor)
-                return &zeroobj; /* dungeon feature */
-
             boolean show_discouraged = FALSE;
             int qflags = (INVORDER_SORT | SIGNAL_ESCAPE);
             menu_item *selection = NULL;

--- a/src/invent.c
+++ b/src/invent.c
@@ -1232,13 +1232,15 @@ boolean allow_floor;
 
     if (!*buf) /* no encouraged selections */
         Strcpy(buf, "*");
-    else if (!inv) /* only suggesting floor/bare hands */
-        Sprintf(eos(buf), " or *", buf);
-    else {
+    else if (inv) { /* encouraged inventory objects */
         lets['?'] = TRUE;
         Sprintf(eos(buf), " or ?*", buf);
-    }
+    } else if (altinv) /* valid (but not encouraged) inventory objects */
+        Sprintf(eos(buf), " or *", buf);
 
+    /* Yes, allow this even if !inv && !altinv. This allows use to give
+       feedback to the player as to how nothing in the inventory is a
+       valid choice. */
     lets['*'] = TRUE;
 
     /* Done with letter selections. */

--- a/src/invent.c
+++ b/src/invent.c
@@ -1262,12 +1262,10 @@ boolean allow_floor;
     }
 
     /* add the " or ?*" part */
-    if (!*buf) {
-        if (!altinv) { /* nothing at all */
-            pline("You don't have anything%s to %s.",
-                  floor || feature ? " else" : "", what);
-            return NULL;
-        }
+    if (!*buf && !res && !altinv) {
+        pline("You don't have anything%s to %s.",
+              floor || feature ? " else" : "", what);
+        return NULL;
     }
 
     if (!*buf) /* no encouraged selections */

--- a/src/invent.c
+++ b/src/invent.c
@@ -14,7 +14,7 @@ STATIC_DCL void NDECL(reorder_invent);
 STATIC_DCL void FDECL(noarmor, (BOOLEAN_P));
 STATIC_DCL void FDECL(invdisp_nothing, (const char *, const char *));
 STATIC_DCL int FDECL(worn_wield_only, (struct obj *));
-STATIC_DCL boolean FDECL(only_here, (struct obj *));
+STATIC_DCL int FDECL(only_here, (struct obj *));
 STATIC_DCL void FDECL(compactify, (char *));
 STATIC_DCL boolean FDECL(taking_off, (const char *));
 STATIC_DCL boolean FDECL(putting_on, (const char *));
@@ -1540,13 +1540,13 @@ wearing_armor()
                       || uarmh || uarms || uarmu);
 }
 
-boolean
+int
 is_worn(otmp)
 struct obj *otmp;
 {
-    return (otmp->owornmask & (W_ARMOR | W_ACCESSORY | W_SADDLE | W_WEAPON))
-            ? TRUE
-            : FALSE;
+    if (otmp->owornmask & (W_ARMOR | W_ACCESSORY | W_SADDLE | W_WEAPON))
+        return 2;
+    return 0;
 }
 
 /* extra xprname() input that askchain() can't pass through safe_qbuf() */
@@ -1588,7 +1588,7 @@ boolean combo; /* combination menu flag */
 unsigned *resultflags;
 {
     int FDECL((*ckfn), (OBJ_P)) = (int FDECL((*), (OBJ_P))) 0;
-    int FDECL((*ofilter), (OBJ_P)) = (boolean FDECL((*), (OBJ_P))) 0;
+    int FDECL((*ofilter), (OBJ_P)) = (int FDECL((*), (OBJ_P))) 0;
     boolean takeoff, ident, allflag, m_seen;
     int itemcount;
     int oletct, iletct, unpaid, oc_of_sym;
@@ -2456,7 +2456,7 @@ int
 count_buc(list, type, filterfunc)
 struct obj *list;
 int type;
-boolean FDECL((*filterfunc), (OBJ_P));
+int FDECL((*filterfunc), (OBJ_P));
 {
     int count = 0;
 
@@ -2723,7 +2723,7 @@ dotypeinv()
          */
         types[0] = 0;
         class_count = collect_obj_classes(types, invent, FALSE,
-                                          (boolean FDECL((*), (OBJ_P))) 0,
+                                          (int FDECL((*), (OBJ_P))) 0,
                                           &itemcount);
         if (unpaid_count || billx || (bcnt + ccnt + ucnt + xcnt) != 0)
             types[class_count++] = ' ';
@@ -3938,11 +3938,13 @@ register struct obj *obj;
 /* query objlist callback: return TRUE if obj is at given location */
 static coord only;
 
-STATIC_OVL boolean
+STATIC_OVL int
 only_here(obj)
 struct obj *obj;
 {
-    return (obj->ox == only.x && obj->oy == only.y);
+    if (obj->ox == only.x && obj->oy == only.y)
+        return 2;
+    return 0;
 }
 
 /*

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -1256,14 +1256,15 @@ struct obj *obj;
     return doname_base(obj, DONAME_VAGUE_QUAN);
 }
 
-/* used from invent.c */
-boolean
+/* used from invent.c with query_objlist */
+int
 not_fully_identified(otmp)
 struct obj *otmp;
 {
     /* gold doesn't have any interesting attributes [yet?] */
     if (otmp->oclass == COIN_CLASS)
-        return FALSE; /* always fully ID'd */
+        return 0; /* always fully ID'd */
+
     /* check fundamental ID hallmarks first */
     if (!otmp->known || !otmp->dknown
 #ifdef MAIL
@@ -1272,12 +1273,12 @@ struct obj *otmp;
         || !otmp->bknown
 #endif
         || !objects[otmp->otyp].oc_name_known)
-        return TRUE;
+        return 2;
     if ((!otmp->cknown && (Is_container(otmp) || otmp->otyp == STATUE))
         || (!otmp->lknown && Is_box(otmp)))
-        return TRUE;
+        return 2;
     if (otmp->oartifact && undiscovered_artifact(otmp->oartifact))
-        return TRUE;
+        return 2;
     /* otmp->rknown is the only item of interest if we reach here */
     /*
      *  Note:  if a revision ever allows scrolls to become fireproof or
@@ -1288,10 +1289,11 @@ struct obj *otmp;
         || (otmp->oclass != ARMOR_CLASS && otmp->oclass != WEAPON_CLASS
             && !is_weptool(otmp)            /* (redundant) */
             && otmp->oclass != BALL_CLASS)) /* (useless) */
-        return FALSE;
-    else /* lack of `rknown' only matters for vulnerable objects */
-        return (boolean) (is_rustprone(otmp) || is_corrodeable(otmp)
-                          || is_flammable(otmp));
+        return 0;
+    else if (is_rustprone(otmp) || is_corrodeable(otmp) ||
+             is_flammable(otmp))
+        return 2;
+    return 0;
 }
 
 /* format a corpse name (xname() omits monster type; doname() calls us);

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -108,7 +108,7 @@ collect_obj_classes(ilets, otmp, here, filter, itemcount)
 char ilets[];
 register struct obj *otmp;
 boolean here;
-boolean FDECL((*filter), (OBJ_P));
+int FDECL((*filter), (OBJ_P));
 int *itemcount;
 {
     register int iletct = 0;
@@ -161,7 +161,7 @@ int *menu_on_demand;
     if (menu_on_demand)
         *menu_on_demand = 0;
     iletct = collect_obj_classes(ilets, objs, here,
-                                 (boolean FDECL((*), (OBJ_P))) 0, &itemcount);
+                                 (int FDECL((*), (OBJ_P))) 0, &itemcount);
     if (iletct == 0)
         return FALSE;
 
@@ -471,11 +471,13 @@ struct obj *obj;
 #endif
 
 /* query_objlist callback: return TRUE if valid class and worn */
-boolean
+int
 is_worn_by_type(otmp)
 register struct obj *otmp;
 {
-    return (is_worn(otmp) && allow_category(otmp)) ? TRUE : FALSE;
+    if (is_worn(otmp) && allow_category(otmp))
+        return 2;
+    return 0;
 }
 
 /*
@@ -1033,7 +1035,7 @@ int how;               /* type of query */
     boolean collected_type_name;
     char invlet;
     int ccount;
-    boolean FDECL((*ofilter), (OBJ_P)) = (boolean FDECL((*), (OBJ_P))) 0;
+    int FDECL((*ofilter), (OBJ_P)) = (int FDECL((*), (OBJ_P))) 0;
     boolean do_unpaid = FALSE;
     boolean do_blessed = FALSE, do_cursed = FALSE, do_uncursed = FALSE,
             do_buc_unknown = FALSE;

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -16,10 +16,10 @@ STATIC_DCL boolean FDECL(query_classes, (char *, boolean *, boolean *,
                                          BOOLEAN_P, int *));
 STATIC_DCL boolean FDECL(fatal_corpse_mistake, (struct obj *, BOOLEAN_P));
 STATIC_DCL void FDECL(check_here, (BOOLEAN_P));
-STATIC_DCL boolean FDECL(n_or_more, (struct obj *));
-STATIC_DCL boolean FDECL(all_but_uchain, (struct obj *));
+STATIC_DCL int FDECL(n_or_more, (struct obj *));
+STATIC_DCL int FDECL(all_but_uchain, (struct obj *));
 #if 0 /* not used */
-STATIC_DCL boolean FDECL(allow_cat_no_uchain, (struct obj *));
+STATIC_DCL int FDECL(allow_cat_no_uchain, (struct obj *));
 #endif
 STATIC_DCL int FDECL(autopick, (struct obj *, int, menu_item **));
 STATIC_DCL int FDECL(count_categories, (struct obj *, int));
@@ -327,13 +327,15 @@ boolean picked_some;
 static long val_for_n_or_more;
 
 /* query_objlist callback: return TRUE if obj's count is >= reference value */
-STATIC_OVL boolean
+STATIC_OVL int
 n_or_more(obj)
 struct obj *obj;
 {
     if (obj == uchain)
-        return FALSE;
-    return (boolean) (obj->quan >= val_for_n_or_more);
+        return 0;
+    if (obj->quan >= val_for_n_or_more)
+        return 2;
+    return 0;
 }
 
 /* list of valid menu classes for query_objlist() and allow_category callback
@@ -380,23 +382,16 @@ int c;
 }
 
 /* query_objlist callback: return TRUE if not uchain */
-STATIC_OVL boolean
+STATIC_OVL int
 all_but_uchain(obj)
 struct obj *obj;
 {
-    return (boolean) (obj != uchain);
+    if (obj && obj != uchain)
+        return 2;
+    return 0;
 }
 
-/* query_objlist callback: return TRUE */
-/*ARGUSED*/
-boolean
-allow_all(obj)
-struct obj *obj UNUSED;
-{
-    return TRUE;
-}
-
-boolean
+int
 allow_category(obj)
 struct obj *obj;
 {
@@ -406,15 +401,18 @@ struct obj *obj;
      * If no class filtering is specified but bless/curse state is,
      * coins are either unknown or uncursed based on an option setting.
      */
-    if (obj->oclass == COIN_CLASS)
-        return class_filter
-                 ? (index(valid_menu_classes, COIN_CLASS) ? TRUE : FALSE)
-                 : shop_filter /* coins are never unpaid, but check anyway */
-                    ? (obj->unpaid ? TRUE : FALSE)
-                    : bucx_filter
-                       ? (index(valid_menu_classes, iflags.goldX ? 'X' : 'U')
-                          ? TRUE : FALSE)
-                       : TRUE; /* catchall: no filters specified, so accept */
+    if (obj->oclass == COIN_CLASS) {
+        if (class_filter
+            ? (index(valid_menu_classes, COIN_CLASS) ? TRUE : FALSE)
+            : shop_filter /* coins are never unpaid, but check anyway */
+            ? (obj->unpaid ? TRUE : FALSE)
+            : bucx_filter
+            ? (index(valid_menu_classes, iflags.goldX ? 'X' : 'U')
+               ? TRUE : FALSE)
+            : TRUE) /* catchall: no filters specified, so accept */
+            return 2;
+        return 0;
+    }
 
     if (Role_if(PM_PRIEST))
         obj->bknown = TRUE;
@@ -438,12 +436,12 @@ struct obj *obj;
 
     /* if class is expected but obj's class is not in the list, reject */
     if (class_filter && !index(valid_menu_classes, obj->oclass))
-        return FALSE;
+        return 0;
     /* if unpaid is expected and obj isn't unpaid, reject (treat a container
        holding any unpaid object as unpaid even if isn't unpaid itself) */
     if (shop_filter && !obj->unpaid
         && !(Has_contents(obj) && count_unpaid(obj->cobj) > 0))
-        return FALSE;
+        return 0;
     /* check for particular bless/curse state */
     if (bucx_filter) {
         /* first categorize this object's bless/curse state */
@@ -452,23 +450,23 @@ struct obj *obj;
 
         /* if its category is not in the list, reject */
         if (!index(valid_menu_classes, bucx))
-            return FALSE;
+            return 0;
     }
     /* obj didn't fail any of the filter checks, so accept */
-    return TRUE;
+    return 2;
 }
 
 #if 0 /* not used */
 /* query_objlist callback: return TRUE if valid category (class), no uchain */
-STATIC_OVL boolean
+STATIC_OVL int
 allow_cat_no_uchain(obj)
 struct obj *obj;
 {
     if (obj != uchain
         && ((index(valid_menu_classes, 'u') && obj->unpaid)
             || index(valid_menu_classes, obj->oclass)))
-        return TRUE;
-    return FALSE;
+        return 2;
+    return 0;
 }
 #endif
 
@@ -644,7 +642,7 @@ int what; /* should be a long */
                     traverse_how |= INVORDER_SORT;
                 n = query_objlist("Pick up what?", objchain_p, traverse_how,
                                   &pick_list, PICK_ANY,
-                                  (via_menu == -2) ? allow_all
+                                  (via_menu == -2) ? allow_any_obj
                                                    : allow_category);
                 goto menu_pickup;
             }
@@ -830,6 +828,8 @@ menu_item **pick_list; /* list of objects and counts to pick up */
  *      SIGNAL_ESCAPE     - Return -1 rather than 0 if player uses ESC to
  *                          pick nothing.
  *      FEEL_COCKATRICE   - touch corpse.
+ *      HIDE_DISCOURAGED  - hides allowed but discouraged items
+ *      INCLUDE_FEATURE   - if allow() allows it, include dungeon features
  */
 int
 query_objlist(qstr, olist_p, qflags, pick_list, how, allow)
@@ -838,31 +838,37 @@ struct obj **olist_p;             /* the list to pick from */
 int qflags;                       /* options to control the query */
 menu_item **pick_list;            /* return list of items picked */
 int how;                          /* type of query */
-boolean FDECL((*allow), (OBJ_P)); /* allow function */
+int FDECL((*allow), (OBJ_P));     /* allow function */
 {
     int i, n;
+    int allowmin = 1;
+    if (qflags & HIDE_DISCOURAGED)
+        allowmin = 2;
     winid win;
-    struct obj *curr, *last, fake_hero_object, *olist = *olist_p;
+    struct obj *curr, *last, *olist = *olist_p;
     char *pack;
     anything any;
     boolean printed_type_name, first,
-            sorted = (qflags & INVORDER_SORT) != 0,
-            engulfer = (qflags & INCLUDE_HERO) != 0;
+        sorted = (qflags & INVORDER_SORT) != 0,
+        engulfer = (qflags & INCLUDE_HERO) != 0;
+    boolean feature;
+    feature = ((qflags & INCLUDE_FEATURE) && (*allow)(&zeroobj) >= allowmin);
 
     *pick_list = (menu_item *) 0;
-    if (!olist && !engulfer)
+    if (!olist && !engulfer && !feature)
         return 0;
 
     /* count the number of items allowed */
     for (n = 0, last = 0, curr = olist; curr; curr = FOLLOW(curr, qflags))
-        if ((*allow)(curr)) {
+        if ((*allow)(curr) >= allowmin) {
             last = curr;
             n++;
         }
-    if (engulfer) {
+    if (engulfer || feature) {
         ++n;
         /* don't autoselect swallowed hero if it's the only choice */
-        qflags &= ~AUTOSELECT_SINGLE;
+        if (engulfer)
+            qflags &= ~AUTOSELECT_SINGLE;
     }
 
     if (n == 0) /* nothing to pick here */
@@ -908,7 +914,7 @@ boolean FDECL((*allow), (OBJ_P)); /* allow function */
                 (void) look_here(0, FALSE);
                 return 0;
             }
-            if ((*allow)(curr)) {
+            if ((*allow)(curr) >= allowmin) {
                 /* if sorting, print type name (once only) */
                 if (sorted && !printed_type_name) {
                     any = zeroany;
@@ -932,23 +938,37 @@ boolean FDECL((*allow), (OBJ_P)); /* allow function */
         pack++;
     } while (sorted && *pack);
 
-    if (engulfer) {
+    if (engulfer || feature) {
         char buf[BUFSZ];
+        struct trap *trap = t_at(u.ux, u.uy);
 
         any = zeroany;
         if (sorted && n > 1) {
-            Sprintf(buf, "%s Creatures",
-                    is_animal(u.ustuck->data) ? "Swallowed" : "Engulfed");
+            if (engulfer)
+                Sprintf(buf, "%s Creatures",
+                        is_animal(u.ustuck->data) ? "Swallowed" : "Engulfed");
+            else if (trap)
+                Strcpy(buf, "Traps");
+            else
+                Strcpy(buf, "Dungeon Features");
+
             add_menu(win, NO_GLYPH, &any, 0, 0, iflags.menu_headings, buf,
                      MENU_UNSELECTED);
         }
-        fake_hero_object = zeroobj;
-        fake_hero_object.quan = 1L; /* not strictly necessary... */
-        any.a_obj = &fake_hero_object;
-        add_menu(win, mon_to_glyph(&youmonst), &any,
-                 /* fake inventory letter, no group accelerator */
-                 CONTAINED_SYM, 0, ATR_NONE, an(self_lookat(buf)),
-                 MENU_UNSELECTED);
+        any.a_obj = &zeroobj;
+        if (engulfer)
+            add_menu(win, mon_to_glyph(&youmonst), &any,
+                     /* fake inventory letter, no group accelerator */
+                     CONTAINED_SYM, 0, ATR_NONE, an(self_lookat(buf)),
+                     MENU_UNSELECTED);
+        else {
+            int sym = back_to_glyph(u.ux, u.uy);
+            if (trap)
+                sym = trap_to_defsym(what_trap(trap->ttyp));
+            add_menu(win, cmap_to_glyph(sym), &any,
+                     0, 0, ATR_NONE, an(defsyms[sym].explanation),
+                     MENU_UNSELECTED);
+        }
     }
 
     end_menu(win, qstr);
@@ -960,23 +980,27 @@ boolean FDECL((*allow), (OBJ_P)); /* allow function */
         int k;
 
         /* fix up counts:  -1 means no count used => pick all;
-           if fake_hero_object was picked, discard that choice */
+           if zeroobj was picked if engulfed, discard that choice */
         for (i = k = 0, mi = *pick_list; i < n; i++, mi++) {
-            if (mi->item.a_obj == &fake_hero_object)
-                continue;
-            if (mi->count == -1L || mi->count > mi->item.a_obj->quan)
+            /* for zeroobj, only allow counts of 0 and 1 */
+            if (mi->item.a_obj == &zeroobj) {
+                if (engulfer)
+                    continue;
+                if (mi->count)
+                    mi->count = 1;
+            } else if (mi->count == -1L || mi->count > mi->item.a_obj->quan)
                 mi->count = mi->item.a_obj->quan;
             if (k < i)
                 (*pick_list)[k] = *mi;
             ++k;
         }
         if (!k) {
-            /* fake_hero was only choice so discard whole list */
+            /* zeroobj was only choice so discard whole list */
             free((genericptr_t) *pick_list);
             *pick_list = 0;
             n = 0;
         } else if (k < n) {
-            /* other stuff plus fake_hero; last slot is now unused */
+            /* other stuff plus zeroobj; last slot is now unused */
             (*pick_list)[k].item = zeroany;
             (*pick_list)[k].count = 0L;
             n = k;
@@ -2204,7 +2228,13 @@ int
 ck_bag(obj)
 struct obj *obj;
 {
-    return (current_container && obj != current_container);
+    if (current_container && obj != current_container)
+        return 2;
+
+    if (current_container)
+        return 1; /* keep the topological exercise YAFM */
+
+    return 0;
 }
 
 /* Returns: -1 to stop, 1 item was removed, 0 item was not removed. */
@@ -2595,8 +2625,10 @@ boolean more_containers; /* True iff #loot multiple and this isn't last one */
             used |= (menu_loot(0, TRUE) > 0);
         add_valid_menu_class(0);
     } else if (stash_one) {
-        /* put one item into container */
-        if ((otmp = getobj(stashable, "stash")) != 0) {
+        /* Put one item into the container.
+           Currently, we only allow inventory items. Maybe we should also allow
+           floor items? */
+        if ((otmp = getobj("stash", ck_bag, FALSE, FALSE)) != 0) {
             if (in_container(otmp)) {
                 used = 1;
             } else {
@@ -2736,7 +2768,7 @@ boolean put_in;
         Sprintf(buf, "%s what?", action);
         n = query_objlist(buf, put_in ? &invent : &(current_container->cobj),
                           mflags, &pick_list, PICK_ANY,
-                          all_categories ? allow_all : allow_category);
+                          all_categories ? allow_any_obj : allow_category);
         if (n) {
             n_looted = n;
             for (i = 0; i < n; i++) {
@@ -2843,7 +2875,28 @@ boolean outokay, inokay, alreadyused, more_containers;
     return (n == 0 && more_containers) ? 'n' : 'q'; /* next or quit */
 }
 
-static const char tippables[] = { ALL_CLASSES, TOOL_CLASS, 0 };
+STATIC_OVL int
+tip_ok(obj)
+struct obj *obj;
+{
+    if (!obj || obj == &zeroobj)
+        return 0;
+
+    if (Is_container(obj))
+        return 2;
+
+    /* only allow containers on the floor */
+    if (obj->where != OBJ_INVENT)
+        return 0;
+
+    /* also encourage known horns of plenty. */
+    if (obj->otyp == HORN_OF_PLENTY && obj->dknown &&
+        objects[obj->otyp].oc_name_known)
+        return 2;
+
+    /* allow trying anything else in inventory */
+    return 1;
+}
 
 /* #tip command -- empty container contents onto floor */
 int
@@ -2863,87 +2916,7 @@ dotip()
     /* at present, can only tip things at current spot, not adjacent ones */
     cc.x = u.ux, cc.y = u.uy;
 
-    /* check floor container(s) first; at most one will be accessed */
-    if ((boxes = container_at(cc.x, cc.y, TRUE)) > 0) {
-        Sprintf(buf, "You can't tip %s while carrying so much.",
-                !flags.verbose ? "a container" : (boxes > 1) ? "one" : "it");
-        if (!check_capacity(buf) && able_to_loot(cc.x, cc.y, FALSE)) {
-            if (boxes > 1 && (flags.menu_style != MENU_TRADITIONAL
-                              || iflags.menu_requested)) {
-                /* use menu to pick a container to tip */
-                int n, i;
-                winid win;
-                anything any;
-                menu_item *pick_list = (menu_item *) 0;
-                struct obj dummyobj, *otmp;
-
-                any = zeroany;
-                win = create_nhwindow(NHW_MENU);
-                start_menu(win);
-
-                for (cobj = level.objects[cc.x][cc.y], i = 0; cobj;
-                     cobj = cobj->nexthere)
-                    if (Is_container(cobj)) {
-                        ++i;
-                        any.a_obj = cobj;
-                        add_menu(win, NO_GLYPH, &any, 0, 0, ATR_NONE,
-                                 doname(cobj), MENU_UNSELECTED);
-                    }
-                if (invent) {
-                    any = zeroany;
-                    add_menu(win, NO_GLYPH, &any, 0, 0, ATR_NONE,
-                             "", MENU_UNSELECTED);
-                    any.a_obj = &dummyobj;
-                    /* use 'i' for inventory unless there are so many
-                       containers that it's already being used */
-                    i = (i <= 'i' - 'a' && !flags.lootabc) ? 'i' : 0;
-                    add_menu(win, NO_GLYPH, &any, i, 0, ATR_NONE,
-                             "tip something being carried", MENU_SELECTED);
-                }
-                end_menu(win, "Tip which container?");
-                n = select_menu(win, PICK_ONE, &pick_list);
-                destroy_nhwindow(win);
-                /*
-                 * Deal with quirk of preselected item in pick-one menu:
-                 * n ==  0 => picked preselected entry, toggling it off;
-                 * n ==  1 => accepted preselected choice via SPACE or RETURN;
-                 * n ==  2 => picked something other than preselected entry;
-                 * n == -1 => cancelled via ESC;
-                 */
-                otmp = (n <= 0) ? (struct obj *) 0 : pick_list[0].item.a_obj;
-                if (n > 1 && otmp == &dummyobj)
-                    otmp = pick_list[1].item.a_obj;
-                if (pick_list)
-                    free((genericptr_t) pick_list);
-                if (otmp && otmp != &dummyobj) {
-                    tipcontainer(otmp);
-                    return 1;
-                }
-                if (n == -1)
-                    return 0;
-                /* else pick-from-invent below */
-            } else {
-                for (cobj = level.objects[cc.x][cc.y]; cobj; cobj = nobj) {
-                    nobj = cobj->nexthere;
-                    if (!Is_container(cobj))
-                        continue;
-                    c = ynq(safe_qbuf(qbuf, "There is ", " here, tip it?",
-                                      cobj,
-                                      doname, ansimpleoname, "container"));
-                    if (c == 'q')
-                        return 0;
-                    if (c == 'n')
-                        continue;
-                    tipcontainer(cobj);
-                    /* can only tip one container at a time */
-                    return 1;
-                }
-            }
-        }
-    }
-
-    /* either no floor container(s) or couldn't tip one or didn't tip any */
-    cobj = getobj(tippables, "tip");
+    cobj = getobj("tip5", tip_ok, FALSE, TRUE);
     if (!cobj)
         return 0;
 

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -964,7 +964,7 @@ int FDECL((*allow), (OBJ_P));     /* allow function */
                      CONTAINED_SYM, 0, ATR_NONE, an(self_lookat(buf)),
                      MENU_UNSELECTED);
         else {
-            int sym = back_to_glyph(u.ux, u.uy);
+            int sym = back_to_defsym(u.ux, u.uy);
             if (trap)
                 sym = trap_to_defsym(what_trap(trap->ttyp));
             add_menu(win, cmap_to_glyph(sym), &any,

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -2651,7 +2651,7 @@ boolean more_containers; /* True iff #loot multiple and this isn't last one */
         /* Put one item into the container.
            Currently, we only allow inventory items. Maybe we should also allow
            floor items? */
-        if ((otmp = getobj("stash", ck_bag, FALSE, FALSE)) != 0) {
+        if ((otmp = getobj("stash", ck_bag, TRUE, FALSE)) != 0) {
             if (in_container(otmp)) {
                 used = 1;
             } else {

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1630,18 +1630,6 @@ boolean countem;
     return container_count;
 }
 
-int
-floor_loot_ok(obj)
-struct obj *obj;
-{
-    if (Is_container(obj)) {
-        if (able_to_loot(obj->ox, obj->oy, TRUE, TRUE))
-            return 2;
-        return 1;
-    }
-    return 0;
-}
-
 STATIC_OVL boolean
 able_to_loot(x, y, looting, silent)
 int x, y;

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -968,7 +968,9 @@ int FDECL((*allow), (OBJ_P));     /* allow function */
             if (trap)
                 sym = trap_to_defsym(what_trap(trap->ttyp));
             add_menu(win, cmap_to_glyph(sym), &any,
-                     0, 0, ATR_NONE, an(defsyms[sym].explanation),
+                     0, 0, ATR_NONE,
+                     an(trap ? defsyms[sym].explanation :
+                        dfeature_at(u.ux, u.uy, buf)),
                      MENU_UNSELECTED);
         }
     }

--- a/src/trap.c
+++ b/src/trap.c
@@ -4069,9 +4069,25 @@ struct trap *ttmp;
     return 1;
 }
 
-/* getobj will filter down to cans of grease and known potions of oil */
-static NEARDATA const char oil[] = { ALL_CLASSES, TOOL_CLASS, POTION_CLASS,
-                                     0 };
+STATIC_OVL int
+oil_ok(obj)
+struct obj *obj;
+{
+    if (!obj)
+        return 0;
+
+    if (obj->otyp == CAN_OF_GREASE)
+        return 2;
+
+    if (obj->otyp == POT_OIL && obj->dknown &&
+        objects[POT_OIL].oc_name_known)
+        return 2;
+
+    if (obj->oclass == POTION_CLASS)
+        return 1; /* let players try any potion, but don't encourage it */
+
+    return 0;
+}
 
 /* it may not make much sense to use grease on floor boards, but so what? */
 STATIC_OVL int
@@ -4082,7 +4098,7 @@ struct trap *ttmp;
     boolean bad_tool;
     int fails;
 
-    obj = getobj(oil, "untrap with");
+    obj = getobj("untrap with", oil_ok, FALSE, FALSE);
     if (!obj)
         return 0;
 

--- a/src/wield.c
+++ b/src/wield.c
@@ -290,7 +290,7 @@ dowield()
     }
 
     /* Prompt for a new weapon */
-    if (!(wep = getobj("wield", wield_ok, TRUE, FALSE)))
+    if (!(wep = getobj("wield", wield_ok, FALSE, FALSE)))
         /* Cancelled */
         return 0;
     else if (wep == uwep) {
@@ -389,7 +389,7 @@ dowieldquiver()
     /* Prompt for a new quiver: "What do you want to ready?"
        (Include gems/stones as likely candidates if either primary
        or secondary weapon is a sling.) */
-    newquiver = getobj("ready", ready_ok, TRUE, FALSE);
+    newquiver = getobj("ready", ready_ok, FALSE, FALSE);
 
     if (!newquiver) {
         /* Cancelled */

--- a/src/write.c
+++ b/src/write.c
@@ -87,7 +87,15 @@ struct obj *objlist;
     return FALSE;
 }
 
-static NEARDATA const char write_on[] = { SCROLL_CLASS, SPBOOK_CLASS, 0 };
+STATIC_OVL int
+write_ok(obj)
+struct obj *obj;
+{
+    if (obj &&
+        (obj->oclass == SCROLL_CLASS || obj->oclass == SPBOOK_CLASS))
+        return 2;
+    return 0;
+}
 
 /* write -- applying a magic marker */
 int
@@ -115,7 +123,7 @@ register struct obj *pen;
     }
 
     /* get paper to write on */
-    paper = getobj(write_on, "write on");
+    paper = getobj("write on", write_ok, FALSE, FALSE);
     if (!paper)
         return 0;
     /* can't write on a novel (unless/until it's been converted into a blank

--- a/src/zap.c
+++ b/src/zap.c
@@ -2135,7 +2135,14 @@ struct obj *otmp;
     useup(otmp);
 }
 
-static NEARDATA const char zap_syms[] = { WAND_CLASS, 0 };
+STATIC_OVL int
+zap_ok(obj)
+struct obj *obj;
+{
+    if (obj && obj->oclass == WAND_CLASS)
+        return 2;
+    return 0;
+}
 
 /* 'z' command (or 'y' if numbed_pad==-1) */
 int
@@ -2146,7 +2153,7 @@ dozap()
 
     if (check_capacity((char *) 0))
         return 0;
-    obj = getobj(zap_syms, "zap");
+    obj = getobj("zap", zap_ok, FALSE, FALSE);
     if (!obj)
         return 0;
 


### PR DESCRIPTION
This pull request refactors getobj as to allow the selection of objects, or dungeon traps/features, from the floor. This is done by supplying a "," reply when it asks for a letter. Doing so will pick the floor item/feature (if only one choice is valid) or give a list of items + feature, if there are multiple choices. '.' can also be selected, but it is merely an alias (it doesn't display as a valid option or similar), to allow for SLASH'EM muscle memory. If menulist is set to anything other than FULL, getobj prompts will work as they did earlier and prompt individually for each object or feature on the floor.

This code is not based on code from either SLASH'EM or NetHack4, but was created from scratch for 3.6.1. It works by, instead of having a list of object classes as a parameter for getobj, and having getobj special case basically every single case, use a callback for figuring out whether or not a choice is valid. The callback is an int, takes a normal object, NULL (for bare hands check) or &zeroobj (for dungeon feature/trap, if allow_floor is enabled), and returns 2 (valid option, and encouraged by being listed), 1 (possible choice, but not listed among choices or '?'), 0 (invalid).

This allows one to do away with all the special cases that surrounded getobj, meaning it only has the actual code for doing the logic in it.

Screenshots: http://home.fiq.se/nh/getobj.html