### PR TITLE
curses - remove unused variable in curses_str_remainder()

### DIFF
--- a/win/curses/cursmisc.c
+++ b/win/curses/cursmisc.c
@@ -377,7 +377,6 @@ curses_str_remainder(const char *str, int width, int line_num)
     int strsize = strlen(str) + 1;
 #if __STDC_VERSION__ >= 199901L
     char substr[strsize];
-    char curstr[strsize];
     char tmpstr[strsize];
 
     strcpy(substr, str);
@@ -386,7 +385,6 @@ curses_str_remainder(const char *str, int width, int line_num)
 #define BUFSZ 256
 #endif
     char substr[BUFSZ * 2];
-    char curstr[BUFSZ * 2];
     char tmpstr[BUFSZ * 2];
 
     if (strsize > (BUFSZ * 2) - 1) {
@@ -414,11 +412,7 @@ curses_str_remainder(const char *str, int width, int line_num)
         if (last_space == 0) {  /* No spaces found */
             last_space = count - 1;
         }
-        for (count = 0; count < last_space; count++) {
-            curstr[count] = substr[count];
-        }
-        curstr[count] = '\0';
-        if (substr[count] == '\0') {
+        if (substr[last_space] == '\0') {
             break;
         }
         for (count = (last_space + 1); count < (int) strlen(substr); count++) {


### PR DESCRIPTION
I noticed a previous attempt at removing this as a larger push to silence various compiler warnings resulted in an infinite loop in the message window (the first line of a split message repeated indefinitely until ESC is pressed), so this was reverted.  The issue was that a 'for' loop which affected the value of 'count' was removed, but a subsequent check on 'substr[count]' which relied on the value of 'count' after the for loop was left in.
This PR contains the correct fix.