### PR TITLE
Changed build to default to using latest SDK available on build machine

### DIFF
--- a/sys/winnt/Install.nt
+++ b/sys/winnt/Install.nt
@@ -56,30 +56,16 @@ The Visual Studio 2017 NetHack solution file can be found here:
 So the steps are:
     1. Launch the IDE.
     2. Open the appropriate solution file.
-    3. If you have a newer version of Visual Studio than what was used to build 
-       the solution and project files distributed with the NetHack sources, you 
-       can easily retarget the solution before the next step. Refer to the
-       "Note about the Windows SDK version" a couple of paragraphs below.
-    4. Select the build configuration you wish to use (Release, Debug, etc.).
-    5. From the build menu, select build solution.
-    6. Type F5 to start debugging.
+    3. Select the build configuration you wish to use (Release, Debug, etc.).
+    4. From the build menu, select build solution.
+    5. Type F5 to start debugging.
 
 You can also build all the projects for all platforms and configurations
 using a "build.bat" batch file found in the same directory as the solution.
 
-Change to the appropriate directory (i.e. win\win32\vs2015 for VS2015 builds,
-win\win32\vs2017 for VS2017 builds) and run "build.bat".
-
------------------------------------
-Note about the Windows SDK Version:
------------------------------------
-    The Visual Studio project files distributed for NetHack 3.6.1 are configured for the 
-    Windows SDK version 10.0.15063.0. At the time of writing, the Windows SDK version that
-    is distributed with VS2017 Community Edition is a newer 10.0.16299.0. If you have a build
-    error MSB8036, you will simply need to change the expected SDK version as follows:
-
-          o Open the solution in the IDE and in the project property pages, right-click the 
-            solution and select "Retarget solution".
+Open a developer command prompt for the version of Visual Studio you are
+using.  Change to the appropriate directory (i.e. win\win32\vs2015 for
+VS2015 builds, win\win32\vs2017 for VS2017 builds) and run "build.bat".
 
 /-----------------------------------\
 | Building Using Make               |

--- a/win/win32/vs2017/config.props
+++ b/win/win32/vs2017/config.props
@@ -20,6 +20,9 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(WindowsTargetPlatformVersion)'==''">
+    <LatestTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</LatestTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Modified build configuration to use latest SDK available by default.  This change will eliminate the need for us to hard code an SDK version into our configuration file and will eliminate the need for developers to set the SDK version when they do not have the matching SDK version installed.  Updated the Install.nt file removing the mention of having to set the SDK version.
