### PR TITLE
Align add_opvars formats with their parameters

### DIFF
--- a/sys/share/lev_yacc.c
+++ b/sys/share/lev_yacc.c
@@ -2644,7 +2644,7 @@ case 7:
 				     VA_PASS9(LVLINIT_SOLIDFILL, bg, 0,0,
 					      0,0,0,0, SPO_INITLEVEL));
 		      }
-		      add_opvars(splev, "io",
+		      add_opvars(splev, "lo",
 				 VA_PASS2(MAZELEVEL, SPO_LEVEL_FLAGS));
 		      max_x_map = COLNO-1;
 		      max_y_map = ROWNO;
@@ -3186,7 +3186,7 @@ case 138:
 			     splev->n_opcodes - switch_check_jump->vardata.l);
 
 		      for (i = 0; i < n_switch_case_list; i++) {
-			  add_opvars(splev, "oio",
+			  add_opvars(splev, "olo",
 				     VA_PASS3(SPO_COPY,
 					      switch_case_value[i], SPO_CMP));
 			  set_opvar_int(switch_case_list[i],
@@ -3461,7 +3461,7 @@ case 161:
 break;
 case 162:
 {
-		      add_opvars(splev, "iiiiiio",
+		      add_opvars(splev, "iliiiio",
 			      VA_PASS7(-1, yyvsp[0].i, -1, -1, -1, -1, SPO_CORRIDOR));
 		  }
 break;
@@ -3473,7 +3473,7 @@ case 163:
 break;
 case 164:
 {
-		      add_opvars(splev, "iiiiiio",
+		      add_opvars(splev, "llllllo",
 				 VA_PASS7(yyvsp[-2].corpos.room, yyvsp[-2].corpos.door, yyvsp[-2].corpos.wall,
 					  yyvsp[0].corpos.room, yyvsp[0].corpos.door, yyvsp[0].corpos.wall,
 					  SPO_CORRIDOR));
@@ -3481,7 +3481,7 @@ case 164:
 break;
 case 165:
 {
-		      add_opvars(splev, "iiiiiio",
+		      add_opvars(splev, "llliilo",
 				 VA_PASS7(yyvsp[-2].corpos.room, yyvsp[-2].corpos.door, yyvsp[-2].corpos.wall,
 					  -1, -1, (long)yyvsp[0].i,
 					  SPO_CORRIDOR));
@@ -3499,7 +3499,7 @@ case 167:
 		      if ((yyvsp[-2].i < 100) && (yyvsp[-3].i == OROOM))
 			  lc_error("Only typed rooms can have a chance.");
 		      else {
-			  add_opvars(splev, "iii",
+			  add_opvars(splev, "lll",
 				     VA_PASS3((long)yyvsp[-3].i, (long)yyvsp[-2].i, (long)yyvsp[0].i));
 		      }
                   }
@@ -3509,7 +3509,7 @@ case 168:
 		      long rflags = yyvsp[0].i;
 
 		      if (rflags == -1) rflags = (1 << 0);
-		      add_opvars(splev, "iiiiiiio",
+		      add_opvars(splev, "liillllo",
 				 VA_PASS8(rflags, ERR, ERR,
 					  yyvsp[-3].crd.x, yyvsp[-3].crd.y, yyvsp[-1].sze.width, yyvsp[-1].sze.height,
 					  SPO_SUBROOM));
@@ -3527,7 +3527,7 @@ case 170:
 		      long rflags = yyvsp[-2].i;
 
 		      if (rflags == -1) rflags = (1 << 0);
-		      add_opvars(splev, "iiiiiiio",
+		      add_opvars(splev, "lllllllo",
 				 VA_PASS8(rflags,
 					  yyvsp[-3].crd.x, yyvsp[-3].crd.y, yyvsp[-5].crd.x, yyvsp[-5].crd.y,
 					  yyvsp[-1].sze.width, yyvsp[-1].sze.height, SPO_ROOM));
@@ -3609,7 +3609,7 @@ case 182:
 			if (yyvsp[-2].i == ERR && yyvsp[0].i != ERR) {
 			    lc_error("If the door wall is random, so must be its pos!");
 			} else {
-			    add_opvars(splev, "iiiio",
+			    add_opvars(splev, "llllo",
 				       VA_PASS5((long)yyvsp[0].i, (long)yyvsp[-4].i, (long)yyvsp[-6].i,
 						(long)yyvsp[-2].i, SPO_ROOM_DOOR));
 			}
@@ -3617,7 +3617,7 @@ case 182:
 break;
 case 183:
 {
-		      add_opvars(splev, "io", VA_PASS2((long)yyvsp[-2].i, SPO_DOOR));
+		      add_opvars(splev, "lo", VA_PASS2((long)yyvsp[-2].i, SPO_DOOR));
 		  }
 break;
 case 188:
@@ -3633,7 +3633,7 @@ break;
 case 192:
 {
 		      add_opvars(splev, "ciisiio",
-				 VA_PASS7(0, 0, 1, (char *) 0, 0, 0, SPO_MAP));
+				 VA_PASS7(0L, 0, 1, (char *) 0, 0, 0, SPO_MAP));
 		      max_x_map = COLNO-1;
 		      max_y_map = ROWNO;
 		  }
@@ -3999,7 +3999,7 @@ case 246:
 			   state = -1;
 		       else
 			   lc_error("A drawbridge can only be open, closed or random!");
-		       add_opvars(splev, "iio",
+		       add_opvars(splev, "llo",
 				  VA_PASS3(state, dir, SPO_DRAWBRIDGE));
 		   }
 break;
@@ -4042,7 +4042,7 @@ case 252:
 break;
 case 253:
 {
-		      add_opvars(splev, "iiiii iiiii iiso",
+		      add_opvars(splev, "lllll lllll liso",
 				 VA_PASS14(yyvsp[-4].lregn.x1, yyvsp[-4].lregn.y1, yyvsp[-4].lregn.x2, yyvsp[-4].lregn.y2, yyvsp[-4].lregn.area,
 					   yyvsp[-2].lregn.x1, yyvsp[-2].lregn.y1, yyvsp[-2].lregn.x2, yyvsp[-2].lregn.y2, yyvsp[-2].lregn.area,
 				     (long) ((yyvsp[0].i) ? LR_UPSTAIR : LR_DOWNSTAIR),
@@ -4051,7 +4051,7 @@ case 253:
 break;
 case 254:
 {
-		      add_opvars(splev, "iiiii iiiii iiso",
+		      add_opvars(splev, "lllll lllll iiso",
 				 VA_PASS14(yyvsp[-4].lregn.x1, yyvsp[-4].lregn.y1, yyvsp[-4].lregn.x2, yyvsp[-4].lregn.y2, yyvsp[-4].lregn.area,
 					   yyvsp[-2].lregn.x1, yyvsp[-2].lregn.y1, yyvsp[-2].lregn.x2, yyvsp[-2].lregn.y2, yyvsp[-2].lregn.area,
 					   LR_PORTAL, 0, yyvsp[0].map, SPO_LEVREGION));
@@ -4066,7 +4066,7 @@ case 255:
 		      case  0: rtyp = LR_DOWNTELE; break;
 		      case  1: rtyp = LR_UPTELE; break;
 		      }
-		      add_opvars(splev, "iiiii iiiii iiso",
+		      add_opvars(splev, "lllll lllll liso",
 				 VA_PASS14(yyvsp[-3].lregn.x1, yyvsp[-3].lregn.y1, yyvsp[-3].lregn.x2, yyvsp[-3].lregn.y2, yyvsp[-3].lregn.area,
 					   yyvsp[-1].lregn.x1, yyvsp[-1].lregn.y1, yyvsp[-1].lregn.x2, yyvsp[-1].lregn.y2, yyvsp[-1].lregn.area,
 					   rtyp, 0, (char *)0, SPO_LEVREGION));
@@ -4074,7 +4074,7 @@ case 255:
 break;
 case 256:
 {
-		      add_opvars(splev, "iiiii iiiii iiso",
+		      add_opvars(splev, "lllll lllll liso",
 				 VA_PASS14(yyvsp[-2].lregn.x1, yyvsp[-2].lregn.y1, yyvsp[-2].lregn.x2, yyvsp[-2].lregn.y2, yyvsp[-2].lregn.area,
 					   yyvsp[0].lregn.x1, yyvsp[0].lregn.y1, yyvsp[0].lregn.x2, yyvsp[0].lregn.y2, yyvsp[0].lregn.area,
 					   (long) LR_BRANCH, 0,
@@ -4120,7 +4120,7 @@ case 263:
 break;
 case 264:
 {
-		      add_opvars(splev, "io",
+		      add_opvars(splev, "lo",
 				 VA_PASS2(yyvsp[0].i, SPO_REPLACETERRAIN));
 		  }
 break;
@@ -4148,7 +4148,7 @@ case 268:
 		      if (rflags == -1) rflags = (1 << 0);
 		      if (!(rflags & 1)) rt += MAXRTYPE+1;
 		      irr = ((rflags & 2) != 0);
-		      add_opvars(splev, "iiio",
+		      add_opvars(splev, "lllo",
 				 VA_PASS4((long)yyvsp[-3].i, rt, rflags, SPO_REGION));
 		      yyval.i = (irr || (rflags & 1) || rt != OROOM);
 		      break_stmt_start();
@@ -4175,7 +4175,7 @@ case 271:
 break;
 case 272:
 {
-		      add_opvars(splev, "iio",
+		      add_opvars(splev, "llo",
 				 VA_PASS3((long)yyvsp[0].i, (long)yyvsp[-2].i, SPO_ALTAR));
 		  }
 break;
@@ -4203,7 +4203,7 @@ case 276:
 break;
 case 277:
 {
-		      add_opvars(splev, "io",
+		      add_opvars(splev, "lo",
 				 VA_PASS2((long)yyvsp[-2].i, SPO_ENGRAVING));
 		  }
 break;
@@ -4214,7 +4214,7 @@ case 278:
 break;
 case 279:
 {
-		      add_opvars(splev, "iiiio",
+		      add_opvars(splev, "llllo",
 				 VA_PASS5(-1L, -1L, -1L, -1L, SPO_MINERALIZE));
 		  }
 break;
@@ -4582,7 +4582,7 @@ case 341:
 break;
 case 342:
 {
-		      add_opvars(splev, "i", VA_PASS1(yyvsp[0].i));
+		      add_opvars(splev, "l", VA_PASS1(yyvsp[0].i));
 		  }
 break;
 case 343:
@@ -4592,7 +4592,7 @@ case 343:
 break;
 case 344:
 {
-		      add_opvars(splev, "i", VA_PASS1(yyvsp[-1].i));
+		      add_opvars(splev, "l", VA_PASS1(yyvsp[-1].i));
 		  }
 break;
 case 345:
@@ -4762,12 +4762,12 @@ case 371:
 break;
 case 372:
 {
-		      add_opvars(splev, "io", VA_PASS2(yyvsp[-3].i, SPO_SEL_GROW));
+		      add_opvars(splev, "lo", VA_PASS2(yyvsp[-3].i, SPO_SEL_GROW));
 		  }
 break;
 case 373:
 {
-		      add_opvars(splev, "iio",
+		      add_opvars(splev, "lio",
 			     VA_PASS3(yyvsp[-3].i, SPOFILTER_PERCENT, SPO_SEL_FILTER));
 		  }
 break;
@@ -4796,7 +4796,7 @@ case 377:
 break;
 case 378:
 {
-		      add_opvars(splev, "oio",
+		      add_opvars(splev, "olo",
 				 VA_PASS3(SPO_COPY, yyvsp[-1].i, SPO_SEL_ELLIPSE));
 		  }
 break;
@@ -4807,12 +4807,12 @@ case 379:
 break;
 case 380:
 {
-		      add_opvars(splev, "io", VA_PASS2(yyvsp[-1].i, SPO_SEL_ELLIPSE));
+		      add_opvars(splev, "lo", VA_PASS2(yyvsp[-1].i, SPO_SEL_ELLIPSE));
 		  }
 break;
 case 381:
 {
-		      add_opvars(splev, "iio",
+		      add_opvars(splev, "llo",
 				 VA_PASS3(yyvsp[-5].i, yyvsp[-11].i, SPO_SEL_GRADIENT));
 		  }
 break;
@@ -4846,23 +4846,23 @@ case 386:
 break;
 case 387:
 {
-		      add_opvars(splev, "iio",
+		      add_opvars(splev, "llo",
 				 VA_PASS3(yyvsp[0].dice.num, yyvsp[0].dice.die, SPO_DICE));
 		  }
 break;
 case 391:
 {
-		      add_opvars(splev, "i", VA_PASS1(yyvsp[0].i));
+		      add_opvars(splev, "l", VA_PASS1(yyvsp[0].i));
 		  }
 break;
 case 392:
 {
-		      add_opvars(splev, "i", VA_PASS1(yyvsp[0].i));
+		      add_opvars(splev, "l", VA_PASS1(yyvsp[0].i));
 		  }
 break;
 case 393:
 {
-		      add_opvars(splev, "i", VA_PASS1(yyvsp[0].i));
+		      add_opvars(splev, "l", VA_PASS1(yyvsp[0].i));
 		  }
 break;
 case 394:

--- a/util/clang/compat.h
+++ b/util/clang/compat.h
@@ -1,0 +1,21 @@
+// Some shims for compatibility with different versions of LLVM and Clang
+
+#ifndef COMPAT_H
+#define COMPAT_H
+
+#include <clang/Basic/Version.h>
+
+namespace clang_compat {
+
+	// The pointer type returned by CreateASTConsumer...
+#if ((CLANG_VERSION_MAJOR<<8) + CLANG_VERSION_MINOR) >= 0x0306
+	// ...requires a unique_ptr in 3.6 and later...
+	typedef std::unique_ptr<clang::ASTConsumer> ASTConsumerPtr;
+#else
+	// ...and a bare pointer otherwise
+	typedef clang::ASTConsumer *ASTConsumerPtr;
+#endif
+
+}
+
+#endif // COMPAT_H

--- a/util/clang/opvars-plugin.cpp
+++ b/util/clang/opvars-plugin.cpp
@@ -1,0 +1,149 @@
+// Use with:
+// -Xclang -load -Xclang path/to/opvars-plugin.so -Xclang -add-plugin -Xclang opvars-plugin
+
+#include <fstream>
+#include <string>
+#include <vector>
+#include <cstdlib>
+#include <iostream>
+
+#define __STDC_LIMIT_MACROS 1
+#define __STDC_CONSTANT_MACROS 1
+#include <clang/AST/AST.h>
+#include <clang/AST/ASTConsumer.h>
+#include <clang/AST/RecursiveASTVisitor.h>
+#include <clang/Basic/Version.h>
+#include <clang/Frontend/CompilerInstance.h>
+#include <clang/Frontend/FrontendPluginRegistry.h>
+
+#include "compat.h"
+
+namespace {
+
+class OpVarsVisitor : public clang::RecursiveASTVisitor<OpVarsVisitor> {
+public:
+    explicit OpVarsVisitor(clang::CompilerInstance& inst) :
+    diagnostics(inst.getDiagnostics())
+    {
+        arg_wrong_type = diagnostics.getCustomDiagID(
+                clang::DiagnosticsEngine::Error,
+                "argument %0 to '%1' has type '%2', but format character '%3' expects '%4'");
+        arg_not_constant = diagnostics.getCustomDiagID(
+                clang::DiagnosticsEngine::Error,
+                "argument %0 to '%1' is not a string literal");
+        arg_bad_character = diagnostics.getCustomDiagID(
+                clang::DiagnosticsEngine::Error,
+                "Invalid format character '%0'");
+    }
+
+    bool VisitCallExpr(clang::CallExpr *exp)
+    {
+        clang::FunctionDecl *d = exp->getDirectCallee();
+        if (d == nullptr) { return true; }
+
+        // Determine whether the function is one we're looking for
+        auto ident = d->getIdentifier();
+        if (ident == nullptr) { return true; }
+        llvm::StringRef const name = ident->getName();
+        if (name == "add_opvars") {
+            // Argument 2 must be a string literal
+            clang::Expr const *arg = exp->getArg(1);
+            arg = arg->IgnoreImplicit();
+            clang::StringLiteral const *str_p = llvm::dyn_cast_or_null<clang::StringLiteral>(arg);
+            if (str_p == nullptr
+                || (str_p->getKind() != clang::StringLiteral::Ascii
+                 && str_p->getKind() != clang::StringLiteral::UTF8)) {
+                std::cout << "str_p is " << (void *)str_p;
+                if (str_p)
+                    std::cout << " getKind() is " << str_p->getKind();
+                std::cout << "\n";
+                diagnostics.Report(arg->getLocStart(), arg_not_constant) << 2 << name;
+            } else {
+                std::string str = str_p->getString().str();
+                std::size_t argnum = 2;
+                const char *target1 = "", *target2 = "";
+
+                for (std::size_t i = 0; i < str.size(); ++i) {
+                    char ch = str.at(i);
+                    switch (ch) {
+                    case ' ':
+                        continue;
+
+                    case 'i': /* integer */
+                    case 'o': /* opcode */
+                        target1 = "int";
+                        target2 = "unsigned";
+                        break;
+
+                    case 'l': /* integer */
+                    case 'c': /* coordinate */
+                    case 'r': /* region */
+                    case 'm': /* mapchar */
+                    case 'M': /* monster */
+                    case 'O': /* object */
+                        target1 = "long";
+                        target2 = "unsigned long";
+                        break;
+
+                    case 's': /* string */
+                    case 'v': /* variable */
+                        target1 = "const char *";
+                        target2 = "char *";
+                        break;
+
+                    default:
+                        diagnostics.Report(arg->getLocStart(), arg_bad_character) << str.substr(i, 1);
+                        continue;
+                    }
+                    clang::Expr const *arg2 = exp->getArg(argnum++);
+                    auto tname = arg2->getType().getAsString();
+                    if (tname != target1 && tname != target2) {
+                        diagnostics.Report(arg2->getLocStart(), arg_wrong_type)
+                        << static_cast<unsigned>(argnum)
+                        << name << tname << str.substr(i, 1) << target1;
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+private:
+    clang::DiagnosticsEngine& diagnostics;
+    unsigned arg_wrong_type;
+    unsigned arg_not_constant;
+    unsigned arg_bad_character;
+};
+
+struct OpVarsASTConsumer : public clang::ASTConsumer {
+public:
+    explicit OpVarsASTConsumer(clang::CompilerInstance& inst)
+    : Visitor(inst) {}
+
+    virtual void HandleTranslationUnit(clang::ASTContext &Context)
+    {
+        Visitor.TraverseDecl(Context.getTranslationUnitDecl());
+    }
+private:
+    OpVarsVisitor Visitor;
+};
+
+class OpVarsAction : public clang::PluginASTAction {
+public:
+	clang_compat::ASTConsumerPtr CreateASTConsumer(clang::CompilerInstance& inst, llvm::StringRef str) override
+    {
+        return clang_compat::ASTConsumerPtr(new OpVarsASTConsumer(inst));
+    }
+
+    bool ParseArgs(const clang::CompilerInstance& inst,
+                   const std::vector<std::string>& args) override
+    {
+        return true;
+    }
+};
+
+}
+
+static clang::FrontendPluginRegistry::Add<OpVarsAction>
+X("opvars-plugin", "check add_opvars arguments");

--- a/util/clang/plugin-Makefile
+++ b/util/clang/plugin-Makefile
@@ -1,0 +1,18 @@
+# clang plugin for nethack-i18n; verify varargs calls to add_opvars
+
+default: opvars-plugin.so
+
+LIB = opvars-plugin.so
+
+CXX = /usr/bin/clang
+CXXFLAGS = -Wall -g -I/usr/lib/llvm-6.0/include
+LDFLAGS = -std=c++11 -fPIC -fno-rtti
+
+$(LIB) : opvars-plugin.o
+	$(CXX) $(LDFLAGS) -shared -o opvars-plugin.so opvars-plugin.o
+
+opvars-plugin.o : opvars-plugin.cpp compat.h
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -c -o opvars-plugin.o opvars-plugin.cpp
+
+clean:
+	rm -f $(LIB) opvars-plugin.o

--- a/util/lev_comp.y
+++ b/util/lev_comp.y
@@ -328,7 +328,7 @@ level_def	: LEVEL_ID ':' STRING
 				     VA_PASS9(LVLINIT_SOLIDFILL, bg, 0,0,
 					      0,0,0,0, SPO_INITLEVEL));
 		      }
-		      add_opvars(splev, "io",
+		      add_opvars(splev, "lo",
 				 VA_PASS2(MAZELEVEL, SPO_LEVEL_FLAGS));
 		      max_x_map = COLNO-1;
 		      max_y_map = ROWNO;
@@ -938,7 +938,7 @@ switchstatement	: SWITCH_ID
 			     splev->n_opcodes - switch_check_jump->vardata.l);
 
 		      for (i = 0; i < n_switch_case_list; i++) {
-			  add_opvars(splev, "oio",
+			  add_opvars(splev, "olo",
 				     VA_PASS3(SPO_COPY,
 					      switch_case_value[i], SPO_CMP));
 			  set_opvar_int(switch_case_list[i],
@@ -1221,7 +1221,7 @@ random_corridors: RAND_CORRIDOR_ID
 		  }
 		| RAND_CORRIDOR_ID ':' all_integers
 		  {
-		      add_opvars(splev, "iiiiiio",
+		      add_opvars(splev, "iliiiio",
 			      VA_PASS7(-1, $3, -1, -1, -1, -1, SPO_CORRIDOR));
 		  }
 		| RAND_CORRIDOR_ID ':' RANDOM_TYPE
@@ -1233,14 +1233,14 @@ random_corridors: RAND_CORRIDOR_ID
 
 corridor	: CORRIDOR_ID ':' corr_spec ',' corr_spec
 		  {
-		      add_opvars(splev, "iiiiiio",
+		      add_opvars(splev, "llllllo",
 				 VA_PASS7($3.room, $3.door, $3.wall,
 					  $5.room, $5.door, $5.wall,
 					  SPO_CORRIDOR));
 		  }
 		| CORRIDOR_ID ':' corr_spec ',' all_integers
 		  {
-		      add_opvars(splev, "iiiiiio",
+		      add_opvars(splev, "llliilo",
 				 VA_PASS7($3.room, $3.door, $3.wall,
 					  -1, -1, (long)$5,
 					  SPO_CORRIDOR));
@@ -1260,7 +1260,7 @@ room_begin      : room_type opt_percent ',' light_state
 		      if (($2 < 100) && ($1 == OROOM))
 			  lc_error("Only typed rooms can have a chance.");
 		      else {
-			  add_opvars(splev, "iii",
+			  add_opvars(splev, "lll",
 				     VA_PASS3((long)$1, (long)$2, (long)$4));
 		      }
                   }
@@ -1271,7 +1271,7 @@ subroom_def	: SUBROOM_ID ':' room_begin ',' subroom_pos ',' room_size optroomreg
 		      long rflags = $8;
 
 		      if (rflags == -1) rflags = (1 << 0);
-		      add_opvars(splev, "iiiiiiio",
+		      add_opvars(splev, "liillllo",
 				 VA_PASS8(rflags, ERR, ERR,
 					  $5.x, $5.y, $7.width, $7.height,
 					  SPO_SUBROOM));
@@ -1289,7 +1289,7 @@ room_def	: ROOM_ID ':' room_begin ',' room_pos ',' room_align ',' room_size optr
 		      long rflags = $8;
 
 		      if (rflags == -1) rflags = (1 << 0);
-		      add_opvars(splev, "iiiiiiio",
+		      add_opvars(splev, "lllllllo",
 				 VA_PASS8(rflags,
 					  $7.x, $7.y, $5.x, $5.y,
 					  $9.width, $9.height, SPO_ROOM));
@@ -1371,14 +1371,14 @@ door_detail	: ROOMDOOR_ID ':' secret ',' door_state ',' door_wall ',' door_pos
 			if ($7 == ERR && $9 != ERR) {
 			    lc_error("If the door wall is random, so must be its pos!");
 			} else {
-			    add_opvars(splev, "iiiio",
+			    add_opvars(splev, "llllo",
 				       VA_PASS5((long)$9, (long)$5, (long)$3,
 						(long)$7, SPO_ROOM_DOOR));
 			}
 		  }
 		| DOOR_ID ':' door_state ',' ter_selection
 		  {
-		      add_opvars(splev, "io", VA_PASS2((long)$3, SPO_DOOR));
+		      add_opvars(splev, "lo", VA_PASS2((long)$3, SPO_DOOR));
 		  }
 		;
 
@@ -1407,7 +1407,7 @@ door_pos	: INTEGER
 map_definition	: NOMAP_ID
 		  {
 		      add_opvars(splev, "ciisiio",
-				 VA_PASS7(0, 0, 1, (char *) 0, 0, 0, SPO_MAP));
+				 VA_PASS7(0L, 0, 1, (char *) 0, 0, 0, SPO_MAP));
 		      max_x_map = COLNO-1;
 		      max_y_map = ROWNO;
 		  }
@@ -1753,7 +1753,7 @@ drawbridge_detail: DRAWBRIDGE_ID ':' coord_or_var ',' DIRECTION ',' door_state
 			   state = -1;
 		       else
 			   lc_error("A drawbridge can only be open, closed or random!");
-		       add_opvars(splev, "iio",
+		       add_opvars(splev, "llo",
 				  VA_PASS3(state, dir, SPO_DRAWBRIDGE));
 		   }
 		;
@@ -1774,7 +1774,7 @@ mazewalk_detail : MAZEWALK_ID ':' coord_or_var ',' DIRECTION
 wallify_detail	: WALLIFY_ID
 		  {
 		      add_opvars(splev, "rio",
-				 VA_PASS3(SP_REGION_PACK(-1,-1,-1,-1),
+				 VA_PASS3((long) SP_REGION_PACK(-1,-1,-1,-1),
 					  0, SPO_WALLIFY));
 		  }
 		| WALLIFY_ID ':' ter_selection
@@ -1799,7 +1799,7 @@ stair_detail	: STAIR_ID ':' coord_or_var ',' UP_OR_DOWN
 
 stair_region	: STAIR_ID ':' lev_region ',' lev_region ',' UP_OR_DOWN
 		  {
-		      add_opvars(splev, "iiiii iiiii iiso",
+		      add_opvars(splev, "lllll lllll liso",
 				 VA_PASS14($3.x1, $3.y1, $3.x2, $3.y2, $3.area,
 					   $5.x1, $5.y1, $5.x2, $5.y2, $5.area,
 				     (long) (($7) ? LR_UPSTAIR : LR_DOWNSTAIR),
@@ -1809,7 +1809,7 @@ stair_region	: STAIR_ID ':' lev_region ',' lev_region ',' UP_OR_DOWN
 
 portal_region	: PORTAL_ID ':' lev_region ',' lev_region ',' STRING
 		  {
-		      add_opvars(splev, "iiiii iiiii iiso",
+		      add_opvars(splev, "lllll lllll iiso",
 				 VA_PASS14($3.x1, $3.y1, $3.x2, $3.y2, $3.area,
 					   $5.x1, $5.y1, $5.x2, $5.y2, $5.area,
 					   LR_PORTAL, 0, $7, SPO_LEVREGION));
@@ -1825,7 +1825,7 @@ teleprt_region	: TELEPRT_ID ':' lev_region ',' lev_region teleprt_detail
 		      case  0: rtyp = LR_DOWNTELE; break;
 		      case  1: rtyp = LR_UPTELE; break;
 		      }
-		      add_opvars(splev, "iiiii iiiii iiso",
+		      add_opvars(splev, "lllll lllll liso",
 				 VA_PASS14($3.x1, $3.y1, $3.x2, $3.y2, $3.area,
 					   $5.x1, $5.y1, $5.x2, $5.y2, $5.area,
 					   rtyp, 0, (char *)0, SPO_LEVREGION));
@@ -1834,7 +1834,7 @@ teleprt_region	: TELEPRT_ID ':' lev_region ',' lev_region teleprt_detail
 
 branch_region	: BRANCH_ID ':' lev_region ',' lev_region
 		  {
-		      add_opvars(splev, "iiiii iiiii iiso",
+		      add_opvars(splev, "lllll lllll liso",
 				 VA_PASS14($3.x1, $3.y1, $3.x2, $3.y2, $3.area,
 					   $5.x1, $5.y1, $5.x2, $5.y2, $5.area,
 					   (long) LR_BRANCH, 0,
@@ -1884,7 +1884,7 @@ terrain_type	: CHAR
 
 replace_terrain_detail : REPLACE_TERRAIN_ID ':' region_or_var ',' mapchar_or_var ',' mapchar_or_var ',' SPERCENT
 		  {
-		      add_opvars(splev, "io",
+		      add_opvars(splev, "lo",
 				 VA_PASS2($9, SPO_REPLACETERRAIN));
 		  }
 		;
@@ -1916,7 +1916,7 @@ region_detail	: REGION_ID ':' region_or_var ',' light_state ',' room_type optroo
 		      if (rflags == -1) rflags = (1 << 0);
 		      if (!(rflags & 1)) rt += MAXRTYPE+1;
 		      irr = ((rflags & 2) != 0);
-		      add_opvars(splev, "iiio",
+		      add_opvars(splev, "lllo",
 				 VA_PASS4((long)$5, rt, rflags, SPO_REGION));
 		      $<i>$ = (irr || (rflags & 1) || rt != OROOM);
 		      break_stmt_start();
@@ -1943,7 +1943,7 @@ region_detail_end : /* nothing */
 
 altar_detail	: ALTAR_ID ':' coord_or_var ',' alignment ',' altar_type
 		  {
-		      add_opvars(splev, "iio",
+		      add_opvars(splev, "llo",
 				 VA_PASS3((long)$7, (long)$5, SPO_ALTAR));
 		  }
 		;
@@ -1972,7 +1972,7 @@ gold_detail	: GOLD_ID ':' math_expr_var ',' coord_or_var
 
 engraving_detail: ENGRAVING_ID ':' coord_or_var ',' engraving_type ',' string_expr
 		  {
-		      add_opvars(splev, "io",
+		      add_opvars(splev, "lo",
 				 VA_PASS2((long)$5, SPO_ENGRAVING));
 		  }
 		;
@@ -1983,7 +1983,7 @@ mineralize	: MINERALIZE_ID ':' integer_or_var ',' integer_or_var ',' integer_or_
 		  }
 		| MINERALIZE_ID
 		  {
-		      add_opvars(splev, "iiiio",
+		      add_opvars(splev, "llllo",
 				 VA_PASS5(-1L, -1L, -1L, -1L, SPO_MINERALIZE));
 		  }
 		;
@@ -2366,7 +2366,7 @@ string_expr	: string_or_var                 { }
 
 math_expr_var	: INTEGER
 		  {
-		      add_opvars(splev, "i", VA_PASS1($1));
+		      add_opvars(splev, "l", VA_PASS1($1));
 		  }
 		| dice
 		  {
@@ -2374,7 +2374,7 @@ math_expr_var	: INTEGER
 		  }
 		| '(' MINUS_INTEGER ')'
 		  {
-		      add_opvars(splev, "i", VA_PASS1($2));
+		      add_opvars(splev, "l", VA_PASS1($2));
 		  }
 		| VARSTRING_INT
 		  {
@@ -2540,11 +2540,11 @@ ter_selection_x	: coord_or_var
 		  }
 		| grow_ID '(' dir_list ',' ter_selection ')'
 		  {
-		      add_opvars(splev, "io", VA_PASS2($3, SPO_SEL_GROW));
+		      add_opvars(splev, "lo", VA_PASS2($3, SPO_SEL_GROW));
 		  }
 		| filter_ID '(' SPERCENT ',' ter_selection ')'
 		  {
-		      add_opvars(splev, "iio",
+		      add_opvars(splev, "lio",
 			     VA_PASS3($3, SPOFILTER_PERCENT, SPO_SEL_FILTER));
 		  }
 		| filter_ID '(' ter_selection ',' ter_selection ')'
@@ -2568,7 +2568,7 @@ ter_selection_x	: coord_or_var
 		  }
 		| circle_ID '(' coord_or_var ',' math_expr_var ',' FILLING ')'
 		  {
-		      add_opvars(splev, "oio",
+		      add_opvars(splev, "olo",
 				 VA_PASS3(SPO_COPY, $7, SPO_SEL_ELLIPSE));
 		  }
 		| ellipse_ID '(' coord_or_var ',' math_expr_var ',' math_expr_var ')'
@@ -2577,11 +2577,11 @@ ter_selection_x	: coord_or_var
 		  }
 		| ellipse_ID '(' coord_or_var ',' math_expr_var ',' math_expr_var ',' FILLING ')'
 		  {
-		      add_opvars(splev, "io", VA_PASS2($9, SPO_SEL_ELLIPSE));
+		      add_opvars(splev, "lo", VA_PASS2($9, SPO_SEL_ELLIPSE));
 		  }
 		| gradient_ID '(' GRADIENT_TYPE ',' '(' math_expr_var '-' math_expr_var opt_limited ')' ',' coord_or_var opt_coord_or_var ')'
 		  {
-		      add_opvars(splev, "iio",
+		      add_opvars(splev, "llo",
 				 VA_PASS3($9, $3, SPO_SEL_GRADIENT));
 		  }
 		| complement_ID ter_selection_x
@@ -2613,7 +2613,7 @@ ter_selection	: ter_selection_x
 
 dice		: DICE
 		  {
-		      add_opvars(splev, "iio",
+		      add_opvars(splev, "llo",
 				 VA_PASS3($1.num, $1.die, SPO_DICE));
 		  }
 		;
@@ -2625,15 +2625,15 @@ all_integers	: MINUS_INTEGER
 
 all_ints_push	: MINUS_INTEGER
 		  {
-		      add_opvars(splev, "i", VA_PASS1($1));
+		      add_opvars(splev, "l", VA_PASS1($1));
 		  }
 		| PLUS_INTEGER
 		  {
-		      add_opvars(splev, "i", VA_PASS1($1));
+		      add_opvars(splev, "l", VA_PASS1($1));
 		  }
 		| INTEGER
 		  {
-		      add_opvars(splev, "i", VA_PASS1($1));
+		      add_opvars(splev, "l", VA_PASS1($1));
 		  }
 		| dice
 		  {


### PR DESCRIPTION
This change fixes all add_opvars calls in lev_comp.y and its Yacc output, lev_yacc.c. Most of the changes consist of changing 'i' formats to 'l'.

A separate commit bears the Clang plugin that I used to find these mismatches. You may or may not want this in your tree.