### PR TITLE
Display weights of objects in inventory

### DIFF
--- a/doc/Guidebook.mn
+++ b/doc/Guidebook.mn
@@ -3765,6 +3765,9 @@ other aspects of the description (default on).
 Persistent.
 .lp ""
 If you use menu coloring, you may want to turn this off.
+.lp invweight
+Augment inventory object descriptions with their objects' weight
+(default on).
 .lp legacy
 Display an introductory message when starting the game (default on).
 Persistent.
@@ -4345,9 +4348,6 @@ For a comma-separated list in NETHACKOPTIONS or an OPTIONS line in a
 configuration file,
 that would
 be the \fIrightmost\fP option in the list.
-.lp wizweight
-Augment object descriptions with their objects' weight (default off).
-Debug mode only.
 .lp zerocomp
 When writing out a save file, perform zero-comp compression of the
 contents. Not all ports support zero-comp compression. It has no effect
@@ -5554,17 +5554,17 @@ The syntax is the same as WIZARDS.
 MAXPLAYERS\ =\ Limit the maximum number of games that can be running
 at the same time.
 .lp
-SAVEFORMAT\ =\ A list of up to two save file formats separated by space. 
-The first format in the list will written as well as read. The second format 
+SAVEFORMAT\ =\ A list of up to two save file formats separated by space.
+The first format in the list will written as well as read. The second format
 will be read only if no save file in the first format exists.
-Valid choices are \(lqhistorical\(rq for binary writing of entire structs, 
+Valid choices are \(lqhistorical\(rq for binary writing of entire structs,
 \(lqlendian\(rq for binary writing of each field in little-endian order,
 \(lqascii\(rq for writing the save file content in ascii text.
 .lp
-BONESFORMAT\ =\ A list of up to two bones file formats separated by space. 
-The first format in the list will written as well as read. The second format 
+BONESFORMAT\ =\ A list of up to two bones file formats separated by space.
+The first format in the list will written as well as read. The second format
 will be read only if no bones files in the first format exist.
-Valid choices are \(lqhistorical\(rq for binary writing of entire structs, 
+Valid choices are \(lqhistorical\(rq for binary writing of entire structs,
 \(lqlendian\(rq for binary writing of each field in little-endian order,
 \(lqascii\(rq for writing the bones file content in ascii text.
 .lp
@@ -5598,7 +5598,7 @@ to identify unique people for the score file.
 MAX_STATUENAME_RANK\ =\ Maximum number of score file entries to use for
 random statue names (default is 10).
 .lp
-ACCESSIBILITY\ =\ 0 or 1 to disable or enable, respectively, the ability for players 
+ACCESSIBILITY\ =\ 0 or 1 to disable or enable, respectively, the ability for players
 to set S_pet_override and S_hero_override symbols in their configuration file.
 .lp
 PORTABLE_DEVICE_PATHS\ =\ 0 or 1 Windows OS only, the game will look

--- a/include/flag.h
+++ b/include/flag.h
@@ -294,8 +294,8 @@ struct instance_flags {
     boolean clicklook;       /* allow right-clicking for look */
     boolean cmdassist;       /* provide detailed assistance for some comnds */
     boolean time_botl;       /* context.botl for 'time' (moves) only */
-    boolean wizweight;       /* display weight of everything in wizard mode */
     boolean wizmgender;      /* test gender info from core in window port */
+    boolean invweight;       /* display weights of items in inventory */
     /*
      * Window capability support.
      */

--- a/include/optlist.h
+++ b/include/optlist.h
@@ -237,6 +237,8 @@ opt_##a,
 #endif
     NHOPTB(implicit_uncursed, 0, opt_out, set_in_game, On, Yes, No, No,
                 NoAlias, &flags.implicit_uncursed)
+    NHOPTB(invweight, 0, opt_out, set_in_game, On, Yes, No, No, NoAlias,
+                &iflags.invweight)
 #if 0   /* obsolete - pre-OSX Mac */
     NHOPTB(large_font, 0, opt_in, set_in_config, Off, Yes, No, No, NoAlias,
                 &iflags.obsolete)
@@ -416,10 +418,10 @@ opt_##a,
                 &flags.showrace)
 #ifdef SCORE_ON_BOTL
     NHOPTB(showscore, 0, opt_in, set_in_game, Off, Yes, No, No, NoAlias,
-                &flags.showscore) 
+                &flags.showscore)
 #else
     NHOPTB(showscore, 0, opt_in, set_in_config, Off, Yes, No, No, NoAlias,
-                (boolean *) 0) 
+                (boolean *) 0)
 #endif
     NHOPTB(silent, 0, opt_out, set_in_game, On, Yes, No, No, NoAlias,
                 &flags.silent)
@@ -441,7 +443,7 @@ opt_##a,
                 &iflags.status_updates)
     NHOPTO("status condition fields", o_status_cond, BUFSZ, opt_in,
            set_in_game, No, Yes, No, NoAlias, "edit status condition fields")
-#ifdef STATUS_HILITES 
+#ifdef STATUS_HILITES
     NHOPTC(statushilites, 20, opt_in, set_in_game, Yes, Yes, Yes, No, NoAlias,
                 "0=no status highlighting, N=show highlights for N turns")
     NHOPTO("status hilite rules", o_status_hilites, BUFSZ, opt_in, set_in_game,
@@ -556,8 +558,6 @@ opt_##a,
                 NoAlias, "windowing system to use (should be specified first)")
     NHOPTB(wizmgender, 0, opt_in, set_wizonly, Off, Yes, No, No, NoAlias,
                 &iflags.wizmgender)
-    NHOPTB(wizweight, 0, opt_in, set_wizonly, Off, Yes, No, No, NoAlias,
-                &iflags.wizweight)
     NHOPTB(wraptext, 0, opt_in, set_in_game, Off, Yes, No, No, NoAlias,
                 &iflags.wc2_wraptext)
 

--- a/src/invent.c
+++ b/src/invent.c
@@ -2410,8 +2410,13 @@ xprname(struct obj *obj,
     boolean use_invlet = (flags.invlet_constant
                           && let != CONTAINED_SYM && let != HANDS_SYM);
     long savequan = 0;
+    long save_owt = 0;
 
     if (quan && obj) {
+        if (iflags.invweight) {
+            save_owt = obj->owt;
+            obj->owt = obj->owt * quan / obj->quan;
+        }
         savequan = obj->quan;
         obj->quan = quan;
     }
@@ -2433,8 +2438,12 @@ xprname(struct obj *obj,
         Sprintf(li, "%c - %s%s", (use_invlet ? obj->invlet : let),
                 (txt ? txt : doname(obj)), (dot ? "." : ""));
     }
-    if (savequan)
+    if (savequan) {
         obj->quan = savequan;
+    }
+    if (save_owt) {
+        obj->owt = save_owt;
+    }
 
     return li;
 }

--- a/src/invent.c
+++ b/src/invent.c
@@ -2648,6 +2648,17 @@ display_pickinv(
         gotsomething = TRUE;
     }
 
+    /* Show weight total and item limit. Only for full invent display, not
+     * within getobj. */
+    if (!lets) {
+        char invheading[QBUFSZ];
+        int wcap = weight_cap();
+        Sprintf(invheading, "Inventory: %d/%d weight (%d/52 slots)",
+                inv_weight() + wcap, wcap, inv_cnt(FALSE));
+        add_menu(win, &nul_glyphinfo, &any, 0, 0, ATR_BOLD, invheading,
+                 MENU_ITEMFLAGS_NONE);
+    }
+
  nextclass:
     classcount = 0;
     for (srtinv = sortedinvent; (otmp = srtinv->obj) != 0; ++srtinv) {

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -1307,15 +1307,11 @@ doname_base(struct obj* obj, unsigned int doname_flags)
         Strcat(prefix, tmpbuf);
     }
 
-    /* show weight for items (debug tourist info);
-       "aum" is stolen from Crawl's "Arbitrary Unit of Measure" */
-    if (wizard && iflags.wizweight) {
-        /* wizard mode user has asked to see object weights */
-        if (with_price && (*(eos(bp)-1) == ')'))
-            Sprintf(eos(bp)-1, ", %u aum)", obj->owt);
-        else
-            Sprintf(eos(bp), " (%u aum)", obj->owt);
+    /* show weight for items */
+    if (iflags.invweight && (obj->where == OBJ_INVENT || wizard)) {
+        Sprintf(eos(bp), " {%d}", obj->owt);
     }
+
     bp = strprepend(bp, prefix);
     return bp;
 }


### PR DESCRIPTION
The bulk of this pull request is the commit adding the 'invweight' option, which allows the player to see the weight of any object they are carrying. See its commit message for full details.

I also put in the complementary feature in which showing your inventory will display your total carried weight compared to your current carrying capacity, and your slots used/total.