### PR TITLE
Update description of OPTIONS=video

### DIFF
--- a/doc/Guidebook.mn
+++ b/doc/Guidebook.mn
@@ -3987,14 +3987,19 @@ if needed.
 Cannot be set with the \(oqO\(cq command.
 .lp video
 Set the video mode used (PC NetHack only).
-Values are \(lqautodetect\(rq, \(lqdefault\(rq, or \(lqvga\(rq.
-Setting \(lqvga\(rq (or \(lqautodetect\(rq with vga hardware present)
-will cause the game to display tiles.
+Values are \(lqautodetect\(rq, \(lqdefault\(rq, \(lqvga\(rq, or \(lqvesa\(rq.
+Setting \(lqvesa\(rq will cause the game to display tiles, using the full
+capability of the VGA hardware.
+Setting \(lqvga\(rq will cause the game to display tiles, fixed at 640x480
+in 16 colors, a mode that is compatible with all VGA hardware. Third party
+tilesets will probably not work.
+Setting \(lqautodetect\(rq attempts \(lqvesa\(rq, then \(lqvga\(rq, and
+finally sets \(lqdefault\(rq if neither of those modes works.
 Cannot be set with the \(oqO\(cq command.
 .lp video_height
-Set the VGA mode resolution height (MS-DOS only, with video:vga)
+Set the VGA mode resolution height (MS-DOS only, with video:vesa)
 .lp video_width
-Set the VGA mode resolution width (MS-DOS only, with video:vga)
+Set the VGA mode resolution width (MS-DOS only, with video:vesa)
 .lp videocolors
 Set the color palette for PC systems using NO_TERMS
 (default 4-2-6-1-5-3-15-12-10-14-9-13-11, (PC NetHack only).

--- a/doc/Guidebook.tex
+++ b/doc/Guidebook.tex
@@ -1993,7 +1993,7 @@ than as 7 and 25, respectively, and total to 2 when both are at the
 same location).
 
 %.pg
-The \{\tt nopickup} command prefix (default `\{\tt m}') can be
+The {\tt nopickup} command prefix (default `{\tt m}') can be
 used before a movement direction to step on objects without attempting
 auto-pickup and without giving feedback about them.
 
@@ -3911,7 +3911,7 @@ something pushes the old item into your alternate weapon slot (default off).
 Likewise for the `a' (apply) command if it causes the applied item to
 become wielded.  Persistent.
 %.lp
-\item[\ib(quick\verb+_+farsight}
+\item[\ib{quick\verb+_+farsight}]
 When set, usually prevents the ``you sense your surroundings'' message
 where play pauses to allow you to browse the map whenever clairvoyance
 randomly activates.
@@ -4428,16 +4428,21 @@ Cannot be set with the `{\tt O}' command.
 %.lp
 \item[\ib{video}]
 Set the video mode used ({\it PC\/ NetHack\/} only).
-Values are {\it autodetect\/}, {\it default\/}, or {\it vga\/}.
-Setting {\it vga\/} (or {\it autodetect\/} with vga hardware present) will
-cause the game to display tiles.
+Values are {\it autodetect\/}, {\it default\/}, {\it vga\/}, or {\it vesa\/}.
+Setting {\it vesa\/} will cause the game to display tiles, using the full
+capability of the VGA hardware.
+Setting {\it vga\/} will cause the game to display tiles, fixed at 640x480
+in 16 colors, a mode that is compatible with all VGA hardware. Third party
+tilesets will probably not work.
+Setting {\it autodetect\/} attempts {\it vesa\/}, then {\it vga\/}, and
+finally sets {\it default\/} if neither of those modes works.
 Cannot be set with the `{\tt O}' command.
 %.lp
 \item[\ib{video\verb+_+height}]
-Set the VGA mode resolution height (MS-DOS only, with video:vga)
+Set the VGA mode resolution height (MS-DOS only, with video:vesa)
 %.lp
 \item[\ib{video\verb+_+width}]
-Set the VGA mode resolution width (MS-DOS only, with video:vga)
+Set the VGA mode resolution width (MS-DOS only, with video:vesa)
 %.lp
 \item[\ib{videocolors}]
 \begin{sloppypar}


### PR DESCRIPTION
A recent change to the Guidebook says that video_width and video_height work with video:vga. That setting in fact forces the 640x480x16 mode, in which video_width and video_height do not operate. The desired setting is video:vesa. Update the description of OPTIONS=video, video_width and video_height to reflect this.

Also, fix some syntax errors in Guidebook.tex encountered while trying to compile it.

Attempting to update Guidebook.txt, using the Makefile, produced many more differences than expected. I am leaving that file unchanged.