### PR TITLE
Specify both width and height when creating font for width testing.

### DIFF
--- a/sys/winnt/nttty.c
+++ b/sys/winnt/nttty.c
@@ -1550,7 +1550,7 @@ check_font_widths()
     LOGFONTW console_font_log_font = matching_log_font;
     console_font_log_font.lfWeight = console_font_info.FontWeight;
     console_font_log_font.lfHeight = console_font_info.dwFontSize.Y;
-    console_font_log_font.lfWidth = 0;
+    console_font_log_font.lfWidth = console_font_info.dwFontSize.X;
     HFONT console_font = CreateFontIndirectW(&console_font_log_font);
 
     if (console_font == NULL) {


### PR DESCRIPTION
When we are creating the console font for testing character widths, we were not specifying width.  Because of this, the created font's average width might be larger then what we expect and we might falsely detect that the font was inappropriate for playing Nethack.  Fix provides the width that we are expecting when creating the font.