### PR TITLE
Fix copy-paste error causing bad shopkeeper placement in some shops

### DIFF
--- a/src/shknam.c
+++ b/src/shknam.c
@@ -613,7 +613,7 @@ struct mkroom *sroom;
             sy--;
         else if (isok(sx, sy + 1) && !levl[sx][sy + 1].edge
                  && (int) levl[sx][sy + 1].roomno == rmno)
-            sx++;
+            sy++;
         else
             goto shk_failed;
     } else if (sx == sroom->lx - 1)

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -2454,6 +2454,7 @@ boolean prefilled;
         case BEEHIVE:
         case MORGUE:
         case BARRACKS:
+        case ANTHOLE:
             fill_zoo(croom);
             break;
         }


### PR DESCRIPTION
Fix copy-paste error leading to bad shopkeeper placement in irregularly-shaped shops with the door at the top.

The last case from a set of 4 very similar if statements increments sx after testing sy.  As a result, the shopkeeper is placed one space to the right of a north-facing door, instead of one space to the south (ie, the shopkeeper is placed in the wall next to the door, instead of behind it).  As noted, this was pretty clearly a copy-paste error from the first pair of if statements, which *do* adjust the x coordinate.

This bug is latent in vanilla NetHack, because no levels include such a shop.