### PR TITLE
Fix resurfacing of "foxen" pluralization bug

### DIFF
--- a/src/objnam.c
+++ b/src/objnam.c
@@ -2115,7 +2115,7 @@ const char *const *alt_as_is; /* another set like as_is[] */
     /* skip "ox" -> "oxen" entry when pluralizing "<something>ox"
        unless it is muskox */
     if (to_plural && baselen > 2 && !strcmpi(endstring - 2, "ox")
-        && baselen > 5 && strcmpi(endstring - 6, "muskox")) {
+        && !(baselen > 5 && !strcmpi(endstring - 6, "muskox"))) {
         /* "fox" -> "foxes" */
         Strcasecpy(endstring, "es");
         return TRUE;


### PR DESCRIPTION
Inadvertently reintroduced in f9f1236. It was just the conditional
that was bad: due to resolving the possible buffer underflow when
comparing to "muskox", the pluralizer now only adds -es when the length
of the string is greater than 5. So for "box" and "fox" the pluralizer
will never add the -es ending, since they are greater than 5.

This commit checks for "does not end in muskox" correctly.