### PR TITLE
Allow Specification of the Length of the Sparkle Animation

### DIFF
--- a/dat/opthelp
+++ b/dat/opthelp
@@ -55,8 +55,6 @@ showexp        display your accumulated experience points         [FALSE]
 showrace       show yourself by your race rather than by role     [FALSE]
 silent         don't use your terminal's bell sound               [TRUE]
 sortpack       group similar kinds of objects in inventory        [TRUE]
-sparkle        display sparkly effect for resisted magical        [TRUE]
-               attacks (e.g. fire attack on fire-resistant monster)
 standout       use standout mode for --More-- on messages         [FALSE]
 status_updates update the status lines                            [TRUE]
 time           display elapsed game time, in moves                [FALSE]
@@ -261,6 +259,8 @@ role       Your starting role (e.g., role:Barbarian, role:Valk).   [random]
            as possible.  You can also still denote your role by
            appending it to the "name" option (e.g., name:Vic-V), but
            the "role" option will take precedence.
+sparkle    the length of the sparkly effect for resisted magical   [7]
+           attacks (e.g. fire attack on fire-resistant monster)
 windowtype windowing system to be used    [depends on operating system and
            compile-time setup]    if more than one choice is available.
            Most instances of the program support only one window-type;

--- a/dat/opthelp
+++ b/dat/opthelp
@@ -259,7 +259,7 @@ role       Your starting role (e.g., role:Barbarian, role:Valk).   [random]
            as possible.  You can also still denote your role by
            appending it to the "name" option (e.g., name:Vic-V), but
            the "role" option will take precedence.
-sparkle    the length of the sparkly effect for resisted magical   [7]
+sparkle    the length of the sparkly effect for resisted magical   [21]
            attacks (e.g. fire attack on fire-resistant monster)
 windowtype windowing system to be used    [depends on operating system and
            compile-time setup]    if more than one choice is available.

--- a/doc/Guidebook.tex
+++ b/doc/Guidebook.tex
@@ -3929,8 +3929,9 @@ Sort the pack contents by type when displaying inventory (default on).
 Persistent.
 %.lp
 \item[\ib{sparkle}]
-Display a sparkly effect when a monster (including yourself) is hit by an
-attack to which it is resistant (default on).  Persistent.
+Length in animation frames of the sparkly effect that displaays when you
+or another monster is hit by an attack to which it is resistant (default 21).
+Persistent.
 %.lp
 \item[\ib{standout}]
 Boldface monsters and ``{\tt --More--}'' (default off).  Persistent.

--- a/include/display.h
+++ b/include/display.h
@@ -202,7 +202,7 @@
 #define DISP_FREEMEM (-8) /* Free all memory during exit only. */
 
 /* Total number of cmap indices in the shield_static[] array. */
-#define SHIELD_COUNT 21
+#define SHIELD_COUNT 7
 #define BACKTRACK (-1)    /* flag for DISP_END to display each prior location */
 
 /*

--- a/include/flag.h
+++ b/include/flag.h
@@ -55,7 +55,6 @@ struct flag {
     boolean showscore;       /* show score */
     boolean silent;          /* whether the bell rings or not */
     boolean sortpack;        /* sorted inventory */
-    boolean sparkle;         /* show "resisting" special FX (Scott Bigham) */
     boolean standout;        /* use standout for --More-- */
     boolean time;            /* display elapsed 'time' */
     boolean tombstone;       /* print tombstone */
@@ -79,6 +78,7 @@ struct flag {
     int pickup_burden; /* maximum burden before prompt */
     int pile_limit;    /* controls feedback when walking over objects */
     char sortloot; /* 'n'=none, 'l'=loot (pickup), 'f'=full ('l'+invent) */
+    unsigned sparkle;  /* show "resisting" special FX (Scott Bigham & VIVIT) */
     char inv_order[MAXOCLASSES];
     char pickup_types[MAXOCLASSES];
 #define NUM_DISCLOSURE_OPTIONS 6 /* i,a,v,g,c,o (decl.c) */

--- a/src/decl.c
+++ b/src/decl.c
@@ -57,8 +57,6 @@ const int zapcolors[NUM_ZAP] = {
 #endif /* text color */
 
 const int shield_static[SHIELD_COUNT] = {
-    S_ss1, S_ss2, S_ss3, S_ss2, S_ss1, S_ss2, S_ss4, /* 7 per row */
-    S_ss1, S_ss2, S_ss3, S_ss2, S_ss1, S_ss2, S_ss4,
     S_ss1, S_ss2, S_ss3, S_ss2, S_ss1, S_ss2, S_ss4,
 };
 

--- a/src/display.c
+++ b/src/display.c
@@ -901,13 +901,15 @@ void
 shieldeff(x, y)
 xchar x, y;
 {
-    register int i;
+    register int i, offset;
 
     if (!flags.sparkle)
         return;
     if (cansee(x, y)) { /* Don't see anything if can't see the location */
-        for (i = 0; i < SHIELD_COUNT; i++) {
-            show_glyph(x, y, cmap_to_glyph(shield_static[i]));
+        offset = rn2(SHIELD_COUNT); /* Start on random frame of animation */
+        for (i = 0; i < flags.sparkle; i++) {
+            show_glyph(x, y, cmap_to_glyph(shield_static[(i+offset) %
+                        SHIELD_COUNT]));
             flush_screen(1); /* make sure the glyph shows up */
             delay_output();
         }

--- a/src/options.c
+++ b/src/options.c
@@ -3320,7 +3320,7 @@ boolean tinitial, tfrom_file;
     if (match_optname(opts, fullname, 4, TRUE)) {
         if (duplicate)
             complain_about_duplicate(opts, 1);
-        op = string_for_opt(opts, negated);
+        op = string_for_opt(opts, TRUE);
         if ((negated && op == empty_optstr)
             || (!negated && op != empty_optstr))
             flags.sparkle = negated ? 0 : atoi(op);

--- a/src/options.c
+++ b/src/options.c
@@ -216,7 +216,6 @@ static const struct Bool_Opt {
     { "silent", &flags.silent, TRUE, SET_IN_GAME },
     { "softkeyboard", &iflags.wc2_softkeyboard, FALSE, SET_IN_FILE }, /*WC2*/
     { "sortpack", &flags.sortpack, TRUE, SET_IN_GAME },
-    { "sparkle", &flags.sparkle, TRUE, SET_IN_GAME },
     { "splash_screen", &iflags.wc_splash_screen, TRUE, DISP_IN_GAME }, /*WC*/
     { "standout", &flags.standout, FALSE, SET_IN_GAME },
     { "status_updates", &iflags.status_updates, TRUE, DISP_IN_GAME },
@@ -387,6 +386,7 @@ static struct Comp_Opt {
       DISP_IN_GAME }, /*WC*/
     { "sortloot", "sort object selection lists by description", 4,
       SET_IN_GAME },
+    { "sparkle", "length of resistance sparkle animation", 20, SET_IN_GAME },
     { "statushilites",
 #ifdef STATUS_HILITES
       "0=no status highlighting, N=show highlights for N turns",
@@ -3316,6 +3316,26 @@ boolean tinitial, tfrom_file;
         return retval;
     }
 
+    fullname = "sparkle";
+    if (match_optname(opts, fullname, 4, TRUE)) {
+        if (duplicate)
+            complain_about_duplicate(opts, 1);
+        op = string_for_opt(opts, negated);
+        if ((negated && op == empty_optstr)
+            || (!negated && op != empty_optstr))
+            flags.sparkle = negated ? 0 : atoi(op);
+        else if (negated) {
+            bad_negation(fullname, TRUE);
+            return FALSE;
+        } else /* op == empty_optstr */
+            /* loop thrice over shield_static array */
+            flags.sparkle = 3 * SHIELD_COUNT;
+        /* sanity check */
+        if (flags.sparkle < 0)
+            flags.sparkle = 3 * SHIELD_COUNT;
+        return retval;
+    }
+
     fullname = "suppress_alert";
     if (match_optname(opts, fullname, 4, TRUE)) {
         if (duplicate)
@@ -5854,6 +5874,8 @@ char *buf;
                 Strcpy(buf, sortltype[i]);
                 break;
             }
+    } else if (!strcmp(optname, "sparkle")) {
+        Sprintf(buf, "%d", flags.sparkle);
     } else if (!strcmp(optname, "player_selection")) {
         Sprintf(buf, "%s", iflags.wc_player_selection ? "prompts" : "dialog");
 #ifdef STATUS_HILITES


### PR DESCRIPTION
`sparkle` used to be a boolean option whether or not to show the the sparkly magic resistance animation. This branch changes it to a compound option that specifies how many frames the animation should run for. The argument to the option is optional and the default value is 21, so there will be no change in the behavior of existing .nethackrcs.

I had opened a PR about this against 3.6 a few months ago, but it couldn't be done then because it required changing the flags, which would have broken save compatibility with the rest of 3.6. Now that 3.7 is being worked on, that won't be a problem.