### PR TITLE
Added missing period in unmul().

### DIFF
--- a/src/hack.c
+++ b/src/hack.c
@@ -2909,7 +2909,7 @@ const char *msg_override;
            if life-saved while poly'd and Unchanging (explore or wizard mode
            declining to die since can't be both Unchanging and Lifesaved) */
         if (Upolyd && !strncmpi(nomovemsg, "You survived that ", 18))
-            You("are %s", an(mons[u.umonnum].mname)); /* (ignore Hallu) */
+            You("are %s.", an(mons[u.umonnum].mname)); /* (ignore Hallu) */
     }
     nomovemsg = 0;
     u.usleep = 0;


### PR DESCRIPTION
Being resurrected while polymorphed produces an orphaned phrase. For example, a lifesaved player polymorphed into a lichen will see the following phrase in the middle of the message log:

> "You are a lichen"

The orphaned message immediately runs into the next sentence, making events difficult to follow. This change simply fixes the typo by adding a period.

> "You are a lichen."