### PR TITLE
Allow teleportation onto the Vibrating Square

### DIFF
--- a/src/teleport.c
+++ b/src/teleport.c
@@ -260,8 +260,12 @@ teleok(x, y, trapok)
 register int x, y;
 boolean trapok;
 {
-    if (!trapok && t_at(x, y))
-        return FALSE;
+    if (!trapok) {
+        /* allow teleportation onto vibrating square, it's not a real trap */
+        struct trap *trap = t_at(x, y);
+        if (trap && trap->ttyp != VIBRATING_SQUARE)
+            return FALSE;
+    }
     if (!goodpos(x, y, &g.youmonst, 0))
         return FALSE;
     if (!tele_jump_ok(u.ux, u.uy, x, y))


### PR DESCRIPTION
It's a minor annoyance when you forget you can't do this in vanilla and
then get relocated somewhere random on the level. Since it's not a
harmful "trap", just allow the adventurer to teleport directly onto it.