### PR TITLE
Allow teleportation onto the vibrating square in wizard mode

### DIFF
--- a/src/teleport.c
+++ b/src/teleport.c
@@ -260,7 +260,8 @@ teleok(x, y, trapok)
 register int x, y;
 boolean trapok;
 {
-    if (!trapok && t_at(x, y))
+    if (!trapok && t_at(x, y) && 
+            !(wizard && t_at(x, y)->ttyp == VIBRATING_SQUARE))
         return FALSE;
     if (!goodpos(x, y, &g.youmonst, 0))
         return FALSE;


### PR DESCRIPTION
The vibrating square is classified as a trap, and as such cannot be teleported onto. Testing the vibrating square in wizard mode can be frustrating, since it cannot be teleported onto directly.