### PR TITLE
Fix for bug H7132 - conflict between extra choice accelerator and menu accelerator

### DIFF
--- a/win/win32/mhmenu.c
+++ b/win/win32/mhmenu.c
@@ -1208,6 +1208,21 @@ onListChar(HWND hWnd, HWND hwndList, WORD ch)
 
     data = (PNHMenuWindow) GetWindowLongPtr(hWnd, GWLP_USERDATA);
 
+    is_accelerator = FALSE;
+    for (i = 0; i < data->menu.size; i++) {
+        if (data->menu.items[i].accelerator == ch) {
+            is_accelerator = TRUE;
+            break;
+        }
+    }
+
+    /* Don't use switch if input matched an accelerator.  Sometimes
+     * accelerators can conflict with menu actions.  For example, when
+     * engraving the extra choice of using fingers matches MENU_UNSELECT_ALL.
+     */
+    if (is_accelerator)
+        goto accelerator;
+
     switch (ch) {
     case MENU_FIRST_PAGE:
         i = 0;
@@ -1402,6 +1417,7 @@ onListChar(HWND hWnd, HWND hwndList, WORD ch)
         }
     } break;
 
+    accelerator:
     default:
         if (strchr(data->menu.gacc, ch)
             && !(ch == '0' && data->menu.counting)) {
@@ -1448,14 +1464,6 @@ onListChar(HWND hWnd, HWND hwndList, WORD ch)
                 }
             }
             return -2;
-        }
-
-        is_accelerator = FALSE;
-        for (i = 0; i < data->menu.size; i++) {
-            if (data->menu.items[i].accelerator == ch) {
-                is_accelerator = TRUE;
-                break;
-            }
         }
 
         if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')


### PR DESCRIPTION
In nethackw, there can be conflicts between menu accelerators and an extra
choice accelerator.  For example, when engraving the using fingers options
conflicts with the unselect all menu accelerator.  The extra choice
accelerator should take precedence.