### PR TITLE
Antholes in .des files will not be filled

### DIFF
--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -2454,6 +2454,7 @@ boolean prefilled;
         case BEEHIVE:
         case MORGUE:
         case BARRACKS:
+        case ANTHOLE:
             fill_zoo(croom);
             break;
         }


### PR DESCRIPTION
This is due to a missing case in the fill_zoo section of sp_lev.c

This bug is latent in NetHack, since no special levels include antholes.