### PR TITLE
Allow rereading spellbooks to refresh memory at any time

### DIFF
--- a/src/spell.c
+++ b/src/spell.c
@@ -386,10 +386,7 @@ learn(VOID_ARGS)
             book->otyp = booktype = SPE_BLANK_PAPER;
             /* reset spestudied as if polymorph had taken place */
             book->spestudied = rn2(book->spestudied);
-        } else if (spellknow(i) > KEEN / 10) {
-            You("know %s quite well already.", splname);
-            costly = FALSE;
-        } else { /* spellknow(i) <= KEEN/10 */
+        } else {
             Your("knowledge of %s is %s.", splname,
                  spellknow(i) ? "keener" : "restored");
             incrnknow(i, 1);
@@ -438,7 +435,7 @@ int
 study_book(spellbook)
 register struct obj *spellbook;
 {
-    int booktype = spellbook->otyp;
+    int booktype = spellbook->otyp, i;
     boolean confused = (Confusion != 0);
     boolean too_hard = FALSE;
 
@@ -520,6 +517,16 @@ register struct obj *spellbook;
             impossible("Unknown spellbook level %d, book %d;",
                        objects[booktype].oc_level, booktype);
             return 0;
+        }
+
+        /* check to see if we already know it and want to refresh our memory */
+        for (i = 0; i < MAXSPELL; i++)
+            if (spellid(i) == booktype || spellid(i) == NO_SPELL)
+                break;
+        if (spellid(i) == booktype && spellknow(i) > KEEN / 10) {
+            You("know \"%s\" quite well already.", OBJ_NAME(objects[booktype]));
+            if (yn("Refresh your memory anyway?") == 'n')
+                return 0;
         }
 
         /* Books are often wiser than their readers (Rus.) */


### PR DESCRIPTION
Aimed at fixing the problem where the player knows they're going to
forget a spell in a few thousand turns, so they go back and get the
book... only to find out that they "know it quite well already", and
need to wait an indeterminate amount of time until they are on the verge
of forgetting it (< 2000 turns) before the book will let them read it
again.

This commit simply removes that 2000 turn limit, so the player can fully
restore their memory at any time with the spellbook. Naturally, this
still consumes a read charge, so the book won't ultimately last as long
if you keep rereading it early.

If you do have more than 2000 turns left, the game will prompt you to
confirm that you do want to refresh your memory anyway. As before,
rereading with fewer turns will not prompt.