### PR TITLE
Fixed scatter not updating the pile symbol.

### DIFF
--- a/src/explode.c
+++ b/src/explode.c
@@ -759,6 +759,8 @@ struct obj *obj; /* only scatter this obj        */
         free((genericptr_t) stmp);
         newsym(x, y);
     }
+    if (total > 0)
+        newsym(sx, sy);
 
     return total;
 }


### PR DESCRIPTION
If you call scatter on a group of objects, the symbol for the pile is never actually updated, leading to an erroneous pile of objects on the screen that disappears as soon as the tile is updated. This pull request adds a call to newsym(), but only if the total number of objects scattered is greater than zero, thus fixing this bug.