### PR TITLE
Correct Jon Wätte's name in many places to account for encoding.

### DIFF
--- a/dat/history
+++ b/dat/history
@@ -54,7 +54,7 @@ Mike Passaretti, and Olaf Seibert, developed NetHack 3.1 for the Amiga.
 Norm Meluch and Kevin Smolkowski, with help from Carl Schelin, Stephen
 Spackman, Steve VanDevender, and Paul Winner, ported NetHack 3.1 to the PC.
 
-Jon W{tte and Hao-yang Wang, with help from Ross Brown, Mike Engber, David
+Jon Watte and Hao-yang Wang, with help from Ross Brown, Mike Engber, David
 Hairston, Michael Hamel, Jonathan Handler, Johnny Lee, Tim Lennan, Rob Menke,
 and Andy Swanson developed NetHack 3.1 for the Macintosh, porting it for
 MPW.  Building on their development, Barton House added a Think C port.
@@ -237,7 +237,7 @@ miscreants in this, the list of Dungeoneers:
     Barton House              John Rupley               Paul Winner
     Benson I. Margulies       John S. Bien              Pierre Martineau
     Bill Dyer                 Johnny Lee                Ralf Brown
-    Boudewijn Waijers         Jon W{tte                 Ray Chason
+    Boudewijn Waijers         Jon Watte                 Ray Chason
     Bruce Cox                 Jonathan Handler          Richard Addison
     Bruce Holloway            Joshua Delahunty          Richard Beigel
     Bruce Mewborne            Keizo Yamamoto            Richard P. Hughey

--- a/doc/Guidebook.mn
+++ b/doc/Guidebook.mn
@@ -4404,7 +4404,7 @@ developed NetHack 3.1 for the Amiga.
 \fBCarl Schelin\fP, \fBStephen Spackman\fP, \fBSteve VanDevender\fP,
 and \fBPaul Winner\fP, ported NetHack 3.1 to the PC.
 .pg
-\fBJon W{tte\fP and \fBHao-yang Wang\fP, with help from \fBRoss Brown\fP,
+\fBJon Watte\fP and \fBHao-yang Wang\fP, with help from \fBRoss Brown\fP,
 \fBMike Engber\fP, \fBDavid Hairston\fP, \fBMichael Hamel\fP,
 \fBJonathan Handler\fP, \fBJohnny Lee\fP, \fBTim Lennan\fP, \fBRob Menke\fP,
 and \fBAndy Swanson\fP, developed NetHack 3.1 for the Macintosh,
@@ -4623,7 +4623,7 @@ Ari Huttunen	John Kallen	Patric Mueller
 Barton House	John Rupley	Paul Winner
 Benson I. Margulies	John S. Bien	Pierre Martineau
 Bill Dyer	Johnny Lee	Ralf Brown
-Boudewijn Waijers	Jon W{tte	Ray Chason
+Boudewijn Waijers	Jon Watte	Ray Chason
 Bruce Cox	Jonathan Handler	Richard Addison
 Bruce Holloway	Joshua Delahunty	Richard Beigel
 Bruce Mewborne	Keizo Yamamoto	Richard P. Hughey

--- a/doc/Guidebook.tex
+++ b/doc/Guidebook.tex
@@ -5116,7 +5116,7 @@ and {\it Paul Winner}, ported {\it NetHack\/} 3.1 to the PC.
 
 %.pg
 \medskip
-\nd {\it Jon W\{tte} and {\it Hao-yang Wang},
+\nd {\it Jon W\"{a}tte} and {\it Hao-yang Wang},
 with help from {\it Ross Brown}, {\it Mike Engber}, {\it David Hairston},
 {\it Michael Hamel}, {\it Jonathan Handler}, {\it Johnny Lee},
 {\it Tim Lennan}, {\it Rob Menke}, and {\it Andy Swanson},
@@ -5406,7 +5406,7 @@ Ari Huttunen & John Kallen & Patric Mueller\\
 Barton House & John Rupley & Paul Winner\\
 Benson I. Margulies & John S. Bien & Pierre Martineau\\
 Bill Dyer & Johnny Lee & Ralf Brown\\
-Boudewijn Waijers & Jon W\{tte & Ray Chason\\
+Boudewijn Waijers & Jon W\"{a}tte & Ray Chason\\
 Bruce Cox & Jonathan Handler & Richard Addison\\
 Bruce Holloway & Joshua Delahunty & Richard Beigel\\
 Bruce Mewborne & Keizo Yamamoto & Richard P. Hughey\\

--- a/doc/Guidebook.txt
+++ b/doc/Guidebook.txt
@@ -5504,7 +5504,7 @@
           lin, Stephen Spackman, Steve VanDevender, and Paul Winner, ported
           NetHack 3.1 to the PC.
 
-               Jon W{tte and Hao-yang Wang, with help from Ross Brown, Mike
+               Jon Watte and Hao-yang Wang, with help from Ross Brown, Mike
           Engber,  David  Hairston, Michael Hamel, Jonathan Handler, Johnny
           Lee, Tim Lennan, Rob Menke, and Andy Swanson,  developed  NetHack
           3.1 for the Macintosh, porting it for MPW.  Building on their de-
@@ -5763,7 +5763,7 @@
               Barton House             John Rupley            Paul Winner
            Benson I. Margulies         John S. Bien         Pierre Martineau
                 Bill Dyer               Johnny Lee             Ralf Brown
-            Boudewijn Waijers           Jon W{tte              Ray Chason
+            Boudewijn Waijers           Jon Watte              Ray Chason
                 Bruce Cox            Jonathan Handler       Richard Addison
              Bruce Holloway          Joshua Delahunty        Richard Beigel
              Bruce Mewborne           Keizo Yamamoto       Richard P. Hughey

--- a/include/mactty.h
+++ b/include/mactty.h
@@ -1,5 +1,5 @@
 /* NetHack 3.6	mactty.h	$NHDT-Date: 1447755970 2015/11/17 10:26:10 $  $NHDT-Branch: master $:$NHDT-Revision: 1.12 $ */
-/* Copyright (c) Jon W{tte 1993.                                        */
+/* Copyright (c) Jon Watte 1993.                                        */
 /* NetHack may be freely redistributed.  See license for details.       */
 
 /*
@@ -13,7 +13,7 @@
  * alignment doesn't matter, and for 8-bit color, alignment to every
  * fourth pixel is most efficient.
  *
- * (c) Copyright 1993 Jon W{tte
+ * (c) Copyright 1993 Jon Watte
  */
 
 /*

--- a/include/mttypriv.h
+++ b/include/mttypriv.h
@@ -1,5 +1,5 @@
 /* NetHack 3.6	mttypriv.h	$NHDT-Date: 1432512780 2015/05/25 00:13:00 $  $NHDT-Branch: master $:$NHDT-Revision: 1.9 $ */
-/* Copyright (c) Jon W{tte 1993.					*/
+/* Copyright (c) Jon Watte 1993.					*/
 /* NetHack may be freely redistributed.  See license for details.	*/
 
 /*

--- a/sys/mac/dprintf.c
+++ b/sys/mac/dprintf.c
@@ -1,5 +1,5 @@
 /* NetHack 3.6	dprintf.c	$NHDT-Date: 1432512798 2015/05/25 00:13:18 $  $NHDT-Branch: master $:$NHDT-Revision: 1.7 $ */
-/* Copyright (c) Jon W{tte, 1993.				  */
+/* Copyright (c) Jon Watte, 1993.				  */
 /* NetHack may be freely redistributed.  See license for details. */
 
 #include "hack.h"

--- a/sys/mac/maccurs.c
+++ b/sys/mac/maccurs.c
@@ -1,5 +1,5 @@
 /* NetHack 3.6	maccurs.c	$NHDT-Date: 1432512797 2015/05/25 00:13:17 $  $NHDT-Branch: master $:$NHDT-Revision: 1.9 $ */
-/* Copyright (c) Jon W{tte, 1992.				  */
+/* Copyright (c) Jon Watte, 1992.				  */
 /* NetHack may be freely redistributed.  See license for details. */
 
 #include "hack.h"

--- a/sys/mac/macfile.c
+++ b/sys/mac/macfile.c
@@ -1,5 +1,5 @@
 /* NetHack 3.6	macfile.c	$NHDT-Date: 1432512798 2015/05/25 00:13:18 $  $NHDT-Branch: master $:$NHDT-Revision: 1.11 $ */
-/* Copyright (c) Jon W{tte, Hao-Yang Wang, Jonathan Handler 1992. */
+/* Copyright (c) Jon Watte, Hao-Yang Wang, Jonathan Handler 1992. */
 /* NetHack may be freely redistributed.  See license for details. */
 /*
  * macfile.c

--- a/sys/mac/macmenu.c
+++ b/sys/mac/macmenu.c
@@ -14,8 +14,8 @@
 /****************************************\
  * Edit History:
  *
- * 930512	- More bug fixes and getting tty to work again, Jon W{tte
- * 930508	- Bug fixes in-flight, Jon W{tte
+ * 930512	- More bug fixes and getting tty to work again, Jon Watte
+ * 930508	- Bug fixes in-flight, Jon Watte
  * 04/29/93 - 1st Release Draft, David Hairston
  * 04/11/93 - 1st Draft, David Hairston
 \****************************************/

--- a/sys/mac/mactty.c
+++ b/sys/mac/mactty.c
@@ -1,5 +1,5 @@
 /* NetHack 3.6	mactty.c	$NHDT-Date: 1432512797 2015/05/25 00:13:17 $  $NHDT-Branch: master $:$NHDT-Revision: 1.9 $ */
-/* Copyright (c) Jon W{tte 1993.					*/
+/* Copyright (c) Jon Watte 1993.					*/
 /* NetHack may be freely redistributed.  See license for details.	*/
 
 /*

--- a/sys/mac/macwin.c
+++ b/sys/mac/macwin.c
@@ -1,5 +1,5 @@
 /* NetHack 3.6	macwin.c	$NHDT-Date: 1432512796 2015/05/25 00:13:16 $  $NHDT-Branch: master $:$NHDT-Revision: 1.26 $ */
-/* Copyright (c) Jon W{tte, Hao-Yang Wang, Jonathan Handler 1992. */
+/* Copyright (c) Jon Watte, Hao-Yang Wang, Jonathan Handler 1992. */
 /* NetHack may be freely redistributed.  See license for details. */
 
 /**********************************************************************

--- a/sys/mac/mmodal.c
+++ b/sys/mac/mmodal.c
@@ -1,5 +1,5 @@
 /* NetHack 3.6	mmodal.c	$NHDT-Date: 1432512797 2015/05/25 00:13:17 $  $NHDT-Branch: master $:$NHDT-Revision: 1.11 $ */
-/* Copyright (c) Jon W{tte, Hao-Yang Wang, Jonathan Handler 1992. */
+/* Copyright (c) Jon Watte, Hao-Yang Wang, Jonathan Handler 1992. */
 /* NetHack may be freely redistributed.  See license for details. */
 
 #if 1 /*!TARGET_API_MAC_CARBON*/

--- a/sys/mac/mttymain.c
+++ b/sys/mac/mttymain.c
@@ -1,5 +1,5 @@
 /* NetHack 3.6	mttymain.c	$NHDT-Date: 1432512797 2015/05/25 00:13:17 $  $NHDT-Branch: master $:$NHDT-Revision: 1.12 $ */
-/* Copyright (c) Jon W{tte, 1993					*/
+/* Copyright (c) Jon Watte, 1993					*/
 /* NetHack may be freely redistributed.  See license for details.	*/
 
 #include "hack.h"

--- a/sys/share/sounds/README
+++ b/sys/share/sounds/README
@@ -29,6 +29,6 @@ for the available hardware.
 
 Any comment on the sounds or their use is welcome:
 
-						Jon W{tte
+						Jon Watte
 						Mac Team
 						nethack-bugs@nethack.org


### PR DESCRIPTION
I noticed repeated references to `Jon W{tte` and variations of that in various places where credit was given (e.g., guidebook, copyrights). Grepping for `Jon W` showed me all of those references, in addition to two for `Jon Watte`. This seemed like an search-and-replace gone awry or a locale issue, but nothing in the Git history went back far enough. So I pulled down the source for 3.1.0 and found `Jon Watte` as expected, but also `Jon Wätte` (in LaTeX as `Jon W\"atte`).

This commit restores the name to its previous representation of `Jon Watte` in source code and other text files, and `Jon Wätte` in `Guidebook.tex`.

Note that the name `Janne Salmijärvi` is also represented outside of the ASCII (and Unicode) encoding in several places, but it isn't wacky the way Jon's name was.

(Disclaimer: I've never heard of any of these people, but I'm on a proofreading spree.)