### PR TITLE
Fix pluralization of Nazgûl in rumors.tru

### DIFF
--- a/dat/rumors.tru
+++ b/dat/rumors.tru
@@ -299,7 +299,7 @@ They say that the Leprechaun King is rich as Croesus.
 They say that the Wizard of Yendor is schizophrenic and suicidal.
 They say that the experienced character knows how to convert an altar.
 They say that the gods are happy when they drop objects at your feet.
-They say that the idea of invisible Nazguls has a certain ring to it.
+They say that the idea of invisible Nazgul has a certain ring to it.
 They say that the lady of the lake now lives in a fountain somewhere.
 They say that the local shopkeeper frowns upon the rude tourist.
 They say that the only door to the vampire's tower is on its lowest level.


### PR DESCRIPTION
Pedantic fix because it showed up in my game and made me cringe: the proper plural of Nazgûl is Nazgul, not Nazguls. A quick grep shows a note in the 3.6.0 fixes list referencing this exact issue, but the rumor was missed when correcting the game's pluralization.

A few references in case there's any doubt. :-)

- http://tolkiengateway.net/wiki/Nazgûl
- https://en.wikipedia.org/wiki/Nazgûl
- https://scifi.stackexchange.com/questions/214683/are-all-ringwraiths-called-nazgûl-in-lotr