### PR TITLE
Remove the mysterious force

### DIFF
--- a/src/do.c
+++ b/src/do.c
@@ -1265,48 +1265,6 @@ boolean at_stairs, falling, portal;
     if (new_ledger <= 0)
         done(ESCAPED); /* in fact < 0 is impossible */
 
-    /* If you have the amulet and are trying to get out of Gehennom,
-     * going up a set of stairs sometimes does some very strange things!
-     * Biased against law and towards chaos.  (The chance to be sent
-     * down multiple levels when attempting to go up are significantly
-     * less than the corresponding comment in older versions indicated
-     * due to overlooking the effect of the call to assign_rnd_lvl().)
-     *
-     * Odds for making it to the next level up, or of being sent down:
-     *  "up"    L      N      C
-     *   +1   75.0   75.0   75.0
-     *    0    6.25   8.33  12.5
-     *   -1   11.46  12.50  12.5
-     *   -2    5.21   4.17   0.0
-     *   -3    2.08   0.0    0.0
-     */
-    if (Inhell && up && u.uhave.amulet && !newdungeon && !portal
-        && (dunlev(&u.uz) < dunlevs_in_dungeon(&u.uz) - 3)) {
-        if (!rn2(4)) {
-            int odds = 3 + (int) u.ualign.type,   /* 2..4 */
-                diff = odds <= 1 ? 0 : rn2(odds); /* paranoia */
-
-            if (diff != 0) {
-                assign_rnd_level(newlevel, &u.uz, diff);
-                /* if inside the tower, stay inside */
-                if (was_in_W_tower && !On_W_tower_level(newlevel))
-                    diff = 0;
-            }
-            if (diff == 0)
-                assign_level(newlevel, &u.uz);
-
-            new_ledger = ledger_no(newlevel);
-
-            pline("A mysterious force momentarily surrounds you...");
-            if (on_level(newlevel, &u.uz)) {
-                (void) safe_teleds(FALSE);
-                (void) next_to_u();
-                return;
-            } else
-                at_stairs = g.at_ladder = FALSE;
-        }
-    }
-
     /* Prevent the player from going past the first quest level unless
      * (s)he has been given the go-ahead by the leader.
      */

--- a/src/muse.c
+++ b/src/muse.c
@@ -675,7 +675,7 @@ struct monst *mtmp;
                 mtmp->mtrapseen |= (1 << (TELEP_TRAP - 1));
             return 2;
         }
-        if ((mon_has_amulet(mtmp) || On_W_tower_level(&u.uz)) && !rn2(3)) {
+        if (mon_has_amulet(mtmp) || On_W_tower_level(&u.uz)) {
             if (vismon)
                 pline("%s seems disoriented for a moment.", Monnam(mtmp));
             return 2;
@@ -858,24 +858,10 @@ struct monst *mtmp;
         m_flee(mtmp);
         if (ledger_no(&u.uz) == 1)
             goto escape; /* impossible; level 1 upstairs are SSTAIRS */
-        if (Inhell && mon_has_amulet(mtmp) && !rn2(4)
-            && (dunlev(&u.uz) < dunlevs_in_dungeon(&u.uz) - 3)) {
-            if (vismon)
-                pline(
-    "As %s climbs the stairs, a mysterious force momentarily surrounds %s...",
-                      mon_nam(mtmp), mhim(mtmp));
-            /* simpler than for the player; this will usually be
-               the Wizard and he'll immediately go right to the
-               upstairs, so there's not much point in having any
-               chance for a random position on the current level */
-            migrate_to_level(mtmp, ledger_no(&u.uz) + 1, MIGR_RANDOM,
-                             (coord *) 0);
-        } else {
-            if (vismon)
-                pline("%s escapes upstairs!", Monnam(mtmp));
-            migrate_to_level(mtmp, ledger_no(&u.uz) - 1, MIGR_STAIRS_DOWN,
-                             (coord *) 0);
-        }
+        if (vismon)
+            pline("%s escapes upstairs!", Monnam(mtmp));
+        migrate_to_level(mtmp, ledger_no(&u.uz) - 1, MIGR_STAIRS_DOWN,
+                            (coord *) 0);
         return 2;
     case MUSE_DOWNSTAIRS:
         m_flee(mtmp);

--- a/src/teleport.c
+++ b/src/teleport.c
@@ -494,7 +494,7 @@ struct obj *scroll;
     if (!Blinded)
         make_blinded(0L, FALSE);
 
-    if ((u.uhave.amulet || On_W_tower_level(&u.uz)) && !rn2(3)) {
+    if (u.uhave.amulet || On_W_tower_level(&u.uz)) {
         You_feel("disoriented for a moment.");
         if (!wizard || yn("Override?") != 'y')
             return FALSE;


### PR DESCRIPTION
The mysterious force is the single most universally hated feature in
NetHack.

Backsliding through Gehennom has proven to be so boring and tedious for
the player, while adding nothing of value to the game, that nearly every
variant removes it. (The sole exception is NetHack4, which makes very
few gameplay changes.)

To compensate for this, all horizontal teleportation within a level is
blocked when carrying the Amulet, rather than 1/3 of the time.

This makes alignments slightly less differentiated, since there is no
longer an advantage to playing chaotic to make the force less odious.
However, this behavior was already on a shaky basis flavor-wise (Moloch
and Gehennom itself have no bias against any alignment, and plenty of
lawful devils and demon lords reside there).

I would also note that in the absence of the mysterious force, there are
several other proposals and implementations of ways to make post-Amulet
Gehennom more interesting than simply backtracking through completed
levels, ranging from monster spawning behavior to a boss rush of demon
lords to the entire branch beginning to collapse.