### PR TITLE
curses: Add nonl() call after raw() call.

### DIFF
--- a/doc/fixes36.3
+++ b/doc/fixes36.3
@@ -89,6 +89,11 @@ curses: when display windows get reconfigured (after setting align_status,
 curses: plug memory leak when getting a line of input is cancelled by ESC
 curses: after requesting a line of input from player, next line of message
 	window could end up being skipped
+curses: disable carriage return into newline conversion by default, to allow
+	player to use Ctrl+M for answering prompts while not causing
+	character to run towards bottom edge of map if pressed while on map.
+	Also, players can configure their terminal to issue carriage returns
+	instead of newlines on Enter keypress to further remedy this.
 tty: re-do one optimization used when status conditions have all been removed
 	and remove another that tried to check whether condition text to be
 	displayed next was the same as the existing value; sometimes new

--- a/win/curses/cursmain.c
+++ b/win/curses/cursmain.c
@@ -143,6 +143,7 @@ curses_init_nhwindows(int *argcp UNUSED,
 #endif
     noecho();
     raw();
+    nonl();
     meta(stdscr, TRUE);
     orig_cursor = curs_set(0);
     keypad(stdscr, TRUE);


### PR DESCRIPTION
Fixes #195

Various implementations of curses may deal differently with raw() call,
but unless explicitly requested with nonl() call, curses implementation
is not obliged to disable CR-to-LF mapping. NetHack already handles \r
in input very well and it's possible to use both \r and \n for prompts.

What's this useful for: When not in prompt, line feed (Ctrl+J) is also a
command for "go down". This can cause frustration and YASD, because if
you accidentally hit Enter or Ctrl+J, your character will run towards
bottom edge of map. However, if you will use Ctrl+M to answer the
prompts (or use `stty -icrnl` to make Enter default to carriage return),
this will work for prompts, but if you accidentally hit it while on map,
it will just yield:

Unknown command: ^M