### PR TITLE
A few code simplifications to attribute handling

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -594,50 +594,47 @@ void
 init_attr(np)
 register int np;
 {
-    register int i, x, tryct;
+    register int i, x, maxrng = 0;
+    int dist[A_MAX];
 
     for (i = 0; i < A_MAX; i++) {
-        ABASE(i) = AMAX(i) = urole.attrbase[i];
+        ABASE(i) = urole.attrbase[i];
         ATEMP(i) = ATIME(i) = 0;
         np -= urole.attrbase[i];
+        maxrng += dist[i] = urole.attrdist[i];
     }
 
-    tryct = 0;
-    while (np > 0 && tryct < 100) {
-        x = rn2(100);
-        for (i = 0; (i < A_MAX) && ((x -= urole.attrdist[i]) > 0); i++)
+    while (np > 0 && maxrng > 0) {
+        x = rn2(maxrng);
+        for (i = 0; (x -= dist[i]) > 0; i++)
             ;
-        if (i >= A_MAX)
-            continue; /* impossible */
 
         if (ABASE(i) >= ATTRMAX(i)) {
-            tryct++;
+            maxrng -= dist[i];
+            dist[i] = 0;
             continue;
         }
-        tryct = 0;
         ABASE(i)++;
-        AMAX(i)++;
         np--;
     }
 
-    tryct = 0;
-    while (np < 0 && tryct < 100) { /* for redistribution */
+    while (np < 0 && maxrng > 0) { /* for redistribution */
 
-        x = rn2(100);
-        for (i = 0; (i < A_MAX) && ((x -= urole.attrdist[i]) > 0); i++)
+        x = rn2(maxrng);
+        for (i = 0; (x -= dist[i]) > 0; i++)
             ;
-        if (i >= A_MAX)
-            continue; /* impossible */
 
         if (ABASE(i) <= ATTRMIN(i)) {
-            tryct++;
+            maxrng -= dist[i];
+            dist[i] = 0;
             continue;
         }
-        tryct = 0;
         ABASE(i)--;
-        AMAX(i)--;
         np++;
     }
+
+    for (i = 0; i < A_MAX; i++)
+        AMAX(i) = ABASE(i);
 }
 
 void

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -105,7 +105,7 @@ static const struct innate {
 
 STATIC_DCL void NDECL(exerper);
 STATIC_DCL void FDECL(postadjabil, (long *));
-STATIC_DCL const struct innate *FDECL(role_abil, (int));
+STATIC_DCL const struct innate *FDECL(role_abil, (unsigned));
 STATIC_DCL const struct innate *FDECL(check_innate_abil, (long *, long));
 STATIC_DCL int FDECL(innately, (long *));
 
@@ -673,32 +673,30 @@ long *ability;
 
 STATIC_OVL const struct innate *
 role_abil(r)
-int r;
+unsigned r;
 {
-    const struct {
-        short role;
-        const struct innate *abil;
-    } roleabils[] = {
-        { PM_ARCHEOLOGIST, arc_abil },
-        { PM_BARBARIAN, bar_abil },
-        { PM_CAVEMAN, cav_abil },
-        { PM_HEALER, hea_abil },
-        { PM_KNIGHT, kni_abil },
-        { PM_MONK, mon_abil },
-        { PM_PRIEST, pri_abil },
-        { PM_RANGER, ran_abil },
-        { PM_ROGUE, rog_abil },
-        { PM_SAMURAI, sam_abil },
-        { PM_TOURIST, tou_abil },
-        { PM_VALKYRIE, val_abil },
-        { PM_WIZARD, wiz_abil },
-        { 0, 0 }
+    static const struct innate *roleabils[] = {
+        arc_abil, /* PM_ARCHEOLOGIST */
+        bar_abil, /* PM_BARBARIAN */
+        cav_abil, /* PM_CAVEMAN */
+        0,        /* PM_CAVEWOMAN */
+        hea_abil, /* PM_HEALER */
+        kni_abil, /* PM_KNIGHT */
+        mon_abil, /* PM_MONK */
+        pri_abil, /* PM_PRIEST */
+        0,        /* PM_PRIESTESS */
+        ran_abil, /* PM_RANGER */
+        rog_abil, /* PM_ROGUE */
+        sam_abil, /* PM_SAMURAI */
+        tou_abil, /* PM_TOURIST */
+        val_abil, /* PM_VALKYRIE */
+        wiz_abil, /* PM_WIZARD */
     };
-    int i;
 
-    for (i = 0; roleabils[i].abil && roleabils[i].role != r; i++)
-        continue;
-    return roleabils[i].abil;
+    if ((r -= PM_ARCHEOLOGIST) >= SIZE(roleabils))
+      return 0;
+
+    return roleabils[r];
 }
 
 STATIC_OVL const struct innate *

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -115,7 +115,7 @@ adjattrib(ndx, incr, msgflg)
 int ndx, incr;
 int msgflg; /* positive => no message, zero => message, and */
 {           /* negative => conditional (msg if change made) */
-    int old_acurr, old_abase;
+    int old_acurr, old_abase, new_abase;
     boolean abonflg;
     const char *attrstr;
 
@@ -130,25 +130,23 @@ int msgflg; /* positive => no message, zero => message, and */
 
     old_acurr = ACURR(ndx);
     old_abase = ABASE(ndx);
+    new_abase = old_abase + incr;
     if (incr > 0) {
-        ABASE(ndx) += incr;
-        if (ABASE(ndx) > AMAX(ndx)) {
-            incr = ABASE(ndx) - AMAX(ndx);
-            AMAX(ndx) += incr;
-            if (AMAX(ndx) > ATTRMAX(ndx))
-                AMAX(ndx) = ATTRMAX(ndx);
-            ABASE(ndx) = AMAX(ndx);
-        }
+        ABASE(ndx) = min(new_abase, ATTRMAX(ndx));
+        AMAX(ndx) = max(ABASE(ndx), AMAX(ndx));
         attrstr = plusattr[ndx];
         abonflg = (ABON(ndx) < 0);
     } else {
-        ABASE(ndx) += incr;
-        if (ABASE(ndx) < ATTRMIN(ndx)) {
-            incr = ABASE(ndx) - ATTRMIN(ndx);
+        if (ATTRMIN(ndx) <= new_abase) {
+            ABASE(ndx) = new_abase;
+        } else {
+            /*
+             * Player has already abused base attributed below the race minimum.
+             * We move the penalty to affect maximum attribute which can be
+             * restored.
+             */
             ABASE(ndx) = ATTRMIN(ndx);
-            AMAX(ndx) += incr;
-            if (AMAX(ndx) < ATTRMIN(ndx))
-                AMAX(ndx) = ATTRMIN(ndx);
+            AMAX(ndx) = max(AMAX(ndx) - (ATTRMIN(ndx) - new_abase), ATTRMIN(ndx));
         }
         attrstr = minusattr[ndx];
         abonflg = (ABON(ndx) > 0);


### PR DESCRIPTION
I was reading the attribute code to understand how exactly training works. There was a couple of places that I tough could be simplified which makes it easier to read and improve algorithms in use. Changes keep functionally same except for attribute initialization where I considered _tryct_ as a bug instead of feature.

More details for each change can be found from commit messages.

I did only a few quick tests for each change.
- adjttrib changes were tested using a non-cursed tin of spinach, 20 cursed tins of spinach, amulet of magic breathing and two potion of restore ability. I tested restoring points after eating a tin works correctly. Then I tested raising the maximum with non-cursed spinach followed by cursed. Last I tested eating enough tins to go bellow three strength and restoring back to bellow earlier maximum.
- init_attr changes I checked with breakpoint inside the branch preventing going over the racial maximum attribute (I created three orc wizards). I didn't test redistribution branch (I don't even know how to trigger that branch with a few wizard mode turns.)
- role_abi changes was tested with a wizard and a _#levelchange_ to level 17. Wizard gained warning and teleport control like excepted.