### PR TITLE
Use faster method to write characters to VGA

### DIFF
--- a/sys/msdos/portio.h
+++ b/sys/msdos/portio.h
@@ -44,6 +44,7 @@
 #define READ_ABSOLUTE_WORD(x) *(x)
 #define WRITE_ABSOLUTE(x, y) *(x) = (y)
 #define WRITE_ABSOLUTE_WORD(x, y) *(x) = (y)
+#define WRITE_ABSOLUTE_DWORD(x, y) *(x) = (y)
 #endif
 
 #if defined(__GO32__) || defined(__DJGPP__)
@@ -57,6 +58,8 @@
     _farpokeb(_go32_conventional_mem_selector(), (unsigned) x, (y))
 #define WRITE_ABSOLUTE_WORD(x, y) \
     _farpokew(_go32_conventional_mem_selector(), (unsigned) x, (y))
+#define WRITE_ABSOLUTE_DWORD(x, y) \
+    _farpokel(_go32_conventional_mem_selector(), (unsigned) x, (y))
 #endif
 
 #ifdef OBSOLETE /* old djgpp V1.x way of mapping 1st MB */
@@ -66,6 +69,7 @@
 #define READ_ABSOLUTE_WORD(x) *(x)
 #define WRITE_ABSOLUTE(x, y) *(x) = (y)
 #define WRITE_ABSOLUTE_WORD(x, y) *(x) = (y)
+#define WRITE_ABSOLUTE_DWORD(x, y) *(x) = (y)
 #endif
 #endif /* MK_PTR */
 


### PR DESCRIPTION
It was necessary, when updating the MS-DOS port for 3.6, to revise the screen-clearing and character-drawing functions, because the background color is no longer zero. But the 3.6.1 method is rather slow, using write mode 2 and a lot more calls to outportb.

outportb is expensive when running under a virtual machine, the typical use case for the MS-DOS port these days, because it traps to the hypervisor rather than actually writing to hardware.

This change restores the speed of the 3.4.3 version. The adapter is left in write mode 0. Clearing is accomplished by writing zero to planes where the background color has a zero bit, and 0xFF where  the background color has a one bit. Characters are drawn by writing 0x00, 0xFF, the font data, or the inverse of the font data, as appropriate, to each plane.

When testing, be sure to use OPTIONS=videomode:vga, because autodetect will go to VESA mode if it can.