### PR TITLE
Add paranoid swim for both water and lava

### DIFF
--- a/include/flag.h
+++ b/include/flag.h
@@ -71,6 +71,7 @@ struct flag {
 #define PARANOID_BREAKWAND  0x0080
 #define PARANOID_WERECHANGE 0x0100
 #define PARANOID_EATING     0x0200
+#define PARANOID_SWIM       0x0400
     int pickup_burden; /* maximum burden before prompt */
     int pile_limit;    /* controls feedback when walking over objects */
     char sortloot; /* 'n'=none, 'l'=loot (pickup), 'f'=full ('l'+invent) */
@@ -477,6 +478,9 @@ enum runmode_types {
 /* continue eating: prompt given _after_first_bite_ when eating something
    while satiated */
 #define ParanoidEating ((flags.paranoia_bits & PARANOID_EATING) != 0)
+/* swim: require prefixing stepping into water or lava from a non-similar square
+ * with 'm' */
+#define ParanoidSwim ((flags.paranoia_bits & PARANOID_SWIM) != 0)
 
 /* command parsing, mainly dealing with number_pad handling;
    not saved and restored */

--- a/src/options.c
+++ b/src/options.c
@@ -1311,6 +1311,8 @@ static const struct paranoia_opts {
       "y to pray (supersedes old \"prayconfirm\" option)" },
     { PARANOID_REMOVE, "Remove", 1, "Takeoff", 1,
       "always pick from inventory for Remove and Takeoff" },
+    { PARANOID_SWIM, "swim", 1, NULL, 0,
+      "require 'm' to step onto a water or lava space" },
     /* for config file parsing; interactive menu skips these */
     { 0, "none", 4, 0, 0, 0 }, /* require full word match */
     { ~0, "all", 3, 0, 0, 0 }, /* ditto */


### PR DESCRIPTION
Adds "swim" to the list of paranoid options, which prevents you from
accidentally moving into liquids.

The mechanics are similar to what I believe NetHack4 has, where you
must use the 'm' movement prefix in order to deliberately move onto a liquid
space from a space with a different terrain type. Attempting to move into the
liquid without using 'm' will do nothing.

This behavior is suppressed if you are levitating, flying, wearing known
[fireproof] water walking boots, or have the option turned off.

I'm not sure that this fits better as a paranoid option than just a regular
option. It logically fits in, but it doesn't involve any prompts. As with all
the other paranoid options, it is settable via config file, as "swim". This
doesn't seem like the best name to me, but I don't have a better one.

In xNetHack, where this code comes from, the m-movement into liquids is
enforced for all players and ParanoidSwim just provides an additional failsafe,
but it turns out there are many players who want to have the ability to die by
making a typo and stepping into lava, so the implementation here allows this
current behavior by having the option off.

Final note: Since having no confirmation for walking on lava means you must
have fire resistance, there's a minor and extremely marginal exploit which
allows a player with identified fireproof water walking boots to informally
test whether an unidentified ring is fire resistance. I did not think it was
important enough to be worth adding code that figures out whether the player
knows they have fire resistance.