### PR TITLE
Better semantics for mintrinsics (and bug fix)

### DIFF
--- a/include/mondata.h
+++ b/include/mondata.h
@@ -10,14 +10,22 @@
 
 #define pm_resistance(ptr, typ) (((ptr)->mresists & (typ)) != 0)
 
-#define resists_fire(mon) (((mon)->mintrinsics & MR_FIRE) != 0)
-#define resists_cold(mon) (((mon)->mintrinsics & MR_COLD) != 0)
-#define resists_sleep(mon) (((mon)->mintrinsics & MR_SLEEP) != 0)
-#define resists_disint(mon) (((mon)->mintrinsics & MR_DISINT) != 0)
-#define resists_elec(mon) (((mon)->mintrinsics & MR_ELEC) != 0)
-#define resists_poison(mon) (((mon)->mintrinsics & MR_POISON) != 0)
-#define resists_acid(mon) (((mon)->mintrinsics & MR_ACID) != 0)
-#define resists_ston(mon) (((mon)->mintrinsics & MR_STONE) != 0)
+#define resists_fire(mon) \
+    ((((mon)->data->mresists | (mon)->mintrinsics) & MR_FIRE) != 0)
+#define resists_cold(mon) \
+    ((((mon)->data->mresists | (mon)->mintrinsics) & MR_COLD) != 0)
+#define resists_sleep(mon) \
+    ((((mon)->data->mresists | (mon)->mintrinsics) & MR_SLEEP) != 0)
+#define resists_disint(mon) \
+    ((((mon)->data->mresists | (mon)->mintrinsics) & MR_DISINT) != 0)
+#define resists_elec(mon) \
+    ((((mon)->data->mresists | (mon)->mintrinsics) & MR_ELEC) != 0)
+#define resists_poison(mon) \
+    ((((mon)->data->mresists | (mon)->mintrinsics) & MR_POISON) != 0)
+#define resists_acid(mon) \
+    ((((mon)->data->mresists | (mon)->mintrinsics) & MR_ACID) != 0)
+#define resists_ston(mon) \
+    ((((mon)->data->mresists | (mon)->mintrinsics) & MR_STONE) != 0)
 
 #define is_lminion(mon) \
     (is_minion((mon)->data) && mon_aligntyp(mon) == A_LAWFUL)

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -22,11 +22,6 @@ int flag;
     if (flag == -1)
         return; /* "don't care" */
 
-    if (flag == 1)
-        mon->mintrinsics |= (ptr->mresists & 0x00FF);
-    else
-        mon->mintrinsics = (ptr->mresists & 0x00FF);
-
     if (mon->movement) { /* same adjustment as poly'd hero undergoes */
         new_speed = ptr->mmove;
         /* prorate unused movement if new form is slower so that


### PR DESCRIPTION
This addresses a bug I found and wrote a report for, and then decided to
provide a fix for it along with the report. The bug consists of
monster intrinsics (resistances, such as from armor) being wiped when a
monster changes form, resulting in a monster that lacks the resistances
even though it is still wearing the armor that should confer them.

This addresses the problem by disentangling the two meanings that
mintrinsics was trying to cover: resistances granted by the monster
form, and resistances from other sources like armor. Now, mintrinsics
refers only to the second one.

The resists_* macros defined in mondata.h (which are what the game
always uses to check resistances, instead of directly reading
mintrinsics) have been changed to also check the permonst directly for
its resistances. Under this system, a monster will always have the
resistances that its form conveys (the same as before), while also being
able to gain resistances from other sources (the same as before). The
difference is that since the permonst no longer affects mintrinsics,
it's no longer possible to have bugs like this one.

This removes the mintrinsic updating code from set_mon_data, and
as such it makes it irrelevant whether set_mon_data is called with a
flag of 0 or 1. The only place it's ever actually _called_ with a flag
of 1 (which forced it to preserve the mintrinsics of the younger form as
well as taking on any new ones) is in grow_up(). Strictly speaking, this
new system won't preserve those younger form intrinsics, but I haven't
been able to locate any monsters in NetHack that lose resistances by
growing up, so I think it didn't actually matter in the first place.