### PR TITLE
Add paranoid trap, which prevents accidental triggering of harmful traps

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -144,7 +144,7 @@ E void FDECL(Lift_covet_and_placebc, (int, const char *, int));
 #define unplacebc_and_covet_placebc() \
             Unplacebc_and_covet_placebc(__FUNCTION__, __LINE__)
 #define lift_covet_and_placebc(x) \
-            Lift_covet_and_placebc(x, __FUNCTION__, __LINE__) 
+            Lift_covet_and_placebc(x, __FUNCTION__, __LINE__)
 #endif
 E void FDECL(set_bc, (int));
 E void FDECL(move_bc, (int, int, XCHAR_P, XCHAR_P, XCHAR_P, XCHAR_P));
@@ -2606,6 +2606,7 @@ E struct monst *FDECL(animate_statue,
                       (struct obj *, XCHAR_P, XCHAR_P, int, int *));
 E struct monst *FDECL(activate_statue_trap,
                       (struct trap *, XCHAR_P, XCHAR_P, BOOLEAN_P));
+E int FDECL(immune_to_trap, (struct monst*, xchar));
 E void FDECL(set_utrap, (unsigned, unsigned));
 E void FDECL(reset_utrap, (BOOLEAN_P));
 E void FDECL(dotrap, (struct trap *, unsigned));

--- a/include/flag.h
+++ b/include/flag.h
@@ -71,6 +71,7 @@ struct flag {
 #define PARANOID_BREAKWAND  0x0080
 #define PARANOID_WERECHANGE 0x0100
 #define PARANOID_EATING     0x0200
+#define PARANOID_TRAP       0x0800
     int pickup_burden; /* maximum burden before prompt */
     int pile_limit;    /* controls feedback when walking over objects */
     char sortloot; /* 'n'=none, 'l'=loot (pickup), 'f'=full ('l'+invent) */
@@ -477,6 +478,8 @@ enum runmode_types {
 /* continue eating: prompt given _after_first_bite_ when eating something
    while satiated */
 #define ParanoidEating ((flags.paranoia_bits & PARANOID_EATING) != 0)
+/* trap: move onto a trap that you know is there */
+#define ParanoidTrap ((flags.paranoia_bits & PARANOID_TRAP) != 0)
 
 /* command parsing, mainly dealing with number_pad handling;
    not saved and restored */

--- a/include/trap.h
+++ b/include/trap.h
@@ -85,4 +85,11 @@ enum trap_types {
 #define is_pit(ttyp) ((ttyp) == PIT || (ttyp) == SPIKED_PIT)
 #define is_hole(ttyp)  ((ttyp) == HOLE || (ttyp) == TRAPDOOR)
 
+/* Return codes from immune_to_trap. */
+enum trap_immunities {
+    TRAP_NOT_IMMUNE = 0,
+    TRAP_CLEARLY_IMMUNE,
+    TRAP_HIDDEN_IMMUNE
+};
+
 #endif /* TRAP_H */

--- a/src/options.c
+++ b/src/options.c
@@ -1311,6 +1311,8 @@ static const struct paranoia_opts {
       "y to pray (supersedes old \"prayconfirm\" option)" },
     { PARANOID_REMOVE, "Remove", 1, "Takeoff", 1,
       "always pick from inventory for Remove and Takeoff" },
+    { PARANOID_TRAP, "trap", 1, "move-trap", 1,
+      "yes to move onto a trap" },
     /* for config file parsing; interactive menu skips these */
     { 0, "none", 4, 0, 0, 0 }, /* require full word match */
     { ~0, "all", 3, 0, 0, 0 }, /* ditto */

--- a/src/trap.c
+++ b/src/trap.c
@@ -883,6 +883,161 @@ boolean msg;
     }
 }
 
+/* Will a monster suffer any adverse effects from a certain trap?
+ * Note: this does NOT mean "will a monster trigger a trap in the first place",
+ * though if it won't that does imply that they'll not suffer adverse effects.
+ * For example, an elf is considered immune to sleeping gas traps even though
+ * they'll set the trap off.
+ * Return value:
+ *  TRAP_NOT_IMMUNE = not immune at the moment
+ *  TRAP_CLEARLY_IMMUNE = obviously immune (if player is polymorphed, assume
+ *    they know which traps they are immune to in their current form)
+ *  TRAP_HIDDEN_IMMUNE = immune but in a non-obvious way such as an unidentified
+ *    item or hidden intrinsic providing a resistance; the player should still
+ *    be warned of this trap, while monsters implicitly know they're immune. */
+int
+immune_to_trap(mon, ttype)
+struct monst* mon;
+xchar ttype;
+{
+    if (!mon) {
+        impossible("immune_to_trap: null monster");
+        return TRAP_NOT_IMMUNE;
+    }
+    struct permonst * pm = mon->data;
+    boolean you = (mon == &g.youmonst);
+
+    switch(ttype) {
+    case ARROW_TRAP:
+    case DART_TRAP:
+    case ROCKTRAP:
+        /* can hit anything. Even noncorporeal monsters might get a blessed
+         * projectile. */
+        return TRAP_NOT_IMMUNE;
+    case BEAR_TRAP:
+        if (pm->msize <= MZ_SMALL || amorphous(pm) || is_whirly(pm)
+            || unsolid(pm))
+            return TRAP_CLEARLY_IMMUNE;
+        /* FALLTHRU */
+    case SQKY_BOARD:
+    case LANDMINE:
+    case ROLLING_BOULDER_TRAP:
+    case HOLE:
+    case TRAPDOOR:
+    case PIT:
+    case SPIKED_PIT:
+        /* ground-based traps, which can be evaded by levitation, flying, or
+         * hanging to the ceiling */
+        if (Sokoban && (ttype == PIT || ttype == SPIKED_PIT || ttype == HOLE
+                        || ttype == TRAPDOOR))
+            return TRAP_NOT_IMMUNE;
+        if (is_floater(pm) || is_flyer(pm) || is_clinger(pm))
+            return TRAP_CLEARLY_IMMUNE;
+        else if (you && (Levitation || Flying))
+            return TRAP_CLEARLY_IMMUNE;
+        return TRAP_NOT_IMMUNE;
+    case SLP_GAS_TRAP:
+        if (breathless(pm))
+            return TRAP_CLEARLY_IMMUNE;
+        else if (!you && resists_sleep(mon))
+            return TRAP_CLEARLY_IMMUNE;
+        else if (you && Sleep_resistance)
+            return TRAP_HIDDEN_IMMUNE;
+        return TRAP_NOT_IMMUNE;
+    case LEVEL_TELEP:
+    case TELEP_TRAP:
+        /* Consider unintended teleporting to be an adverse effect. If in the
+         * endgame or carrying the Amulet, the teleport trap won't work anyway,
+         * so anything hitting it is immune. */
+        if (In_endgame(&u.uz) || mon_has_amulet(mon))
+            return TRAP_CLEARLY_IMMUNE;
+        return TRAP_NOT_IMMUNE;
+    case POLY_TRAP:
+        if (resists_magm(mon))
+            /* covers Antimagic for player */
+            return (you ? TRAP_HIDDEN_IMMUNE : TRAP_CLEARLY_IMMUNE);
+        return TRAP_NOT_IMMUNE;
+    case STATUE_TRAP:
+        /* no effect on monsters, only affects players; only trap detection can
+         * let a player know that there is a statue trap there ahead of time;
+         * in the rare case this happens, do consider it an adverse effect */
+        if (!you)
+            return TRAP_CLEARLY_IMMUNE;
+        return TRAP_NOT_IMMUNE;
+    case WEB:
+        /* most of this code is lifted from mu_maybe_destroy_web */
+        if (webmaker(pm) || amorphous(pm) || is_whirly(pm) || flaming(pm)
+            || unsolid(pm) || pm == &mons[PM_GELATINOUS_CUBE])
+            return TRAP_CLEARLY_IMMUNE;
+        return TRAP_NOT_IMMUNE;
+    case ANTI_MAGIC:
+        /* doesn't hurt any non-magic-resistant monster with no magic */
+        if (you) {
+            if (Antimagic)
+                return TRAP_NOT_IMMUNE;
+            else if (u.uenmax == 0)
+                /* player won't lose HP and can't lose more Pw */
+                return TRAP_HIDDEN_IMMUNE;
+        }
+        /* following conditional lifted from mintrap ANTI_MAGIC logic */
+        else if (!resists_magm(mon)
+                 && (mon->mcan || (!attacktype(pm, AT_MAGC)
+                                   && !attacktype(pm, AT_BREA)))) {
+            return TRAP_CLEARLY_IMMUNE;
+        }
+        return TRAP_NOT_IMMUNE;
+    case RUST_TRAP:
+        /* harmful if wearing anything rustable or if the monster is an iron
+         * golem */
+        if (pm == &mons[PM_IRON_GOLEM])
+            return TRAP_NOT_IMMUNE;
+        else {
+            struct obj * obj = (you ? g.invent : mon->minvent);
+            for (; obj; obj = obj->nobj) {
+                /* rust traps can currently hit only worn armor and weapons */
+                if (is_rustprone(obj) && obj->owornmask) {
+                    return TRAP_NOT_IMMUNE;
+                }
+            }
+        }
+        return TRAP_CLEARLY_IMMUNE;
+    case MAGIC_TRAP:
+        /* for player, any number of bad effects.
+         * for monsters, only replicates fire trap, so fall through */
+        if (you)
+            return TRAP_NOT_IMMUNE;
+        /* else FALLTHRU */
+    case FIRE_TRAP: /* can always destroy items being carried */
+        /* harmful if not resistant or if carrying anything that could burn */
+        if (you && !Fire_resistance)
+            return TRAP_NOT_IMMUNE;
+        else if (!you && !resists_fire(mon))
+            return TRAP_NOT_IMMUNE;
+        else {
+            struct obj * obj = (you ? g.invent : mon->minvent);
+            for (; obj; obj = obj->nobj) {
+                if (obj->oclass == SCROLL_CLASS || obj->oclass == POTION_CLASS
+                    || obj->oclass == SPBOOK_CLASS
+                    || (obj->owornmask && is_flammable(obj)))
+                    return TRAP_NOT_IMMUNE;
+            }
+        }
+        return (you ? TRAP_HIDDEN_IMMUNE : TRAP_CLEARLY_IMMUNE);
+    case MAGIC_PORTAL:
+        /* never hurts anything, but player is considered non-immune so they
+         * can be asked about entering it */
+        if (!you)
+            return TRAP_CLEARLY_IMMUNE;
+        return TRAP_NOT_IMMUNE;
+    case VIBRATING_SQUARE:
+        /* no adverse effects */
+        return TRAP_CLEARLY_IMMUNE;
+    default:
+        impossible("immune_to_trap: bad ttype %d", ttype);
+    }
+    return TRAP_NOT_IMMUNE;
+}
+
 void
 dotrap(trap, trflags)
 register struct trap *trap;


### PR DESCRIPTION
Primarily, this ports UnNetHack's paranoid_trap to the vanilla 3.6+
paranoid options system via xNetHack. When this option is enabled, the
player must type out "yes" before moving onto a known trap that apparently
poses a danger to them. When not enabled, the game behaves as it did
before, and there is no warning for moving onto traps.

If the hero is hallucinating, there is no way to determine what the trap
actually is, so they will always be prompted to confirm.  If the hero is
stunned or confused or has prefixed their movement command with 'm',
they will not be prompted regardless of the trap type (overriding
the hallucination case).

The bulk of the code in this commit is a new function, immune_to_trap,
which is how the game decides whether a given monster or the hero is
safe from a certain type of trap. This helps avoid interface annoyances
in places like levitating over the holes in the Castle (a levitating
hero can never trigger a hole just by moving onto the space, so they're
"immune" to it). The function has three possible results: obviously
immune, obviously not immune, or immune but only by way of items or
intrinsics the hero might not have identified. Only the first case lets
you move onto that trap type freely. Since the game doesn't track your
knowledge of your own intrinsics, this is imperfect; a player with
innate fire resistance (and no other source of it) will still be
prompted before moving onto a fire trap.

I have not currently implemented logic allowing monsters to freely move
onto traps they have seen and are immune to, though this should
theoretically only require changing a couple lines in monmove.c.