### PR TITLE
Added guard for definition of WIN_STATUS for Linux and GCC 10

### DIFF
--- a/src/windows.c
+++ b/src/windows.c
@@ -860,7 +860,13 @@ const char *status_fieldnm[MAXBLSTATS];
 const char *status_fieldfmt[MAXBLSTATS];
 char *status_vals[MAXBLSTATS];
 boolean status_activefields[MAXBLSTATS];
+#if __linux__
+# if __GNUC__ < 10
 NEARDATA winid WIN_STATUS;
+# endif
+#else
+NEARDATA winid WIN_STATUS;
+#endif
 
 void
 genl_status_init()


### PR DESCRIPTION
Compiling with GCC 10 causes a duplicate definition error during linking with the `WIN_STATUS` definition in `decl.c`.