### PR TITLE
Fix behavior of selection_do_grow

### DIFF
--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -3840,31 +3840,39 @@ int dir;
 
     for (x = 0; x < COLNO; x++)
         for (y = 0; y < ROWNO; y++) {
+            if (!isok(x, y))
+                continue;
             c = 0;
-            if ((dir & W_WEST) && (x > 0)
-                && (selection_getpoint(x - 1, y, ov)))
+            if ((dir & W_WEST) && selection_getpoint(x + 1, y, ov)) {
                 c++;
-            if ((dir & (W_WEST | W_NORTH)) && (x > 0) && (y > 0)
-                && (selection_getpoint(x - 1, y - 1, ov)))
+            }
+            /* Note: extra parens around these operands are critical, due to ==
+             * having precedence over & and |. */
+            else if (((dir & (W_WEST | W_NORTH)) == (W_WEST | W_NORTH))
+                && selection_getpoint(x + 1, y + 1, ov)) {
                 c++;
-            if ((dir & W_NORTH) && (y > 0)
-                && (selection_getpoint(x, y - 1, ov)))
+            }
+            else if ((dir & W_NORTH) && selection_getpoint(x, y + 1, ov)) {
                 c++;
-            if ((dir & (W_NORTH | W_EAST)) && (y > 0) && (x < COLNO - 1)
-                && (selection_getpoint(x + 1, y - 1, ov)))
+            }
+            else if (((dir & (W_NORTH | W_EAST)) == (W_NORTH | W_EAST))
+                && selection_getpoint(x - 1, y + 1, ov)) {
                 c++;
-            if ((dir & W_EAST) && (x < COLNO - 1)
-                && (selection_getpoint(x + 1, y, ov)))
+            }
+            else if ((dir & W_EAST) && selection_getpoint(x - 1, y, ov)) {
                 c++;
-            if ((dir & (W_EAST | W_SOUTH)) && (x < COLNO - 1)
-                && (y < ROWNO - 1) && (selection_getpoint(x + 1, y + 1, ov)))
+            }
+            else if (((dir & (W_EAST | W_SOUTH)) == (W_EAST | W_SOUTH))
+                && selection_getpoint(x - 1, y - 1, ov)) {
                 c++;
-            if ((dir & W_SOUTH) && (y < ROWNO - 1)
-                && (selection_getpoint(x, y + 1, ov)))
+            }
+            else if ((dir & W_SOUTH) && selection_getpoint(x, y - 1, ov)) {
                 c++;
-            if ((dir & (W_SOUTH | W_WEST)) && (y < ROWNO - 1) && (x > 0)
-                && (selection_getpoint(x - 1, y + 1, ov)))
+            }
+            else if (((dir & (W_SOUTH | W_WEST)) == (W_SOUTH | W_WEST))
+                && selection_getpoint(x + 1, y - 1, ov)) {
                 c++;
+            }
             if (c)
                 tmp[x][y] = 1;
         }


### PR DESCRIPTION
The function previously had two issues. First, the directional behavior
was reversed, so specifying a grow direction of "north" would actually
grow the selection downwards, etc. Second, the edge-of-map checks in the
function didn't actually correspond to isok() map boundaries, enabling
the function to, for instance, grow the selection into x=0, which could
break other things in the level. This commit fixes both.

The old behavior also was implemented with "fanning-out" behavior; that
is, a north grow from a single point would not only grow into the point
north of it, but it would also fan out into the points northwest and
northeast of it. Since this behavior might not always be wanted, I
removed it; the selection will only grow diagonally if it's specified to
grow in both adjacent cardinal directions. (I suppose this could
ultimately be added to the level compiler as a third argument to grow,
but I doubt there's a need for it right now.)