### PR TITLE
Autopickup Exception Priority

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1893,7 +1893,7 @@ E boolean NDECL(u_handsy);
 E int FDECL(use_container, (struct obj **, int, BOOLEAN_P));
 E int FDECL(loot_mon, (struct monst *, int *, boolean *));
 E int NDECL(dotip);
-E boolean FDECL(is_autopickup_exception, (struct obj *, BOOLEAN_P));
+E struct autopickup_exception *FDECL(check_autopickup_exceptions, (struct obj *));
 E boolean FDECL(autopick_testobj, (struct obj *, BOOLEAN_P));
 
 /* ### pline.c ### */

--- a/include/flag.h
+++ b/include/flag.h
@@ -423,9 +423,12 @@ struct instance_flags {
     int wc2_statuslines;        /* default = 2, curses can handle 3 */
     int wc2_windowborders;	/* display borders on NetHack windows */
     int wc2_petattr;            /* text attributes for pet */
-    struct autopickup_exception *autopickup_exceptions[2];
+    /* VE edit: APE overhaul */
+    struct autopickup_exception *autopickup_exceptions;
+/*
 #define AP_LEAVE 0
 #define AP_GRAB 1
+*/
 #ifdef WIN32
 #define MAX_ALTKEYHANDLER 25
     char altkeyhandler[MAX_ALTKEYHANDLER];

--- a/include/flag.h
+++ b/include/flag.h
@@ -423,12 +423,7 @@ struct instance_flags {
     int wc2_statuslines;        /* default = 2, curses can handle 3 */
     int wc2_windowborders;	/* display borders on NetHack windows */
     int wc2_petattr;            /* text attributes for pet */
-    /* VE edit: APE overhaul */
     struct autopickup_exception *autopickup_exceptions;
-/*
-#define AP_LEAVE 0
-#define AP_GRAB 1
-*/
 #ifdef WIN32
 #define MAX_ALTKEYHANDLER 25
     char altkeyhandler[MAX_ALTKEYHANDLER];

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -2139,8 +2139,7 @@ int final;
                 *ocl ? "'" : "", *ocl ? ocl : "all types", *ocl ? "'" : "");
         if (flags.pickup_thrown && *ocl) /* *ocl: don't show if 'all types' */
             Strcat(buf, " plus thrown");
-        if (iflags.autopickup_exceptions[AP_GRAB]
-            || iflags.autopickup_exceptions[AP_LEAVE])
+        if (iflags.autopickup_exceptions)
             Strcat(buf, ", with exceptions");
     } else
         Strcpy(buf, "off");

--- a/src/options.c
+++ b/src/options.c
@@ -573,7 +573,6 @@ STATIC_DCL boolean FDECL(special_handling, (const char *,
 STATIC_DCL const char *FDECL(get_compopt_value, (const char *, char *));
 STATIC_DCL void FDECL(remove_autopickup_exception,
                       (struct autopickup_exception *));
-STATIC_DCL int NDECL(count_ape_maps);
 
 STATIC_DCL boolean FDECL(is_wc_option, (const char *));
 STATIC_DCL boolean FDECL(wc_supported, (const char *));
@@ -4414,7 +4413,15 @@ int nset;
 int
 count_apes(VOID_ARGS)
 {
-    return count_ape_maps();
+    int numapes = 0;
+    struct autopickup_exception *ape = iflags.autopickup_exceptions;
+
+    while (ape) {
+      numapes++;
+      ape = ape->next;
+    }
+
+    return numapes;
 }
 
 enum opt_other_enums {
@@ -5290,7 +5297,7 @@ boolean setinitial, setfromfile;
         struct autopickup_exception *ape;
 
  ape_again:
-        numapes = count_ape_maps();
+        numapes = count_apes();
         opt_idx = handle_add_list_remove("autopickup exception", numapes);
         if (opt_idx == 3) { /* done */
             return TRUE;
@@ -5891,7 +5898,7 @@ dotogglepickup()
         oc_to_str(flags.pickup_types, ocl);
         Sprintf(buf, "ON, for %s objects%s", ocl[0] ? ocl : "all",
                 (iflags.autopickup_exceptions)
-                    ? ((count_ape_maps() == 1)
+                    ? ((count_apes() == 1)
                            ? ", with one exception"
                            : ", with some exceptions")
                     : "");
@@ -5972,20 +5979,6 @@ struct autopickup_exception *whichape;
             ape = ape->next;
         }
     }
-}
-
-STATIC_OVL int
-count_ape_maps()
-{
-    int numapes = 0;
-    struct autopickup_exception *ape = iflags.autopickup_exceptions;
-
-    while (ape) {
-      numapes++;
-      ape = ape->next;
-    }
-
-    return numapes;
 }
 
 void

--- a/src/options.c
+++ b/src/options.c
@@ -573,7 +573,7 @@ STATIC_DCL boolean FDECL(special_handling, (const char *,
 STATIC_DCL const char *FDECL(get_compopt_value, (const char *, char *));
 STATIC_DCL void FDECL(remove_autopickup_exception,
                       (struct autopickup_exception *));
-STATIC_DCL int NDECL(count_ape_maps); /* VE edit: APE overhaul */
+STATIC_DCL int NDECL(count_ape_maps);
 
 STATIC_DCL boolean FDECL(is_wc_option, (const char *));
 STATIC_DCL boolean FDECL(wc_supported, (const char *));
@@ -4411,7 +4411,6 @@ int nset;
     add_menu(win, NO_GLYPH, &any, 0, 0, ATR_NONE, buf, MENU_UNSELECTED);
 }
 
-/* VE edit: APE overhaul */
 int
 count_apes(VOID_ARGS)
 {
@@ -5903,7 +5902,6 @@ dotogglepickup()
     return 0;
 }
 
-/* VE edit: APE overhaul */
 int
 add_autopickup_exception(mapping)
 const char *mapping;
@@ -5952,7 +5950,6 @@ const char *mapping;
     return 1;
 }
 
-/* VE edit: APE overhaul */
 STATIC_OVL void
 remove_autopickup_exception(whichape)
 struct autopickup_exception *whichape;
@@ -5977,7 +5974,6 @@ struct autopickup_exception *whichape;
     }
 }
 
-/* VE edit: APE overhaul */
 STATIC_OVL int
 count_ape_maps()
 {
@@ -5992,7 +5988,6 @@ count_ape_maps()
     return numapes;
 }
 
-/* VE edit: APE overhaul */
 void
 free_autopickup_exceptions()
 {

--- a/src/options.c
+++ b/src/options.c
@@ -5285,7 +5285,7 @@ boolean setinitial, setfromfile;
                 goto menucolors_again;
         }
     } else if (!strcmp("autopickup_exception", optname)) {
-        int opt_idx, pass, numapes = 0;
+        int opt_idx, numapes = 0;
         char apebuf[2 + BUFSZ]; /* so &apebuf[1] is BUFSZ long for getlin() */
         struct autopickup_exception *ape;
 

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -722,9 +722,9 @@ struct obj *obj;
         *ape = iflags.autopickup_exceptions;
     if (ape) {
         char *objdesc = makesingular(doname(obj));
-        do if (regex_match(objdesc, ape->regex)) return ape;
-        while (ape = ape->next);
+        while (ape && !regex_match(objdesc, ape->regex)) ape = ape->next;
     }
+    return ape;
 }
 
 boolean


### PR DESCRIPTION
One major limitation of the autopickup exception system is that you can't define an exception from an exception, despite both menucolors and msgtypes prioritizing rules based on the order they are defined in `.nethackrc`. This is because the "always pickup" and "never pickup" exceptions are tracked in different lists, and at runtime, when the player steps over an object, the game checks these lists seperately, with "never pickup" taking precedence. This means that if you want to pick up some but not all items matching a given expression, [you may need to write a long and kludgy list of regexes to get the behavior you want.](https://nethackwiki.com/mediawiki/index.php?title=Autopickup_exception&oldid=125825#Never_pick_up_corpses_except_lizards.2C_newts.2C_lichen.2C_wraiths.2C_and_floating_eyes)

I've edited the autopickup exception code to remove this necessity: now the exceptions are stored in one list, and conflicts between them are resolved based on their relative position in that list. Whether an exception was inclusive or exclusive was already tracked individually for each exception; I don't know why they were stored separately in the first place.  This edit makes the system both more convenient and more consistent with the semantics of menucolors and msgtypes.

With these changes, the 33 autopickup exception rules in the wiki article linked above may be replaced with the following 7 much simpler rules for the exact same effect:
```
AUTOPICKUP_EXCEPTION=">.* corpse.*"
AUTOPICKUP_EXCEPTION="<.* newt corpse.*"
AUTOPICKUP_EXCEPTION="<.* lichen corpse.*"
AUTOPICKUP_EXCEPTION="<.* lizard corpse.*"
AUTOPICKUP_EXCEPTION="<.* floating eye corpse.*"
AUTOPICKUP_EXCEPTION="<.* wraith corpse.*
AUTOPICKUP_EXCEPTION=">.*>.*"
```