### PR TITLE
Fix bug in really_close() which can cause standard input to be closed prematurely

### DIFF
--- a/src/files.c
+++ b/src/files.c
@@ -664,13 +664,17 @@ int lev, oflag;
 void
 really_close()
 {
-    int fd = lftrack.fd;
+    int fd;
+    
+    if (lftrack.init) {
+        fd = lftrack.fd;
 
-    lftrack.nethack_thinks_it_is_open = FALSE;
-    lftrack.fd = -1;
-    lftrack.oflag = 0;
-    if (fd != -1)
-        (void) close(fd);
+        lftrack.nethack_thinks_it_is_open = FALSE;
+        lftrack.fd = -1;
+        lftrack.oflag = 0;
+        if (fd != -1)
+            (void) close(fd);
+    }
     return;
 }
 


### PR DESCRIPTION
Fix bug where user is unable to confirm exit.  If the user chooses to quit when prompted for player name to choose, then they will find that they can not confirm the exit by hitting the return key.  This is due to a bug in really_close() which mistakenly closes the file descriptor zero which is the input stream.  really_close() needs to test lftrack.init before it attempts to access and modify lftrack state.