### PR TITLE
Refactor and simplify the rndmonst function

### DIFF
--- a/include/decl.h
+++ b/include/decl.h
@@ -979,12 +979,6 @@ struct instance_globals {
     /* lock.c */
     struct xlock_s xlock;
 
-    /* makemon.c */
-    struct {
-        int choice_count;
-        char mchoices[SPECIAL_PM]; /* value range is 0..127 */
-    } rndmonst_state;
-
     /* mhitm.c */
     boolean vis;
     boolean far_noise;

--- a/include/extern.h
+++ b/include/extern.h
@@ -1193,7 +1193,6 @@ E void FDECL(dealloc_mextra, (struct monst *));
 E struct monst *FDECL(makemon, (struct permonst *, int, int, int));
 E boolean FDECL(create_critters, (int, struct permonst *, BOOLEAN_P));
 E struct permonst *NDECL(rndmonst);
-E void FDECL(reset_rndmonst, (int));
 E struct permonst *FDECL(mkclass, (CHAR_P, int));
 E struct permonst *FDECL(mkclass_aligned, (CHAR_P, int, ALIGNTYP_P));
 E int FDECL(mkclass_poly, (int));

--- a/include/monst.h
+++ b/include/monst.h
@@ -201,4 +201,13 @@ struct monst {
 #define is_obj_mappear(mon,otyp) (M_AP_TYPE(mon) == M_AP_OBJECT \
                                   && (mon)->mappearance == (otyp))
 
+/* Get the maximum difficulty monsters that can currently be generated,
+ * given the current level difficulty and the hero's level. */
+#define max_difficulty() ((level_difficulty() + u.ulevel) / 2)
+#define min_difficulty() (level_difficulty() / 6)
+
+/* Macros for whether a given monster is too strong for a specific level. */
+#define toostrong(monindx, lev) (mons[monindx].difficulty > lev)
+#define tooweak(monindx, lev) (mons[monindx].difficulty < lev)
+
 #endif /* MONST_H */

--- a/src/decl.c
+++ b/src/decl.c
@@ -460,10 +460,6 @@ const struct instance_globals g_init = {
     /* lock.c */
     UNDEFINED_VALUES,
 
-    /* makemon.c */
-    { -1, /* choice_count */
-     { 0 } }, /* mchoices */
-
     /* mhitm.c */
     UNDEFINED_VALUE, /* vis */
     UNDEFINED_VALUE, /* far_noise */

--- a/src/do.c
+++ b/src/do.c
@@ -1454,7 +1454,6 @@ boolean at_stairs, falling, portal;
             || dunlev(&u.uz) < dunlev_reached(&u.uz))
             dunlev_reached(&u.uz) = dunlev(&u.uz);
     }
-    reset_rndmonst(NON_PM); /* u.uz change affects monster generation */
 
     /* set default level change destination areas */
     /* the special level code may override these */

--- a/src/exper.c
+++ b/src/exper.c
@@ -215,7 +215,6 @@ const char *drainer; /* cause of death, if drain should be fatal */
         pline("%s level %d.", Goodbye(), u.ulevel--);
         /* remove intrinsic abilities */
         adjabil(u.ulevel + 1, u.ulevel);
-        reset_rndmonst(NON_PM); /* new monster selection */
     } else {
         if (drainer) {
             g.killer.format = KILLED_BY;
@@ -315,7 +314,6 @@ boolean incr; /* true iff via incremental experience growth */
         if (u.ulevelmax < u.ulevel)
             u.ulevelmax = u.ulevel;
         adjabil(u.ulevel - 1, u.ulevel); /* give new intrinsics */
-        reset_rndmonst(NON_PM);          /* new monster selection */
     }
     g.context.botl = TRUE;
 }

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -943,7 +943,6 @@ boolean ghostly;
                         makeplural(mons[mndx].mname));
         }
         g.mvitals[mndx].mvflags |= G_EXTINCT;
-        reset_rndmonst(mndx);
     }
     return result;
 }
@@ -1520,92 +1519,61 @@ rndmonst()
     if (u.uz.dnum == quest_dnum && rn2(7) && (ptr = qt_montype()) != 0)
         return ptr;
 
-    if (g.rndmonst_state.choice_count < 0) { /* need to recalculate */
-        int minmlev, maxmlev;
-        boolean elemlevel;
-        boolean upper;
+    /* determine the level of the weakest monster to make. */
+    int minmlev = min_difficulty();
+    /* determine the level of the strongest monster to make. */
+    int maxmlev = max_difficulty();
+    /* Only generate capital-letter monsters on the Rogue level. */
+    boolean uppercase = Is_rogue_level(&u.uz);
+    /* Only generate monsters appropriate to an Elemental Plane, if on plane. */
+    boolean elemlevel = In_endgame(&u.uz) && !Is_astralevel(&u.uz);
 
-        g.rndmonst_state.choice_count = 0;
-        /* look for first common monster */
-        for (mndx = LOW_PM; mndx < SPECIAL_PM; mndx++) {
-            if (!uncommon(mndx))
-                break;
-            g.rndmonst_state.mchoices[mndx] = 0;
-        }
-        if (mndx == SPECIAL_PM) {
-            /* evidently they've all been exterminated */
-            debugpline0("rndmonst: no common mons!");
-            return (struct permonst *) 0;
-        } /* else `mndx' now ready for use below */
-        /* determine the level of the weakest monster to make. */
-        minmlev = min_difficulty();
-        /* determine the level of the strongest monster to make. */
-        maxmlev = max_difficulty();
-        upper = Is_rogue_level(&u.uz);
-        elemlevel = In_endgame(&u.uz) && !Is_astralevel(&u.uz);
+    int totalweight = 0;
+    int selected_mndx = NON_PM;
+    for (mndx = LOW_PM; mndx < SPECIAL_PM; mndx++) {
+        ptr = &mons[mndx];
+        if (tooweak(mndx, minmlev) || toostrong(mndx, maxmlev))
+            continue;
+        if (uppercase && !isupper((uchar) def_monsyms[(int) ptr->mlet].sym))
+            continue;
+        if (elemlevel && wrong_elem_type(ptr))
+            continue;
+        if (uncommon(mndx))
+            /* actually means extinct, genocided, unique, or out of place in/out
+             * of Gehennom */
+            continue;
+        if (Inhell && (ptr->geno & G_NOHELL))
+            continue;
 
-        /*
-         * Find out how many monsters exist in the range we have selected.
+        /* Weighted reservoir sampling: select ptr with a
+         * (ptr weight)/(total of all weights so far including ptr's)
+         * probability. For example, if the previous total is 10, and this is
+         * now looking at acid blobs with a frequency of 2, it has a 2/12 chance
+         * of abandoning ptr's previous value in favor of acid blobs, and a
+         * 10/12 chance of keeping it at whatever it was.
+         *
+         * Surprisingly, this does not bias results towards either the earlier
+         * or the later monsters: the smaller pool and better odds from being
+         * earlier are exactly canceled out by having more monsters to
+         * potentially steal its spot.
          */
-        for ( ; mndx < SPECIAL_PM; mndx++) { /* (`mndx' initialized above) */
-            ptr = &mons[mndx];
-            g.rndmonst_state.mchoices[mndx] = 0;
-            if (tooweak(mndx, minmlev) || toostrong(mndx, maxmlev))
-                continue;
-            if (upper && !isupper((uchar) def_monsyms[(int) ptr->mlet].sym))
-                continue;
-            if (elemlevel && wrong_elem_type(ptr))
-                continue;
-            if (uncommon(mndx))
-                continue;
-            if (Inhell && (ptr->geno & G_NOHELL))
-                continue;
-            ct = (int) (ptr->geno & G_FREQ) + align_shift(ptr);
-            if (ct < 0 || ct > 127)
-                panic("rndmonst: bad count [#%d: %d]", mndx, ct);
-            g.rndmonst_state.choice_count += ct;
-            g.rndmonst_state.mchoices[mndx] = (char) ct;
+        int weight = (int) (ptr->geno & G_FREQ) + align_shift(ptr);
+        if (weight < 0 || weight > 127) {
+            impossible("bad weight in rndmonst for mndx %d", mndx);
+            weight = 0;
         }
-        /*
-         *      Possible modification:  if choice_count is "too low",
-         *      expand minmlev..maxmlev range and try again.
-         */
-    } /* choice_count+mchoices[] recalc */
-
-    if (g.rndmonst_state.choice_count <= 0) {
-        /* maybe no common mons left, or all are too weak or too strong */
-        debugpline1("rndmonst: choice_count=%d", g.rndmonst_state.choice_count);
-        return (struct permonst *) 0;
+        totalweight += weight;
+        if (rn2(totalweight) < weight)
+            selected_mndx = mndx;
+        /* Possible modification:  if there aren't "enough" candidate monsters,
+         * expand minmlev..maxmlev range and try again. */
     }
 
-    /*
-     *  Now, select a monster at random.
-     */
-    ct = rnd(g.rndmonst_state.choice_count);
-    for (mndx = LOW_PM; mndx < SPECIAL_PM; mndx++)
-        if ((ct -= (int) g.rndmonst_state.mchoices[mndx]) <= 0)
-            break;
-
-    if (mndx == SPECIAL_PM || uncommon(mndx)) { /* shouldn't happen */
-        impossible("rndmonst: bad `mndx' [#%d]", mndx);
+    if (selected_mndx == NON_PM || uncommon(selected_mndx)) { /* shouldn't happen */
+        impossible("rndmonst: bad `mndx' [#%d]", selected_mndx);
         return (struct permonst *) 0;
     }
-    return &mons[mndx];
-}
-
-/* called when you change level (experience or dungeon depth) or when
-   monster species can no longer be created (genocide or extinction) */
-void
-reset_rndmonst(mndx)
-int mndx; /* particular species that can no longer be created */
-{
-    /* cached selection info is out of date */
-    if (mndx == NON_PM) {
-        g.rndmonst_state.choice_count = -1; /* full recalc needed */
-    } else if (mndx < SPECIAL_PM) {
-        g.rndmonst_state.choice_count -= g.rndmonst_state.mchoices[mndx];
-        g.rndmonst_state.mchoices[mndx] = 0;
-    } /* note: safe to ignore extinction of unique monsters */
+    return &mons[selected_mndx];
 }
 
 /* decide whether it's ok to generate a candidate monster by mkclass() */

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -1565,7 +1565,7 @@ rndmonst()
         totalweight += weight;
         if (rn2(totalweight) < weight)
             selected_mndx = mndx;
-        /* Possible modification:  if there aren't "enough" candidate monsters,
+        /* Possible modification:  if totalweight is "too low",
          * expand minmlev..maxmlev range and try again. */
     }
 

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -27,8 +27,6 @@ static boolean FDECL(makemon_rnd_goodpos, (struct monst *,
 
 #define m_initsgrp(mtmp, x, y, mmf) m_initgrp(mtmp, x, y, 3, mmf)
 #define m_initlgrp(mtmp, x, y, mmf) m_initgrp(mtmp, x, y, 10, mmf)
-#define toostrong(monindx, lev) (mons[monindx].difficulty > lev)
-#define tooweak(monindx, lev) (mons[monindx].difficulty < lev)
 
 boolean
 is_home_elemental(ptr)
@@ -1523,7 +1521,7 @@ rndmonst()
         return ptr;
 
     if (g.rndmonst_state.choice_count < 0) { /* need to recalculate */
-        int zlevel, minmlev, maxmlev;
+        int minmlev, maxmlev;
         boolean elemlevel;
         boolean upper;
 
@@ -1539,11 +1537,10 @@ rndmonst()
             debugpline0("rndmonst: no common mons!");
             return (struct permonst *) 0;
         } /* else `mndx' now ready for use below */
-        zlevel = level_difficulty();
         /* determine the level of the weakest monster to make. */
-        minmlev = zlevel / 6;
+        minmlev = min_difficulty();
         /* determine the level of the strongest monster to make. */
-        maxmlev = (zlevel + u.ulevel) / 2;
+        maxmlev = max_difficulty();
         upper = Is_rogue_level(&u.uz);
         elemlevel = In_endgame(&u.uz) && !Is_astralevel(&u.uz);
 

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -299,7 +299,6 @@ newman()
         change_sex();
 
     adjabil(oldlvl, (int) u.ulevel);
-    reset_rndmonst(NON_PM); /* new monster generation criteria */
 
     /* random experience points for the new experience level */
     u.uexp = rndexp(FALSE);

--- a/src/read.c
+++ b/src/read.c
@@ -2107,7 +2107,6 @@ do_class_genocide()
                      * have G_GENOD or !G_GENO.
                      */
                     g.mvitals[i].mvflags |= (G_GENOD | G_NOCORPSE);
-                    reset_rndmonst(i);
                     kill_genocided_monsters();
                     update_inventory(); /* eggs & tins */
                     pline("Wiped out all %s.", nam);
@@ -2324,7 +2323,6 @@ int how;
         } else if (ptr == g.youmonst.data) {
             rehumanize();
         }
-        reset_rndmonst(mndx);
         kill_genocided_monsters();
         update_inventory(); /* in case identified eggs were affected */
     } else {


### PR DESCRIPTION
This changes rndmonst() to use a weighted reservoir sampling algorithm, rather than a unwieldy pre-computed cache of eligible monsters that needs to be updated every time the hero goes up or down a floor, gains or loses a level, or extincts or genocides a monster. It removes the rndmonst_cache global (and thus is not save compatible) and the reset_rndmonst function.

This algorithm still requires only a linear pass over the list of monsters (the same as what rndmonst() required even when not updating the cache). 

Many of NetHack's loops could benefit from being rewritten using [reservoir sampling](https://en.wikipedia.org/wiki/Reservoir_sampling), but rndmonst was one of the biggest candidates due to being able to get rid of the cache.

This is a code-only change and does not change the distribution of monsters selected by rndmonst() at all.

c1c90bb is the same commit in the consolidated pull request.