### PR TITLE
add a new option: autosave

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -576,6 +576,11 @@ typedef unsigned char uchar;
 
 #define USE_ISAAC64 /* Use cross-plattform, bundled RNG */
 
+/* AUTOSAVE enables a new 'autosave' compound option, which allows
+ * to specify max number of turns to play, before doing automatic
+ * save-and-quit, defaults to off. */
+/* #define AUTOSAVE */
+
 /* End of Section 4 */
 
 #ifdef TTY_TILES_ESCCODES

--- a/include/flag.h
+++ b/include/flag.h
@@ -217,6 +217,9 @@ struct instance_flags {
 #ifdef ALTMETA
     boolean altmeta;      /* Alt-c sends ESC c rather than M-c */
 #endif
+#ifdef AUTOSAVE
+    int autosave;         /* controls, how many turns to wait before autosave */
+#endif
     boolean autodescribe;     /* autodescribe mode in getpos() */
     boolean cbreak;           /* in cbreak mode, rogue format */
     boolean deferred_X;       /* deferred entry into explore mode */

--- a/include/optlist.h
+++ b/include/optlist.h
@@ -102,6 +102,10 @@ pfx_##a,
                 &flags.pickup)
     NHOPTB(autoquiver, 0, opt_in, set_in_game, Off, Yes, No, No, NoAlias,
                 &flags.autoquiver)
+#ifdef AUTOSAVE
+    NHOPTC(autosave, 20, opt_in, set_in_game, Yes, Yes, No, No, NoAlias,
+                "quit game after N turns")
+#endif
     NHOPTB(autounlock, 0, opt_out, set_in_game, On, Yes, No, No, NoAlias,
                 &flags.autounlock)
 #if defined(MICRO) && !defined(AMIGA)

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -193,6 +193,11 @@ boolean resuming;
                     if (u.ublesscnt)
                         u.ublesscnt--;
 
+#ifdef AUTOSAVE
+                    if (iflags.autosave > 0)
+                        iflags.autosave--;
+#endif
+
                     /* One possible result of prayer is healing.  Whether or
                      * not you get healed depends on your current hit points.
                      * If you are allowed to regenerate during the prayer,

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -3143,6 +3143,10 @@ register char *cmd;
     if (g.program_state.done_hup)
         end_of_input();
 #endif
+#ifdef AUTOSAVE
+    if (!iflags.autosave)
+        dosave();
+#endif
     if (firsttime) {
         g.context.nopick = 0;
         cmd = parse();

--- a/src/save.c
+++ b/src/save.c
@@ -54,7 +54,11 @@ dosave()
     if (iflags.debug_fuzzer)
         return 0;
     clear_nhwindow(WIN_MESSAGE);
+#ifdef AUTOSAVE
+    if (iflags.autosave && yn("Really save?") == 'n') {
+#else
     if (yn("Really save?") == 'n') {
+#endif
         clear_nhwindow(WIN_MESSAGE);
         if (g.multi > 0)
             nomul(0);


### PR DESCRIPTION
This patch adds a new compound option: autosave (as proposed in GitHub
issue #208).

The idea behind patch is to allow artificially limiting game session
duration, by automatically saving-and-quitting after playing for N turns
(where N is argument of the option). This could be useful for public
servers, where *Robin accounts are used as a form of multiplayer and
players play for N turns, and then give control to another person.
Another use case is to use this option to just keep yourself from
playing too long game sessions (e.g. during coffee-break, etc.).

Option is specified like this:

OPTIONS=autosave:500

Which would save-and-quit after playing for 500 turns.

Defaults to -1 (autosave disabled). 0 is invalid value, because game
would then quit right after starting. Any positive value is used as turn
countdown, and when it reaches 0, game is saved and quit automatically.

Signed-off-by: Vitaly Ostrosablin <tmp6154@yandex.ru>