### PR TITLE
fix issue with wiz_identify and char unsigned

### DIFF
--- a/include/wintype.h
+++ b/include/wintype.h
@@ -59,6 +59,9 @@ typedef struct mi {
 } menu_item;
 #define MENU_ITEM_P struct mi
 
+/* constant for wiz_identify char return value */
+#define WIZ_IDENT_VAL 127
+
 /* select_menu() "how" argument types */
 /* [MINV_PICKMASK in monst.h assumes these have values of 0, 1, 2] */
 #define PICK_NONE 0 /* user picks nothing (display only) */

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -625,7 +625,7 @@ wiz_identify(VOID_ARGS)
 {
     if (wizard) {
         iflags.override_ID = (int) cmd_from_func(wiz_identify);
-        if ((signed char) display_inventory((char *) 0, TRUE) == -1)
+        if (display_inventory((char *) 0, TRUE) == WIZ_IDENT_VAL)
             identify_pack(0, FALSE);
         iflags.override_ID = 0;
     } else

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -625,7 +625,7 @@ wiz_identify(VOID_ARGS)
 {
     if (wizard) {
         iflags.override_ID = (int) cmd_from_func(wiz_identify);
-        if (display_inventory((char *) 0, TRUE) == -1)
+        if ((signed char) display_inventory((char *) 0, TRUE) == -1)
             identify_pack(0, FALSE);
         iflags.override_ID = 0;
     } else

--- a/src/invent.c
+++ b/src/invent.c
@@ -2580,7 +2580,7 @@ long *out_cnt;
     if (wizard && iflags.override_ID) {
         char prompt[QBUFSZ];
 
-        any.a_char = -1;
+        any.a_char = WIZ_IDENT_VAL;
         /* wiz_identify stuffed the wiz_identify command character (^I)
            into iflags.override_ID for our use as an accelerator */
         Sprintf(prompt, "Debug Identify (%s to permanently identify)",


### PR DESCRIPTION
I emailed the dev team about a problem I had with identify in wizard mode on the Raspberry Pi. If you press control-I twice in a row it is supposed to permanently identify the objects in your inventory. The first control-I shows the identified inventory but the second control-I does nothing and after you are done if you check the inventory the items you wanted to identify are still unidentified.

This issue is caused by the C compiler on the Raspberry Pi implementing the char type as unsigned. The wiz_identify code that was introduced in 3.6.0 assumes that char is signed. According to this Stackoverflow article there is no guarantee that char is signed in C:

https://stackoverflow.com/questions/2054939/is-char-signed-or-unsigned-by-default

Here are the lines in the 3.6.0 code that assume that char is signed:

line 2083 in invent.c:

        any.a_char = -1;

line 595 in cmd.c:

        if (display_inventory((char *) 0, TRUE) == -1)

On the Raspberry Pi with char being unsigned display_inventory((char *) 0, TRUE) returned 255 instead of -1.

This pull request just casts the output of display_inventory to a signed char and the 255 is converted back to -1 and the wiz_identify works. The dev team may choose to fix this another way. Maybe we could choose a different value besides -1 such as 127 which would be the same with signed or unsigned char types.

Bobby