### PR TITLE
Keep wintty.c's maxwin up-to-date.

### DIFF
--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -1503,6 +1503,7 @@ int type;
         panic("No window slots!");
         return WIN_ERR;
     }
+    maxwin = max(newid + 1, maxwin);
 
     if (newwin->maxrow) {
         newwin->data = (char **) alloc(


### PR DESCRIPTION
Otherwise the check in https://github.com/NetHack/NetHack/blob/2172c5e7ff40ea073e2749a0f7034db9e6a7f835/win/tty/wintty.c#L1423 doesn't seem to make sense.

An alternative would be to remove both the check and  `maxwin` altogether.