### PR TITLE
proposed to link with -lncurses, not /usr/lib/libncurses.a

### DIFF
--- a/sys/unix/README.linux
+++ b/sys/unix/README.linux
@@ -85,7 +85,7 @@ System:  gcc-3.2, XFree86-libs-4.2.1, ncurses-5.2, glibc-2.3.2 (GLIBC_2.3)
 		  LFLAGS = -L/usr/X11R6/lib
 		  WINSRC = $(WINTTYSRC) $(WINX11SRC)
 		  WINOBJ = $(WINTTYOBJ) $(WINX11OBJ)
-		  WINTTYLIB = /usr/lib/libncurses.a
+		  WINTTYLIB = -lncurses
 		  WINX11LIB = -lXaw -lXmu -lXext -lXt -lXpm -lX11
 		  WINLIB = $(WINTTYLIB) $(WINX11LIB)
 


### PR DESCRIPTION
Following the instructions in `README.linux` to build the binary on Slackware 14.2 (i486) results in link-time failure.  The assumption of `libncurses.a` existing in `/usr/lib` does not appear to be a Linux-wide rule.

Following the original `-lncurses` suggestion specified in `Makefile.src` instead of trying to specify an absolute path to the library works perfectly.  I thought this change would prevent confusing anyone else on some distributions trying to build NetHack based on the `README.linux` instructions.