### PR TITLE
Fix other spelling issues.

### DIFF
--- a/doc/Guidebook.mn
+++ b/doc/Guidebook.mn
@@ -54,7 +54,7 @@
 .in -\\n(PYu				\" undo indent past label (etc)
 .sn \\n(pdu				\" tmac.n: inter-paragraph space
 ..
-.\" end of labeled paragrah
+.\" end of labeled paragraph
 .\"
 .\" aligned single character key with SHORT definition (if it overflows one
 .\" line, all bets are off)
@@ -1583,7 +1583,7 @@ debt or credit, if any.  The `Iu' command lists unpaid items
 The `Ix' command shows an inventory-like display of any unpaid
 items which have been used up, along with other shop fees, if any.
 .hn 3
-Shop idiosyncracies
+Shop idiosyncrasies
 .pg
 Several aspects of shop behavior might be unexpected.
 .\" note: using * instead of \(bu is better for plain text output
@@ -2463,19 +2463,19 @@ defaults to the location of the NetHack.exe or NetHackw.exe file
 so setting HACKDIR to override that is not usually necessary or recommended.
 .lp LEVELDIR
 The location that in-progress level files are stored. Defaults to HACKDIR,
-must be writeable.
+must be writable.
 .lp SAVEDIR
 The location where saved games are kept. Defaults to HACKDIR, must be
-writeable.
+writable.
 .lp BONESDIR
 The location that bones files are kept. Defaults to HACKDIR, must be
-writeable.
+writable.
 .lp LOCKDIR
 The location that file synchronization locks are stored. Defaults to
-HACKDIR, must be writeable.
+HACKDIR, must be writable.
 .lp TROUBLEDIR
 The location that a record of game aborts and self-diagnosed game problems
-is kept. Defaults to HACKDIR, must be writeable.
+is kept. Defaults to HACKDIR, must be writable.
 .lp AUTOCOMPLETE
 Enable or disable an extended command autocompletion.
 Autocompletion has no effect for the X11 windowport.
@@ -4017,7 +4017,7 @@ m	S_mimic	(mimic)
 ]	S_mimic_def	(mimic)
 M	S_mummy	(mummy)
 N	S_naga	(naga)
-\.	S_ndoor	(doorway witout door)
+\.	S_ndoor	(doorway without door)
 n	S_nymph	(nymph)
 O	S_ogre	(ogre)
 o	S_orc	(orc)

--- a/doc/Guidebook.tex
+++ b/doc/Guidebook.tex
@@ -1452,7 +1452,7 @@ be automatically turned off.
 \item[\tb{\#untrap}]
 Untrap something (trap, door, or chest). Default key is '{\tt M-u}', and '{\tt u}' if {\it number\verb+_+pad\/} is on.
 %.lp ""
-In some circumstancs it can also be used to rescue trapped monsters.
+In some circumstances it can also be used to rescue trapped monsters.
 %.lp
 \item[\tb{\#up}]
 Go up a staircase. Default key is '{\tt <}'.
@@ -1830,7 +1830,7 @@ The {\tt Ix} command shows an inventory-like display of any unpaid
 items which have been used up, along with other shop fees, if any.
 
 %.hn 3
-\subsubsection*{Shop idiosyncracies}
+\subsubsection*{Shop idiosyncrasies}
 
 %.pg
 Several aspects of shop behavior might be unexpected.
@@ -2848,23 +2848,23 @@ so setting HACKDIR to override that is not usually necessary or recommended.
 %.lp
 \item[\bb{LEVELDIR}]
 The location that in-progress level files are stored. Defaults to HACKDIR,
-must be writeable.
+must be writable.
 %.lp
 \item[\bb{SAVEDIR}]
 The location where saved games are kept. Defaults to HACKDIR, must be
-writeable.
+writable.
 %.lp
 \item[\bb{BONESDIR}]
 The location that bones files are kept. Defaults to HACKDIR, must be
-writeable.
+writable.
 %.lp
 \item[\bb{LOCKDIR}]
 The location that file synchronization locks are stored. Defaults to
-HACKDIR, must be writeable.
+HACKDIR, must be writable.
 %.lp
 \item[\bb{TROUBLEDIR}]
 The location that a record of game aborts and self-diagnosed game problems
-is kept. Defaults to HACKDIR, must be writeable.
+is kept. Defaults to HACKDIR, must be writable.
 %.lp
 \item[\bb{AUTOCOMPLETE}]
 Enable or disable an extended command autocompletion.

--- a/doc/Guidebook.txt
+++ b/doc/Guidebook.txt
@@ -1926,7 +1926,7 @@
           any  unpaid  items which have been used up, along with other shop
           fees, if any.
 
-          5.4.1.  Shop idiosyncracies
+          5.4.1.  Shop idiosyncrasies
 
                Several aspects of shop behavior might be unexpected.
 
@@ -3015,19 +3015,19 @@
 
           LEVELDIR
             The  location that in-progress level files are stored. Defaults
-            to HACKDIR, must be writeable.
+            to HACKDIR, must be writable.
 
           SAVEDIR
             The location where saved games are kept. Defaults  to  HACKDIR,
-            must be writeable.
+            must be writable.
 
           BONESDIR
             The  location  that  bones files are kept. Defaults to HACKDIR,
-            must be writeable.
+            must be writable.
 
           LOCKDIR
             The  location  that  file  synchronization  locks  are  stored.
-            Defaults to HACKDIR, must be writeable.
+            Defaults to HACKDIR, must be writable.
 
 
           NetHack 3.6                                          May 27, 2018
@@ -3042,7 +3042,7 @@
 
           TROUBLEDIR
             The  location  that  a record of game aborts and self-diagnosed
-            game problems is kept. Defaults to HACKDIR, must be writeable.
+            game problems is kept. Defaults to HACKDIR, must be writable.
 
           AUTOCOMPLETE
             Enable or disable an extended command autocompletion.  Autocom-
@@ -5043,7 +5043,7 @@
              ]    S_mimic_def            (mimic)
              M    S_mummy                (mummy)
              N    S_naga                 (naga)
-             .    S_ndoor                (doorway witout door)
+             .    S_ndoor                (doorway without door)
              n    S_nymph                (nymph)
              O    S_ogre                 (ogre)
              o    S_orc                  (orc)

--- a/doc/config.nh
+++ b/doc/config.nh
@@ -398,21 +398,21 @@
 #HACKDIR=c:\games\nethack
 
 # The location that level files in progress are stored
-# (default=HACKDIR, writeable)
+# (default=HACKDIR, writable)
 #LEVELDIR=c:\nethack\levels
 
-# The location where saved games are kept (default=HACKDIR, writeable)
+# The location where saved games are kept (default=HACKDIR, writable)
 #SAVEDIR=c:\nethack\save
 
-# The location that bones files are kept (default=HACKDIR, writeable)
+# The location that bones files are kept (default=HACKDIR, writable)
 #BONESDIR=c:\nethack\save
 
 # The location that file synchronization locks are stored
-# (default=HACKDIR, writeable)
+# (default=HACKDIR, writable)
 #LOCKDIR=c:\nethack\levels
 
 # The location that a record of game aborts and self-diagnosed game problems
-# is kept (default=HACKDIR, writeable)
+# is kept (default=HACKDIR, writable)
 #TROUBLEDIR=c:\nethack\trouble
 
 # Finnish keyboards might need these modifications uncommented. Windows GUI.

--- a/doc/nethack.6
+++ b/doc/nethack.6
@@ -93,7 +93,7 @@ To win the game (as opposed to merely playing to beat other people's high
 scores) you must locate the Amulet of Yendor which is somewhere below
 the 20th level of the dungeon and get it out.
 Few people achieve this; most never do.  Those who have go down
-in history as heros among heroes - and then they find ways of making the
+in history as heroes among heroes - and then they find ways of making the
 game even harder.  See the
 .I Guidebook
 section on Conduct if this game has gotten too easy for you.

--- a/doc/nethack.txt
+++ b/doc/nethack.txt
@@ -26,7 +26,7 @@ DESCRIPTION
        To  win  the  game (as opposed to merely playing to beat other people's
        high scores) you must locate the Amulet of Yendor  which  is  somewhere
        below the 20th level of the dungeon and get it out.  Few people achieve
-       this; most never do.  Those who have go down in history as heros  among
+       this; most never do.  Those who have go down in history as heroes among
        heroes  -  and then they find ways of making the game even harder.  See
        the Guidebook section on Conduct if this game has gotten too  easy  for
        you.

--- a/doc/window.doc
+++ b/doc/window.doc
@@ -334,7 +334,7 @@ add_menu(windid window, int glyph, const anything identifier,
 		   outside of the standard accelerator (see above) or a
 		   number.  If 0, the item is unaffected by any group
 		   accelerator.  If this accelerator conflicts with
-		   the menu command (or their user defined alises), it loses.
+		   the menu command (or their user defined aliases), it loses.
 		   The menu commands and aliases take care not to interfere
 		   with the default object class symbols.
 		-- If you want this choice to be preselected when the
@@ -461,7 +461,7 @@ status_update(int fldindex, genericptr_t ptr, int chg, int percentage, int color
 
                    For the user's chosen set of BL_MASK_ condition bits,
                    They are stored internally in the cond_hilites[] array,
-                   at the array offset aligned to the color those condtion
+                   at the array offset aligned to the color those condition
                    bits should display in.
 
                    For example, if the user has chosen to display strngl

--- a/sys/wince/mswproc.c
+++ b/sys/wince/mswproc.c
@@ -1048,7 +1048,7 @@ identifier
                    outside of the standard accelerator (see above) or a
                    number.  If 0, the item is unaffected by any group
                    accelerator.  If this accelerator conflicts with
-                   the menu command (or their user defined alises), it loses.
+                   the menu command (or their user defined aliases), it loses.
                    The menu commands and aliases take care not to interfere
                    with the default object class symbols.
                 -- If you want this choice to be preselected when the

--- a/win/gnome/gnbind.c
+++ b/win/gnome/gnbind.c
@@ -702,7 +702,7 @@ identifier
                    outside of the standard accelerator (see above) or a
                    number.  If 0, the item is unaffected by any group
                    accelerator.  If this accelerator conflicts with
-                   the menu command (or their user defined alises), it loses.
+                   the menu command (or their user defined aliases), it loses.
                    The menu commands and aliases take care not to interfere
                    with the default object class symbols.
                 -- If you want this choice to be preselected when the

--- a/win/win32/mswproc.c
+++ b/win/win32/mswproc.c
@@ -1102,7 +1102,7 @@ identifier
                    outside of the standard accelerator (see above) or a
                    number.  If 0, the item is unaffected by any group
                    accelerator.  If this accelerator conflicts with
-                   the menu command (or their user defined alises), it loses.
+                   the menu command (or their user defined aliases), it loses.
                    The menu commands and aliases take care not to interfere
                    with the default object class symbols.
                 -- If you want this choice to be preselected when the


### PR DESCRIPTION
Another slew of spelling corrections. These corrections come from going through the `doc` directory, but ignoring the `fixes*` files since those feel less 'timeless'. Propagated fixes for issues found in `doc` to rest of codebase where I felt it was appropriate. Tried to mitigate spacing changes that were caused.

This is the last of the 'obvious' and automate-able spelling fixes. Going to run some grammar checkers next to see if they can detect more subtle issues. Will try not to send lame fixes or ones that seem intentional (e.g., dialog choices).