### PR TITLE
Quiet most of the -Wcomma warnings

### DIFF
--- a/src/allmain.c
+++ b/src/allmain.c
@@ -551,7 +551,7 @@ display_gamewindows()
     WIN_INVEN = create_nhwindow(NHW_MENU);
     /* in case of early quit where WIN_INVEN could be destroyed before
        ever having been used, use it here to pacify the Qt interface */
-    start_menu(WIN_INVEN), end_menu(WIN_INVEN, (char *) 0);
+    start_menu(WIN_INVEN); end_menu(WIN_INVEN, (char *) 0);
 
 #ifdef MAC
     /* This _is_ the right place for this - maybe we will

--- a/src/apply.c
+++ b/src/apply.c
@@ -82,7 +82,7 @@ struct obj *obj;
     } else if ((mtmp = bhit(u.dx, u.dy, COLNO, FLASHED_LIGHT,
                             (int FDECL((*), (MONST_P, OBJ_P))) 0,
                             (int FDECL((*), (OBJ_P, OBJ_P))) 0, &obj)) != 0) {
-        obj->ox = u.ux, obj->oy = u.uy;
+        obj->ox = u.ux; obj->oy = u.uy;
         (void) flash_hits_mon(mtmp, obj);
     }
     return 1;
@@ -325,7 +325,7 @@ register struct obj *obj;
     context.stethoscope_move = moves;
     context.stethoscope_movement = youmonst.movement;
 
-    bhitpos.x = u.ux, bhitpos.y = u.uy; /* tentative, reset below */
+    bhitpos.x = u.ux; bhitpos.y = u.uy; /* tentative, reset below */
     notonhead = u.uswallow;
     if (u.usteed && u.dz > 0) {
         if (interference) {
@@ -374,7 +374,7 @@ register struct obj *obj;
                                    SUPPRESS_IT | SUPPRESS_INVISIBLE, FALSE);
 
         /* bhitpos needed by mstatusline() iff mtmp is a long worm */
-        bhitpos.x = rx, bhitpos.y = ry;
+        bhitpos.x = rx; bhitpos.y = ry;
         notonhead = (mtmp->mx != rx || mtmp->my != ry);
 
         if (mtmp->mundetected) {
@@ -438,7 +438,7 @@ register struct obj *obj;
         return res;
     case SCORR:
         You_hear(hollow_str, "passage");
-        lev->typ = CORR, lev->flags = 0;
+        lev->typ = CORR; lev->flags = 0;
         unblock_point(rx, ry);
         feel_newsym(rx, ry);
         return res;
@@ -509,7 +509,7 @@ struct obj *obj;
                    actually moves because line-of-sight may change */
                 if (M_AP_TYPE(mtmp))
                     seemimic(mtmp);
-                omx = mtmp->mx, omy = mtmp->my;
+                omx = mtmp->mx; omy = mtmp->my;
                 mnexto(mtmp);
                 if (mtmp->mx != omx || mtmp->my != omy) {
                     mtmp->mundetected = 0; /* reveal non-mimic hider */
@@ -1613,8 +1613,8 @@ boolean showmsg;
                 You_cant("jump diagonally out of a doorway.");
             return FALSE;
         }
-        uc.x = u.ux, uc.y = u.uy;
-        tc.x = x, tc.y = y; /* target */
+        uc.x = u.ux; uc.y = u.uy;
+        tc.x = x; tc.y = y; /* target */
         if (!walk_path(&uc, &tc, check_jump, (genericptr_t) &traj)) {
             if (showmsg)
                 There("is an obstacle preventing that jump.");
@@ -2541,7 +2541,7 @@ struct obj *otmp;
         return;
     }
     trapinfo.tobj = otmp;
-    trapinfo.tx = u.ux, trapinfo.ty = u.uy;
+    trapinfo.tx = u.ux; trapinfo.ty = u.uy;
     tmp = ACURR(A_DEX);
     trapinfo.time_needed =
         (tmp > 17) ? 2 : (tmp > 12) ? 3 : (tmp > 7) ? 4 : 5;
@@ -2920,8 +2920,8 @@ int min_range, max_range;
     impaired = (Confusion || Stunned || Hallucination);
     mpos.x = mpos.y = 0; /* no candidate location yet */
     rt = isqrt(max_range);
-    lo_x = max(u.ux - rt, 1), hi_x = min(u.ux + rt, COLNO - 1);
-    lo_y = max(u.uy - rt, 0), hi_y = min(u.uy + rt, ROWNO - 1);
+    lo_x = max(u.ux - rt, 1); hi_x = min(u.ux + rt, COLNO - 1);
+    lo_y = max(u.uy - rt, 0); hi_y = min(u.uy + rt, ROWNO - 1);
     for (x = lo_x; x <= hi_x; ++x) {
         for (y = lo_y; y <= hi_y; ++y) {
             if (distu(x, y) < min_range || distu(x, y) > max_range
@@ -2939,7 +2939,7 @@ int min_range, max_range;
                 || (glyph_is_statue(glyph) && impaired)) {
                 if (mpos.x)
                     return FALSE; /* more than one candidate location */
-                mpos.x = x, mpos.y = y;
+                mpos.x = x; mpos.y = y;
             }
         }
     }
@@ -3429,7 +3429,7 @@ struct obj *obj;
                  */
                 typ = fillholetyp(x, y, FALSE);
                 if (typ != ROOM) {
-                    levl[x][y].typ = typ, levl[x][y].flags = 0;
+                    levl[x][y].typ = typ; levl[x][y].flags = 0;
                     liquid_flow(x, y, typ, t_at(x, y),
                                 fillmsg
                                   ? (char *) 0

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -694,8 +694,9 @@ struct monst *mon;
         touch_blasted = TRUE;
         dmg = d((Antimagic ? 2 : 4), (self_willed ? 10 : 4));
         /* add half (maybe quarter) of the usual silver damage bonus */
-        if (objects[obj->otyp].oc_material == SILVER && Hate_silver)
-            tmp = rnd(10), dmg += Maybe_Half_Phys(tmp);
+        if (objects[obj->otyp].oc_material == SILVER && Hate_silver) {
+            tmp = rnd(10); dmg += Maybe_Half_Phys(tmp);
+        }
         Sprintf(buf, "touching %s", oart->name);
         losehp(dmg, buf, KILLED_BY); /* magic damage, not physical */
         exercise(A_WIS, FALSE);
@@ -1949,8 +1950,9 @@ boolean loseit;    /* whether to drop it if hero can longer touch it */
         if (!touch_blasted) {
             /* damage is somewhat arbitrary; half the usual 1d20 physical
                for silver, 1d10 magical for <foo>bane, potentially both */
-            if (ag)
-                tmp = rnd(10), dmg += Maybe_Half_Phys(tmp);
+            if (ag) {
+                tmp = rnd(10); dmg += Maybe_Half_Phys(tmp);
+            }
             if (bane)
                 dmg += rnd(10);
             Sprintf(buf, "handling %s", killer_xname(obj));

--- a/src/ball.c
+++ b/src/ball.c
@@ -1094,15 +1094,16 @@ bc_sanity_check()
 
         /* non-free chain should be under or next to the hero;
            non-free ball should be on or next to the chain or else carried */
-        cx = uchain->ox, cy = uchain->oy;
-        cdx = cx - u.ux, cdy = cy - u.uy;
-        cdx = abs(cdx), cdy = abs(cdy);
-        if (uball->where == OBJ_INVENT) /* carried(uball) */
-            bx = u.ux, by = u.uy; /* get_obj_location() */
-        else
-            bx = uball->ox, by = uball->oy;
-        bdx = bx - cx, bdy = by - cy;
-        bdx = abs(bdx), bdy = abs(bdy);
+        cx = uchain->ox; cy = uchain->oy;
+        cdx = cx - u.ux; cdy = cy - u.uy;
+        cdx = abs(cdx); cdy = abs(cdy);
+        if (uball->where == OBJ_INVENT) { /* carried(uball) */
+            bx = u.ux; by = u.uy; /* get_obj_location() */
+        } else {
+            bx = uball->ox; by = uball->oy;
+        }
+        bdx = bx - cx; bdy = by - cy;
+        bdx = abs(bdx); bdy = abs(bdy);
         if (cdx > 1 || cdy > 1 || bdx > 1 || bdy > 1)
             impossible(
                      "b&c distance: you@<%d,%d>, chain@<%d,%d>, ball@<%d,%d>",

--- a/src/bones.c
+++ b/src/bones.c
@@ -482,7 +482,7 @@ struct obj *corpse;
     resetobjs(level.buriedobjlist, FALSE);
 
     /* Hero is no longer on the map. */
-    u.ux0 = u.ux, u.uy0 = u.uy;
+    u.ux0 = u.ux; u.uy0 = u.uy;
     u.ux = u.uy = 0;
 
     /* Clear all memory from the level. */
@@ -508,7 +508,7 @@ struct obj *corpse;
     formatkiller(newbones->how, sizeof newbones->how, how, TRUE);
     Strcpy(newbones->when, yyyymmddhhmmss(when));
     /* final resting place, used to decide when bones are discovered */
-    newbones->frpx = u.ux0, newbones->frpy = u.uy0;
+    newbones->frpx = u.ux0; newbones->frpy = u.uy0;
     newbones->bonesknown = FALSE;
     /* if current character died on a bones level, the cemetery list
        will have multiple entries, most recent (this dead hero) first */

--- a/src/botl.c
+++ b/src/botl.c
@@ -983,10 +983,12 @@ status_finish()
 
     /* free memory that we alloc'd now */
     for (i = 0; i < MAXBLSTATS; ++i) {
-        if (blstats[0][i].val)
-            free((genericptr_t) blstats[0][i].val), blstats[0][i].val = 0;
-        if (blstats[1][i].val)
-            free((genericptr_t) blstats[1][i].val), blstats[1][i].val = 0;
+        if (blstats[0][i].val) {
+            free((genericptr_t) blstats[0][i].val); blstats[0][i].val = 0;
+        }
+        if (blstats[1][i].val) {
+            free((genericptr_t) blstats[1][i].val); blstats[1][i].val = 0;
+        }
 #ifdef STATUS_HILITES
         /* pointer to an entry in thresholds list; Null it out since
            that list is about to go away */
@@ -1239,7 +1241,7 @@ struct istat_s *bl, *maxbl;
         return 0;
     }
 
-    ival = 0, lval = 0L, uval = 0U, ulval = 0UL;
+    ival = 0; lval = 0L; uval = 0U; ulval = 0UL;
     anytype = bl->anytype;
     if (maxbl->a.a_void) {
         switch (anytype) {
@@ -3409,8 +3411,9 @@ choose_value:
                 hilite.rel = TXT_VALUE;
                 Strcpy(hilite.textmatch, rolelist[rv]);
             }
-            for (i = 0; i < j; i++)
-                free((genericptr_t) rolelist[i]), rolelist[i] = 0;
+            for (i = 0; i < j; i++) {
+                free((genericptr_t) rolelist[i]); rolelist[i] = 0;
+            }
             if (rv < 0)
                 goto choose_behavior;
         } else {
@@ -3752,7 +3755,7 @@ shlmenu_redo:
             status_hilites_viewall();
         else
             (void) status_hilite_menu_fld(i);
-        free((genericptr_t) picks), picks = (menu_item *) 0;
+        free((genericptr_t) picks); picks = (menu_item *) 0;
         redo = TRUE;
     }
 

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -5381,7 +5381,7 @@ int x, y;
         int dm = levl[x][y].doormask;
 
         if ((dm & (D_CLOSED | D_LOCKED))) {
-            add_herecmd_menuitem(win, doopen, "Open the door"), ++K;
+            add_herecmd_menuitem(win, doopen, "Open the door"); ++K;
             /* unfortunately there's no lknown flag for doors to
                remember the locked/unlocked state */
             key_or_pick = (carrying(SKELETON_KEY) || carrying(LOCK_PICK));
@@ -5389,26 +5389,28 @@ int x, y;
             if (key_or_pick || card) {
                 Sprintf(buf, "%sunlock the door",
                         key_or_pick ? "lock or " : "");
-                add_herecmd_menuitem(win, doapply, upstart(buf)), ++K;
+                add_herecmd_menuitem(win, doapply, upstart(buf)); ++K;
             }
             /* unfortunately there's no tknown flag for doors (or chests)
                to remember whether a trap had been found */
             add_herecmd_menuitem(win, dountrap,
-                                 "Search the door for a trap"), ++K;
+                                 "Search the door for a trap"); ++K;
             /* [what about #force?] */
-            add_herecmd_menuitem(win, dokick, "Kick the door"), ++K;
+            add_herecmd_menuitem(win, dokick, "Kick the door"); ++K;
         } else if ((dm & D_ISOPEN)) {
-            add_herecmd_menuitem(win, doclose, "Close the door"), ++K;
+            add_herecmd_menuitem(win, doclose, "Close the door"); ++K;
         }
     }
 
-    if (typ <= SCORR)
-        add_herecmd_menuitem(win, dosearch, "Search for secret doors"), ++K;
+    if (typ <= SCORR) {
+        add_herecmd_menuitem(win, dosearch, "Search for secret doors"); ++K;
+    }
 
     if ((ttmp = t_at(x, y)) != 0 && ttmp->tseen) {
-        add_herecmd_menuitem(win, doidtrap, "Examine trap"), ++K;
-        if (ttmp->ttyp != VIBRATING_SQUARE)
-            add_herecmd_menuitem(win, dountrap, "Attempt to disarm trap"), ++K;
+        add_herecmd_menuitem(win, doidtrap, "Examine trap"); ++K;
+        if (ttmp->ttyp != VIBRATING_SQUARE) {
+            add_herecmd_menuitem(win, dountrap, "Attempt to disarm trap"); ++K;
+        }
     }
 
     mtmp = m_at(x, y);
@@ -5420,10 +5422,10 @@ int x, y;
 
         if (!u.usteed) {
             Sprintf(buf, "Ride %s", mnam);
-            add_herecmd_menuitem(win, doride, buf), ++K;
+            add_herecmd_menuitem(win, doride, buf); ++K;
         }
         Sprintf(buf, "Remove saddle from %s", mnam);
-        add_herecmd_menuitem(win, doloot, buf), ++K;
+        add_herecmd_menuitem(win, doloot, buf); ++K;
     }
     if (mtmp && can_saddle(mtmp) && !which_armor(mtmp, W_SADDLE)
         && carrying(SADDLE)) {
@@ -5587,7 +5589,7 @@ int x, y, mod;
 
     if (flags.travelcmd) {
         if (abs(x) <= 1 && abs(y) <= 1) {
-            x = sgn(x), y = sgn(y);
+            x = sgn(x); y = sgn(y);
         } else {
             u.tx = u.ux + x;
             u.ty = u.uy + y;
@@ -5666,16 +5668,17 @@ int x, y, mod;
         }
     } else {
         /* convert without using floating point, allowing sloppy clicking */
-        if (x > 2 * abs(y))
-            x = 1, y = 0;
-        else if (y > 2 * abs(x))
-            x = 0, y = 1;
-        else if (x < -2 * abs(y))
-            x = -1, y = 0;
-        else if (y < -2 * abs(x))
-            x = 0, y = -1;
-        else
-            x = sgn(x), y = sgn(y);
+        if (x > 2 * abs(y)) {
+            x = 1; y = 0;
+        } else if (y > 2 * abs(x)) {
+            x = 0; y = 1;
+        } else if (x < -2 * abs(y)) {
+            x = -1; y = 0;
+        } else if (y < -2 * abs(x)) {
+            x = 0; y = -1;
+        } else {
+            x = sgn(x); y = sgn(y);
+        }
 
         if (x == 0 && y == 0) {
             /* map click on player to "rest" command */

--- a/src/dbridge.c
+++ b/src/dbridge.c
@@ -453,7 +453,7 @@ int xkill_flags, how;
             }
         }
         /* we might have crawled out of the moat to survive */
-        etmp->ex = u.ux, etmp->ey = u.uy;
+        etmp->ex = u.ux; etmp->ey = u.uy;
     } else {
         int entitycnt;
 

--- a/src/detect.c
+++ b/src/detect.c
@@ -37,9 +37,9 @@ unconstrain_map()
     boolean res = u.uinwater || u.uburied || u.uswallow;
 
     /* bring Underwater, buried, or swallowed hero to normal map */
-    iflags.save_uinwater = u.uinwater, u.uinwater = 0;
-    iflags.save_uburied  = u.uburied,  u.uburied  = 0;
-    iflags.save_uswallow = u.uswallow, u.uswallow = 0;
+    iflags.save_uinwater = u.uinwater; u.uinwater = 0;
+    iflags.save_uburied  = u.uburied;  u.uburied  = 0;
+    iflags.save_uswallow = u.uswallow; u.uswallow = 0;
 
     return res;
 }
@@ -48,9 +48,9 @@ unconstrain_map()
 STATIC_OVL void
 reconstrain_map()
 {
-    u.uinwater = iflags.save_uinwater, iflags.save_uinwater = 0;
-    u.uburied  = iflags.save_uburied,  iflags.save_uburied  = 0;
-    u.uswallow = iflags.save_uswallow, iflags.save_uswallow = 0;
+    u.uinwater = iflags.save_uinwater; iflags.save_uinwater = 0;
+    u.uburied  = iflags.save_uburied;  iflags.save_uburied  = 0;
+    u.uswallow = iflags.save_uswallow; iflags.save_uswallow = 0;
 }
 
 /* use getpos()'s 'autodescribe' to view whatever is currently shown on map */
@@ -62,7 +62,7 @@ const char *ter_explain;
     coord dummy_pos; /* don't care whether player actually picks a spot */
     boolean save_autodescribe;
 
-    dummy_pos.x = u.ux, dummy_pos.y = u.uy; /* starting spot for getpos() */
+    dummy_pos.x = u.ux; dummy_pos.y = u.uy; /* starting spot for getpos() */
     save_autodescribe = iflags.autodescribe;
     iflags.autodescribe = TRUE;
     iflags.terrainmode = ter_typ;
@@ -463,8 +463,9 @@ register struct obj *sobj;
     const char *what = confused ? something : "food";
 
     stale = clear_stale_map(oclass, 0);
-    if (u.usteed) /* some situations leave steed with stale coordinates */
-        u.usteed->mx = u.ux, u.usteed->my = u.uy;
+    if (u.usteed) { /* some situations leave steed with stale coordinates */
+        u.usteed->mx = u.ux; u.usteed->my = u.uy;
+    }
 
     for (obj = fobj; obj; obj = obj->nobj)
         if (o_in(obj, oclass)) {
@@ -642,8 +643,9 @@ int class;            /* an object class, 0 for all */
             do_dknown_of(obj);
     }
 
-    if (u.usteed)
-        u.usteed->mx = u.ux, u.usteed->my = u.uy;
+    if (u.usteed) {
+        u.usteed->mx = u.ux; u.usteed->my = u.uy;
+    }
 
     for (mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
         if (DEADMONSTER(mtmp))
@@ -939,8 +941,9 @@ struct obj *sobj; /* null if crystal ball, *scroll if gold detection scroll */
     boolean found = FALSE;
     coord cc;
 
-    if (u.usteed)
-        u.usteed->mx = u.ux, u.usteed->my = u.uy;
+    if (u.usteed) {
+        u.usteed->mx = u.ux; u.usteed->my = u.uy;
+    }
 
     /* floor/ceiling traps */
     for (ttmp = ftrap; ttmp; ttmp = ttmp->ntrap) {

--- a/src/dig.c
+++ b/src/dig.c
@@ -397,12 +397,12 @@ dig(VOID_ARGS)
             }
             if (IS_TREE(lev->typ)) {
                 digtxt = "You cut down the tree.";
-                lev->typ = ROOM, lev->flags = 0;
+                lev->typ = ROOM; lev->flags = 0;
                 if (!rn2(5))
                     (void) rnd_treefruit_at(dpx, dpy);
             } else {
                 digtxt = "You succeed in cutting away some rock.";
-                lev->typ = CORR, lev->flags = 0;
+                lev->typ = CORR; lev->flags = 0;
             }
         } else if (IS_WALL(lev->typ)) {
             if (shopedge) {
@@ -410,11 +410,11 @@ dig(VOID_ARGS)
                 dmgtxt = "damage";
             }
             if (level.flags.is_maze_lev) {
-                lev->typ = ROOM, lev->flags = 0;
+                lev->typ = ROOM; lev->flags = 0;
             } else if (level.flags.is_cavernous_lev && !in_town(dpx, dpy)) {
-                lev->typ = CORR, lev->flags = 0;
+                lev->typ = CORR; lev->flags = 0;
             } else {
-                lev->typ = DOOR, lev->doormask = D_NODOOR;
+                lev->typ = DOOR; lev->doormask = D_NODOOR;
             }
             digtxt = "You make an opening in the wall.";
         } else if (lev->typ == SDOOR) {
@@ -949,7 +949,7 @@ coord *cc;
         pline_The("grave seems unused.  Strange....");
         break;
     }
-    levl[dig_x][dig_y].typ = ROOM, levl[dig_x][dig_y].flags = 0;
+    levl[dig_x][dig_y].typ = ROOM; levl[dig_x][dig_y].flags = 0;
     del_engr_at(dig_x, dig_y);
     newsym(dig_x, dig_y);
     return;
@@ -1286,7 +1286,7 @@ register struct monst *mtmp;
         newsym(mtmp->mx, mtmp->my);
         return FALSE;
     } else if (here->typ == SCORR) {
-        here->typ = CORR, here->flags = 0;
+        here->typ = CORR; here->flags = 0;
         unblock_point(mtmp->mx, mtmp->my);
         newsym(mtmp->mx, mtmp->my);
         draft_message(FALSE); /* "You feel a draft." */
@@ -1311,19 +1311,19 @@ register struct monst *mtmp;
         if (*in_rooms(mtmp->mx, mtmp->my, SHOPBASE))
             add_damage(mtmp->mx, mtmp->my, 0L);
         if (level.flags.is_maze_lev) {
-            here->typ = ROOM, here->flags = 0;
+            here->typ = ROOM; here->flags = 0;
         } else if (level.flags.is_cavernous_lev
                    && !in_town(mtmp->mx, mtmp->my)) {
-            here->typ = CORR, here->flags = 0;
+            here->typ = CORR; here->flags = 0;
         } else {
-            here->typ = DOOR, here->doormask = D_NODOOR;
+            here->typ = DOOR; here->doormask = D_NODOOR;
         }
     } else if (IS_TREE(here->typ)) {
-        here->typ = ROOM, here->flags = 0;
+        here->typ = ROOM; here->flags = 0;
         if (pile && pile < 5)
             (void) rnd_treefruit_at(mtmp->mx, mtmp->my);
     } else {
-        here->typ = CORR, here->flags = 0;
+        here->typ = CORR; here->flags = 0;
         if (pile && pile < 5)
             (void) mksobj_at((pile == 1) ? BOULDER : ROCK, mtmp->mx, mtmp->my,
                              TRUE, FALSE);
@@ -1524,21 +1524,21 @@ zap_dig()
                         add_damage(zx, zy, SHOP_WALL_COST);
                         shopwall = TRUE;
                     }
-                    room->typ = ROOM, room->flags = 0;
+                    room->typ = ROOM; room->flags = 0;
                     unblock_point(zx, zy); /* vision */
                 } else if (!Blind)
                     pline_The("wall glows then fades.");
                 break;
             } else if (IS_TREE(room->typ)) { /* check trees before stone */
                 if (!(room->wall_info & W_NONDIGGABLE)) {
-                    room->typ = ROOM, room->flags = 0;
+                    room->typ = ROOM; room->flags = 0;
                     unblock_point(zx, zy); /* vision */
                 } else if (!Blind)
                     pline_The("tree shudders but is unharmed.");
                 break;
             } else if (room->typ == STONE || room->typ == SCORR) {
                 if (!(room->wall_info & W_NONDIGGABLE)) {
-                    room->typ = CORR, room->flags = 0;
+                    room->typ = CORR; room->flags = 0;
                     unblock_point(zx, zy); /* vision */
                 } else if (!Blind)
                     pline_The("rock glows then fades.");
@@ -1554,16 +1554,16 @@ zap_dig()
                 }
                 watch_dig((struct monst *) 0, zx, zy, TRUE);
                 if (level.flags.is_cavernous_lev && !in_town(zx, zy)) {
-                    room->typ = CORR, room->flags = 0;
+                    room->typ = CORR; room->flags = 0;
                 } else {
-                    room->typ = DOOR, room->doormask = D_NODOOR;
+                    room->typ = DOOR; room->doormask = D_NODOOR;
                 }
                 digdepth -= 2;
             } else if (IS_TREE(room->typ)) {
-                room->typ = ROOM, room->flags = 0;
+                room->typ = ROOM; room->flags = 0;
                 digdepth -= 2;
             } else { /* IS_ROCK but not IS_WALL or SDOOR */
-                room->typ = CORR, room->flags = 0;
+                room->typ = CORR; room->flags = 0;
                 digdepth--;
             }
             unblock_point(zx, zy); /* vision */
@@ -1611,7 +1611,7 @@ char *msg;
         return FALSE;
     *msg = '\0';
     room = &levl[cc->x][cc->y];
-    ltyp = room->typ, room->flags = 0;
+    ltyp = room->typ; room->flags = 0;
 
     if (is_pool(cc->x, cc->y) || is_lava(cc->x, cc->y)) {
         /* this is handled by the caller after we return FALSE */
@@ -1696,7 +1696,7 @@ schar filltyp;
         int idx;
 
         t = *trap;
-        levl[t.tx][t.ty].typ = filltyp, levl[t.tx][t.ty].flags = 0;
+        levl[t.tx][t.ty].typ = filltyp; levl[t.tx][t.ty].flags = 0;
         liquid_flow(t.tx, t.ty, filltyp, trap,
                     (t.tx == u.ux && t.ty == u.uy)
                         ? "Suddenly %s flows in from the adjacent pit!"
@@ -1973,7 +1973,7 @@ long timeout UNUSED;
     while (Has_contents(obj)) {
         /* We don't need to place contained object on the floor
            first, but we do need to update its map coordinates. */
-        obj->cobj->ox = obj->ox, obj->cobj->oy = obj->oy;
+        obj->cobj->ox = obj->ox; obj->cobj->oy = obj->oy;
         /* Everything which can be held in a container can also be
            buried, so bury_an_obj's use of obj_extract_self insures
            that Has_contents(obj) will eventually become false. */

--- a/src/do.c
+++ b/src/do.c
@@ -66,8 +66,9 @@ boolean pushing;
             if (ltyp == DRAWBRIDGE_UP) {
                 levl[rx][ry].drawbridgemask &= ~DB_UNDER; /* clear lava */
                 levl[rx][ry].drawbridgemask |= DB_FLOOR;
-            } else
-                levl[rx][ry].typ = ROOM, levl[rx][ry].flags = 0;
+            } else {
+                levl[rx][ry].typ = ROOM; levl[rx][ry].flags = 0;
+            }
 
             if (ttmp)
                 (void) delfloortrap(ttmp);
@@ -1748,10 +1749,12 @@ deferred_goto()
             pline1(dfr_post_msg);
     }
     u.utotype = 0; /* our caller keys off of this */
-    if (dfr_pre_msg)
-        free((genericptr_t) dfr_pre_msg), dfr_pre_msg = 0;
-    if (dfr_post_msg)
-        free((genericptr_t) dfr_post_msg), dfr_post_msg = 0;
+    if (dfr_pre_msg) {
+        free((genericptr_t) dfr_pre_msg); dfr_pre_msg = 0;
+    }
+    if (dfr_post_msg) {
+        free((genericptr_t) dfr_post_msg); dfr_post_msg = 0;
+    }
 }
 
 /*

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -927,7 +927,7 @@ const char *goal;
                                 }
                                 continue;
                             foundc:
-                                cx = tx, cy = ty;
+                                cx = tx; cy = ty;
                                 if (msg_given) {
                                     clear_nhwindow(WIN_MESSAGE);
                                     msg_given = FALSE;
@@ -1133,7 +1133,7 @@ do_mname()
     if (getpos(&cc, FALSE, "the monster you want to name") < 0
         || !isok(cc.x, cc.y))
         return;
-    cx = cc.x, cy = cc.y;
+    cx = cc.x; cy = cc.y;
 
     if (cx == u.ux && cy == u.uy) {
         if (u.usteed && canspotmon(u.usteed)) {
@@ -1522,7 +1522,7 @@ namefloorobj()
     struct obj *obj = 0;
     boolean fakeobj = FALSE, use_plural;
 
-    cc.x = u.ux, cc.y = u.uy;
+    cc.x = u.ux; cc.y = u.uy;
     /* "dot for under/over you" only makes sense when the cursor hasn't
        been moved off the hero's '@' yet, but there's no way to adjust
        the help text once getpos() has started */

--- a/src/dog.c
+++ b/src/dog.c
@@ -327,7 +327,7 @@ boolean with_you;
     mtmp->mstrategy |= STRAT_ARRIVE;
 
     /* make sure mnexto(rloc_to(set_apparxy())) doesn't use stale data */
-    mtmp->mux = u.ux, mtmp->muy = u.uy;
+    mtmp->mux = u.ux; mtmp->muy = u.uy;
     xyloc = mtmp->mtrack[0].x;
     xyflags = mtmp->mtrack[0].y;
     xlocale = mtmp->mtrack[1].x;
@@ -374,22 +374,22 @@ boolean with_you;
         wander = 0;
         break;
     case MIGR_WITH_HERO:
-        xlocale = u.ux, ylocale = u.uy;
+        xlocale = u.ux; ylocale = u.uy;
         break;
     case MIGR_STAIRS_UP:
-        xlocale = xupstair, ylocale = yupstair;
+        xlocale = xupstair; ylocale = yupstair;
         break;
     case MIGR_STAIRS_DOWN:
-        xlocale = xdnstair, ylocale = ydnstair;
+        xlocale = xdnstair; ylocale = ydnstair;
         break;
     case MIGR_LADDER_UP:
-        xlocale = xupladder, ylocale = yupladder;
+        xlocale = xupladder; ylocale = yupladder;
         break;
     case MIGR_LADDER_DOWN:
-        xlocale = xdnladder, ylocale = ydnladder;
+        xlocale = xdnladder; ylocale = ydnladder;
         break;
     case MIGR_SSTAIRS:
-        xlocale = sstairs.sx, ylocale = sstairs.sy;
+        xlocale = sstairs.sx; ylocale = sstairs.sy;
         break;
     case MIGR_PORTAL:
         if (In_endgame(&u.uz)) {
@@ -407,7 +407,7 @@ boolean with_you;
             if (t->ttyp == MAGIC_PORTAL)
                 break;
         if (t) {
-            xlocale = t->tx, ylocale = t->ty;
+            xlocale = t->tx; ylocale = t->ty;
             break;
         } else {
             impossible("mon_arrive: no corresponding portal?");
@@ -433,9 +433,9 @@ boolean with_you;
             coord c;
 
             /* somexy() handles irregular rooms */
-            if (somexy(&rooms[*r - ROOMOFFSET], &c))
-                xlocale = c.x, ylocale = c.y;
-            else
+            if (somexy(&rooms[*r - ROOMOFFSET], &c)) {
+                xlocale = c.x; ylocale = c.y;
+            } else
                 xlocale = ylocale = 0;
         } else { /* not in a room */
             int i, j;

--- a/src/dokick.c
+++ b/src/dokick.c
@@ -559,10 +559,12 @@ xchar x, y;
         /* you're in air, since is_pool did not match */
         range += rnd(3);
     } else {
-        if (is_ice(x, y))
-            range += rnd(3), slide = TRUE;
-        if (kickedobj->greased)
-            range += rnd(3), slide = TRUE;
+        if (is_ice(x, y)) {
+            range += rnd(3); slide = TRUE;
+        }
+        if (kickedobj->greased) {
+            range += rnd(3); slide = TRUE;
+        }
     }
 
     /* Mjollnir is magically too heavy to kick */
@@ -1649,16 +1651,16 @@ boolean near_hero;
 
         switch (where) {
         case MIGR_STAIRS_UP:
-            nx = xupstair, ny = yupstair;
+            nx = xupstair; ny = yupstair;
             break;
         case MIGR_LADDER_UP:
-            nx = xupladder, ny = yupladder;
+            nx = xupladder; ny = yupladder;
             break;
         case MIGR_SSTAIRS:
-            nx = sstairs.sx, ny = sstairs.sy;
+            nx = sstairs.sx; ny = sstairs.sy;
             break;
         case MIGR_WITH_HERO:
-            nx = u.ux, ny = u.uy;
+            nx = u.ux; ny = u.uy;
             break;
         default:
         case MIGR_RANDOM:

--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -1203,12 +1203,14 @@ int x, y;
     cliparound(u.ux, u.uy);
 #endif
     /* ridden steed always shares hero's location */
-    if (u.usteed)
-        u.usteed->mx = u.ux, u.usteed->my = u.uy;
+    if (u.usteed) {
+        u.usteed->mx = u.ux; u.usteed->my = u.uy;
+    }
     /* when changing levels, don't leave old position set with
        stale values from previous level */
-    if (!on_level(&u.uz, &u.uz0))
-        u.ux0 = u.ux, u.uy0 = u.uy;
+    if (!on_level(&u.uz, &u.uz0)) {
+        u.ux0 = u.ux; u.uy0 = u.uy;
+    }
 }
 
 /* place you on a random location when arriving on a level */
@@ -2333,7 +2335,7 @@ d_level *lev;
     (void) memset((genericptr_t) init, 0, sizeof *init);
     /* memset is fine for feature bits, flags, and rooms array;
        explicitly initialize pointers to null */
-    init->next = 0, init->br = 0, init->custom = 0;
+    init->next = 0; init->br = 0; init->custom = 0;
     init->final_resting_place = 0;
     /* lastseentyp[][] is reused for each level, so get rid of
        previous level's data */
@@ -2629,8 +2631,9 @@ recalc_mapseen()
                 /*FALLTHRU*/
             case DBWALL:
             case DRAWBRIDGE_DOWN:
-                if (Is_stronghold(&u.uz))
-                    mptr->flags.castle = 1, mptr->flags.castletune = 1;
+                if (Is_stronghold(&u.uz)) {
+                    mptr->flags.castle = 1; mptr->flags.castletune = 1;
+                }
                 break;
             default:
                 break;

--- a/src/eat.c
+++ b/src/eat.c
@@ -158,7 +158,7 @@ eatmdone(VOID_ARGS)
     if (eatmbuf) {
         if (nomovemsg == eatmbuf)
             nomovemsg = 0;
-        free((genericptr_t) eatmbuf), eatmbuf = 0;
+        free((genericptr_t) eatmbuf); eatmbuf = 0;
     }
     /* update display */
     if (U_AP_TYPE) {
@@ -1565,13 +1565,14 @@ struct obj *obj;
         const char *what, *where;
         int duration = rnd(10);
 
-        if (!Blind)
-            what = "goes", where = "dark";
-        else if (Levitation || Is_airlevel(&u.uz) || Is_waterlevel(&u.uz))
-            what = "you lose control of", where = "yourself";
-        else
-            what = "you slap against the",
+        if (!Blind) {
+            what = "goes"; where = "dark";
+        } else if (Levitation || Is_airlevel(&u.uz) || Is_waterlevel(&u.uz)) {
+            what = "you lose control of"; where = "yourself";
+        } else {
+            what = "you slap against the";
             where = (u.usteed) ? "saddle" : surface(u.ux, u.uy);
+        }
         pline_The("world spins and %s %s.", what, where);
         incr_itimeout(&HDeaf, duration);
         context.botl = TRUE;
@@ -1906,8 +1907,8 @@ int old, inc, typ;
         old -= uright->spe;
     if (uleft && uleft->otyp == typ && typ != RIN_PROTECTION)
         old -= uleft->spe;
-    absold = abs(old), absinc = abs(inc);
-    sgnold = sgn(old), sgninc = sgn(inc);
+    absold = abs(old); absinc = abs(inc);
+    sgnold = sgn(old); sgninc = sgn(inc);
 
     if (absinc == 0 || sgnold != sgninc || absold + absinc < 10) {
         ; /* use inc as-is */

--- a/src/end.c
+++ b/src/end.c
@@ -1022,20 +1022,21 @@ done_object_cleanup()
      * not being knocked down holes, but it seems better to get this
      * game over with than risk being tangled up in more and more details.
      */
-    ox = u.ux + u.dx, oy = u.uy + u.dy;
-    if (!isok(ox, oy) || !accessible(ox, oy))
-        ox = u.ux, oy = u.uy;
+    ox = u.ux + u.dx; oy = u.uy + u.dy;
+    if (!isok(ox, oy) || !accessible(ox, oy)) {
+        ox = u.ux; oy = u.uy;
+    }
     /* put thrown or kicked object on map (for bones); location might
        be incorrect (perhaps killed by divine lightning when throwing at
        a temple priest?) but this should be better than just vanishing
        (fragile stuff should be taken care of before getting here) */
     if (thrownobj && thrownobj->where == OBJ_FREE) {
         place_object(thrownobj, ox, oy);
-        stackobj(thrownobj), thrownobj = 0;
+        stackobj(thrownobj); thrownobj = 0;
     }
     if (kickedobj && kickedobj->where == OBJ_FREE) {
         place_object(kickedobj, ox, oy);
-        stackobj(kickedobj), kickedobj = 0;
+        stackobj(kickedobj); kickedobj = 0;
     }
     /* if Punished hero dies during level change or dies or quits while
        swallowed, uball and uchain will be in limbo; put them on floor
@@ -1431,15 +1432,16 @@ int how;
         wait_synch();
         free_pickinv_cache(); /* extra persistent window if perm_invent */
         if (WIN_INVEN != WIN_ERR) {
-            destroy_nhwindow(WIN_INVEN),  WIN_INVEN = WIN_ERR;
+            destroy_nhwindow(WIN_INVEN);  WIN_INVEN = WIN_ERR;
             /* precaution in case any late update_inventory() calls occur */
             iflags.perm_invent = 0;
         }
         display_nhwindow(WIN_MESSAGE, TRUE);
-        destroy_nhwindow(WIN_MAP),  WIN_MAP = WIN_ERR;
-        if (WIN_STATUS != WIN_ERR)
-            destroy_nhwindow(WIN_STATUS),  WIN_STATUS = WIN_ERR;
-        destroy_nhwindow(WIN_MESSAGE),  WIN_MESSAGE = WIN_ERR;
+        destroy_nhwindow(WIN_MAP);  WIN_MAP = WIN_ERR;
+        if (WIN_STATUS != WIN_ERR) {
+            destroy_nhwindow(WIN_STATUS);  WIN_STATUS = WIN_ERR;
+        }
+        destroy_nhwindow(WIN_MESSAGE);  WIN_MESSAGE = WIN_ERR;
 
         if (!done_stopprint || flags.tombstone)
             endwin = create_nhwindow(NHW_TEXT);
@@ -1609,8 +1611,9 @@ int how;
     dump_close_log();
     /* "So when I die, the first thing I will see in Heaven is a
      * score list?" */
-    if (have_windows && !iflags.toptenwin)
-        exit_nhwindows((char *) 0), have_windows = FALSE;
+    if (have_windows && !iflags.toptenwin) {
+        exit_nhwindows((char *) 0); have_windows = FALSE;
+    }
     topten(how, endtime);
     if (have_windows)
         exit_nhwindows((char *) 0);
@@ -1769,12 +1772,12 @@ const genericptr vptr2;
     default:
     case VANQ_MLVL_MNDX:
         /* sort by monster level */
-        mlev1 = mons[indx1].mlevel, mlev2 = mons[indx2].mlevel;
+        mlev1 = mons[indx1].mlevel; mlev2 = mons[indx2].mlevel;
         res = mlev2 - mlev1; /* mlevel high to low */
         break;
     case VANQ_MSTR_MNDX:
         /* sort by monster toughness */
-        mstr1 = mons[indx1].difficulty, mstr2 = mons[indx2].difficulty;
+        mstr1 = mons[indx1].difficulty; mstr2 = mons[indx2].difficulty;
         res = mstr2 - mstr1; /* monstr high to low */
         break;
     case VANQ_ALPHA_SEP:
@@ -1786,7 +1789,7 @@ const genericptr vptr2;
         } /* else both unique or neither unique */
         /*FALLTHRU*/
     case VANQ_ALPHA_MIX:
-        name1 = mons[indx1].mname, name2 = mons[indx2].mname;
+        name1 = mons[indx1].mname; name2 = mons[indx2].mname;
         res = strcmpi(name1, name2); /* caseblind alhpa, low to high */
         break;
     case VANQ_MCLS_HTOL:
@@ -1795,7 +1798,7 @@ const genericptr vptr2;
            if 'char' happens to be unsigned, (mlet1 - mlet2) would yield
            an inappropriate result when mlet2 is greater than mlet1,
            so force our copies (mcls1, mcls2) to be signed */
-        mcls1 = (schar) mons[indx1].mlet, mcls2 = (schar) mons[indx2].mlet;
+        mcls1 = (schar) mons[indx1].mlet; mcls2 = (schar) mons[indx2].mlet;
         /* S_ANT through S_ZRUTY correspond to lowercase monster classes,
            S_ANGEL through S_ZOMBIE correspond to uppercase, and various
            punctuation characters are used for classes beyond those */
@@ -1815,7 +1818,7 @@ const genericptr vptr2;
         }
         res = mcls1 - mcls2; /* class */
         if (res == 0) {
-            mlev1 = mons[indx1].mlevel, mlev2 = mons[indx2].mlevel;
+            mlev1 = mons[indx1].mlevel; mlev2 = mons[indx2].mlevel;
             res = mlev1 - mlev2; /* mlevel low to high */
             if (vanq_sortmode == VANQ_MCLS_HTOL)
                 res = -res; /* mlevel high to low */
@@ -1823,7 +1826,7 @@ const genericptr vptr2;
         break;
     case VANQ_COUNT_H_L:
     case VANQ_COUNT_L_H:
-        died1 = mvitals[indx1].died, died2 = mvitals[indx2].died;
+        died1 = mvitals[indx1].died; died2 = mvitals[indx2].died;
         res = died2 - died1; /* dead count high to low */
         if (vanq_sortmode == VANQ_COUNT_L_H)
             res = -res; /* dead count low to high */

--- a/src/engrave.c
+++ b/src/engrave.c
@@ -99,7 +99,7 @@ unsigned seed; /* for semi-controlled randomization */
                    supplying the same arguments later, or a pseudo-random
                    sequence by varying any of them */
                 nxt = seed % lth;
-                seed *= 31, seed %= (BUFSZ - 1);
+                seed *= 31; seed %= (BUFSZ - 1);
                 use_rubout = seed & 3;
             }
             s = &engr[nxt];
@@ -123,7 +123,7 @@ unsigned seed; /* for semi-controlled randomization */
                         if (!seed)
                             j = rn2(strlen(rubouts[i].wipeto));
                         else {
-                            seed *= 31, seed %= (BUFSZ - 1);
+                            seed *= 31; seed %= (BUFSZ - 1);
                             j = seed % (strlen(rubouts[i].wipeto));
                         }
                         *s = rubouts[i].wipeto[j];

--- a/src/exper.c
+++ b/src/exper.c
@@ -331,10 +331,11 @@ boolean gaining; /* gaining XP via potion vs setting XP for polyself */
 
     minexp = (u.ulevel == 1) ? 0L : newuexp(u.ulevel - 1);
     maxexp = newuexp(u.ulevel);
-    diff = maxexp - minexp, factor = 1L;
+    diff = maxexp - minexp; factor = 1L;
     /* make sure that `diff' is an argument which rn2() can handle */
-    while (diff >= (long) LARGEST_INT)
-        diff /= 2L, factor *= 2L;
+    while (diff >= (long) LARGEST_INT) {
+        diff /= 2L; factor *= 2L;
+    }
     result = minexp + factor * (long) rn2((int) diff);
     /* 3.4.1:  if already at level 30, add to current experience
        points rather than to threshold needed to reach the current

--- a/src/files.c
+++ b/src/files.c
@@ -3118,8 +3118,9 @@ boolean FDECL((*proc), (char *));
 
                 if (!config_error_nextline(inbuf)) {
                     rv = FALSE;
-                    if (buf)
-                        free(buf), buf = (char *) 0;
+                    if (buf) {
+                        free(buf); buf = (char *) 0;
+                    }
                     break;
                 }
 

--- a/src/fountain.c
+++ b/src/fountain.c
@@ -137,7 +137,7 @@ genericptr_t poolcnt;
         pline("Water gushes forth from the overflowing fountain!");
 
     /* Put a pool at x, y */
-    levl[x][y].typ = POOL, levl[x][y].flags = 0;
+    levl[x][y].typ = POOL; levl[x][y].flags = 0;
     /* No kelp! */
     del_engr_at(x, y);
     water_damage_chain(level.objects[x][y], TRUE);
@@ -205,7 +205,7 @@ boolean isyou;
                 return;
         }
         /* replace the fountain with ordinary floor */
-        levl[x][y].typ = ROOM, levl[x][y].flags = 0;
+        levl[x][y].typ = ROOM; levl[x][y].flags = 0;
         levl[x][y].blessedftn = 0;
         if (cansee(x, y))
             pline_The("fountain dries up!");
@@ -396,7 +396,7 @@ register struct obj *obj;
             exercise(A_WIS, TRUE);
         }
         update_inventory();
-        levl[u.ux][u.uy].typ = ROOM, levl[u.ux][u.uy].flags = 0;
+        levl[u.ux][u.uy].typ = ROOM; levl[u.ux][u.uy].flags = 0;
         newsym(u.ux, u.uy);
         level.flags.nfountains--;
         if (in_town(u.ux, u.uy))
@@ -509,7 +509,7 @@ int x, y;
     if (cansee(x, y) || (x == u.ux && y == u.uy))
         pline_The("pipes break!  Water spurts out!");
     level.flags.nsinks--;
-    levl[x][y].typ = FOUNTAIN, levl[x][y].looted = 0;
+    levl[x][y].typ = FOUNTAIN; levl[x][y].looted = 0;
     levl[x][y].blessedftn = 0;
     SET_FOUNTAIN_LOOTED(x, y);
     level.flags.nfountains++;

--- a/src/hack.c
+++ b/src/hack.c
@@ -109,7 +109,7 @@ moverock()
     register struct trap *ttmp;
     register struct monst *mtmp;
 
-    sx = u.ux + u.dx, sy = u.uy + u.dy; /* boulder starting position */
+    sx = u.ux + u.dx; sy = u.uy + u.dy; /* boulder starting position */
     while ((otmp = sobj_at(BOULDER, sx, sy)) != 0) {
         /* make sure that this boulder is visible as the top object */
         if (otmp != level.objects[sx][sy])
@@ -1281,7 +1281,7 @@ struct trap *desttrap; /* nonnull if another trap at <x,y> */
         if (anchored) {
             coord cc;
 
-            cc.x = u.ux, cc.y = u.uy;
+            cc.x = u.ux; cc.y = u.uy;
             /* can move normally within radius 1 of buried ball */
             if (buried_ball(&cc) && dist2(x, y, cc.x, cc.y) <= 2) {
                 /* ugly hack: we need to issue some message here
@@ -1795,43 +1795,47 @@ domove_core()
         /* seemimic/newsym should be done before moving hero, otherwise
            the display code will draw the hero here before we possibly
            cancel the swap below (we can ignore steed mx,my here) */
-        u.ux = u.ux0, u.uy = u.uy0;
+        u.ux = u.ux0; u.uy = u.uy0;
         mtmp->mundetected = 0;
         if (M_AP_TYPE(mtmp))
             seemimic(mtmp);
         else if (!mtmp->mtame)
             newsym(mtmp->mx, mtmp->my);
-        u.ux = mtmp->mx, u.uy = mtmp->my; /* resume swapping positions */
+        u.ux = mtmp->mx; u.uy = mtmp->my; /* resume swapping positions */
 
         if (mtmp->mtrapped && (trap = t_at(mtmp->mx, mtmp->my)) != 0
             && is_pit(trap->ttyp)
             && sobj_at(BOULDER, trap->tx, trap->ty)) {
             /* can't swap places with pet pinned in a pit by a boulder */
-            u.ux = u.ux0, u.uy = u.uy0; /* didn't move after all */
-            if (u.usteed)
-                u.usteed->mx = u.ux, u.usteed->my = u.uy;
+            u.ux = u.ux0; u.uy = u.uy0; /* didn't move after all */
+            if (u.usteed) {
+                u.usteed->mx = u.ux; u.usteed->my = u.uy;
+            }
         } else if (u.ux0 != x && u.uy0 != y && NODIAG(mtmp->data - mons)) {
             /* can't swap places when pet can't move to your spot */
-            u.ux = u.ux0, u.uy = u.uy0;
-            if (u.usteed)
-                u.usteed->mx = u.ux, u.usteed->my = u.uy;
+            u.ux = u.ux0; u.uy = u.uy0;
+            if (u.usteed) {
+                u.usteed->mx = u.ux; u.usteed->my = u.uy;
+            }
             You("stop.  %s can't move diagonally.", upstart(y_monnam(mtmp)));
         } else if (u_with_boulder
                     && !(verysmall(mtmp->data)
                          && (!mtmp->minvent || (curr_mon_load(mtmp) <= 600)))) {
             /* can't swap places when pet won't fit there with the boulder */
-            u.ux = u.ux0, u.uy = u.uy0; /* didn't move after all */
-            if (u.usteed)
-                u.usteed->mx = u.ux, u.usteed->my = u.uy;
+            u.ux = u.ux0; u.uy = u.uy0; /* didn't move after all */
+            if (u.usteed) {
+                u.usteed->mx = u.ux; u.usteed->my = u.uy;
+            }
             You("stop.  %s won't fit into the same spot that you're at.",
                  upstart(y_monnam(mtmp)));
         } else if (u.ux0 != x && u.uy0 != y && bad_rock(mtmp->data, x, u.uy0)
                    && bad_rock(mtmp->data, u.ux0, y)
                    && (bigmonst(mtmp->data) || (curr_mon_load(mtmp) > 600))) {
             /* can't swap places when pet won't fit thru the opening */
-            u.ux = u.ux0, u.uy = u.uy0; /* didn't move after all */
-            if (u.usteed)
-                u.usteed->mx = u.ux, u.usteed->my = u.uy;
+            u.ux = u.ux0; u.uy = u.uy0; /* didn't move after all */
+            if (u.usteed) {
+                u.usteed->mx = u.ux; u.usteed->my = u.uy;
+            }
             You("stop.  %s won't fit through.", upstart(y_monnam(mtmp)));
         } else {
             char pnambuf[BUFSZ];
@@ -2164,7 +2168,7 @@ boolean pick;
 
     ++inspoteffects;
     spotterrain = levl[u.ux][u.uy].typ;
-    spotloc.x = u.ux, spotloc.y = u.uy;
+    spotloc.x = u.ux; spotloc.y = u.uy;
 
     /* moving onto different terrain might cause Lev or Fly to toggle */
     if (spotterrain != levl[u.ux0][u.uy0].typ || !on_level(&u.uz, &u.uz0))

--- a/src/invent.c
+++ b/src/invent.c
@@ -79,7 +79,7 @@ struct obj *obj;
      */
     if (!Blind)
         obj->dknown = 1; /* xname(obj) does this; we want it sooner */
-    seen = obj->dknown ? TRUE : FALSE,
+    seen = obj->dknown ? TRUE : FALSE;
     /* class order */
     classorder = flags.sortpack ? flags.inv_order : def_srt_order;
     p = index(classorder, oclass);
@@ -227,7 +227,7 @@ struct obj *obj;
      * remember 'obj's current settings.
      */
     saveo.odiluted = obj->odiluted;
-    saveo.blessed = obj->blessed, saveo.cursed = obj->cursed;
+    saveo.blessed = obj->blessed; saveo.cursed = obj->cursed;
     saveo.spe = obj->spe;
     saveo.owt = obj->owt;
     save_oname = has_oname(obj) ? ONAME(obj) : 0;
@@ -236,8 +236,9 @@ struct obj *obj;
        sortloot() will deal with them using other criteria than name */
     if (obj->oclass == POTION_CLASS) {
         obj->odiluted = 0;
-        if (obj->otyp == POT_WATER)
-            obj->blessed = 0, obj->cursed = 0;
+        if (obj->otyp == POT_WATER) {
+            obj->blessed = 0; obj->cursed = 0;
+        }
     }
     /* make "wet towel" and "moist towel" format as "towel" so that all
        three group together */
@@ -268,8 +269,9 @@ struct obj *obj;
     /* restore the object */
     if (obj->oclass == POTION_CLASS) {
         obj->odiluted = saveo.odiluted;
-        if (obj->otyp == POT_WATER)
-            obj->blessed = saveo.blessed, obj->cursed = saveo.cursed;
+        if (obj->otyp == POT_WATER) {
+            obj->blessed = saveo.blessed; obj->cursed = saveo.cursed;
+        }
     }
     if (obj->otyp == TOWEL) {
         obj->spe = saveo.spe;
@@ -507,14 +509,14 @@ boolean FDECL((*filterfunc), (OBJ_P));
             && (!augment_filter || o->otyp != CORPSE
                 || !touch_petrifies(&mons[o->corpsenm])))
             continue;
-        sliarray[i].obj = o, sliarray[i].indx = (int) i;
+        sliarray[i].obj = o; sliarray[i].indx = (int) i;
         sliarray[i].str = (char *) 0;
         sliarray[i].orderclass = sliarray[i].subclass = sliarray[i].disco = 0;
         ++i;
     }
     n = i;
     /* add a terminator so that we don't have to pass 'n' back to caller */
-    sliarray[n].obj = (struct obj *) 0, sliarray[n].indx = -1;
+    sliarray[n].obj = (struct obj *) 0; sliarray[n].indx = -1;
     sliarray[n].str = (char *) 0;
     sliarray[n].orderclass = sliarray[n].subclass = sliarray[n].disco = 0;
 
@@ -525,9 +527,11 @@ boolean FDECL((*filterfunc), (OBJ_P));
         qsort((genericptr_t) sliarray, n, sizeof *sliarray, sortloot_cmp);
         sortlootmode = 0; /* reset static mode flags */
         /* if sortloot_cmp formatted any objects, discard their strings now */
-        for (i = 0; i < n; ++i)
-            if (sliarray[i].str)
-                free((genericptr_t) sliarray[i].str), sliarray[i].str = 0;
+        for (i = 0; i < n; ++i) {
+            if (sliarray[i].str) {
+                free((genericptr_t) sliarray[i].str); sliarray[i].str = 0;
+            }
+        }
     }
     return sliarray;
 }
@@ -537,8 +541,9 @@ void
 unsortloot(loot_array_p)
 Loot **loot_array_p;
 {
-    if (*loot_array_p)
-        free((genericptr_t) *loot_array_p), *loot_array_p = (Loot *) 0;
+    if (*loot_array_p) {
+        free((genericptr_t) *loot_array_p); *loot_array_p = (Loot *) 0;
+    }
 }
 
 #if 0 /* 3.6.0 'revamp' */
@@ -725,8 +730,9 @@ struct obj **potmp, **pobj;
         if (!otmp->globby)
             otmp->quan += obj->quan;
         /* temporary special case for gold objects!!!! */
-        if (otmp->oclass == COIN_CLASS)
-            otmp->owt = weight(otmp), otmp->bknown = 0;
+        if (otmp->oclass == COIN_CLASS) {
+            otmp->owt = weight(otmp); otmp->bknown = 0;
+        }
         /* and puddings!!!1!!one! */
         else if (!Is_pudding(otmp))
             otmp->owt += obj->owt;
@@ -1444,10 +1450,12 @@ register const char *let, *word;
     long dummymask;
     Loot *sortedinvent, *srtinv;
 
-    if (*let == ALLOW_COUNT)
-        let++, allowcnt = 1;
-    if (*let == COIN_CLASS)
-        let++, usegold = TRUE;
+    if (*let == ALLOW_COUNT) {
+        let++; allowcnt = 1;
+    }
+    if (*let == COIN_CLASS) {
+        let++; usegold = TRUE;
+    }
 
     /* Equivalent of an "ugly check" for gold */
     if (usegold && !strcmp(word, "eat")
@@ -1455,10 +1463,12 @@ register const char *let, *word;
             || youmonst.data == &mons[PM_RUST_MONSTER]))
         usegold = FALSE;
 
-    if (*let == ALL_CLASSES)
-        let++, allowall = TRUE;
-    if (*let == ALLOW_NONE)
-        let++, allownone = TRUE;
+    if (*let == ALL_CLASSES) {
+        let++; allowall = TRUE;
+    }
+    if (*let == ALLOW_NONE) {
+        let++; allownone = TRUE;
+    }
     /* "ugly check" for reading fortune cookies, part 1.
      * The normal 'ugly check' keeps the object on the inventory list.
      * We don't want to do that for shirts/cookies, so the check for
@@ -1473,8 +1483,9 @@ register const char *let, *word;
         && throws_rocks(youmonst.data))
         useboulder = TRUE;
 
-    if (allownone)
-        *bp++ = HANDS_SYM, *bp++ = ' '; /* '-' */
+    if (allownone) {
+        *bp++ = HANDS_SYM; *bp++ = ' '; /* '-' */
+    }
     ap = altlets;
 
     if (!flags.invlet_constant)
@@ -3324,8 +3335,9 @@ char *buf;
             break; /* "closed door" */
         }
         /* override door description for open drawbridge */
-        if (is_drawbridge_wall(x, y) >= 0)
-            dfeature = "open drawbridge portcullis", cmap = -1;
+        if (is_drawbridge_wall(x, y) >= 0) {
+            dfeature = "open drawbridge portcullis"; cmap = -1;
+        }
     } else if (IS_FOUNTAIN(ltyp))
         cmap = S_fountain; /* "fountain" */
     else if (IS_THRONE(ltyp))
@@ -3968,8 +3980,9 @@ boolean unpaid, showsym;
 void
 free_invbuf()
 {
-    if (invbuf)
-        free((genericptr_t) invbuf), invbuf = (char *) 0;
+    if (invbuf) {
+        free((genericptr_t) invbuf); invbuf = (char *) 0;
+    }
     invbufsiz = 0;
 }
 
@@ -4227,8 +4240,9 @@ doorganize() /* inventory organizer by Del Lamb */
                         ONAME(obj) = objname;
                 } else {
                     /* will merge; discard 'from' name */
-                    if (objname)
-                        free((genericptr_t) objname), objname = 0;
+                    if (objname) {
+                        free((genericptr_t) objname); objname = 0;
+                    }
                 }
 
                 if (merged(&otmp, &obj)) {

--- a/src/lock.c
+++ b/src/lock.c
@@ -388,14 +388,15 @@ struct obj *pick;
                     return PICKLOCK_LEARNED_SOMETHING;
                 }
                 it = 0;
-                if (otmp->obroken)
+                if (otmp->obroken) {
                     verb = "fix";
-                else if (!otmp->olocked)
-                    verb = "lock", it = 1;
-                else if (picktyp != LOCK_PICK)
-                    verb = "unlock", it = 1;
-                else
+                } else if (!otmp->olocked) {
+                    verb = "lock"; it = 1;
+                } else if (picktyp != LOCK_PICK) {
+                    verb = "unlock"; it = 1;
+                } else {
                     verb = "pick";
+                }
 
                 /* "There is <a box> here; <verb> <it|its lock>?" */
                 Sprintf(qsfx, " here; %s %s?", verb, it ? "it" : "its lock");
@@ -968,7 +969,7 @@ int x, y;
                 return FALSE;
             }
             block_point(x, y);
-            door->typ = SDOOR, door->doormask = D_NODOOR;
+            door->typ = SDOOR; door->doormask = D_NODOOR;
             if (vis)
                 pline_The("doorway vanishes!");
             newsym(x, y);

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -1449,11 +1449,12 @@ boolean neverask;
             } else
                 ask = FALSE; /* ESC will shut off prompting */
         }
-        x = u.ux, y = u.uy;
+        x = u.ux; y = u.uy;
         /* if in water, try to encourage an aquatic monster
            by finding and then specifying another wet location */
-        if (!mptr && u.uinwater && enexto(&c, x, y, &mons[PM_GIANT_EEL]))
-            x = c.x, y = c.y;
+        if (!mptr && u.uinwater && enexto(&c, x, y, &mons[PM_GIANT_EEL])) {
+            x = c.x; y = c.y;
+        }
 
         mon = makemon(mptr, x, y, NO_MM_FLAGS);
         if (mon && canspotmon(mon))

--- a/src/mhitm.c
+++ b/src/mhitm.c
@@ -199,9 +199,9 @@ boolean quietly;
     /* sanity checks; could matter if we unexpectedly get a long worm */
     if (!magr || !mdef || magr == mdef)
         return MM_MISS;
-    pa = magr->data, pd = mdef->data;
-    tx = mdef->mx, ty = mdef->my; /* destination */
-    fx = magr->mx, fy = magr->my; /* current location */
+    pa = magr->data; pd = mdef->data;
+    tx = mdef->mx; ty = mdef->my; /* destination */
+    fx = magr->mx; fy = magr->my; /* current location */
     if (m_at(fx, fy) != magr || m_at(tx, ty) != mdef)
         return MM_MISS;
 
@@ -714,9 +714,10 @@ struct monst *magr, *mdef;
     /* don't swallow something in a spot where attacker wouldn't
        otherwise be able to move onto; we don't want to engulf
        a wall-phaser and end up with a non-phaser inside a wall */
-    dx = mdef->mx, dy = mdef->my;
-    if (mdef == &youmonst)
-        dx = u.ux, dy = u.uy;
+    dx = mdef->mx; dy = mdef->my;
+    if (mdef == &youmonst) {
+        dx = u.ux; dy = u.uy;
+    }
     lev = &levl[dx][dy];
     if (IS_ROCK(lev->typ) || closed_door(dx, dy) || IS_TREE(lev->typ)
         /* not passes_bars(); engulfer isn't squeezing through */

--- a/src/mhitu.c
+++ b/src/mhitu.c
@@ -1879,10 +1879,12 @@ struct attack *mattk;
     if (Punished) {
         /* ball&chain are in limbo while swallowed; update their internal
            location to be at swallower's spot */
-        if (uchain->where == OBJ_FREE)
-            uchain->ox = mtmp->mx, uchain->oy = mtmp->my;
-        if (uball->where == OBJ_FREE)
-            uball->ox = mtmp->mx, uball->oy = mtmp->my;
+        if (uchain->where == OBJ_FREE) {
+            uchain->ox = mtmp->mx; uchain->oy = mtmp->my;
+        }
+        if (uball->where == OBJ_FREE) {
+            uball->ox = mtmp->mx; uball->oy = mtmp->my;
+        }
     }
     if (u.uswldtim > 0)
         u.uswldtim -= 1;

--- a/src/mklev.c
+++ b/src/mklev.c
@@ -958,7 +958,7 @@ boolean skip_lvl_checks;
                        && levl[x - 1][y + 1].typ == STONE) {
                 if (rn2(1000) < goldprob) {
                     if ((otmp = mksobj(GOLD_PIECE, FALSE, FALSE)) != 0) {
-                        otmp->ox = x, otmp->oy = y;
+                        otmp->ox = x; otmp->oy = y;
                         otmp->quan = 1L + rnd(goldprob * 3);
                         otmp->owt = weight(otmp);
                         if (!rn2(3))
@@ -973,7 +973,7 @@ boolean skip_lvl_checks;
                             if (otmp->otyp == ROCK) {
                                 dealloc_obj(otmp); /* discard it */
                             } else {
-                                otmp->ox = x, otmp->oy = y;
+                                otmp->ox = x; otmp->oy = y;
                                 if (!rn2(3))
                                     add_to_buried(otmp);
                                 else
@@ -1669,7 +1669,7 @@ struct mkroom *croom;
 
         gold->quan = (long) (rnd(20) + level_difficulty() * rnd(5));
         gold->owt = weight(gold);
-        gold->ox = m.x, gold->oy = m.y;
+        gold->ox = m.x; gold->oy = m.y;
         add_to_buried(gold);
     }
     for (tryct = rn2(5); tryct; tryct--) {

--- a/src/mkmaze.c
+++ b/src/mkmaze.c
@@ -415,10 +415,11 @@ baalz_fixup()
         for (y = bughack.inarea.y1; y <= bughack.inarea.y2; ++y)
             if (levl[x][y].typ == POOL) {
                 levl[x][y].typ = HWALL;
-                if (bughack.delarea.x1 == COLNO)
-                    bughack.delarea.x1 = x, bughack.delarea.y1 = y;
-                else
-                    bughack.delarea.x2 = x, bughack.delarea.y2 = y;
+                if (bughack.delarea.x1 == COLNO) {
+                    bughack.delarea.x1 = x; bughack.delarea.y1 = y;
+                } else {
+                    bughack.delarea.x2 = x; bughack.delarea.y2 = y;
+                }
             } else if (levl[x][y].typ == IRONBARS) {
                 /* novelty effect; allowing digging in front of 'eyes' */
                 levl[x - 1][y].wall_info &= ~W_NONDIGGABLE;
@@ -434,7 +435,7 @@ baalz_fixup()
     /* bughack hack for rear-most legs on baalz level; first joint on
        both top and bottom gets a bogus extra connection to room area,
        producing unwanted rectangles; change back to separated legs */
-    x = bughack.delarea.x1, y = bughack.delarea.y1;
+    x = bughack.delarea.x1; y = bughack.delarea.y1;
     if (isok(x, y) && levl[x][y].typ == TLWALL
         && isok(x, y + 1) && levl[x][y + 1].typ == TUWALL) {
         levl[x][y].typ = BRCORNER;
@@ -442,7 +443,7 @@ baalz_fixup()
         if ((mtmp = m_at(x, y)) != 0) /* something at temporary pool... */
             (void) rloc(mtmp, FALSE);
     }
-    x = bughack.delarea.x2, y = bughack.delarea.y2;
+    x = bughack.delarea.x2; y = bughack.delarea.y2;
     if (isok(x, y) && levl[x][y].typ == TLWALL
         && isok(x, y - 1) && levl[x][y - 1].typ == TDWALL) {
         levl[x][y].typ = TRCORNER;
@@ -530,8 +531,9 @@ fixup_special()
             break;
         }
 
-        if (r->rname.str)
-            free((genericptr_t) r->rname.str), r->rname.str = 0;
+        if (r->rname.str) {
+            free((genericptr_t) r->rname.str); r->rname.str = 0;
+        }
     }
 
     /* place dungeon branch if not placed above */
@@ -614,8 +616,9 @@ fixup_special()
        stolen_booty();
     }
 
-    if (lregions)
-        free((genericptr_t) lregions), lregions = 0;
+    if (lregions) {
+        free((genericptr_t) lregions); lregions = 0;
+    }
     num_lregions = 0;
 }
 

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -718,8 +718,9 @@ int alter_type;
     } else {
         /* this get_obj_location shouldn't fail, but if it does,
            use hero's location */
-        if (!get_obj_location(obj, &ox, &oy, CONTAINED_TOO))
-            ox = u.ux, oy = u.uy;
+        if (!get_obj_location(obj, &ox, &oy, CONTAINED_TOO)) {
+            ox = u.ux; oy = u.uy;
+        }
         if (!costly_spot(ox, oy))
             return;
         objroom = *in_rooms(ox, oy, SHOPBASE);
@@ -728,10 +729,11 @@ int alter_type;
             return;
     }
 
-    if (obj->quan == 1L)
-        those = "that", them = "it";
-    else
-        those = "those", them = "them";
+    if (obj->quan == 1L) {
+        those = "that"; them = "it";
+    } else {
+        those = "those"; them = "them";
+    }
 
     /* when shopkeeper describes the object as being uncursed or unblessed
        hero will know that it is now uncursed; will also make the feedback
@@ -1942,8 +1944,9 @@ struct monst *mtmp;
         obj_extract_self(otmp);
         if (otmp->owornmask) {
             if (keeping_mon) {
-                if (otmp == mwep)
-                    mwepgone(mtmp), mwep = 0;
+                if (otmp == mwep) {
+                    mwepgone(mtmp); mwep = 0;
+                }
                 mtmp->misc_worn_check &= ~otmp->owornmask;
                 update_mon_intrinsics(mtmp, otmp, FALSE, TRUE);
             }
@@ -2604,8 +2607,9 @@ struct obj *obj;
         embedded = TRUE;
         if ((owornmask & (W_ARM | I_SPECIAL)) == (W_ARM | I_SPECIAL))
             owornmask &= ~I_SPECIAL;
-        else
-            n = 0,  owornmask = ~0; /* force insane_object("bogus") below */
+        else {
+            n = 0;  owornmask = ~0; /* force insane_object("bogus") below */
+        }
     }
     if (n == 2 && carried(obj)
         && obj == uball && (owornmask & W_BALL) != 0L
@@ -2911,12 +2915,14 @@ struct obj **obj1, **obj2;
             if (!(otmp2->where == OBJ_FLOOR && otmp1->where == OBJ_FREE)
                 && (otmp1->owt > otmp2->owt
                     || (otmp1->owt == otmp2->owt && rn2(2)))) {
-                if (otmp2->where == OBJ_FLOOR)
-                    ox = otmp2->ox, oy = otmp2->oy;
+                if (otmp2->where == OBJ_FLOOR) {
+                    ox = otmp2->ox; oy = otmp2->oy;
+                }
                 result = obj_absorb(obj1, obj2);
             } else {
-                if (otmp1->where == OBJ_FLOOR)
-                    ox = otmp1->ox, oy = otmp1->oy;
+                if (otmp1->where == OBJ_FLOOR) {
+                    ox = otmp1->ox; oy = otmp1->oy;
+                }
                 result = obj_absorb(obj2, obj1);
             }
             /* callers really ought to take care of this; glob melding is

--- a/src/mon.c
+++ b/src/mon.c
@@ -99,7 +99,7 @@ mon_sanity_check()
         if (DEADMONSTER(mtmp) && !mtmp->isgd)
             continue;
 
-        x = mtmp->mx, y = mtmp->my;
+        x = mtmp->mx; y = mtmp->my;
         if (!isok(x, y) && !(mtmp->isgd && x == 0 && y == 0)) {
             impossible("mon (%s) claims to be at <%d,%d>?",
                        fmt_ptr((genericptr_t) mtmp), x, y);
@@ -3275,8 +3275,9 @@ boolean construct;
                       n * sizeof *animal_list);
         animal_list_count = n;
     } else { /* release */
-        if (animal_list)
-            free((genericptr_t) animal_list), animal_list = 0;
+        if (animal_list) {
+            free((genericptr_t) animal_list); animal_list = 0;
+        }
         animal_list_count = 0;
     }
 }

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -1262,7 +1262,7 @@ register int after;
         if (mmoved == 1) {
             /* normal monster move will already have <nix,niy>,
                but pet dog_move() with 'goto postmov' won't */
-            nix = mtmp->mx, niy = mtmp->my;
+            nix = mtmp->mx; niy = mtmp->my;
             /* sequencing issue:  when monster movement decides that a
                monster can move to a door location, it moves the monster
                there before dealing with the door rather than after;
@@ -1281,7 +1281,7 @@ register int after;
                 if (sawmon) {
                     remove_monster(nix, niy);
                     place_monster(mtmp, omx, omy);
-                    newsym(nix, niy), newsym(omx, omy);
+                    newsym(nix, niy); newsym(omx, omy);
                 }
                 if (vamp_shift(mtmp, &mons[PM_FOG_CLOUD], sawmon)) {
                     ptr = mtmp->data; /* update cached value */
@@ -1289,7 +1289,7 @@ register int after;
                 if (sawmon) {
                     remove_monster(omx, omy);
                     place_monster(mtmp, nix, niy);
-                    newsym(omx, omy), newsym(nix, niy);
+                    newsym(omx, omy); newsym(nix, niy);
                 }
             }
 

--- a/src/mthrowu.c
+++ b/src/mthrowu.c
@@ -1060,11 +1060,11 @@ int boulderhandling; /* 0=block, 1=ignore, 2=conditionally block */
            if that lack of sight is due solely to boulders */
         if (boulderhandling == 0)
             return FALSE;
-        dx = sgn(ax - bx), dy = sgn(ay - by);
+        dx = sgn(ax - bx); dy = sgn(ay - by);
         boulderspots = 0;
         do {
             /* <bx,by> is guaranteed to eventually converge with <ax,ay> */
-            bx += dx, by += dy;
+            bx += dx; by += dy;
             if (IS_ROCK(levl[bx][by].typ) || closed_door(bx, by))
                 return FALSE;
             if (sobj_at(BOULDER, bx, by))

--- a/src/muse.c
+++ b/src/muse.c
@@ -442,17 +442,17 @@ struct monst *mtmp;
         for (i = 0; i < 10; ++i) /* 10: 9 spots plus sentinel */
             locs[i][0] = locs[i][1] = 0;
         /* collect viable spots; monster's <mx,my> comes first */
-        locs[0][0] = x, locs[0][1] = y;
+        locs[0][0] = x; locs[0][1] = y;
         i = 1;
         for (xx = x - 1; xx <= x + 1; xx++)
             for (yy = y - 1; yy <= y + 1; yy++)
                 if (isok(xx, yy) && (xx != x || yy != y)) {
-                    locs[i][0] = xx, locs[i][1] = yy;
+                    locs[i][0] = xx; locs[i][1] = yy;
                     ++i;
                 }
         /* look for a suitable trap among the viable spots */
         for (i = 0; i < 10; ++i) {
-            xx = locs[i][0], yy = locs[i][1];
+            xx = locs[i][0]; yy = locs[i][1];
             if (!xx)
                 break; /* we've run out of spots */
             /* skip if it's hero's location
@@ -2410,7 +2410,7 @@ boolean by_you;
                 for (y = mon->my - 1; y <= mon->my + 1; ++y)
                     if (isok(x, y) && accessible(x, y)
                         && !m_at(x, y) && (x != u.ux || y != u.uy)) {
-                        xy[0][nxy] = x, xy[1][nxy] = y;
+                        xy[0][nxy] = x; xy[1][nxy] = y;
                         ++nxy;
                     }
             for (idx = 0; idx < nxy; ++idx) {

--- a/src/o_init.c
+++ b/src/o_init.c
@@ -195,14 +195,15 @@ int *lo_p, *hi_p; /* output: range that item belongs among */
 
     switch (ocls) {
     case ARMOR_CLASS:
-        if (otyp >= HELMET && otyp <= HELM_OF_TELEPATHY)
-            *lo_p = HELMET, *hi_p = HELM_OF_TELEPATHY;
-        else if (otyp >= LEATHER_GLOVES && otyp <= GAUNTLETS_OF_DEXTERITY)
-            *lo_p = LEATHER_GLOVES, *hi_p = GAUNTLETS_OF_DEXTERITY;
-        else if (otyp >= CLOAK_OF_PROTECTION && otyp <= CLOAK_OF_DISPLACEMENT)
-            *lo_p = CLOAK_OF_PROTECTION, *hi_p = CLOAK_OF_DISPLACEMENT;
-        else if (otyp >= SPEED_BOOTS && otyp <= LEVITATION_BOOTS)
-            *lo_p = SPEED_BOOTS, *hi_p = LEVITATION_BOOTS;
+        if (otyp >= HELMET && otyp <= HELM_OF_TELEPATHY) {
+            *lo_p = HELMET; *hi_p = HELM_OF_TELEPATHY;
+        } else if (otyp >= LEATHER_GLOVES && otyp <= GAUNTLETS_OF_DEXTERITY) {
+            *lo_p = LEATHER_GLOVES; *hi_p = GAUNTLETS_OF_DEXTERITY;
+        } else if (otyp >= CLOAK_OF_PROTECTION && otyp <= CLOAK_OF_DISPLACEMENT) {
+            *lo_p = CLOAK_OF_PROTECTION; *hi_p = CLOAK_OF_DISPLACEMENT;
+        } else if (otyp >= SPEED_BOOTS && otyp <= LEVITATION_BOOTS){
+            *lo_p = SPEED_BOOTS; *hi_p = LEVITATION_BOOTS;
+        }
         break;
     case POTION_CLASS:
         /* potion of water has the only fixed description */

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -3042,11 +3042,11 @@ struct obj *no_wish;
             trapped = 2; /* not trapped */
         /* locked, unlocked, broken: box/chest lock states */
         } else if (!strncmpi(bp, "locked ", l = 7)) {
-            locked = 1, unlocked = broken = 0;
+            locked = 1; unlocked = broken = 0;
         } else if (!strncmpi(bp, "unlocked ", l = 9)) {
-            unlocked = 1, locked = broken = 0;
+            unlocked = 1; locked = broken = 0;
         } else if (!strncmpi(bp, "broken ", l = 7)) {
-            broken = 1, locked = unlocked = 0;
+            broken = 1; locked = unlocked = 0;
         } else if (!strncmpi(bp, "greased ", l = 8)) {
             isgreased = 1;
         } else if (!strncmpi(bp, "very ", l = 5)) {
@@ -3243,7 +3243,7 @@ struct obj *no_wish;
         mntmp = NON_PM; /* not useful for "glob of <foo>" object lookup */
         cnt = 0; /* globs don't stack */
         oclass = FOOD_CLASS;
-        actualn = bp, dn = 0;
+        actualn = bp; dn = 0;
         goto srch;
     } else {
         /*
@@ -3832,7 +3832,7 @@ struct obj *no_wish;
      * Create the object, then fine-tune it.
      */
     otmp = typ ? mksobj(typ, TRUE, FALSE) : mkobj(oclass, FALSE);
-    typ = otmp->otyp, oclass = otmp->oclass; /* what we actually got */
+    typ = otmp->otyp; oclass = otmp->oclass; /* what we actually got */
 
     if (islit && (typ == OIL_LAMP || typ == MAGIC_LAMP || typ == BRASS_LANTERN
                   || Is_candle(otmp) || typ == POT_OIL)) {
@@ -4038,11 +4038,11 @@ struct obj *no_wish;
     /* set locked/unlocked/broken */
     if (Is_box(otmp)) {
         if (locked) {
-            otmp->olocked = 1, otmp->obroken = 0;
+            otmp->olocked = 1; otmp->obroken = 0;
         } else if (unlocked) {
-            otmp->olocked = 0, otmp->obroken = 0;
+            otmp->olocked = 0; otmp->obroken = 0;
         } else if (broken) {
-            otmp->olocked = 0, otmp->obroken = 1;
+            otmp->olocked = 0; otmp->obroken = 1;
         }
     }
 

--- a/src/options.c
+++ b/src/options.c
@@ -3103,9 +3103,9 @@ boolean tinitial, tfrom_file;
             wizard = discover = FALSE;
         } else if (!strncmpi(op, "explore", 6)
                    || !strncmpi(op, "discovery", 6)) {
-            wizard = FALSE, discover = TRUE;
+            wizard = FALSE; discover = TRUE;
         } else if (!strncmpi(op, "debug", 5) || !strncmpi(op, "wizard", 6)) {
-            wizard = TRUE, discover = FALSE;
+            wizard = TRUE; discover = FALSE;
         } else {
             config_error_add("Invalid value for \"%s\":%s", fullname, op);
             return FALSE;
@@ -4667,7 +4667,7 @@ doset() /* changing options via menu by Per Liboriussen */
                     preference_update(compopt[opt_indx].name);
             }
         }
-        free((genericptr_t) pick_list), pick_list = (menu_item *) 0;
+        free((genericptr_t) pick_list); pick_list = (menu_item *) 0;
     }
 
     destroy_nhwindow(tmpwin);
@@ -5217,7 +5217,7 @@ boolean setinitial, setfromfile;
                 for (pick_idx = 0; pick_idx < pick_cnt; ++pick_idx)
                     free_one_msgtype(pick_list[pick_idx].item.a_int - 1
                                            - pick_idx);
-                free((genericptr_t) pick_list), pick_list = (menu_item *) 0;
+                free((genericptr_t) pick_list); pick_list = (menu_item *) 0;
             }
             destroy_nhwindow(tmpwin);
             if (pick_cnt >= 0)
@@ -5306,7 +5306,7 @@ boolean setinitial, setfromfile;
                 for (pick_idx = 0; pick_idx < pick_cnt; ++pick_idx)
                     free_one_menu_coloring(pick_list[pick_idx].item.a_int - 1
                                            - pick_idx);
-                free((genericptr_t) pick_list), pick_list = (menu_item *) 0;
+                free((genericptr_t) pick_list); pick_list = (menu_item *) 0;
             }
             destroy_nhwindow(tmpwin);
             if (pick_cnt >= 0)
@@ -5374,7 +5374,7 @@ boolean setinitial, setfromfile;
                     remove_autopickup_exception(
                                          (struct autopickup_exception *)
                                              pick_list[pick_idx].item.a_void);
-                free((genericptr_t) pick_list), pick_list = (menu_item *) 0;
+                free((genericptr_t) pick_list); pick_list = (menu_item *) 0;
             }
             destroy_nhwindow(tmpwin);
             if (pick_cnt >= 0)
@@ -5512,10 +5512,12 @@ boolean setinitial, setfromfile;
         /* clean up */
         while ((sl = symset_list) != 0) {
             symset_list = sl->next;
-            if (sl->name)
-                free((genericptr_t) sl->name), sl->name = (char *) 0;
-            if (sl->desc)
-                free((genericptr_t) sl->desc), sl->desc = (char *) 0;
+            if (sl->name) {
+                free((genericptr_t) sl->name); sl->name = (char *) 0;
+            }
+            if (sl->desc) {
+                free((genericptr_t) sl->desc); sl->desc = (char *) 0;
+            }
             free((genericptr_t) sl);
         }
 
@@ -6287,7 +6289,7 @@ const char *str;
         Strcat(buf, ", ");
     } else {
         putstr(datawin, 0, str);
-        free((genericptr_t) buf), buf = 0;
+        free((genericptr_t) buf); buf = 0;
     }
     return;
 }

--- a/src/pager.c
+++ b/src/pager.c
@@ -207,7 +207,7 @@ struct obj **obj_p;
             otmp->leashmon = 0;
         /* extra fields needed for shop price with doname() formatting */
         otmp->where = OBJ_FLOOR;
-        otmp->ox = x, otmp->oy = y;
+        otmp->ox = x; otmp->oy = y;
         otmp->no_charge = (otmp->otyp == STRANGE_OBJECT && costly_spot(x, y));
     }
     /* if located at adjacent spot, mark it as having been seen up close
@@ -246,7 +246,7 @@ int x, y, glyph;
                      : obj_descr[STRANGE_OBJECT].oc_name);
         if (fakeobj) {
             otmp->where = OBJ_FREE; /* object_from_map set it to OBJ_FLOOR */
-            dealloc_obj(otmp), otmp = 0;
+            dealloc_obj(otmp); otmp = 0;
         }
     } else
         Strcpy(buf, something); /* sanity precaution */
@@ -790,7 +790,7 @@ char *supplemental_name;
                         putstr(datawin, 0, buf + 1);
                     }
                     display_nhwindow(datawin, FALSE);
-                    destroy_nhwindow(datawin), datawin = WIN_ERR;
+                    destroy_nhwindow(datawin); datawin = WIN_ERR;
                 }
             } else if (user_typed_name && pass == 0 && !pass1found_in_file)
                 pline("I don't have any information on those things.");
@@ -1521,7 +1521,7 @@ boolean without_asking;
                     putstr(datawin, 0, txt);
                 }
                 display_nhwindow(datawin, FALSE);
-                destroy_nhwindow(datawin), datawin = WIN_ERR;
+                destroy_nhwindow(datawin); datawin = WIN_ERR;
             }
         }
     }

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -110,8 +110,9 @@ int *itemcount;
     ilets[iletct] = '\0'; /* terminate ilets so that index() will work */
     while (otmp) {
         c = def_oc_syms[(int) otmp->oclass].sym;
-        if (!index(ilets, c) && (!filter || (*filter)(otmp)))
-            ilets[iletct++] = c, ilets[iletct] = '\0';
+        if (!index(ilets, c) && (!filter || (*filter)(otmp))) {
+            ilets[iletct++] = c; ilets[iletct] = '\0';
+        }
         *itemcount += 1;
         otmp = here ? otmp->nexthere : otmp->nobj;
     }
@@ -1986,7 +1987,7 @@ reverse_loot()
             coffers->owt = weight(coffers);
             coffers->cknown = 0;
             if (!coffers->olocked) {
-                boxdummy = zeroobj, boxdummy.otyp = SPE_WIZARD_LOCK;
+                boxdummy = zeroobj; boxdummy.otyp = SPE_WIZARD_LOCK;
                 (void) boxlock(coffers, &boxdummy);
             }
         } else if (levl[x][y].looted != T_LOOTED
@@ -2389,8 +2390,9 @@ boolean makecat, givemsg;
     xchar ox, oy;
     boolean itsalive = !rn2(2);
 
-    if (get_obj_location(box, &ox, &oy, 0))
-        box->ox = ox, box->oy = oy; /* in case it's being carried */
+    if (get_obj_location(box, &ox, &oy, 0)) {
+        box->ox = ox; box->oy = oy; /* in case it's being carried */
+    }
 
     /* this isn't really right, since any form of observation
        (telepathic or monster/object/food detection) ought to
@@ -2417,7 +2419,7 @@ boolean makecat, givemsg;
             (void) christen_monst(livecat, sc);
             if (deadcat) {
                 obj_extract_self(deadcat);
-                obfree(deadcat, (struct obj *) 0), deadcat = 0;
+                obfree(deadcat, (struct obj *) 0); deadcat = 0;
             }
             box->owt = weight(box);
             box->spe = 0;
@@ -2968,7 +2970,7 @@ dotip()
      */
 
     /* at present, can only tip things at current spot, not adjacent ones */
-    cc.x = u.ux, cc.y = u.uy;
+    cc.x = u.ux; cc.y = u.uy;
 
     /* check floor container(s) first; at most one will be accessed */
     if ((boxes = container_at(cc.x, cc.y, TRUE)) > 0) {
@@ -3113,8 +3115,9 @@ struct obj *box; /* or bag */
     /* box is either held or on floor at hero's spot; no need to check for
        nesting; when held, we need to update its location to match hero's;
        for floor, the coordinate updating is redundant */
-    if (get_obj_location(box, &ox, &oy, 0))
-        box->ox = ox, box->oy = oy;
+    if (get_obj_location(box, &ox, &oy, 0)) {
+        box->ox = ox; box->oy = oy;
+    }
 
     /* Shop handling:  can't rely on the container's own unpaid
        or no_charge status because contents might differ with it.
@@ -3216,7 +3219,7 @@ struct obj *box; /* or bag */
         for (otmp = box->cobj; otmp; otmp = nobj) {
             nobj = otmp->nobj;
             obj_extract_self(otmp);
-            otmp->ox = box->ox, otmp->oy = box->oy;
+            otmp->ox = box->ox; otmp->oy = box->oy;
 
             if (box->otyp == ICE_BOX) {
                 removed_from_icebox(otmp); /* resume rotting for corpse */

--- a/src/pline.c
+++ b/src/pline.c
@@ -264,8 +264,9 @@ int siz;
 void
 free_youbuf()
 {
-    if (you_buf)
-        free((genericptr_t) you_buf), you_buf = (char *) 0;
+    if (you_buf) {
+        free((genericptr_t) you_buf); you_buf = (char *) 0;
+    }
     you_buf_siz = 0;
 }
 

--- a/src/potion.c
+++ b/src/potion.c
@@ -1322,7 +1322,7 @@ int how;
     boolean hit_saddle = FALSE, your_fault = (how <= POTHIT_HERO_THROW);
 
     if (isyou) {
-        tx = u.ux, ty = u.uy;
+        tx = u.ux; ty = u.uy;
         distance = 0;
         pline_The("%s crashes on your %s and breaks into shards.", botlnam,
                   body_part(HEAD));
@@ -1331,7 +1331,7 @@ int how;
                                            : "thrown potion",
                KILLED_BY_AN);
     } else {
-        tx = mon->mx, ty = mon->my;
+        tx = mon->mx; ty = mon->my;
         /* sometimes it hits the saddle */
         if (((mon->misc_worn_check & W_SADDLE)
              && (saddle = which_armor(mon, W_SADDLE)))
@@ -1650,25 +1650,31 @@ register struct obj *obj;
         }
         break;
     case POT_FULL_HEALING:
-        if (Upolyd && u.mh < u.mhmax)
-            u.mh++, context.botl = 1;
-        if (u.uhp < u.uhpmax)
-            u.uhp++, context.botl = 1;
+        if (Upolyd && u.mh < u.mhmax) {
+            u.mh++; context.botl = 1;
+        }
+        if (u.uhp < u.uhpmax) {
+            u.uhp++; context.botl = 1;
+        }
         cureblind = TRUE;
         /*FALLTHRU*/
     case POT_EXTRA_HEALING:
-        if (Upolyd && u.mh < u.mhmax)
-            u.mh++, context.botl = 1;
-        if (u.uhp < u.uhpmax)
-            u.uhp++, context.botl = 1;
+        if (Upolyd && u.mh < u.mhmax) {
+            u.mh++; context.botl = 1;
+        }
+        if (u.uhp < u.uhpmax) {
+            u.uhp++; context.botl = 1;
+        }
         if (!obj->cursed)
             cureblind = TRUE;
         /*FALLTHRU*/
     case POT_HEALING:
-        if (Upolyd && u.mh < u.mhmax)
-            u.mh++, context.botl = 1;
-        if (u.uhp < u.uhpmax)
-            u.uhp++, context.botl = 1;
+        if (Upolyd && u.mh < u.mhmax) {
+            u.mh++; context.botl = 1;
+        }
+        if (u.uhp < u.uhpmax) {
+            u.uhp++; context.botl = 1;
+        }
         if (obj->blessed)
             cureblind = TRUE;
         if (cureblind) {

--- a/src/pray.c
+++ b/src/pray.c
@@ -2268,7 +2268,7 @@ int dx, dy;
             count += otmp->quan;
     }
 
-    nx = u.ux + 2 * dx, ny = u.uy + 2 * dy; /* next spot beyond boulder(s) */
+    nx = u.ux + 2 * dx; ny = u.uy + 2 * dy; /* next spot beyond boulder(s) */
     switch (count) {
     case 0:
         /* no boulders--not blocked */

--- a/src/priest.c
+++ b/src/priest.c
@@ -705,7 +705,7 @@ xchar x, y;
     if (mon) {
         if (is_minion(mon->data) || is_rider(mon->data))
             return FALSE;
-        x = mon->mx, y = mon->my;
+        x = mon->mx; y = mon->my;
     }
     if (u.ualign.record <= ALGN_SINNED) /* sinned or worse */
         return FALSE;

--- a/src/questpgr.c
+++ b/src/questpgr.c
@@ -144,12 +144,15 @@ load_qtlist()
 void
 unload_qtlist()
 {
-    if (msg_file)
-        (void) dlb_fclose(msg_file), msg_file = 0;
-    if (qt_list.common)
-        free((genericptr_t) qt_list.common), qt_list.common = 0;
-    if (qt_list.chrole)
-        free((genericptr_t) qt_list.chrole), qt_list.chrole = 0;
+    if (msg_file) {
+        (void) dlb_fclose(msg_file); msg_file = 0;
+    }
+    if (qt_list.common) {
+        free((genericptr_t) qt_list.common); qt_list.common = 0;
+    }
+    if (qt_list.chrole) {
+        free((genericptr_t) qt_list.chrole); qt_list.chrole = 0;
+    }
     return;
 }
 

--- a/src/read.c
+++ b/src/read.c
@@ -558,8 +558,9 @@ int curse_bless;
             if (is_on)
                 Ring_off(obj);
             obj->spe += s; /* update the ring while it's off */
-            if (is_on)
-                setworn(obj, mask), Ring_on(obj);
+            if (is_on) {
+                setworn(obj, mask); Ring_on(obj);
+            }
             /* oartifact: if a touch-sensitive artifact ring is
                ever created the above will need to be revised  */
             /* update shop bill to reflect new higher price */
@@ -2555,7 +2556,7 @@ struct _create_particular_data *d;
             /* otherwise try again */
             continue;
         }
-        mx = mtmp->mx, my = mtmp->my;
+        mx = mtmp->mx; my = mtmp->my;
         /* 'is_FOO()' ought to be called 'always_FOO()' */
         if (d->fem != -1 && !is_male(mtmp->data) && !is_female(mtmp->data))
             mtmp->female = d->fem; /* ignored for is_neuter() */

--- a/src/restore.c
+++ b/src/restore.c
@@ -586,7 +586,7 @@ unsigned int *stuckid, *steedid;
     iflags.deferred_X = (newgameflags.explore && !discover);
     if (newgameflags.debug) {
         /* authorized by startup code; wizard mode exists and is allowed */
-        wizard = TRUE, discover = iflags.deferred_X = FALSE;
+        wizard = TRUE; discover = iflags.deferred_X = FALSE;
     } else if (wizard) {
         /* specified by save file; check authorization now */
         set_playmode();
@@ -1148,7 +1148,7 @@ boolean ghostly;
     rest_regions(fd, ghostly);
     if (ghostly) {
         /* Now get rid of all the temp fruits... */
-        freefruitchn(oldfruit), oldfruit = 0;
+        freefruitchn(oldfruit); oldfruit = 0;
 
         if (lev > ledger_no(&medusa_level)
             && lev < ledger_no(&stronghold_level) && xdnstair == 0) {

--- a/src/rumors.c
+++ b/src/rumors.c
@@ -405,7 +405,7 @@ int fd, mode;
     if (release_data(mode)) {
         if (oracle_cnt) {
             free((genericptr_t) oracle_loc);
-            oracle_loc = 0, oracle_cnt = 0, oracle_flg = 0;
+            oracle_loc = 0; oracle_cnt = 0; oracle_flg = 0;
         }
     }
 }

--- a/src/save.c
+++ b/src/save.c
@@ -116,12 +116,15 @@ dosave0()
        a few of things before saving so that they won't be restored in
        an improper state; these will be no-ops for normal save sequence */
     u.uinvulnerable = 0;
-    if (iflags.save_uswallow)
-        u.uswallow = 1, iflags.save_uswallow = 0;
-    if (iflags.save_uinwater)
-        u.uinwater = 1, iflags.save_uinwater = 0;
-    if (iflags.save_uburied)
-        u.uburied = 1, iflags.save_uburied = 0;
+    if (iflags.save_uswallow) {
+        u.uswallow = 1; iflags.save_uswallow = 0;
+    }
+    if (iflags.save_uinwater) {
+        u.uinwater = 1; iflags.save_uinwater = 0;
+    }
+    if (iflags.save_uburied) {
+        u.uburied = 1; iflags.save_uburied = 0;
+    }
 
     if (!program_state.something_worth_saving || !SAVEF[0])
         return 0;
@@ -1361,19 +1364,25 @@ freedynamicdata()
     free_dungeons();
 
     /* some pointers in iflags */
-    if (iflags.wc_font_map)
-        free((genericptr_t) iflags.wc_font_map), iflags.wc_font_map = 0;
-    if (iflags.wc_font_message)
-        free((genericptr_t) iflags.wc_font_message),
+    if (iflags.wc_font_map) {
+        free((genericptr_t) iflags.wc_font_map); iflags.wc_font_map = 0;
+    }
+    if (iflags.wc_font_message) {
+        free((genericptr_t) iflags.wc_font_message);
         iflags.wc_font_message = 0;
-    if (iflags.wc_font_text)
-        free((genericptr_t) iflags.wc_font_text), iflags.wc_font_text = 0;
-    if (iflags.wc_font_menu)
-        free((genericptr_t) iflags.wc_font_menu), iflags.wc_font_menu = 0;
-    if (iflags.wc_font_status)
-        free((genericptr_t) iflags.wc_font_status), iflags.wc_font_status = 0;
-    if (iflags.wc_tile_file)
-        free((genericptr_t) iflags.wc_tile_file), iflags.wc_tile_file = 0;
+    }
+    if (iflags.wc_font_text) {
+        free((genericptr_t) iflags.wc_font_text); iflags.wc_font_text = 0;
+    }
+    if (iflags.wc_font_menu) {
+        free((genericptr_t) iflags.wc_font_menu); iflags.wc_font_menu = 0;
+    }
+    if (iflags.wc_font_status) {
+        free((genericptr_t) iflags.wc_font_status); iflags.wc_font_status = 0;
+    }
+    if (iflags.wc_tile_file) {
+        free((genericptr_t) iflags.wc_tile_file); iflags.wc_tile_file = 0;
+    }
     free_autopickup_exceptions();
 
     /* miscellaneous */

--- a/src/shk.c
+++ b/src/shk.c
@@ -2125,24 +2125,27 @@ register struct monst *shkp; /* if angry, impose a surcharge */
             divisor *= 3L;
         }
     }
-    if (uarmh && uarmh->otyp == DUNCE_CAP)
-        multiplier *= 4L, divisor *= 3L;
+    if (uarmh && uarmh->otyp == DUNCE_CAP) {
+        multiplier *= 4L; divisor *= 3L;
+    }
     else if ((Role_if(PM_TOURIST) && u.ulevel < (MAXULEV / 2))
-             || (uarmu && !uarm && !uarmc)) /* touristy shirt visible */
-        multiplier *= 4L, divisor *= 3L;
+             || (uarmu && !uarm && !uarmc)) { /* touristy shirt visible */
+        multiplier *= 4L; divisor *= 3L;
+    }
 
-    if (ACURR(A_CHA) > 18)
+    if (ACURR(A_CHA) > 18) {
         divisor *= 2L;
-    else if (ACURR(A_CHA) == 18)
-        multiplier *= 2L, divisor *= 3L;
-    else if (ACURR(A_CHA) >= 16)
-        multiplier *= 3L, divisor *= 4L;
-    else if (ACURR(A_CHA) <= 5)
+    } else if (ACURR(A_CHA) == 18) {
+        multiplier *= 2L; divisor *= 3L;
+    } else if (ACURR(A_CHA) >= 16) {
+        multiplier *= 3L; divisor *= 4L;
+    } else if (ACURR(A_CHA) <= 5) {
         multiplier *= 2L;
-    else if (ACURR(A_CHA) <= 7)
-        multiplier *= 3L, divisor *= 2L;
-    else if (ACURR(A_CHA) <= 10)
-        multiplier *= 4L, divisor *= 3L;
+    } else if (ACURR(A_CHA) <= 7) {
+        multiplier *= 3L; divisor *= 2L;
+    } else if (ACURR(A_CHA) <= 10) {
+        multiplier *= 4L; divisor *= 3L;
+    }
 
     /* tmp = (tmp * multiplier) / divisor [with roundoff tweak] */
     tmp *= multiplier;
@@ -2190,8 +2193,9 @@ boolean unpaid_only;
        puts it in inventory; behave as if it is still on the floor
        during the add-to-bill portion of that situation */
     on_floor = (top->where == OBJ_FLOOR || top->where == OBJ_FREE);
-    if (top->where == OBJ_FREE || !get_obj_location(top, &x, &y, 0))
-        x = u.ux, y = u.uy;
+    if (top->where == OBJ_FREE || !get_obj_location(top, &x, &y, 0)) {
+        x = u.ux; y = u.uy;
+    }
     freespot = (on_floor && x == ESHK(shkp)->shk.x && y == ESHK(shkp)->shk.y);
 
     /* price of contained objects; "top" container handled by caller */
@@ -2347,8 +2351,9 @@ register struct monst *shkp;
                 tmp = (obj->otyp % (6 - shkp->m_id % 3));
                 tmp = (tmp + 3) * obj->quan;
             }
-        } else if (tmp > 1L && !(shkp->m_id % 4))
-            multiplier *= 3L, divisor *= 4L;
+        } else if (tmp > 1L && !(shkp->m_id % 4)) {
+            multiplier *= 3L; divisor *= 4L;
+        }
     }
 
     if (tmp >= 1L) {
@@ -2444,8 +2449,9 @@ boolean include_contents;
     long amt = 0L;
     xchar ox, oy;
 
-    if (!get_obj_location(unp_obj, &ox, &oy, BURIED_TOO | CONTAINED_TOO))
-        ox = u.ux, oy = u.uy; /* (shouldn't happen) */
+    if (!get_obj_location(unp_obj, &ox, &oy, BURIED_TOO | CONTAINED_TOO)) {
+        ox = u.ux; oy = u.uy; /* (shouldn't happen) */
+    }
     if ((shkp = shop_keeper(*in_rooms(ox, oy, SHOPBASE))) != 0) {
         bp = onbill(unp_obj, shkp, TRUE);
     } else {
@@ -4330,7 +4336,7 @@ register struct obj *first_obj;
         }
         Sprintf(buf, "%s%s, %s", contentsonly ? the_contents_of : "",
                 doname(otmp), price);
-        putstr(tmpwin, 0, buf), cnt++;
+        putstr(tmpwin, 0, buf); cnt++;
     }
     if (cnt > 1) {
         display_nhwindow(tmpwin, TRUE);
@@ -4853,7 +4859,7 @@ struct obj *obj_absorber, *obj_absorbed;
         impossible("globby_bill_fixup called for non-globby object");
 
     if (floor_absorber) {
-        x = obj_absorber->ox, y = obj_absorber->oy;
+        x = obj_absorber->ox; y = obj_absorber->oy;
     }
     if (obj_absorber->unpaid) {
         /* look for a shopkeeper who owns this object */

--- a/src/sit.c
+++ b/src/sit.c
@@ -282,7 +282,7 @@ dosit()
 
         if (!rn2(3) && IS_THRONE(levl[u.ux][u.uy].typ)) {
             /* may have teleported */
-            levl[u.ux][u.uy].typ = ROOM, levl[u.ux][u.uy].flags = 0;
+            levl[u.ux][u.uy].typ = ROOM; levl[u.ux][u.uy].flags = 0;
             pline_The("throne vanishes in a puff of logic.");
             newsym(u.ux, u.uy);
         }

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -1050,14 +1050,14 @@ packed_coord pos;
     get_location_coord(&try_x, &try_y, DRY, croom, pos);
     if (levl[try_x][try_y].typ != ROOM) {
         do {
-            try_x = *x, try_y = *y;
+            try_x = *x; try_y = *y;
             get_room_loc(&try_x, &try_y, croom);
         } while (levl[try_x][try_y].typ != ROOM && ++trycnt <= 100);
 
         if (trycnt > 100)
             panic("get_free_room_loc:  can't find a place!");
     }
-    *x = try_x, *y = try_y;
+    *x = try_x; *y = try_y;
 }
 
 boolean
@@ -1638,7 +1638,7 @@ struct mkroom *croom;
 
     /* try to find a close place if someone else is already there */
     if (MON_AT(x, y) && enexto(&cc, x, y, pm))
-        x = cc.x, y = cc.y;
+        x = cc.x; y = cc.y;
 
     if (m->align != -(MAX_REGISTERS + 2))
         mtmp = mk_roamer(pm, Amask2align(amask), x, y, m->peaceful);
@@ -1648,8 +1648,8 @@ struct mkroom *croom;
         mtmp = makemon(pm, x, y, NO_MM_FLAGS);
 
     if (mtmp) {
-        x = mtmp->mx, y = mtmp->my; /* sanity precaution */
-        m->x = x, m->y = y;
+        x = mtmp->mx; y = mtmp->my; /* sanity precaution */
+        m->x = x; m->y = y;
         /* handle specific attributes for some special monsters */
         if (m->name.str)
             mtmp = christen_monst(mtmp, m->name.str);
@@ -1707,8 +1707,9 @@ struct mkroom *croom;
                             x = m->x;
                             y = m->y;
                             get_location(&x, &y, DRY, croom);
-                            if (MON_AT(x, y) && enexto(&cc, x, y, pm))
-                                x = cc.x, y = cc.y;
+                            if (MON_AT(x, y) && enexto(&cc, x, y, pm)) {
+                                x = cc.x; y = cc.y;
+                            }
                         } while (m_bad_boulder_spot(x, y)
                                  && --retrylimit > 0);
                         place_monster(mtmp, x, y);
@@ -2606,7 +2607,7 @@ int humidity;
     } while (!(x % 2) || !(y % 2) || SpLev_Map[x][y]
              || !is_ok_location((schar) x, (schar) y, humidity));
 
-    m->x = (xchar) x, m->y = (xchar) y;
+    m->x = (xchar) x; m->y = (xchar) y;
 }
 
 /*

--- a/src/spell.c
+++ b/src/spell.c
@@ -1536,8 +1536,9 @@ sortspells()
            could just free it since that ordering becomes the default) */
         for (i = 0; i < MAXSPELL; i++)
             tmp_book[i] = spl_book[spl_orderindx[i]];
-        for (i = 0; i < MAXSPELL; i++)
-            spl_book[i] = tmp_book[i], spl_orderindx[i] = i;
+        for (i = 0; i < MAXSPELL; i++) {
+            spl_book[i] = tmp_book[i]; spl_orderindx[i] = i;
+        }
         spl_sortmode = SORTBY_LETTER; /* reset */
         return;
     }

--- a/src/steal.c
+++ b/src/steal.c
@@ -539,8 +539,9 @@ struct monst *mtmp;
        if hero has more than one, choose randomly so that player
        can't use inventory ordering to influence the theft */
     for (n = 0, obj = invent; obj; obj = obj->nobj)
-        if (any_quest_artifact(obj))
-            ++n, otmp = obj;
+        if (any_quest_artifact(obj)) {
+            ++n; otmp = obj;
+        }
     if (n > 1) {
         n = rnd(n);
         for (otmp = invent; otmp; otmp = otmp->nobj)
@@ -565,8 +566,9 @@ struct monst *mtmp;
 
         /* If we get here, real and fake have been set up. */
         for (n = 0, obj = invent; obj; obj = obj->nobj)
-            if (obj->otyp == real || (obj->otyp == fake && !mtmp->iswiz))
-                ++n, otmp = obj;
+            if (obj->otyp == real || (obj->otyp == fake && !mtmp->iswiz)) {
+                ++n; otmp = obj;
+            }
         if (n > 1) {
             n = rnd(n);
             for (otmp = invent; otmp; otmp = otmp->nobj)

--- a/src/steed.c
+++ b/src/steed.c
@@ -562,7 +562,7 @@ int reason; /* Player was thrown off etc. */
      * but we don't know where that was and even if we did, it might
      * be hostile terrain.
      */
-    steedcc.x = u.ux, steedcc.y = u.uy;
+    steedcc.x = u.ux; steedcc.y = u.uy;
     if (m_at(u.ux, u.uy)) {
         /* hero's spot has a monster in it; hero must have been plucked
            from saddle as engulfer moved into his spot--other dismounts
@@ -771,7 +771,7 @@ int x, y;
         impossible("placing %s over %s at <%d,%d>, mstates:%lx %lx on %s?",
                    monnm, othnm, x, y, othermon->mstate, mon->mstate, buf);
     }
-    mon->mx = x, mon->my = y;
+    mon->mx = x; mon->my = y;
     level.monsters[x][y] = mon;
     mon->mstate &= ~(MON_OFFMAP | MON_MIGRATING | MON_LIMBO | MON_BUBBLEMOVE
                      | MON_ENDGAME_FREE | MON_ENDGAME_MIGR);

--- a/src/sys.c
+++ b/src/sys.c
@@ -87,37 +87,48 @@ sys_early_init()
 void
 sysopt_release()
 {
-    if (sysopt.support)
-        free((genericptr_t) sysopt.support), sysopt.support = (char *) 0;
-    if (sysopt.recover)
-        free((genericptr_t) sysopt.recover), sysopt.recover = (char *) 0;
-    if (sysopt.wizards)
-        free((genericptr_t) sysopt.wizards), sysopt.wizards = (char *) 0;
-    if (sysopt.explorers)
-        free((genericptr_t) sysopt.explorers), sysopt.explorers = (char *) 0;
-    if (sysopt.shellers)
-        free((genericptr_t) sysopt.shellers), sysopt.shellers = (char *) 0;
-    if (sysopt.debugfiles)
-        free((genericptr_t) sysopt.debugfiles),
+    if (sysopt.support) {
+        free((genericptr_t) sysopt.support); sysopt.support = (char *) 0;
+    }
+    if (sysopt.recover) {
+        free((genericptr_t) sysopt.recover); sysopt.recover = (char *) 0;
+    }
+    if (sysopt.wizards){
+        free((genericptr_t) sysopt.wizards); sysopt.wizards = (char *) 0;
+    }
+    if (sysopt.explorers) {
+        free((genericptr_t) sysopt.explorers); sysopt.explorers = (char *) 0;
+    }
+    if (sysopt.shellers) {
+        free((genericptr_t) sysopt.shellers); sysopt.shellers = (char *) 0;
+    }
+    if (sysopt.debugfiles) {
+        free((genericptr_t) sysopt.debugfiles);
         sysopt.debugfiles = (char *) 0;
+}
 #ifdef DUMPLOG
-    if (sysopt.dumplogfile)
-        free((genericptr_t)sysopt.dumplogfile), sysopt.dumplogfile=(char *)0;
+    if (sysopt.dumplogfile) {
+        free((genericptr_t)sysopt.dumplogfile); sysopt.dumplogfile=(char *)0;
+    }
 #endif
-    if (sysopt.genericusers)
-        free((genericptr_t) sysopt.genericusers),
+    if (sysopt.genericusers) {
+        free((genericptr_t) sysopt.genericusers);
         sysopt.genericusers = (char *) 0;
+    }
 #ifdef PANICTRACE
-    if (sysopt.gdbpath)
-        free((genericptr_t) sysopt.gdbpath), sysopt.gdbpath = (char *) 0;
-    if (sysopt.greppath)
-        free((genericptr_t) sysopt.greppath), sysopt.greppath = (char *) 0;
+    if (sysopt.gdbpath) {
+        free((genericptr_t) sysopt.gdbpath); sysopt.gdbpath = (char *) 0;
+    }
+    if (sysopt.greppath) {
+        free((genericptr_t) sysopt.greppath); sysopt.greppath = (char *) 0;
+    }
 #endif
     /* this one's last because it might be used in panic feedback, although
        none of the preceding ones are likely to trigger a controlled panic */
-    if (sysopt.fmtd_wizard_list)
-        free((genericptr_t) sysopt.fmtd_wizard_list),
+    if (sysopt.fmtd_wizard_list) {
+        free((genericptr_t) sysopt.fmtd_wizard_list);
         sysopt.fmtd_wizard_list = (char *) 0;
+    }
     return;
 }
 

--- a/src/teleport.c
+++ b/src/teleport.c
@@ -200,7 +200,7 @@ unsigned entflags;
     if (good_ptr == good) {
         /* 3.6.3: earlier versions didn't have the option to try <xx,yy>,
            and left 'cc' uninitialized when returning False */
-        cc->x = xx, cc->y = yy;
+        cc->x = xx; cc->y = yy;
         /* if every spot other than <xx,yy> has failed, try <xx,yy> itself */
         if (allow_xx_yy && goodpos(xx, yy, &fakemon, entflags)) {
             return TRUE; /* 'cc' is set */
@@ -564,7 +564,7 @@ dotelecmd()
         return dotele(FALSE);
 
     added = hidden = NOOP_SPELL;
-    save_HTele = HTeleportation, save_ETele = ETeleportation;
+    save_HTele = HTeleportation; save_ETele = ETeleportation;
     if (!iflags.menu_requested) {
         ignore_restrictions = TRUE;
     } else {
@@ -1232,12 +1232,13 @@ boolean suppress_impossible;
     }
 
     if (mtmp->iswiz && mtmp->mx) { /* Wizard, not just arriving */
-        if (!In_W_tower(u.ux, u.uy, &u.uz))
-            x = xupstair, y = yupstair;
-        else if (!xdnladder) /* bottom level of tower */
-            x = xupladder, y = yupladder;
-        else
-            x = xdnladder, y = ydnladder;
+        if (!In_W_tower(u.ux, u.uy, &u.uz)) {
+            x = xupstair; y = yupstair;
+        } else if (!xdnladder) { /* bottom level of tower */
+            x = xupladder; y = yupladder;
+        } else {
+            x = xdnladder; y = ydnladder;
+        }
         /* if the wiz teleports away to heal, try the up staircase,
            to block the player's escaping before he's healed
            (deliberately use `goodpos' rather than `rloc_pos_ok' here) */

--- a/src/topten.c
+++ b/src/topten.c
@@ -118,7 +118,7 @@ boolean incl_helpless;
     case KILLED_BY:
         (void) strncat(buf, killed_by_prefix[how], siz - 1);
         l = strlen(buf);
-        buf += l, siz -= l;
+        buf += l; siz -= l;
         break;
     }
     /* Copy kname into buf[].
@@ -900,9 +900,9 @@ boolean so;
         Sprintf(eos(linebuf), "  %c%s.", highc(*(t1->death)), t1->death + 1);
 
     lngr = (int) strlen(linebuf);
-    if (t1->hp <= 0)
-        hpbuf[0] = '-', hpbuf[1] = '\0';
-    else
+    if (t1->hp <= 0) {
+        hpbuf[0] = '-'; hpbuf[1] = '\0';
+    } else
         Sprintf(hpbuf, "%d", t1->hp);
     /* beginning of hp column after padding (not actually padded yet) */
     hppos = COLNO - (sizeof("  Hp [max]") - 1); /* sizeof(str) includes \0 */

--- a/src/trap.c
+++ b/src/trap.c
@@ -591,7 +591,7 @@ int *fail_reason;
 
     if (use_saved_traits) {
         /* restore a petrified monster */
-        cc.x = x, cc.y = y;
+        cc.x = x; cc.y = y;
         mon = montraits(statue, &cc, (cause == ANIMATE_SPELL));
         if (mon && mon->mtame && !mon->isminion)
             wary_dog(mon, TRUE);
@@ -851,7 +851,7 @@ struct trap *trap;
     otmp->quan = 1L;
     otmp->owt = weight(otmp);
     otmp->opoisoned = 0;
-    otmp->ox = trap->tx, otmp->oy = trap->ty;
+    otmp->ox = trap->tx; otmp->oy = trap->ty;
     return otmp;
 }
 
@@ -1665,7 +1665,7 @@ struct trap *trap;
         lev->doormask = D_BROKEN;
     /* destroy drawbridge if present */
     if (lev->typ == DRAWBRIDGE_DOWN || is_drawbridge_wall(x, y) >= 0) {
-        dbx = x, dby = y;
+        dbx = x; dby = y;
         /* if under the portcullis, the bridge is adjacent */
         if (find_drawbridge(&dbx, &dby))
             destroy_drawbridge(dbx, dby);
@@ -1929,7 +1929,7 @@ int style;
                 case TRAPDOOR:
                     /* the boulder won't be used up if there is a
                        monster in the trap; stop rolling anyway */
-                    x2 = bhitpos.x, y2 = bhitpos.y; /* stops here */
+                    x2 = bhitpos.x; y2 = bhitpos.y; /* stops here */
                     if (flooreffects(singleobj, x2, y2, "fall")) {
                         used_up = TRUE;
                         launch_drop_spot((struct obj *) 0, 0, 0);
@@ -1976,7 +1976,7 @@ int style;
         /* if about to hit iron bars, do so now */
         if (dist > 0 && isok(bhitpos.x + dx, bhitpos.y + dy)
             && levl[bhitpos.x + dx][bhitpos.y + dy].typ == IRONBARS) {
-            x2 = bhitpos.x, y2 = bhitpos.y; /* object stops here */
+            x2 = bhitpos.x; y2 = bhitpos.y; /* object stops here */
             if (hits_bars(&singleobj,
                           x2, y2, x2+dx, y2+dy,
                           !rn2(20), 0)) {
@@ -2838,7 +2838,7 @@ float_up()
         } else if (u.utraptype == TT_BURIEDBALL) { /* tethered */
             coord cc;
 
-            cc.x = u.ux, cc.y = u.uy;
+            cc.x = u.ux; cc.y = u.uy;
             /* caveat: this finds the first buried iron ball within
                one step of the specified location, not necessarily the
                buried [former] uball at the original anchor point */
@@ -3150,12 +3150,14 @@ struct obj *box; /* null for floor trap */
         }
         if (alt > num)
             num = alt;
-        if (u.mhmax > mons[u.umonnum].mlevel)
-            u.mhmax -= rn2(min(u.mhmax, num + 1)), context.botl = 1;
+        if (u.mhmax > mons[u.umonnum].mlevel) {
+            u.mhmax -= rn2(min(u.mhmax, num + 1)); context.botl = 1;
+        }
     } else {
         num = d(2, 4);
-        if (u.uhpmax > u.ulevel)
-            u.uhpmax -= rn2(min(u.uhpmax, num + 1)), context.botl = 1;
+        if (u.uhpmax > u.ulevel) {
+            u.uhpmax -= rn2(min(u.uhpmax, num + 1)); context.botl = 1;
+        }
     }
     if (!num)
         You("are uninjured.");
@@ -3858,8 +3860,9 @@ crawl:
         pool_of_water = waterbody_name(u.ux, u.uy);
         killer.format = KILLED_BY_AN;
         /* avoid "drowned in [a] water" */
-        if (!strcmp(pool_of_water, "water"))
-            pool_of_water = "deep water", killer.format = KILLED_BY;
+        if (!strcmp(pool_of_water, "water")) {
+            pool_of_water = "deep water"; killer.format = KILLED_BY;
+        }
         Strcpy(killer.name, pool_of_water);
         done(DROWNING);
         /* oops, we're still alive.  better get out of the water. */
@@ -3998,8 +4001,8 @@ struct trap *ttmp;
     /* we know there's no monster in the way, and we're not trapped */
     if (!Punished
         || drag_ball(x, y, &bc, &bx, &by, &cx, &cy, &unused, TRUE)) {
-        u.ux0 = u.ux, u.uy0 = u.uy;
-        u.ux = x, u.uy = y;
+        u.ux0 = u.ux; u.uy0 = u.uy;
+        u.ux = x; u.uy = y;
         u.umoved = TRUE;
         newsym(u.ux0, u.uy0);
         vision_recalc(1);
@@ -4786,8 +4789,9 @@ boolean disarm;
     const char *msg;
     coord cc;
 
-    if (get_obj_location(obj, &cc.x, &cc.y, 0)) /* might be carried */
-        obj->ox = cc.x, obj->oy = cc.y;
+    if (get_obj_location(obj, &cc.x, &cc.y, 0)) { /* might be carried */
+        obj->ox = cc.x; obj->oy = cc.y;
+    }
 
     otmp->otrapped = 0; /* trap is one-shot; clear flag first in case
                            chest kills you and ends up in bones file */

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -564,7 +564,7 @@ struct attack *uattk; /* ... but we don't enforce that here; Null works ok */
         /* ++i, wrap 8 to i=0 /or/ --i, wrap -1 to i=7 */
         i = (i + (clockwise ? 1 : 7)) % 8;
 
-        tx = x + xdir[i], ty = y + ydir[i]; /* current target location */
+        tx = x + xdir[i]; ty = y + ydir[i]; /* current target location */
         if (!isok(tx, ty))
             continue;
         mtmp = m_at(tx, ty);
@@ -578,7 +578,7 @@ struct attack *uattk; /* ... but we don't enforce that here; Null works ok */
                                &attknum, &armorpenalty);
         dieroll = rnd(20);
         mhit = (tmp > dieroll);
-        bhitpos.x = tx, bhitpos.y = ty; /* normally set up by attack() */
+        bhitpos.x = tx; bhitpos.y = ty; /* normally set up by attack() */
         (void) known_hitum(mtmp, uwep, &mhit, tmp, armorpenalty,
                            uattk, dieroll);
         (void) passive(mtmp, uwep, mhit, !DEADMONSTER(mtmp), AT_WEAP, !uwep);
@@ -1571,8 +1571,9 @@ struct attack *mattk;
         obj_extract_self(gold);
 
     while ((otmp = mdef->minvent) != 0) {
-        if (gold) /* put 'mdef's gold back after remembering mdef->minvent */
-            mpickobj(mdef, gold), gold = 0;
+        if (gold) { /* put 'mdef's gold back after remembering mdef->minvent */
+            mpickobj(mdef, gold); gold = 0;
+        }
         if (!Upolyd)
             break; /* no longer have ability to steal */
         /* take the object away from the monster */

--- a/src/vault.c
+++ b/src/vault.c
@@ -329,7 +329,7 @@ invault()
         /* first find the goal for the guard */
         if (!find_guard_dest((struct monst *)0, &rx, &ry))
             return;
-        gx = rx, gy = ry;
+        gx = rx; gy = ry;
 
         /* next find a good place for a door in the wall */
         x = u.ux;
@@ -673,7 +673,7 @@ int goldx, goldy; /* <gold->ox, gold->oy> */
         gdelta = distu(guardx, guardy);
         if (gdelta > 2 && see_it) { /* skip if player won't see it */
             bestdelta = gdelta;
-            bestcc.x = (xchar) guardx, bestcc.y = (xchar) guardy;
+            bestcc.x = (xchar) guardx; bestcc.y = (xchar) guardy;
             tryct = 9;
             do {
                 /* pick an available spot nearest the hero and also try
@@ -1032,7 +1032,7 @@ register struct monst *grd;
         /* At the end of the process, the guard is killed */
         /* in restfakecorr().                             */
  cleanup:
-        x = grd->mx, y = grd->my;
+        x = grd->mx; y = grd->my;
         see_guard = canspotmon(grd);
         parkguard(grd); /* move to <0,0> */
         wallify_vault(grd);

--- a/src/windows.c
+++ b/src/windows.c
@@ -888,8 +888,9 @@ genl_status_finish()
 
     /* free alloc'd memory here */
     for (i = 0; i < MAXBLSTATS; ++i) {
-        if (status_vals[i])
-            free((genericptr_t) status_vals[i]), status_vals[i] = (char *) 0;
+        if (status_vals[i]) {
+            free((genericptr_t) status_vals[i]); status_vals[i] = (char *) 0;
+        }
     }
 }
 

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -370,7 +370,7 @@ register struct monst *mtmp;
 
     switch (strat) {
     case STRAT_HEAL: /* hide and recover */
-        mx = mtmp->mx, my = mtmp->my;
+        mx = mtmp->mx; my = mtmp->my;
         /* if wounded, hole up on or near the stairs (to block them) */
         choose_stairs(&sx, &sy);
         mtmp->mavenge = 1; /* covetous monsters attack while fleeing */
@@ -386,7 +386,7 @@ register struct monst *mtmp;
                 rloc_to(mtmp, mx, my);
                 return 0;
             }
-            mx = mtmp->mx, my = mtmp->my; /* update cached location */
+            mx = mtmp->mx; my = mtmp->my; /* update cached location */
         }
         /* if you're not around, cast healing spells */
         if (distu(mx, my) > (BOLT_LIM * BOLT_LIM))
@@ -439,7 +439,7 @@ register struct monst *mtmp;
                 return 0;
             }
         } else { /* a monster has it - 'port beside it. */
-            mx = mtmp->mx, my = mtmp->my;
+            mx = mtmp->mx; my = mtmp->my;
             if (!mnearto(mtmp, tx, ty, FALSE))
                 rloc_to(mtmp, mx, my); /* no room? stay put */
             return 0;
@@ -654,8 +654,9 @@ resurrect()
                 elapsed /= 50L;
                 if (mtmp->msleeping && rn2((int) elapsed + 1))
                     mtmp->msleeping = 0;
-                if (mtmp->mfrozen == 1) /* would unfreeze on next move */
-                    mtmp->mfrozen = 0, mtmp->mcanmove = 1;
+                if (mtmp->mfrozen == 1) { /* would unfreeze on next move */
+                    mtmp->mfrozen = 0; mtmp->mcanmove = 1;
+                }
                 if (mtmp->mcanmove && !mtmp->msleeping) {
                     *mmtmp = mtmp->nmon;
                     mon_arrive(mtmp, TRUE);

--- a/src/zap.c
+++ b/src/zap.c
@@ -745,10 +745,10 @@ boolean by_hero;
             get_container_location(container, &holder, &container_nesting);
         switch (holder) {
         case OBJ_MINVENT:
-            x = carrier->mx, y = carrier->my;
+            x = carrier->mx; y = carrier->my;
             break;
         case OBJ_INVENT:
-            x = u.ux, y = u.uy;
+            x = u.ux; y = u.uy;
             break;
         case OBJ_FLOOR:
             (void) get_obj_location(corpse, &x, &y, CONTAINED_TOO);
@@ -770,7 +770,7 @@ boolean by_hero;
         return (struct monst *) 0;
 
     /* record the object's location now that we're sure where it is */
-    corpse->ox = x, corpse->oy = y;
+    corpse->ox = x; corpse->oy = y;
 
     /* prepare for the monster */
     montype = corpse->corpsenm;
@@ -779,8 +779,9 @@ boolean by_hero;
        ghost are at same location, revived creature shouldn't be bumped
        to an adjacent spot by ghost which joins with it] */
     if (MON_AT(x, y)) {
-        if (enexto(&xy, x, y, mptr))
-            x = xy.x, y = xy.y;
+        if (enexto(&xy, x, y, mptr)) {
+            x = xy.x; y = xy.y;
+        }
     }
 
     if ((mons[montype].mlet == S_EEL && !IS_POOL(levl[x][y].typ))
@@ -812,7 +813,7 @@ boolean by_hero;
         }
     } else if (has_omonst(corpse)) {
         /* use saved traits */
-        xy.x = x, xy.y = y;
+        xy.x = x; xy.y = y;
         mtmp = montraits(corpse, &xy, FALSE);
         if (mtmp && mtmp->mtame && !mtmp->isminion)
             wary_dog(mtmp, TRUE);
@@ -839,7 +840,7 @@ boolean by_hero;
     if (by_hero) {
         struct monst *shkp = 0;
 
-        x = corpse->ox, y = corpse->oy;
+        x = corpse->ox; y = corpse->oy;
         if (costly_spot(x, y)
             && (carried(corpse) ? corpse->unpaid : !corpse->no_charge))
             shkp = shop_keeper(*in_rooms(x, y, SHOPBASE));
@@ -922,7 +923,7 @@ boolean by_hero;
         break;
     case OBJ_FLOOR:
         /* in case MON_AT+enexto for invisible mon */
-        x = corpse->ox, y = corpse->oy;
+        x = corpse->ox; y = corpse->oy;
         /* not useupf(), which charges */
         if (corpse->quan > 1L)
             corpse = splitobj(corpse, 1L);
@@ -2009,8 +2010,9 @@ struct obj *obj, *otmp;
                 char *corpsname = cxname_singular(obj);
 
                 /* get corpse's location before revive() uses it up */
-                if (!get_obj_location(obj, &ox, &oy, 0))
-                    ox = obj->ox, oy = obj->oy; /* won't happen */
+                if (!get_obj_location(obj, &ox, &oy, 0)){
+                    ox = obj->ox; oy = obj->oy; /* won't happen */
+                }
 
                 mtmp = revive(obj, TRUE);
                 if (!mtmp) {
@@ -2668,7 +2670,7 @@ struct obj *obj; /* wand or spell */
 {
     int steedhit = FALSE;
 
-    bhitpos.x = u.usteed->mx, bhitpos.y = u.usteed->my;
+    bhitpos.x = u.usteed->mx; bhitpos.y = u.usteed->my;
     notonhead = FALSE;
     switch (obj->otyp) {
     /*
@@ -3373,7 +3375,7 @@ struct obj **pobj; /* object tossed/used, set to NULL
                    not canspotmon() because it makes no difference
                    whether the hero can see the monster or not. */
                 if (mtmp->minvis) {
-                    obj->ox = u.ux, obj->oy = u.uy;
+                    obj->ox = u.ux; obj->oy = u.uy;
                     (void) flash_hits_mon(mtmp, obj);
                 } else {
                     tmp_at(DISP_END, 0);
@@ -4108,7 +4110,7 @@ boolean say; /* Announce out of sight hit/miss events if true */
         }
 
         /* hit() and miss() need bhitpos to match the target */
-        bhitpos.x = sx, bhitpos.y = sy;
+        bhitpos.x = sx; bhitpos.y = sy;
         /* Fireballs only damage when they explode */
         if (type != ZT_SPELL(ZT_FIRE)) {
             range += zap_over_floor(sx, sy, type, &shopdamage, 0);
@@ -4459,7 +4461,7 @@ short exploding_wand_typ;
                     msgtxt = "Some water evaporates.";
             } else {
                 rangemod -= 3;
-                lev->typ = ROOM, lev->flags = 0;
+                lev->typ = ROOM; lev->flags = 0;
                 t = maketrap(x, y, PIT);
                 if (t)
                     t->tseen = 1;
@@ -4576,14 +4578,14 @@ short exploding_wand_typ;
                     Norep("The %s melt.", defsyms[S_bars].explanation);
                 if (*in_rooms(x, y, SHOPBASE)) {
                     /* in case we ever have a shop bounded by bars */
-                    lev->typ = ROOM, lev->flags = 0;
+                    lev->typ = ROOM; lev->flags = 0;
                     if (see_it)
                         newsym(x, y);
                     add_damage(x, y, (type >= 0) ? SHOP_BARS_COST : 0L);
                     if (type >= 0)
                         *shopdamage = TRUE;
                 } else {
-                    lev->typ = DOOR, lev->doormask = D_NODOOR;
+                    lev->typ = DOOR; lev->doormask = D_NODOOR;
                     if (see_it)
                         newsym(x, y);
                 }

--- a/sys/unix/unixmain.c
+++ b/sys/unix/unixmain.c
@@ -378,7 +378,7 @@ char *argv[];
         case 'd':
             if ((argv[0][1] == 'D' && !argv[0][2])
                 || !strcmpi(*argv, "-debug")) {
-                wizard = TRUE, discover = FALSE;
+                wizard = TRUE; discover = FALSE;
             } else if (!strncmpi(*argv, "-DECgraphics", l)) {
                 load_symset("DECGraphics", PRIMARY);
                 switch_symbols(TRUE);
@@ -388,7 +388,7 @@ char *argv[];
             break;
         case 'X':
 
-            discover = TRUE, wizard = FALSE;
+            discover = TRUE; wizard = FALSE;
             break;
 #ifdef NEWS
         case 'n':
@@ -631,7 +631,7 @@ wd_message()
             free(tmp);
         } else
             pline("Entering explore/discovery mode instead.");
-        wizard = 0, discover = 1; /* (paranoia) */
+        wizard = 0; discover = 1; /* (paranoia) */
     } else if (discover)
         You("are in non-scoring explore/discovery mode.");
 }

--- a/win/curses/cursmesg.c
+++ b/win/curses/cursmesg.c
@@ -143,7 +143,7 @@ curses_message_win_puts(const char *message, boolean recursed)
     if (mx == border_space && message_length > width - 2) {
         /* split needed */
         tmpstr = curses_break_str(message, (width - 2), 1);
-        mvwprintw(win, my, mx, "%s", tmpstr), mx += (int) strlen(tmpstr);
+        mvwprintw(win, my, mx, "%s", tmpstr); mx += (int) strlen(tmpstr);
         /* one space to separate first part of message from rest [is this
            actually useful?] */
         if (mx < width - 2)
@@ -155,7 +155,7 @@ curses_message_win_puts(const char *message, boolean recursed)
         curses_message_win_puts(tmpstr, TRUE);
         free(tmpstr);
     } else {
-        mvwprintw(win, my, mx, "%s", message), mx += message_length;
+        mvwprintw(win, my, mx, "%s", message); mx += message_length;
         if (bold)
             curses_toggle_color_attr(win, NONE, A_BOLD, OFF);
     }
@@ -188,9 +188,9 @@ curses_block(boolean noscroll) /* noscroll - blocking because of msgtype
 
     curses_get_window_size(MESSAGE_WIN, &height, &width);
     if (mx - brdroffset > width - 3) { /* -3: room for ">>_" */
-        if (my - brdroffset < height - 1)
-            ++my, mx = brdroffset;
-        else
+        if (my - brdroffset < height - 1) {
+            ++my; mx = brdroffset;
+        } else
             mx = width - 3 + brdroffset;
     }
     /* if ">>" (--More--) is being rendered at the same spot as before,
@@ -199,18 +199,18 @@ curses_block(boolean noscroll) /* noscroll - blocking because of msgtype
     if (mx == prev_x && my == prev_y) {
         blink = 1 - blink;
     } else {
-        prev_x = mx, prev_y = my;
+        prev_x = mx; prev_y = my;
         blink = 0;
     }
     moreattr = !iflags.wc2_guicolor ? (int) A_REVERSE : NONE;
     curses_toggle_color_attr(win, MORECOLOR, moreattr, ON);
     if (blink) {
         wattron(win, A_BLINK);
-        mvwprintw(win, my, mx, ">"), mx += 1;
+        mvwprintw(win, my, mx, ">"); mx += 1;
         wattroff(win, A_BLINK);
-        waddstr(win, ">"), mx += 1;
+        waddstr(win, ">"); mx += 1;
     } else {
-        mvwprintw(win, my, mx, ">>"), mx += 2;
+        mvwprintw(win, my, mx, ">>"); mx += 2;
     }
     curses_toggle_color_attr(win, MORECOLOR, moreattr, OFF);
     wrefresh(win);
@@ -232,7 +232,7 @@ curses_block(boolean noscroll) /* noscroll - blocking because of msgtype
     if (height == 1) {
         curses_clear_unhighlight_message_window();
     } else {
-        mx -= 2, mvwprintw(win, my, mx, "  "); /* back up and blank out ">>" */
+        mx -= 2; mvwprintw(win, my, mx, "  "); /* back up and blank out ">>" */
         if (!noscroll) {
             scroll_window(MESSAGE_WIN);
         }
@@ -405,8 +405,9 @@ curses_count_window(const char *count_text)
     int messageh, messagew, border;
 
     if (!count_text) {
-        if (countwin)
-            delwin(countwin), countwin = NULL;
+        if (countwin) {
+            delwin(countwin); countwin = NULL;
+        }
         counting = FALSE;
         return;
     }
@@ -895,8 +896,8 @@ boolean restoring_msghist;
         /* hide any messages we've gathered since starting current session
            so that the ^P data will start out empty as we add ones being
            restored from save file; we'll put these back after that's done */
-        stash_count = num_messages, num_messages = 0;
-        stash_head = first_mesg, first_mesg = (nhprev_mesg *) 0;
+        stash_count = num_messages; num_messages = 0;
+        stash_head = first_mesg; first_mesg = (nhprev_mesg *) 0;
         last_mesg = (nhprev_mesg *) 0; /* no need to remember the tail */
         initd = TRUE;
 #ifdef DUMPLOG

--- a/win/curses/cursstat.c
+++ b/win/curses/cursstat.c
@@ -59,7 +59,7 @@ curses_status_init()
         *status_vals_long[i] = '\0';
     }
     curses_condition_bits = 0L;
-    hpbar_percent = 0, hpbar_color = NO_COLOR;
+    hpbar_percent = 0; hpbar_color = NO_COLOR;
     vert_status_dirty = 1;
 
     /* let genl_status_init do most of the initialization */
@@ -73,8 +73,9 @@ curses_status_finish()
     int i;
 
     for (i = 0; i < MAXBLSTATS; ++i) {
-        if (status_vals_long[i])
-            free(status_vals_long[i]), status_vals_long[i] = (char *) 0;
+        if (status_vals_long[i]) {
+            free(status_vals_long[i]); status_vals_long[i] = (char *) 0;
+        }
     }
 
     genl_status_finish();
@@ -308,8 +309,9 @@ boolean border;
 
     /* note: getmaxyx() is a macro which assigns values to height and width */
     getmaxyx(win, height, width);
-    if (border)
-        height -= 2, width -= 2;
+    if (border) {
+        height -= 2; width -= 2;
+    }
 
     /*
      * Potential revisions:
@@ -603,9 +605,10 @@ boolean border;
                     /* encumbrance is truncated if too wide, but other fields
                        aren't; if window is narrower than normal, last field
                        written might have wrapped to the next line */
-                    if (y > j + (border ? 1 : 0))
-                        x = width - (border ? -1 : 0), /* (width-=2 above) */
+                    if (y > j + (border ? 1 : 0)) {
+                        x = width - (border ? -1 : 0); /* (width-=2 above) */
                         y = j + (border ? 1 : 0);
+                    }
                     /* cbuf[] was populated above; clen is its length */
                     if (number_of_lines == 3) {
                         /*
@@ -803,8 +806,9 @@ boolean border;
 #endif
     }
 
-    if (border)
-        x++, y++;
+    if (border) {
+        x++; y++;
+    }
     for (i = 0; (fld = fieldorder[i]) != BL_FLUSH; ++i) {
         if (!status_activefields[fld])
             continue;
@@ -1030,8 +1034,9 @@ curs_stat_conds(int vert_cond, /* 0 => horizontal, 1 => vertical */
                 cndlen = 1 + (int) strlen(condnam); /* count leading space */
                 if (!do_vert) {
                     getyx(win, cy, cx);
-                    if (cy > cy0) /* wrap to next line shouldn't happen */
-                        cx = width, cy = cy0;
+                    if (cy > cy0) { /* wrap to next line shouldn't happen */
+                        cx = width; cy = cy0;
+                    }
                     if (cx + cndlen > width - (border ? 2 : 1)) {
                         /* not enough room for current condition */
                         if (cx + 1 > width - (border ? 2 : 1))

--- a/win/tty/termcap.c
+++ b/win/tty/termcap.c
@@ -331,8 +331,8 @@ tty_shutdown()
     kill_hilite();
 #endif
     if (dynamic_HIHE) {
-        free((genericptr_t) nh_HI), nh_HI = (char *) 0;
-        free((genericptr_t) nh_HE), nh_HE = (char *) 0;
+        free((genericptr_t) nh_HI); nh_HI = (char *) 0;
+        free((genericptr_t) nh_HE); nh_HE = (char *) 0;
         dynamic_HIHE = FALSE;
     }
 #endif
@@ -418,13 +418,13 @@ tty_decgraphics_termcap_fixup()
         }
         /* can't use nethack's case-insensitive strstri() here, and some old
            systems don't have strstr(), so use brute force substring search */
-        ae_length = strlen(ae), he_limit = strlen(nh_he);
+        ae_length = strlen(ae); he_limit = strlen(nh_he);
         while (he_limit >= ae_length) {
             if (strncmp(nh_he, ae, ae_length) == 0) {
                 HE_resets_AS = TRUE;
                 break;
             }
-            ++nh_he, --he_limit;
+            ++nh_he; --he_limit;
         }
     }
 #endif

--- a/win/tty/topl.c
+++ b/win/tty/topl.c
@@ -473,11 +473,11 @@ char def;
             int n_len = 0;
             long value = 0;
 
-            addtopl("#"), n_len++;
+            addtopl("#"); n_len++;
             digit_string[1] = '\0';
             if (q != '#') {
                 digit_string[0] = q;
-                addtopl(digit_string), n_len++;
+                addtopl(digit_string); n_len++;
                 value = q - '0';
                 q = '#';
             }
@@ -490,7 +490,7 @@ char def;
                     if (value < 0)
                         break; /* overflow: try again */
                     digit_string[0] = z;
-                    addtopl(digit_string), n_len++;
+                    addtopl(digit_string); n_len++;
                 } else if (z == 'y' || index(quitchars, z)) {
                     if (z == '\033')
                         value = -1; /* abort */
@@ -501,7 +501,7 @@ char def;
                         break;
                     } else {
                         value /= 10;
-                        removetopl(1), n_len--;
+                        removetopl(1); n_len--;
                     }
                 } else {
                     value = -1; /* abort */
@@ -514,7 +514,7 @@ char def;
             else if (value == 0)
                 q = 'n'; /* 0 => "no" */
             else {       /* remove number from top line, then try again */
-                removetopl(n_len), n_len = 0;
+                removetopl(n_len); n_len = 0;
                 q = '\0';
             }
         }
@@ -604,7 +604,7 @@ boolean purged; /* True: took history's pointers, False: just cloned them */
                 free((genericptr_t) snapshot_mesgs[i]);
         }
 
-        free((genericptr_t) snapshot_mesgs), snapshot_mesgs = (char **) 0;
+        free((genericptr_t) snapshot_mesgs); snapshot_mesgs = (char **) 0;
 
         /* history can resume being updated at will now... */
         if (!purged)

--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -361,7 +361,7 @@ new_status_window()
         if (wins[WIN_STATUS]->maxrow > iflags.wc2_statuslines)
             tty_clear_nhwindow(WIN_STATUS);
 
-        tty_destroy_nhwindow(WIN_STATUS), WIN_STATUS = WIN_ERR;
+        tty_destroy_nhwindow(WIN_STATUS); WIN_STATUS = WIN_ERR;
     }
     /* frees some status tracking data */
     genl_status_finish();
@@ -606,8 +606,9 @@ tty_player_selection()
                             choice = selected[1].item.a_int;
                     } else
                         choice = (n == 0) ? ROLE_RANDOM : ROLE_NONE;
-                    if (selected)
-                        free((genericptr_t) selected), selected = 0;
+                    if (selected) {
+                        free((genericptr_t) selected); selected = 0;
+                    }
                     destroy_nhwindow(win);
 
                     if (choice == ROLE_NONE) {
@@ -695,8 +696,9 @@ tty_player_selection()
                                 choice = selected[1].item.a_int;
                         } else
                             choice = (n == 0) ? ROLE_RANDOM : ROLE_NONE;
-                        if (selected)
-                            free((genericptr_t) selected), selected = 0;
+                        if (selected) {
+                            free((genericptr_t) selected); selected = 0;
+                        }
                         destroy_nhwindow(win);
 
                         if (choice == ROLE_NONE) {
@@ -788,8 +790,9 @@ tty_player_selection()
                                 choice = selected[1].item.a_int;
                         } else
                             choice = (n == 0) ? ROLE_RANDOM : ROLE_NONE;
-                        if (selected)
-                            free((genericptr_t) selected), selected = 0;
+                        if (selected) {
+                            free((genericptr_t) selected); selected = 0;
+                        }
                         destroy_nhwindow(win);
 
                         if (choice == ROLE_NONE) {
@@ -877,8 +880,9 @@ tty_player_selection()
                                 choice = selected[1].item.a_int;
                         } else
                             choice = (n == 0) ? ROLE_RANDOM : ROLE_NONE;
-                        if (selected)
-                            free((genericptr_t) selected), selected = 0;
+                        if (selected) {
+                            free((genericptr_t) selected); selected = 0;
+                        }
                         destroy_nhwindow(win);
 
                         if (choice == ROLE_NONE) {
@@ -973,8 +977,9 @@ tty_player_selection()
         n = select_menu(win, PICK_ONE, &selected);
         /* [pick-one menus with a preselected entry behave oddly...] */
         choice = (n > 0) ? selected[n - 1].item.a_int : (n == 0) ? 1 : -1;
-        if (selected)
-            free((genericptr_t) selected), selected = 0;
+        if (selected) {
+            free((genericptr_t) selected); selected = 0;
+        }
         destroy_nhwindow(win);
 
         switch (choice) {
@@ -992,11 +997,11 @@ tty_player_selection()
             iflags.renameinprogress = TRUE;
             /* plnamesuffix() can change any or all of ROLE, RACE,
                GEND, ALGN; we'll override that and honor only the name */
-            saveROLE = ROLE, saveRACE = RACE, saveGEND = GEND,
+            saveROLE = ROLE; saveRACE = RACE; saveGEND = GEND;
                 saveALGN = ALGN;
             *plname = '\0';
             plnamesuffix(); /* calls askname() when plname[] is empty */
-            ROLE = saveROLE, RACE = saveRACE, GEND = saveGEND,
+            ROLE = saveROLE; RACE = saveRACE; GEND = saveGEND;
                 ALGN = saveALGN;
             break; /* getconfirmation is still True */
         }
@@ -1070,8 +1075,9 @@ reset_role_filtering()
 
         ROLE = RACE = GEND = ALGN = ROLE_NONE;
     }
-    if (selected)
-        free((genericptr_t) selected), selected = 0;
+    if (selected) {
+        free((genericptr_t) selected); selected = 0;
+    }
     destroy_nhwindow(win);
     return (n > 0) ? TRUE : FALSE;
 }
@@ -1253,7 +1259,7 @@ tty_askname()
             tty_curs(BASE_WINDOW, 1, wins[BASE_WINDOW]->cury - 1);
             tty_putstr(BASE_WINDOW, 0, "Enter a name for your character...");
             /* erase previous prompt (in case of ESC after partial response) */
-            tty_curs(BASE_WINDOW, 1, wins[BASE_WINDOW]->cury), cl_end();
+            tty_curs(BASE_WINDOW, 1, wins[BASE_WINDOW]->cury); cl_end();
         }
         tty_putstr(BASE_WINDOW, 0, who_are_you);
         tty_curs(BASE_WINDOW, (int) (sizeof who_are_you),
@@ -3768,7 +3774,7 @@ tty_status_init()
         tty_status[BEFORE][i] = tty_status[NOW][i];
     }
     tty_condition_bits = 0L;
-    hpbar_percent = 0, hpbar_color = NO_COLOR;
+    hpbar_percent = 0; hpbar_color = NO_COLOR;
 #endif /* STATUS_HILITES */
 
     /* let genl_status_init do most of the initialization */


### PR DESCRIPTION
Xcode likes to enable `-Wcomma` warnings when upgrading projects. For the most part, just replacing the offending comma with a semicolon quiets the warning.
I'm not even going to touch those that are in a `for` declaration.