### PR TITLE
Fix spelling and capitalization issues in `dat` and `DEVEL`.

### DIFF
--- a/DEVEL/Developer.txt
+++ b/DEVEL/Developer.txt
@@ -62,7 +62,7 @@ NOTE: The following instructions require perl.  If you do not have perl on
 A. If you have never set up git on this machine before:
    (This assumes you will only be using git for NetHack.  If you are going to
    use it for other projects as well, think before you type.)
-	Tell git what name (or nicname) and email address to use for you:
+	Tell git what name (or nickname) and email address to use for you:
 		git config --global user.name "MY NAME"
 		git config --global user.email USER@EXAMPLE.COM
    You probably want to set up a credential cache.

--- a/DEVEL/code_features.txt
+++ b/DEVEL/code_features.txt
@@ -75,7 +75,7 @@ There is a fqn_prefix[] entry for holding the path to each of the following:
 To recap, they are about enabling "different paths for different things", and
 separation of:
 - read-only stuff from read-write stuff.
-- sysadmin stuff from user-writeable stuff.
+- sysadmin stuff from user-writable stuff.
 etc.
 
 ==============================================

--- a/DEVEL/code_style.txt
+++ b/DEVEL/code_style.txt
@@ -16,7 +16,7 @@ declarations. Due to some incompatibilities, the patch is not publicly
 available and clang-format is not expected to be regularly used.
 
 Developers should do their best to adhere to the coding style to promote
-legibile, easy-to-edit code. Legibility is paramount, so in some cases, it may
+legible, easy-to-edit code. Legibility is paramount, so in some cases, it may
 be better not to fully adhere to the style guidelines.
 
 Recipes for common text editors can be found at the end of this file.
@@ -30,7 +30,7 @@ characters, not tabs.
 Lines should be at most 78 characters wide. If a line would be longer than the
 limit, the line should be wrapped and the wrapped portion should be aligned
 with the parentheses or brackets containing the wrap. If there is no set of
-parenthese or brackets, the line should be indented four spaces. Wrapping
+parentheses or brackets, the line should be indented four spaces. Wrapping
 should normally occur after a comma or before a binary operator, when
 possible:
 
@@ -43,7 +43,7 @@ possible:
 
 Single blank lines should be used wherever convenient to improve readability.
 
-Functions and Control Satements
+Functions and Control Statements
 -------------------------------
 
 For a function definition, the return type, declarator, and opening brace
@@ -183,10 +183,10 @@ many entries that reproducing them here is impractical. Fortunately, the
 options are in plain English, so walking through them with a copy of 
 this Guide handy and making changes as required will suffice.
 
-emacs Configuration
+Emacs Configuration
 ===================
 
-There are no doubt umpteen different ways to handle this in emacs.
+There are no doubt umpteen different ways to handle this in Emacs.
 Putting the following in ~/.emacs.el is one
 
 (defun hook-c ()

--- a/dat/hh
+++ b/dat/hh
@@ -96,7 +96,7 @@ M-2     twoweapon toggle two-weapon combat (unless number_pad is enabled)
 M-a     adjust  adjust inventory letters
 M-A     annotate add a one-line note to the current dungeon level (see M-O)
 M-c     chat    talk to someone
-M-C     conduct view optional challanges
+M-C     conduct view optional challenges
 M-d     dip     dip an object into something
 M-e     enhance advance or check weapon and spell skills
 M-f     force   force a lock

--- a/dat/opthelp
+++ b/dat/opthelp
@@ -104,7 +104,7 @@ preload_tiles  control whether tiles get pre-loaded into RAM at   [TRUE]
                of the tile graphics, but uses more memory.
 
 Boolean option if TTY_TILES_ESCCODES was set at compile time (tty only):
-vt_tiledata    insert extra data escae code markers into output   [FALSE]
+vt_tiledata    insert extra data escape code markers into output  [FALSE]
 
 Any Boolean option can be negated by prefixing it with a '!' or 'no'.
 
@@ -159,7 +159,7 @@ paranoid_confirmation  space separated list    [paranoid_confirmation:pray]
               pray    -- y to confirm an attempt to pray; on by default
               Remove  -- always pick from inventory for 'R' and 'T' even when
               wearing just one applicable item to remove or take off
-pickup_burden when you pick up an item that exceeds this encumberance   [S]
+pickup_burden when you pick up an item that exceeds this encumbrance    [S]
               level (Unencumbered, Burdened, streSsed, straiNed, overTaxed,
               or overLoaded), you will be asked if you want to continue.
 pickup_types  a list of default symbols for kinds of objects to          []

--- a/dat/quest.txt
+++ b/dat/quest.txt
@@ -1668,7 +1668,7 @@ to %ns lair.  If you can manage to defeat %n and return
 undead that befoul the land.
 
 "Go with %d as your guide, %p."
-%E [%nC invaded %H and captured %o.  Defeat %ni and retrive %oh.]
+%E [%nC invaded %H and captured %o.  Defeat %ni and retrieve %oh.]
 %Cp Pri 00025
 "You can prevail, if you rely on %d."
 %E
@@ -2056,7 +2056,7 @@ the Amulet."
 %E [You have succeeded.  Take %o with you as you go to find the Amulet.]
 # assumes The Longbow of Diana
 %Cc Ran 00082
-%l flexs %o reverently.
+%l flexes %o reverently.
 
 "With this wondrous bow, one need never run out of arrows.
 You are its keeper now, and the time has come to resume your
@@ -2967,7 +2967,7 @@ The ice and snow gives way to a valley floor.  You %x ahead of you
 a huge round hill surrounded by pools of lava.  This then is the entrance
 to %i.  It looks like you're not going to get in without
 a fight though.
-%E [This is the entrace to %i.]
+%E [This is the entrance to %i.]
 %Cp Val 00036
 Once again, you stand before the entrance to %i.
 %E


### PR DESCRIPTION
These changes are all 'obviously wrong' to me. They don't occur in any stylistic or old-style dialect instances.

```
nicname         -> nickname
user-writeable  -> user-writable
legibile        -> legible
parenthese      -> parentheses
Satements       -> Statements
challanges      -> challenges
escae           -> escape
retrive         -> retrieve
flexs           -> flexes
entrace         -> entrance
```

This change was made in a heading and nearby, not every instance was changed in the codebase.

```
emacs -> Emacs
```

This change was made to make the usage consistent with the rest of the codebase, which uses the latter.

```
encumberance -> encumbrance
```