### PR TITLE
Allow Specification of Length of Sparkle Animation

### DIFF
--- a/dat/opthelp
+++ b/dat/opthelp
@@ -51,8 +51,6 @@ showexp        display your accumulated experience points         [FALSE]
 showrace       show yourself by your race rather than by role     [FALSE]
 silent         don't use your terminal's bell sound               [TRUE]
 sortpack       group similar kinds of objects in inventory        [TRUE]
-sparkle        display sparkly effect for resisted magical        [TRUE]
-               attacks (e.g. fire attack on fire-resistant monster)
 standout       use standout mode for --More-- on messages         [FALSE]
 status_updates update the status lines                            [TRUE]
 time           display elapsed game time, in moves                [FALSE]
@@ -179,6 +177,9 @@ scores        the parts of the score list you wish    [!own/3 top/2 around]
               to see when the game ends.  You choose a combination of
               top scores, scores around the top scores, and all of your
               own scores.
+sparkle       number of animation frames of sparkly effect for         [21]
+              resisted magical attacks (e.g. fire attack on
+              fire-resistant monster)
 suppress_alert disable various version-specific warnings about changes   []
               in game play or the user interface, such as notification given
               for the 'Q' command that quitting is now done via #quit

--- a/doc/Guidebook.tex
+++ b/doc/Guidebook.tex
@@ -3817,8 +3817,9 @@ Sort the pack contents by type when displaying inventory (default on).
 Persistent.
 %.lp
 \item[\ib{sparkle}]
-Display a sparkly effect when a monster (including yourself) is hit by an
-attack to which it is resistant (default on).  Persistent.
+Specify the length in frames of the sparkly animation the that is displayed
+when a monster (including you) is hit by an effect to which it is resistant
+(default 21). Persistent.
 %.lp
 \item[\ib{standout}]
 Boldface monsters and ``{\tt --More--}'' (default off).  Persistent.

--- a/include/flag.h
+++ b/include/flag.h
@@ -86,13 +86,13 @@ struct flag {
     char    sortloot; /* 'n'=none, 'l'=loot (pickup), 'f'=full ('l'+invent) */
 #endif
     boolean sortpack;        /* sorted inventory */
-    boolean sparkle;         /* show "resisting" special FX (Scott Bigham) */
     boolean standout;        /* use standout for --More-- */
     boolean time;            /* display elapsed 'time' */
     boolean tombstone;       /* print tombstone */
     boolean verbose;         /* max battle info */
     int end_top, end_around; /* describe desired score list */
     unsigned moonphase;
+    int sparkle;             /* number frames of sparkle animation */
     unsigned long suppress_alert;
 #define NEW_MOON 0
 #define FULL_MOON 4

--- a/src/display.c
+++ b/src/display.c
@@ -888,7 +888,7 @@ xchar x, y;
     if (!flags.sparkle)
         return;
     if (cansee(x, y)) { /* Don't see anything if can't see the location */
-        k = random() % SHIELD_COUNT; /* Start on a random frame */
+        k = rand() % SHIELD_COUNT; /* randomly select starting frame */
         for (i = 0; i < flags.sparkle; i++) {
             show_glyph(x, y,
                     cmap_to_glyph(shield_static[(k+i) % SHIELD_COUNT]));

--- a/src/display.c
+++ b/src/display.c
@@ -883,13 +883,15 @@ void
 shieldeff(x, y)
 xchar x, y;
 {
-    register int i;
+    register int i, k;
 
     if (!flags.sparkle)
         return;
     if (cansee(x, y)) { /* Don't see anything if can't see the location */
+        k = random() % SHIELD_COUNT; /* Start on a random frame */
         for (i = 0; i < flags.sparkle; i++) {
-            show_glyph(x, y, cmap_to_glyph(shield_static[i % SHIELD_COUNT]));
+            show_glyph(x, y,
+                    cmap_to_glyph(shield_static[(k+i) % SHIELD_COUNT]));
             flush_screen(1); /* make sure the glyph shows up */
             delay_output();
         }

--- a/src/display.c
+++ b/src/display.c
@@ -888,8 +888,8 @@ xchar x, y;
     if (!flags.sparkle)
         return;
     if (cansee(x, y)) { /* Don't see anything if can't see the location */
-        for (i = 0; i < SHIELD_COUNT; i++) {
-            show_glyph(x, y, cmap_to_glyph(shield_static[i]));
+        for (i = 0; i < flags.sparkle; i++) {
+            show_glyph(x, y, cmap_to_glyph(shield_static[i % SHIELD_COUNT]));
             flush_screen(1); /* make sure the glyph shows up */
             delay_output();
         }

--- a/src/explode.c
+++ b/src/explode.c
@@ -268,7 +268,7 @@ int expltype;
         curs_on_u(); /* will flush screen and output */
 
         if (any_shield && flags.sparkle) { /* simulate shield effect */
-            o = random() % SHIELD_COUNT; /* randomly select starting  frame */
+            o = rand() % SHIELD_COUNT; /* randomly select starting frame */
             for (k = 0; k < flags.sparkle; k++) {
                 for (i = 0; i < 3; i++)
                     for (j = 0; j < 3; j++) {

--- a/src/explode.c
+++ b/src/explode.c
@@ -32,7 +32,7 @@ int dam;
 char olet;
 int expltype;
 {
-    int i, j, k, damu = dam;
+    int i, j, k, o, damu = dam;
     boolean starting = 1;
     boolean visible, any_shield;
     int uhurt = 0; /* 0=unhurt, 1=items damaged, 2=you and items damaged */
@@ -268,6 +268,7 @@ int expltype;
         curs_on_u(); /* will flush screen and output */
 
         if (any_shield && flags.sparkle) { /* simulate shield effect */
+            o = random() % SHIELD_COUNT; /* randomly select starting  frame */
             for (k = 0; k < flags.sparkle; k++) {
                 for (i = 0; i < 3; i++)
                     for (j = 0; j < 3; j++) {
@@ -278,7 +279,7 @@ int expltype;
                              * will clean up the location for us later.
                              */
                             show_glyph(i + x - 1, j + y - 1,
-                                       cmap_to_glyph(shield_static[k % SHIELD_COUNT]));
+                                       cmap_to_glyph(shield_static[(o+k) % SHIELD_COUNT]));
                     }
                 curs_on_u(); /* will flush screen and output */
                 delay_output();

--- a/src/explode.c
+++ b/src/explode.c
@@ -268,7 +268,7 @@ int expltype;
         curs_on_u(); /* will flush screen and output */
 
         if (any_shield && flags.sparkle) { /* simulate shield effect */
-            for (k = 0; k < SHIELD_COUNT; k++) {
+            for (k = 0; k < flags.sparkle; k++) {
                 for (i = 0; i < 3; i++)
                     for (j = 0; j < 3; j++) {
                         if (explmask[i][j] == 1)
@@ -278,7 +278,7 @@ int expltype;
                              * will clean up the location for us later.
                              */
                             show_glyph(i + x - 1, j + y - 1,
-                                       cmap_to_glyph(shield_static[k]));
+                                       cmap_to_glyph(shield_static[k % SHIELD_COUNT]));
                     }
                 curs_on_u(); /* will flush screen and output */
                 delay_output();

--- a/src/options.c
+++ b/src/options.c
@@ -2381,7 +2381,7 @@ boolean tinitial, tfrom_file;
     if (match_optname(opts, fullname, 4, TRUE)) {
         if (duplicate)
             complain_about_duplicate(opts, 1);
-        op = string_for_opt(opts, negated);
+        op = string_for_opt(opts, TRUE);
         if ((negated && !op) || (!negated && op))
             flags.sparkle = negated ? 0 : atoi(op);
         else if (negated) {

--- a/src/options.c
+++ b/src/options.c
@@ -42,6 +42,11 @@ enum window_option_types {
 
 #define PILE_LIMIT_DFLT 5
 
+#ifndef DISPLAY_H
+#include "display.h" /* for SHIELD_COUNT */
+#endif
+#define SPARKLE_DFLT SHIELD_COUNT
+
 /*
  *  NOTE:  If you add (or delete) an option, please update the short
  *  options help (option_help()), the long options help (dat/opthelp),
@@ -212,7 +217,6 @@ static struct Bool_Opt {
     { "silent", &flags.silent, TRUE, SET_IN_GAME },
     { "softkeyboard", &iflags.wc2_softkeyboard, FALSE, SET_IN_FILE }, /*WC2*/
     { "sortpack", &flags.sortpack, TRUE, SET_IN_GAME },
-    { "sparkle", &flags.sparkle, TRUE, SET_IN_GAME },
     { "splash_screen", &iflags.wc_splash_screen, TRUE, DISP_IN_GAME }, /*WC*/
     { "standout", &flags.standout, FALSE, SET_IN_GAME },
     { "status_updates", &iflags.status_updates, TRUE, DISP_IN_GAME },
@@ -385,6 +389,9 @@ static struct Comp_Opt {
 #ifdef MSDOS
     { "soundcard", "type of sound card to use", 20, SET_IN_FILE },
 #endif
+    { "sparkle", "display this many frames of resistance animation",
+      20, SET_IN_GAME
+    },
     { "statushilites",
 #ifdef STATUS_HILITES
       "0=no status highlighting, N=show highlights for N turns",
@@ -2366,6 +2373,24 @@ boolean tinitial, tfrom_file;
             }
         } else
             return FALSE;
+        return retval;
+    }
+
+    fullname = "sparkle";
+    if (match_optname(opts, fullname, 4, TRUE)) {
+        if (duplicate)
+            complain_about_duplicate(opts, 1);
+        op = string_for_opt(opts, negated);
+        if ((negated && !op) || (!negated && op))
+            flags.sparkle = negated ? 0 : atoi(op);
+        else if (negated) {
+            bad_negation(fullname, TRUE);
+            return FALSE;
+        } else /* !op */
+            flags.sparkle = SPARKLE_DFLT;
+        /* sanity check */
+        if (flags.sparkle < 0)
+            flags.sparkle = SPARKLE_DFLT;
         return retval;
     }
 
@@ -5778,6 +5803,8 @@ char *buf;
                 Strcpy(buf, sortltype[i]);
                 break;
             }
+    } else if (!strcmp(optname, "sparkle")) {
+        Sprintf(buf, "%d", flags.sparkle);
     } else if (!strcmp(optname, "player_selection")) {
         Sprintf(buf, "%s", iflags.wc_player_selection ? "prompts" : "dialog");
 #ifdef MSDOS


### PR DESCRIPTION
Currently, the sparkle animation is either 21 or 0 frames long, with no in-between, which is silly. This PR makes the `sparkle` option accept an integer argument to specify the length in frames of the sparkle animation. Under this new definition, `OPTION=nosparkle` is equivalent to `OPTION=sparkle:0`. ~~Config files that specify the default-redundant `OPTION=sparkle` will result in a missing parameter error, but game behavior will not be changed.~~ The behavior of any config file syntactically valid as of 3.6.2 should be unchanged.