### PR TITLE
Fix alternate number pad interpretation only working for diagonals

### DIFF
--- a/win/curses/cursmisc.c
+++ b/win/curses/cursmisc.c
@@ -873,6 +873,9 @@ curses_convert_keys(int key)
            readchar() and stripping the value down to 0..255 yields ^G! */
         ret = C('H');
         break;
+#ifdef KEY_B1
+    case KEY_B1:
+#endif
     case KEY_LEFT:
         if (iflags.num_pad) {
             ret = '4';
@@ -880,6 +883,9 @@ curses_convert_keys(int key)
             ret = 'h';
         }
         break;
+#ifdef KEY_B3
+    case KEY_B3:
+#endif
     case KEY_RIGHT:
         if (iflags.num_pad) {
             ret = '6';
@@ -887,6 +893,9 @@ curses_convert_keys(int key)
             ret = 'l';
         }
         break;
+#ifdef KEY_A2
+    case KEY_A2:
+#endif
     case KEY_UP:
         if (iflags.num_pad) {
             ret = '8';
@@ -894,6 +903,9 @@ curses_convert_keys(int key)
             ret = 'k';
         }
         break;
+#ifdef KEY_C2
+    case KEY_C2:
+#endif
     case KEY_DOWN:
         if (iflags.num_pad) {
             ret = '2';
@@ -903,40 +915,44 @@ curses_convert_keys(int key)
         break;
 #ifdef KEY_A1
     case KEY_A1:
+#endif
+    case KEY_HOME:
         if (iflags.num_pad) {
             ret = '7';
         } else {
             ret = 'y';
         }
         break;
-#endif /* KEY_A1 */
 #ifdef KEY_A3
     case KEY_A3:
+#endif
+    case KEY_PPAGE:
         if (iflags.num_pad) {
             ret = '9';
         } else {
             ret = 'u';
         }
         break;
-#endif /* KEY_A3 */
 #ifdef KEY_C1
     case KEY_C1:
+#endif
+    case KEY_END:
         if (iflags.num_pad) {
             ret = '1';
         } else {
             ret = 'b';
         }
         break;
-#endif /* KEY_C1 */
 #ifdef KEY_C3
     case KEY_C3:
+#endif
+    case KEY_NPAGE:
         if (iflags.num_pad) {
             ret = '3';
         } else {
             ret = 'n';
         }
         break;
-#endif /* KEY_C3 */
 #ifdef KEY_B2
     case KEY_B2:
         if (iflags.num_pad) {


### PR DESCRIPTION
This fixes the issue brought up in https://www.reddit.com/r/nethack/comments/dv3pae/curses_and_the_numberpad/?st=k3hgply6&sh=dbc2bf7d .

I don't know why the "regular" (tty) method doesn't seem to work for him,
but I'm going to chalk it up to a PDCurses oddity. What I do know, however,
is that the alternate method I added a year ago or maybe longer, that allows
numpad usage even with number_pad:0 (to retain the default keybindings in case
an user is used to them, while keeping number pad behaviour making sense,
similar to NetHack4+friends) was only partially implemented, for some reason.
This adds the rest of the keys, meaning that this means of key interpretation
should be more realible. KEY_A2/B1/B3/C2 are not standard keys in the Curses
documentation, and is thus behind an ifdef -- but PDCurses, amongst other
implementations, makes use of them.

As a side effect, Home/End/PgUp/PgDn are now interpreted as diagonal movement,
since some terminals interpret number_pad keys that way. I do not consider this
a problem since they went unused in normal gameplay anyway (This does not
interfere with menus or similar).