### PR TITLE
Remove Sokoban luck penalties for things you can't cheat with

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -1798,7 +1798,6 @@ int magic; /* 0=Physical, otherwise skill level */
          * the effects of landing on the final position.
          */
         teleds(cc.x, cc.y, FALSE);
-        sokoban_guilt();
         nomul(-1);
         g.multi_reason = "jumping around";
         g.nomovemsg = "";
@@ -2513,7 +2512,7 @@ struct obj *otmp;
         return;
     }
     ttyp = (otmp->otyp == LAND_MINE) ? LANDMINE : BEAR_TRAP;
-    if (otmp == g.trapinfo.tobj && u.ux == g.trapinfo.tx 
+    if (otmp == g.trapinfo.tobj && u.ux == g.trapinfo.tx
                                 && u.uy == g.trapinfo.ty) {
         You("resume setting %s%s.", shk_your(buf, otmp),
             defsyms[trap_to_defsym(what_trap(ttyp, rn2))].explanation);

--- a/src/ball.c
+++ b/src/ball.c
@@ -967,7 +967,6 @@ xchar x, y;
         newsym(u.ux0, u.uy0); /* clean up old position */
         if (u.ux0 != u.ux || u.uy0 != u.uy) {
             spoteffects(TRUE);
-            sokoban_guilt();
         }
     }
 }

--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -843,7 +843,6 @@ boolean verbose;
         You("%s in the opposite direction.", range > 1 ? "hurtle" : "float");
     /* if we're in the midst of shooting multiple projectiles, stop */
     endmultishot(TRUE);
-    sokoban_guilt();
     uc.x = u.ux;
     uc.y = u.uy;
     /* this setting of cc is only correct if dx and dy are [-1,0,1] only */


### PR DESCRIPTION
Jumping, Newton's 3rd Law hurtling, and throwing an iron ball:
attempting to do any of these in such a way that you would diagonally
pass between boulders/walls causes the Luck penalty. However, none of
these actually get you through the diagonal gap, thus they can't be used
to cheat and the penalty doesn't make sense.