### PR TITLE
Peaceful displacement: move peaceful monsters aside just like pets

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -128,7 +128,7 @@
  * definition here is convenient.
  */
 #define is_safepet(mon)                                                   \
-    (mon && mon->mtame && canspotmon(mon) && flags.safe_dog && !Confusion \
+    (mon && (mon->mtame || mon->mpeaceful) && canspotmon(mon) && flags.safe_dog && !Confusion \
      && !Hallucination && !Stunned)
 
 /*

--- a/src/hack.c
+++ b/src/hack.c
@@ -1824,10 +1824,11 @@ domove_core()
                    && (!goodpos(u.ux0, u.uy0, mtmp, 0)
                        || t_at(u.ux0, u.uy0) != NULL
                        || mtmp->ispriest
+                       || mtmp->isshk
                        || mtmp->data == &mons[PM_ORACLE]
                        || mtmp->m_id == g.quest_status.leader_m_id)) {
             /* displacing peaceful into unsafe or trapped space, or trying to
-             * displace quest leader, Oracle, or priest */
+             * displace quest leader, Oracle, shopkeeper, or priest */
             You("stop.  %s doesn't want to swap places.",
                 upstart(y_monnam(mtmp)));
             didnt_move = TRUE;

--- a/src/hack.c
+++ b/src/hack.c
@@ -1815,9 +1815,11 @@ domove_core()
         } else if (mtmp->mpeaceful && !mtmp->mtame
                    && (!goodpos(u.ux0, u.uy0, mtmp, 0)
                        || t_at(u.ux0, u.uy0) != NULL
+                       || mtmp->ispriest
+                       || mtmp->data == &mons[PM_ORACLE]
                        || mtmp->m_id == g.quest_status.leader_m_id)) {
             /* displacing peaceful into unsafe or trapped space, or trying to
-             * displace quest leader */
+             * displace quest leader, Oracle, or priest */
             u.ux = u.ux0, u.uy = u.uy0; /* didn't move after all */
             You("stop.  %s doesn't want to swap places.",
                 upstart(y_monnam(mtmp)));

--- a/src/hack.c
+++ b/src/hack.c
@@ -1778,40 +1778,48 @@ domove_core()
      * be caught by the normal falling-monster code.
      */
     if (is_safepet(mtmp) && !(is_hider(mtmp->data) && mtmp->mundetected)) {
+        /* if it turns out we can't actually move */
+        boolean didnt_move = FALSE;
+
+        /* seemimic/newsym should be done before moving hero, otherwise
+           the display code will draw the hero here before we possibly
+           cancel the swap below (we can ignore steed mx,my here) */
+        u.ux = u.ux0, u.uy = u.uy0;
         mtmp->mundetected = 0;
         if (M_AP_TYPE(mtmp))
             seemimic(mtmp);
+        u.ux = mtmp->mx, u.uy = mtmp->my; /* resume swapping positions */
 
         if (mtmp->mtrapped && (trap = t_at(mtmp->mx, mtmp->my)) != 0
             && is_pit(trap->ttyp)
             && sobj_at(BOULDER, trap->tx, trap->ty)) {
             /* can't swap places with pet pinned in a pit by a boulder */
-            u.ux = u.ux0, u.uy = u.uy0; /* didn't move after all */
-            if (u.usteed)
-                u.usteed->mx = u.ux, u.usteed->my = u.uy;
+            didnt_move = TRUE;
         } else if (u.ux0 != x && u.uy0 != y && NODIAG(mtmp->data - mons)) {
             /* can't swap places when pet can't move to your spot */
-            u.ux = u.ux0, u.uy = u.uy0;
-            if (u.usteed)
-                u.usteed->mx = u.ux, u.usteed->my = u.uy;
             You("stop.  %s can't move diagonally.", upstart(y_monnam(mtmp)));
+            didnt_move = TRUE;
         } else if (u_with_boulder
                     && !(verysmall(mtmp->data)
                          && (!mtmp->minvent || (curr_mon_load(mtmp) <= 600)))) {
             /* can't swap places when pet won't fit there with the boulder */
-            u.ux = u.ux0, u.uy = u.uy0; /* didn't move after all */
-            if (u.usteed)
-                u.usteed->mx = u.ux, u.usteed->my = u.uy;
             You("stop.  %s won't fit into the same spot that you're at.",
                  upstart(y_monnam(mtmp)));
+            didnt_move = TRUE;
         } else if (u.ux0 != x && u.uy0 != y && bad_rock(mtmp->data, x, u.uy0)
                    && bad_rock(mtmp->data, u.ux0, y)
                    && (bigmonst(mtmp->data) || (curr_mon_load(mtmp) > 600))) {
             /* can't swap places when pet won't fit thru the opening */
-            u.ux = u.ux0, u.uy = u.uy0; /* didn't move after all */
-            if (u.usteed)
-                u.usteed->mx = u.ux, u.usteed->my = u.uy;
             You("stop.  %s won't fit through.", upstart(y_monnam(mtmp)));
+            didnt_move = TRUE;
+        } else if (mtmp->mpeaceful && !mtmp->mtame && mtmp->mtrapped) {
+            /* TODO: pets can get angered when displaced out of a trap.
+             * Having peaceful monsters simply refuse is inconsistent.
+             * Probably, pets should not be able to be displaced out of a
+             * trap like a pit or bear trap at all. */
+            You("stop.  %s can't move out of that trap.",
+                upstart(y_monnam(mtmp)));
+            didnt_move = TRUE;
         } else if (mtmp->mpeaceful && !mtmp->mtame
                    && (!goodpos(u.ux0, u.uy0, mtmp, 0)
                        || t_at(u.ux0, u.uy0) != NULL
@@ -1820,9 +1828,9 @@ domove_core()
                        || mtmp->m_id == g.quest_status.leader_m_id)) {
             /* displacing peaceful into unsafe or trapped space, or trying to
              * displace quest leader, Oracle, or priest */
-            u.ux = u.ux0, u.uy = u.uy0; /* didn't move after all */
             You("stop.  %s doesn't want to swap places.",
                 upstart(y_monnam(mtmp)));
+            didnt_move = TRUE;
         } else {
             /* if trapped, there's a chance the pet goes wild */
             if (mtmp->mtrapped) {
@@ -1891,6 +1899,12 @@ domove_core()
                 pline("that's strange, unknown mintrap result!");
                 break;
             }
+        }
+
+        if (didnt_move) {
+            u.ux = u.ux0, u.uy = u.uy0; /* didn't move after all */
+            if (u.usteed)
+                u.usteed->mx = u.ux, u.usteed->my = u.uy;
         }
     }
 

--- a/src/hack.c
+++ b/src/hack.c
@@ -1778,28 +1778,9 @@ domove_core()
      * be caught by the normal falling-monster code.
      */
     if (is_safepet(mtmp) && !(is_hider(mtmp->data) && mtmp->mundetected)) {
-        /* if trapped, there's a chance the pet goes wild */
-        if (mtmp->mtrapped) {
-            if (!rn2(mtmp->mtame)) {
-                mtmp->mtame = mtmp->mpeaceful = mtmp->msleeping = 0;
-                if (mtmp->mleashed)
-                    m_unleash(mtmp, TRUE);
-                growl(mtmp);
-            } else {
-                yelp(mtmp);
-            }
-        }
-
-        /* seemimic/newsym should be done before moving hero, otherwise
-           the display code will draw the hero here before we possibly
-           cancel the swap below (we can ignore steed mx,my here) */
-        u.ux = u.ux0, u.uy = u.uy0;
         mtmp->mundetected = 0;
         if (M_AP_TYPE(mtmp))
             seemimic(mtmp);
-        else if (!mtmp->mtame)
-            newsym(mtmp->mx, mtmp->my);
-        u.ux = mtmp->mx, u.uy = mtmp->my; /* resume swapping positions */
 
         if (mtmp->mtrapped && (trap = t_at(mtmp->mx, mtmp->my)) != 0
             && is_pit(trap->ttyp)
@@ -1831,7 +1812,27 @@ domove_core()
             if (u.usteed)
                 u.usteed->mx = u.ux, u.usteed->my = u.uy;
             You("stop.  %s won't fit through.", upstart(y_monnam(mtmp)));
+        } else if (mtmp->mpeaceful && !mtmp->mtame
+                   && (!goodpos(u.ux0, u.uy0, mtmp, 0)
+                       || t_at(u.ux0, u.uy0) != NULL
+                       || mtmp->m_id == g.quest_status.leader_m_id)) {
+            /* displacing peaceful into unsafe or trapped space, or trying to
+             * displace quest leader */
+            u.ux = u.ux0, u.uy = u.uy0; /* didn't move after all */
+            You("stop.  %s doesn't want to swap places.",
+                upstart(y_monnam(mtmp)));
         } else {
+            /* if trapped, there's a chance the pet goes wild */
+            if (mtmp->mtrapped) {
+                if (!rn2(mtmp->mtame)) {
+                    mtmp->mtame = mtmp->mpeaceful = mtmp->msleeping = 0;
+                    if (mtmp->mleashed)
+                        m_unleash(mtmp, TRUE);
+                    growl(mtmp);
+                } else {
+                    yelp(mtmp);
+                }
+            }
             char pnambuf[BUFSZ];
 
             /* save its current description in case of polymorph */
@@ -1842,7 +1843,7 @@ domove_core()
             newsym(x, y);
             newsym(u.ux0, u.uy0);
 
-            You("%s %s.", mtmp->mtame ? "swap places with" : "frighten",
+            You("%s %s.", mtmp->mpeaceful ? "swap places with" : "frighten",
                 pnambuf);
 
             /* check for displacing it into pools and traps */

--- a/src/hack.c
+++ b/src/hack.c
@@ -1769,10 +1769,7 @@ domove_core()
      * previous location using the same conditions as in attack().
      * there are special extenuating circumstances:
      * (1) if the pet dies then your god angers,
-     * (2) if the pet gets trapped then your god may disapprove,
-     * (3) if the pet was already trapped and you attempt to free it
-     * not only do you encounter the trap but you may frighten your
-     * pet causing it to go wild!  moral: don't abuse this privilege.
+     * (2) if the pet gets trapped then your god may disapprove.
      *
      * Ceiling-hiding pets are skipped by this section of code, to
      * be caught by the normal falling-monster code.
@@ -1812,15 +1809,14 @@ domove_core()
             /* can't swap places when pet won't fit thru the opening */
             You("stop.  %s won't fit through.", upstart(y_monnam(mtmp)));
             didnt_move = TRUE;
-        } else if (mtmp->mpeaceful && !mtmp->mtame && mtmp->mtrapped) {
-            /* TODO: pets can get angered when displaced out of a trap.
-             * Having peaceful monsters simply refuse is inconsistent.
-             * Probably, pets should not be able to be displaced out of a
-             * trap like a pit or bear trap at all. */
+        } else if ((mtmp->mpeaceful || mtmp->mtame) && mtmp->mtrapped) {
+            /* Since peaceful monsters simply being unable to move out of traps
+             * was inconsistent with pets being able to but being untamed in the
+             * process, apply this logic equally to pets and peacefuls. */
             You("stop.  %s can't move out of that trap.",
                 upstart(y_monnam(mtmp)));
             didnt_move = TRUE;
-        } else if (mtmp->mpeaceful && !mtmp->mtame
+        } else if (mtmp->mpeaceful
                    && (!goodpos(u.ux0, u.uy0, mtmp, 0)
                        || t_at(u.ux0, u.uy0) != NULL
                        || mtmp->ispriest
@@ -1833,17 +1829,6 @@ domove_core()
                 upstart(y_monnam(mtmp)));
             didnt_move = TRUE;
         } else {
-            /* if trapped, there's a chance the pet goes wild */
-            if (mtmp->mtrapped) {
-                if (!rn2(mtmp->mtame)) {
-                    mtmp->mtame = mtmp->mpeaceful = mtmp->msleeping = 0;
-                    if (mtmp->mleashed)
-                        m_unleash(mtmp, TRUE);
-                    growl(mtmp);
-                } else {
-                    yelp(mtmp);
-                }
-            }
             char pnambuf[BUFSZ];
 
             /* save its current description in case of polymorph */

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -369,8 +369,8 @@ register struct monst *mtmp;
                 g.context.travel = g.context.travel1 = g.context.mv = g.context.run
                     = 0;
                 return TRUE;
-            } else if ((mtmp->mfrozen || (!mtmp->mcanmove)
-                        || (mtmp->data->mmove == 0)) && rn2(6)) {
+            } else if (mtmp->mfrozen || mtmp->msleeping || (!mtmp->mcanmove)
+                       || (mtmp->data->mmove == 0 && rn2(6))) {
                 pline("%s doesn't seem to move!", Monnam(mtmp));
                 g.context.travel = g.context.travel1 = g.context.mv = g.context.run
                     = 0;


### PR DESCRIPTION
This is a very popular feature which has been implemented in several variants so far. It allows you to displace peaceful monsters out of the way, following the code which already exists for pets.

Specifically, this is xNetHack's implementation; there are a few other changes in xNetHack attached to the base implementation that I think work well with it.
* Refactoring a bunch of identical code blocks to occur only in one place (didnt_move).
* Some monsters can't be displaced at all: priests, shopkeepers, the Oracle, and your quest leader.
* Peaceful and tame monsters alike will refuse to switch places with you if you are on a trap or otherwise unsafe terrain for it (such as liquid). This indirectly fixes a source of extreme aggravation where a levitating or water walking hero accidentally displaces their pet onto water, instantly drowning it. It also prevents you from trivially killing any peaceful by the same method.
* Monsters can't be displaced out of a trap they are trapped in, meaning that the logic for untaming your pet by displacing it out of a trap no longer exists.
* Sleeping monsters count as immobilized. Additionally, immobilized monsters can't be displaced at all; there used to be a 1/6 chance of displacing them anyway. The 1/6 chance for sessile monsters is retained.

Other notes:
* I noticed when debugging that attempting to move onto a tame, disguised, mimic's space displaces and decloaks it with no message at all; this seemed weird but that appears to be the existing behavior.