### PR TITLE
Allow user to add to the existing annotation

### DIFF
--- a/doc/fixes36.1
+++ b/doc/fixes36.1
@@ -532,6 +532,8 @@ when #force reports that a chest's lock is already broken or already unlocked,
 	already known, rather than as "a broken chest" or "an unlocked chest"
 honor wish for "locked", "unlocked", or "broken" chest or box
 honor wish for "empty" container including statue, bag-o-tricks, horn-o-plenty
+	if annotation for dungeon level is already set, allow player to choose
+to add to the annotation rather than completely replacing it
 
 
 Fixes to Post-3.6.0 Problems that Were Exposed Via git Repository


### PR DESCRIPTION
Often, it's more desirable to add to the current annotation, rather than replacing it completely. If you have some new piece of information you don't want to forget, naturally, you will probably add it to annotation.

If you add piece of information A into annotation, and then see B, you'll want to add it into annotation.
As it stands, you can only completely replace annotation, causing you to re-type both A and B. If you have even more information in annotation, it's even more tedious to maintain it.

This patch causes annotations to work similarly to engravings. If there's no annotation for current DLVL, annotation will be added as usual. But if annotation is already present, invoking #annotate will ask, whether you want to add to the existing annotation or replace it. Choosing to replace will work same way as it used to work, existing annotation is removed and new annotation is placed in it's place. If you choose to add to the current annotation, then resulting annotation will be a concatenation of existing annotation and newly typed piece of text (pretty much same way as it works for engravings).

Signed-off-by: Vitaly Ostrosablin <tmp6154@yandex.ru>