### PR TITLE
Add the Grudge Patch: monsters with natural enmity will fight each other

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1433,6 +1433,7 @@ E int FDECL(curr_mon_load, (struct monst *));
 E int FDECL(max_mon_load, (struct monst *));
 E int FDECL(can_carry, (struct monst *, struct obj *));
 E int FDECL(mfndpos, (struct monst *, coord *, long *, long));
+E long FDECL(mm_aggression, (struct monst *, struct monst *));
 E boolean FDECL(monnear, (struct monst *, int, int));
 E void NDECL(dmonsfree);
 E void FDECL(elemental_clog, (struct monst *));

--- a/include/mondata.h
+++ b/include/mondata.h
@@ -113,6 +113,10 @@
 #define is_bird(ptr) ((ptr)->mlet == S_BAT && !is_bat(ptr))
 #define is_giant(ptr) (((ptr)->mflags2 & M2_GIANT) != 0L)
 #define is_golem(ptr) ((ptr)->mlet == S_GOLEM)
+#define is_rat(ptr)                                         \
+    (((ptr) == &mons[PM_SEWER_RAT]) || ((ptr) == &mons[PM_GIANT_RAT]) || \
+     ((ptr) == &mons[PM_RABID_RAT]) || ((ptr) == &mons[PM_WERERAT]) || \
+     ((ptr) == &mons[PM_HUMAN_WERERAT]))
 #define is_domestic(ptr) (((ptr)->mflags2 & M2_DOMESTIC) != 0L)
 #define is_demon(ptr) (((ptr)->mflags2 & M2_DEMON) != 0L)
 #define is_mercenary(ptr) (((ptr)->mflags2 & M2_MERC) != 0L)

--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -1015,7 +1015,7 @@ int after; /* this is extra fast monster movement */
                 || ((mtmp->mhp * 4 < mtmp->mhpmax
                      || mtmp2->data->msound == MS_GUARDIAN
                      || mtmp2->data->msound == MS_LEADER) && mtmp2->mpeaceful
-                    && !Conflict)
+                    && !(mm_aggression(mtmp, mtmp2) & ALLOW_M) && !Conflict)
                 || (touch_petrifies(mtmp2->data) && !resists_ston(mtmp)))
                 continue;
 

--- a/src/mon.c
+++ b/src/mon.c
@@ -15,7 +15,6 @@
 static void FDECL(sanity_check_single_mon, (struct monst *, BOOLEAN_P,
                                                 const char *));
 static boolean FDECL(restrap, (struct monst *));
-static long FDECL(mm_aggression, (struct monst *, struct monst *));
 static long FDECL(mm_displacement, (struct monst *, struct monst *));
 static int NDECL(pick_animal);
 static void FDECL(kill_eggs, (struct obj *));
@@ -1584,7 +1583,7 @@ struct monst *magr, *mdef;
    in the absence of Conflict.  There is no provision for targetting
    other monsters; just hand to hand fighting when they happen to be
    next to each other. */
-static long
+long
 mm_aggression(magr, mdef)
 struct monst *magr, /* monster that is currently deciding where to move */
              *mdef; /* another monster which is next to it */


### PR DESCRIPTION
This ultimately derives from Nephi's Grudge Patch back in the 3.4.3 era,
plus some updates from SpliceHack and xNetHack. Its primary purpose is
to make the dungeon a richer, more interesting place by providing more
opportunities for natural monster-to-monster interactions. All of the
code necessary to support monster battling was already in place; this
merely adds more monster pairs to mm_aggression.

Monsters that will fight each other are:
- Quest guardians and hostile non-guardians
- Angels and demons
- Elves and orcs
- Hobbits and Nazguls

Monsters with a one-sided grudge (where the defending monster may
counterattack, but won't use its own turns to retaliate aggressively)
are:
- Baby purple worms against shriekers (purple worms already had this)
- Ravens against floating eyes
- Spiders against insects (x and a)
- Bats against flying insects
- Cats against rats
- Woodchucks against the Oracle

Pets will never attack other pets, even if they would normally be
hostile to each other.