### PR TITLE
Extensions to the MS-DOS VESA mode

### DIFF
--- a/include/flag.h
+++ b/include/flag.h
@@ -367,6 +367,10 @@ struct instance_flags {
     int wc_map_mode;        /* specify map viewing options, mostly
                              * for backward compatibility */
     int wc_player_selection;    /* method of choosing character */
+#if defined(MSDOS)
+    unsigned wc_video_width;    /* X resolution of screen */
+    unsigned wc_video_height;   /* Y resolution of screen */
+#endif
     boolean wc_splash_screen;   /* display an opening splash screen or not */
     boolean wc_popup_dialog;    /* put queries in pop up dialogs instead of
                                  * in the message window */

--- a/include/tileset.h
+++ b/include/tileset.h
@@ -18,8 +18,14 @@ struct TileImage {
 
 boolean FDECL(read_tiles, (const char *filename, BOOLEAN_P true_color));
 const struct Pixel *NDECL(get_palette);
+boolean FDECL(set_tile_type, (BOOLEAN_P true_color));
 void NDECL(free_tiles);
 const struct TileImage *FDECL(get_tile, (unsigned tile_index));
+
+/* For resizing tiles */
+struct TileImage *FDECL(stretch_tile, (const struct TileImage *,
+                                       unsigned, unsigned));
+void FDECL(free_tile, (struct TileImage *));
 
 /* Used internally by the tile set code */
 struct TileSetImage {

--- a/src/options.c
+++ b/src/options.c
@@ -3349,8 +3349,31 @@ boolean tinitial, tfrom_file;
         return retval;
     }
 #endif /* VIDEOSHADES */
-
 #ifdef MSDOS
+    fullname = "video_width";
+    if (match_optname(opts, fullname, 7, TRUE)) {
+        if (duplicate)
+            complain_about_duplicate(opts, 1);
+        if (negated) {
+            bad_negation(fullname, FALSE);
+            return FALSE;
+        }
+        op = string_for_opt(opts, negated);
+        iflags.wc_video_width = strtol(op, NULL, 10);
+        return FALSE;
+    }
+    fullname = "video_height";
+    if (match_optname(opts, fullname, 7, TRUE)) {
+        if (duplicate)
+            complain_about_duplicate(opts, 1);
+        if (negated) {
+            bad_negation(fullname, FALSE);
+            return FALSE;
+        }
+        op = string_for_opt(opts, negated);
+        iflags.wc_video_height = strtol(op, NULL, 10);
+        return FALSE;
+    }
 #ifdef NO_TERMS
     /* video:string -- must be after longer tests */
     fullname = "video";

--- a/sys/msdos/msdos.c
+++ b/sys/msdos/msdos.c
@@ -64,6 +64,11 @@ tgetch()
 {
     char ch;
 
+#ifdef SCREEN_VESA
+    if (iflags.usevesa) {
+        vesa_flush_text();
+    }
+#endif /*SCREEN_VESA*/
 /* BIOSgetch can use the numeric key pad on IBM compatibles. */
 #ifdef SIMULATE_CURSOR
     if (iflags.grmode && cursor_flag)

--- a/sys/msdos/pcvideo.h
+++ b/sys/msdos/pcvideo.h
@@ -181,6 +181,10 @@ struct overview_planar_cell_struct {
 #define ATTRIB_VGA_INTENSE 14      /* Intense White 94/06/07 palette chg*/
 #endif                             /*SCREEN_VGA || SCREEN_8514*/
 
+#if defined(SCREEN_VESA)
+#define BACKGROUND_VESA_COLOR 240
+#endif                             /*SCREEN_VESA*/
+
 #if defined(PC9800)
 static unsigned char attr98[CLR_MAX] = {
     0xe1, /*  0 white            */
@@ -249,6 +253,7 @@ E void FDECL(txt_xputc, (CHAR_P, int));
 
 /* ### vidvga.c ### */
 
+enum vga_pan_direction { pan_left, pan_up, pan_right, pan_down };
 #ifdef SCREEN_VGA
 E void NDECL(vga_backsp);
 E void FDECL(vga_clear_screen, (int));
@@ -274,7 +279,7 @@ E void FDECL(vga_tty_startup, (int *, int *));
 E void FDECL(vga_xputs, (const char *, int, int));
 E void FDECL(vga_xputc, (CHAR_P, int));
 E void FDECL(vga_xputg, (int, int, unsigned));
-E void FDECL(vga_userpan, (BOOLEAN_P));
+E void FDECL(vga_userpan, (enum vga_pan_direction));
 E void FDECL(vga_overview, (BOOLEAN_P));
 E void FDECL(vga_traditional, (BOOLEAN_P));
 E void NDECL(vga_refresh);
@@ -303,10 +308,11 @@ E void FDECL(vesa_tty_startup, (int *, int *));
 E void FDECL(vesa_xputs, (const char *, int, int));
 E void FDECL(vesa_xputc, (CHAR_P, int));
 E void FDECL(vesa_xputg, (int, int, unsigned));
-E void FDECL(vesa_userpan, (BOOLEAN_P));
+E void FDECL(vesa_userpan, (enum vga_pan_direction));
 E void FDECL(vesa_overview, (BOOLEAN_P));
 E void FDECL(vesa_traditional, (BOOLEAN_P));
 E void NDECL(vesa_refresh);
+E void NDECL(vesa_flush_text);
 #endif /* SCREEN_VESA */
 #endif /* NO_TERMS   */
 

--- a/sys/msdos/vidvesa.c
+++ b/sys/msdos/vidvesa.c
@@ -108,7 +108,7 @@ static int viewport_cols = 40;
 static int viewport_rows = ROWNO;
 
 static const struct Pixel defpalette[] = {    /* Colors for text and the position bar */
-	{ 0x18, 0x18, 0x18, 0xff }, /* CLR_BLACK */
+	{ 0x00, 0x00, 0x00, 0xff }, /* CLR_BLACK */
 	{ 0xaa, 0x00, 0x00, 0xff }, /* CLR_RED */
 	{ 0x00, 0xaa, 0x00, 0xff }, /* CLR_GREEN */
 	{ 0x99, 0x40, 0x00, 0xff }, /* CLR_BROWN */

--- a/sys/msdos/vidvesa.c
+++ b/sys/msdos/vidvesa.c
@@ -925,18 +925,21 @@ unsigned mode;
 
     if (mode == MODETEXT) {
         iflags.grmode = 0;
+        memset(&regs, 0, sizeof(regs));
         regs.x.ax = mode;
         (void) __dpmi_int(VIDEO_BIOS, &regs);
     } else if (mode >= 0x100) {
         iflags.grmode = 1;
+        memset(&regs, 0, sizeof(regs));
         regs.x.ax = 0x4F02;
-        regs.x.bx = mode & 0x81FF;
+        regs.x.bx = mode;
         (void) __dpmi_int(VIDEO_BIOS, &regs);
         /* Record that the window position is unknown */
         vesa_win_pos[0] = 0xFFFFFFFF;
         vesa_win_pos[1] = 0xFFFFFFFF;
     } else {
         iflags.grmode = 0; /* force text mode for error msg */
+        memset(&regs, 0, sizeof(regs));
         regs.x.ax = MODETEXT;
         (void) __dpmi_int(VIDEO_BIOS, &regs);
         g_attribute = attrib_text_normal;
@@ -1057,12 +1060,21 @@ vesa_detect()
     vesa_pixel_size = mode_info.BitsPerPixel;
     vesa_pixel_bytes = (vesa_pixel_size + 7) / 8;
     if (vbe_info.VbeVersion >= 0x0300) {
-        vesa_red_pos = mode_info.RedFieldPosition;
-        vesa_red_size = mode_info.RedMaskSize;
-        vesa_green_pos = mode_info.GreenFieldPosition;
-        vesa_green_size = mode_info.GreenMaskSize;
-        vesa_blue_pos = mode_info.BlueFieldPosition;
-        vesa_blue_size = mode_info.BlueMaskSize;
+        if (mode_info.ModeAttributes & 0x80) {
+            vesa_red_pos = mode_info.LinRedFieldPosition;
+            vesa_red_size = mode_info.LinRedMaskSize;
+            vesa_green_pos = mode_info.LinGreenFieldPosition;
+            vesa_green_size = mode_info.LinGreenMaskSize;
+            vesa_blue_pos = mode_info.LinBlueFieldPosition;
+            vesa_blue_size = mode_info.LinBlueMaskSize;
+        } else {
+            vesa_red_pos = mode_info.RedFieldPosition;
+            vesa_red_size = mode_info.RedMaskSize;
+            vesa_green_pos = mode_info.GreenFieldPosition;
+            vesa_green_size = mode_info.GreenMaskSize;
+            vesa_blue_pos = mode_info.BlueFieldPosition;
+            vesa_blue_size = mode_info.BlueMaskSize;
+        }
     } else {
         switch (vesa_pixel_size) {
         case 15:

--- a/sys/msdos/vidvga.c
+++ b/sys/msdos/vidvga.c
@@ -502,18 +502,20 @@ boolean clearfirst;
 #endif /* USE_TILES && CLIPPING */
 
 void
-vga_userpan(left)
-boolean left;
+vga_userpan(pan)
+enum vga_pan_direction pan;
 {
     int x;
 
     /*	pline("Into userpan"); */
     if (iflags.over_view || iflags.traditional_view)
         return;
-    if (left)
+    if (pan == pan_left)
         x = min(COLNO - 1, clipxmax + 10);
-    else
+    else if (pan == pan_right)
         x = max(0, clipx - 10);
+    else
+        return;
     vga_cliparound(x, 10); /* y value is irrelevant on VGA clipping */
     positionbar();
     vga_DrawCursor();

--- a/win/share/bmptiles.c
+++ b/win/share/bmptiles.c
@@ -107,15 +107,6 @@ struct TileSetImage *image;
     if (!read_info_header(fp, &header2)) goto error;
     if (!check_info_header(&header2)) goto error;
 
-#if 0 /* TODO */
-    if (header2.Compression == BI_PNG) {
-        /* Image data is an embedded PNG bit stream */
-        boolean ok = do_read_png_tiles(fp, image));
-        fclose(fp);
-        return ok;
-    }
-#endif
-
     /* header2.Height < 0 means the Y coordinate is reversed; the origin is
      * top left rather than bottom left */
     image->width = header2.Width;
@@ -300,7 +291,7 @@ struct TileSetImage *image;
                 break;
             case 32:
                 for (x = 0; x < image->width; ++x) {
-                    uint32 color = read_u32(row_bytes + x * 2);
+                    uint32 color = read_u32(row_bytes + x * 4);
                     row[x] = build_pixel(&header2, color);
                 }
                 break;
@@ -609,7 +600,7 @@ uint32 color;
     if (mask == 0) return 0;
     bits = 0xFFFF; /* 0xFF, 0xF, 0x3, 0x1 */
     shift = 16;    /*    8,   4,   2,   1 */
-    while (bits != 0) {
+    while (shift != 0) {
         if ((mask & bits) == 0) {
             mask >>= shift;
             color >>= shift;

--- a/win/share/tileset.c
+++ b/win/share/tileset.c
@@ -6,6 +6,7 @@
 #include "tileset.h"
 
 static void FDECL(get_tile_map, (const char *));
+static unsigned FDECL(gcd, (unsigned, unsigned));
 static void FDECL(split_tiles, (const struct TileSetImage *));
 static void FDECL(free_image, (struct TileSetImage *));
 
@@ -100,6 +101,29 @@ error:
     return FALSE;
 }
 
+/* Free tile memory not required by the chosen display mode */
+boolean
+set_tile_type(true_color)
+boolean true_color;
+{
+    unsigned i;
+
+    if (tiles) {
+        if (true_color) {
+            for (i = 0; i < num_tiles; ++i) {
+                free((genericptr_t) tiles[i].indexes);
+                tiles[i].indexes = NULL;
+            }
+            have_palette = FALSE;
+        } else {
+            for (i = 0; i < num_tiles; ++i) {
+                free((genericptr_t) tiles[i].pixels);
+                tiles[i].pixels = NULL;
+            }
+        }
+    }
+}
+
 const struct Pixel *
 get_palette()
 {
@@ -153,6 +177,112 @@ unsigned tile_index;
     if (tile_index >= num_tiles)
         return &blank_tile;
     return &tiles[tile_index];
+}
+
+/* Note that any tile returned by this function must be freed */
+struct TileImage *
+stretch_tile(inp_tile, out_width, out_height)
+const struct TileImage *inp_tile;
+unsigned out_width, out_height;
+{
+    unsigned x_scale_inp, x_scale_out, y_scale_inp, y_scale_out;
+    unsigned divisor;
+    unsigned size;
+    struct TileImage *out_tile;
+    unsigned x_inp, y_inp, x2, y2, x_out, y_out;
+    unsigned pos;
+
+    /* Derive the scale factors */
+    divisor = gcd(out_width, inp_tile->width);
+    x_scale_inp = inp_tile->width / divisor;
+    x_scale_out = out_width / divisor;
+    divisor = gcd(out_height, inp_tile->height);
+    y_scale_inp = inp_tile->height / divisor;
+    y_scale_out = out_height / divisor;
+
+    /* Derive the stretched tile */
+    out_tile = (struct TileImage *) alloc(sizeof(struct TileImage));
+    out_tile->width = out_width;
+    out_tile->height = out_height;
+    size = out_width * out_height;
+    if (inp_tile->pixels != NULL) {
+        out_tile->pixels = (struct Pixel *) alloc(size * sizeof(struct Pixel));
+        divisor = x_scale_inp * y_scale_inp;
+        for (y_out = 0; y_out < out_height; ++y_out) {
+            for (x_out = 0; x_out < out_width; ++x_out) {
+                unsigned r, g, b, a;
+
+                /* Derive output pixels by blending input pixels */
+                r = 0;
+                g = 0;
+                b = 0;
+                a = 0;
+                for (y2 = 0; y2 < y_scale_inp; ++y2) {
+                    y_inp = (y_out * y_scale_inp + y2) / y_scale_out;
+                    for (x2 = 0; x2 < x_scale_inp; ++x2) {
+                        x_inp = (x_out * x_scale_inp + x2) / x_scale_out;
+                        pos = y_inp * inp_tile->width + x_inp;
+                        r += inp_tile->pixels[pos].r;
+                        g += inp_tile->pixels[pos].g;
+                        b += inp_tile->pixels[pos].b;
+                        a += inp_tile->pixels[pos].a;
+                    }
+                }
+
+                pos = y_out * out_width + x_out;
+                out_tile->pixels[pos].r = r / divisor;
+                out_tile->pixels[pos].g = g / divisor;
+                out_tile->pixels[pos].b = b / divisor;
+                out_tile->pixels[pos].a = a / divisor;
+            }
+        }
+    } else {
+        out_tile->pixels = NULL;
+    }
+
+    /* If the output device uses a palette, we can't blend; just pick
+       a subset of the pixels */
+    if (inp_tile->indexes != NULL) {
+        out_tile->indexes = (unsigned char *) alloc(size);
+        for (y_out = 0; y_out < out_height; ++y_out) {
+            for (x_out = 0; x_out < out_width; ++x_out) {
+                pos = y_out * out_width + x_out;
+                x_inp = x_out * x_scale_inp / x_scale_out;
+                y_inp = y_out * y_scale_inp / y_scale_out;
+                out_tile->indexes[pos] =
+                        inp_tile->indexes[y_inp * inp_tile->width + x_inp];
+            }
+        }
+    } else {
+        out_tile->indexes = NULL;
+    }
+    return out_tile;
+}
+
+/* Free a tile returned by stretch_tile */
+/* Do NOT use this with tiles returned by get_tile */
+void
+free_tile(tile)
+struct TileImage *tile;
+{
+    if (tile != NULL) {
+        free(tile->indexes);
+        free(tile->pixels);
+        free(tile);
+    }
+}
+
+/* Return the greatest common divisor */
+static unsigned
+gcd(a, b)
+unsigned a, b;
+{
+    while (TRUE) {
+        if (b == 0) return a;
+        a %= b;
+        if (a == 0) return b;
+        b %= a;
+    }
 }
 
 static void

--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -155,11 +155,12 @@ char defmorestr[] = "--More--";
 #if defined(USE_TILES) && defined(MSDOS)
 boolean clipping = FALSE; /* clipping on? */
 int clipx = 0, clipxmax = 0;
+int clipy = 0, clipymax = 0;
 #else
 static boolean clipping = FALSE; /* clipping on? */
 static int clipx = 0, clipxmax = 0;
-#endif
 static int clipy = 0, clipymax = 0;
+#endif
 #endif /* CLIPPING */
 
 #if defined(USE_TILES) && defined(MSDOS)


### PR DESCRIPTION
The first four commits, through "More bits for linear frame buffer," are incremental changes, adding working support for 8 bit color modes and a linear frame buffer.

Subsequent changes overhaul the VESA BIOS support. Tile sets are no longer limited to 16x16 in 8 colors; any tile set in BMP or GIF format is supported.