### PR TITLE
Make monsters reassess equipment immediately after lifesaving.

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -1796,6 +1796,9 @@ struct monst *mtmp;
             pline_The("medallion crumbles to dust!");
         }
         m_useup(mtmp, lifesave);
+        /* monsters with multiple amulets / disintegrated items will now
+           re-equip themselves at the cost of a single m_dowear call. */
+        m_dowear(mtmp, FALSE);
 
         surviver = !(mvitals[monsndx(mtmp->data)].mvflags & G_GENOD);
         mtmp->mcanmove = 1;


### PR DESCRIPTION
I implemented this a while back. If a monster uses an amulet of lifesaving, they never actually reassess their inventory. So a monster might be carrying three amulets of lifesaving, but never equip a new one after being killed the first time. This commit addresses this, at the cost of a single call to m_dowear() when a monster is lifesaved. This change also allows monsters who died due to disintegration to equip other items they might have.