### PR TITLE
Fix levl buffer overflow in wallify_map

### DIFF
--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -2560,6 +2560,9 @@ int x1, y1, x2, y2;
         lo_yy = (y > 0) ? y - 1 : 0;
         hi_yy = (y < y2) ? y + 1 : y2;
         for (x = x1; x <= x2; x++) {
+            if (!isok(x, y))
+                /* not on the map anyway, can't be wallified */
+                continue;
             if (levl[x][y].typ != STONE)
                 continue;
             lo_xx = (x > 0) ? x - 1 : 0;


### PR DESCRIPTION
Normally, wallify_map iterates through x and y coordinates on the map up
until (80,21) while looking for tiles to convert into walls, even though
column 80 and row 21 don't exist on the map.  This usually does nothing
bad, because position (79,20) is never a ROOM tile on any level where
WALLIFY is used.

However, if WALLIFY without arguments happens to be used on a map which
contains a ROOM tile at (79,20), such as a large open level containing
some rock formations that the programmer desires to wallify, then
wallify_map will write an HWALL into level.locations[80][21] (and
probably into a bunch of other nonexistent coordinates). These overflow
into the level.objects pointers, which results in segfaults when the
program tries to read them.

The fix is to add a check in wallify_map which causes it to ignore any
!isok() positions, which aren't on the map anyway.