### PR TITLE
Invert symset.fallback to symset.explicit and centralize handling.

### DIFF
--- a/include/rm.h
+++ b/include/rm.h
@@ -278,7 +278,7 @@ struct symsetentry {
     Bitfield(nocolor, 1);     /* don't use color if set               */
     Bitfield(primary, 1);     /* restricted for use as primary set    */
     Bitfield(rogue, 1);       /* restricted for use as rogue lev set  */
-    Bitfield(fallback, 1);    /* no explicit symset set               */
+    Bitfield(explicitly, 1);  /* explicit symset set                  */
                               /* 4 free bits */
 };
 

--- a/src/drawing.c
+++ b/src/drawing.c
@@ -543,7 +543,6 @@ boolean name_too;
     /* initialize restriction bits */
     symset[which_set].primary = 0;
     symset[which_set].rogue = 0;
-    symset[which_set].fallback = TRUE;
 
     if (name_too) {
         if (symset[which_set].name)

--- a/src/files.c
+++ b/src/files.c
@@ -3166,9 +3166,11 @@ int which_set;
 {
     FILE *fp;
 
+    symset[which_set].explicitly = FALSE;
     if (!(fp = fopen_sym_file()))
         return 0;
 
+    symset[which_set].explicitly = TRUE;
     symset_count = 0;
     chosen_symset_start = chosen_symset_end = FALSE;
     symset_which_set = which_set;
@@ -3188,7 +3190,14 @@ int which_set;
                 || !strcmpi(symset[which_set].name, "default")))
             clear_symsetentry(which_set, TRUE);
         config_error_done();
-        return (symset[which_set].name == 0) ? 1 : 0;
+
+        /* If name was defined, it was invalid... Then we're loading fallback */
+        if (symset[which_set].name) {
+            symset[which_set].explicitly = FALSE;
+            return 0;
+        }
+
+        return 1;
     }
     if (!chosen_symset_end)
         config_error_add("Missing finish for symset \"%s\"",

--- a/src/options.c
+++ b/src/options.c
@@ -2315,7 +2315,6 @@ boolean tinitial, tfrom_file;
             } else {
                 if (!initial && Is_rogue_level(&u.uz))
                     assign_graphics(ROGUESET);
-                symset[ROGUESET].fallback = FALSE;
                 need_redraw = TRUE;
             }
         } else
@@ -2340,7 +2339,6 @@ boolean tinitial, tfrom_file;
                 return FALSE;
             } else {
                 switch_symbols(symset[PRIMARY].name != (char *) 0);
-                symset[PRIMARY].fallback = FALSE;
                 need_redraw = TRUE;
             }
         } else
@@ -6010,10 +6008,8 @@ int which_set;
 
     if (read_sym_file(which_set)) {
         switch_symbols(TRUE);
-        symset[which_set].fallback = FALSE;
     } else {
         clear_symsetentry(which_set, TRUE);
-        symset[which_set].fallback = TRUE;
         return 0;
     }
     return 1;

--- a/win/curses/cursinit.c
+++ b/win/curses/cursinit.c
@@ -785,7 +785,7 @@ curses_init_options()
     set_option_mod_status("eight_bit_tty", SET_IN_FILE);
 
     /* If we don't have a symset defined, load the curses symset by default */
-    if (symset[PRIMARY].fallback) {
+    if (!symset[PRIMARY].explicitly) {
         load_symset("curses", PRIMARY);
         load_symset("default", ROGUESET);
     }


### PR DESCRIPTION
The invert allows us to default to FALSE, which means we only need
to handle symset.explicit in a single function (read_sym_file).

This allows removing the per-case setting of it, and as a result fixes
an inconsistency where OPTIONS=DECgraphics/IBMgraphics failed to set it
correctly, causing curses to ignore the option.

Tested: result

* no symset or DEC/IBMgraphics; curses
* DECgraphics, no symset: DECgraphics
* default symset: default
* "default2" symset (invalid): curses
* DECgraphics symset: DECgraphics

Trying to load more than one symset (by using DECgraphics and symset:default, for example) will use the last entry. This also happens if the last entry is invalid and a previous one wasn't. I believe this is consistent with tty.