### PR TITLE
Stop all forms of running when stepping over and reading engravings

### DIFF
--- a/src/engrave.c
+++ b/src/engrave.c
@@ -373,7 +373,7 @@ int x, y;
             } else
                 et = ep->engr_txt;
             You("%s: \"%s\".", (Blind) ? "feel the words" : "read", et);
-            if (context.run > 1)
+            if (context.run > 0)
                 nomul(0);
         }
     }


### PR DESCRIPTION
I have been noticing that this happens with capital-letter running
(context.run = 1), but no other forms of it. I can't think of any reason
why capital-letter running should read the engraving but not stop, while
all other forms of running should behave differently and stop. It's also
weird because the "There's some graffiti on the floor here" message is
delivered when the character is paused on top of the engraving, and the
actual engraving text appears to be delivered after the character stops
running.  Particularly so because there's no map representation of
engravings to indicate where it was encountered.

This adjusts the case that checks context.run and stops when moving over
engravings to include capital-letter running.