### PR TITLE
Fix compiling with -fno-common

### DIFF
--- a/src/windows.c
+++ b/src/windows.c
@@ -860,7 +860,6 @@ const char *status_fieldnm[MAXBLSTATS];
 const char *status_fieldfmt[MAXBLSTATS];
 char *status_vals[MAXBLSTATS];
 boolean status_activefields[MAXBLSTATS];
-NEARDATA winid WIN_STATUS;
 
 void
 genl_status_init()

--- a/win/X11/winX.c
+++ b/win/X11/winX.c
@@ -95,9 +95,6 @@ static XtSignalId X11_sig_id;
 #endif
 #endif
 
-/* this is only needed until X11_status_* routines are written */
-extern NEARDATA winid WIN_STATUS;
-
 /* Interface definition, for windows.c */
 struct window_procs X11_procs = {
     "X11",

--- a/win/gnome/gnbind.c
+++ b/win/gnome/gnbind.c
@@ -19,9 +19,6 @@ winid WIN_WORN = WIN_ERR;
 extern void tty_raw_print(const char *);
 extern void tty_raw_print_bold(const char *);
 
-/* this is only needed until gnome_status_* routines are written */
-extern NEARDATA winid WIN_STATUS;
-
 /* Interface definition, for windows.c */
 struct window_procs Gnome_procs = {
     "Gnome", WC_COLOR | WC_HILITE_PET | WC_INVERSE, 0L,

--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -72,9 +72,6 @@ extern short glyph2tile[];
 #define HUPSKIP_RESULT(RES) /*empty*/
 #endif /* ?HANGUP_HANDLING */
 
-/* this is only needed until tty_status_* routines are written */
-extern NEARDATA winid WIN_STATUS;
-
 /* Interface definition, for windows.c */
 struct window_procs tty_procs = {
     "tty",


### PR DESCRIPTION
GCC 10 will enable -fno-common by default[0], which causes the linker to
fail like this [1]:

```
ld: windows.o:(.bss+0x0): multiple definition of `WIN_STATUS';
decl.o:(.data+0x40): first defined here
collect2: error: ld returned 1 exit status
```

So considering that include/decl.h has:

```
E NEARDATA winid WIN_STATUS;
```
which is correct, and that just one of the .c files should use `extern`, and
that src/decl.c aligns nicely with include/decl.h, keep that definition
and remove those invalid defnitions from other .c files.

Contrast this with [2] https://github.com/NetHack/NetHack/pull/289 which
tries to second-guess the problem by checking for GCC 10 / Linux, both
of which are incorrect assumptions.

[0] https://gcc.gnu.org/gcc-10/porting_to.html#common
[1] https://bugs.gentoo.org/706320
[2] https://github.com/NetHack/NetHack/pull/289