### PR TITLE
MSDOS compile error and statue glyphs

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -3412,11 +3412,6 @@ boolean tinitial, tfrom_file;
         return retval;
     }
 #endif /* NO_TERMS */
-        } else if ((opts = string_for_env_opt(fullname, opts, FALSE))
-                                              == empty_optstr) {
-            return FALSE;
-        }
-    }
 #endif /* MSDOS */
 
     /* WINCAP

--- a/sys/msdos/Makefile1.cross
+++ b/sys/msdos/Makefile1.cross
@@ -439,7 +439,7 @@ $(U)tilemap: $(HOST_O)tilemap.o
 	$(HOST_LINK) $(LFLAGS) -o$@ $(HOST_O)tilemap.o
 
 $(HOST_O)tilemap.o: $(WSHR)/tilemap.c $(HACK_H) $(TILE_H)
-	$(HOST_CC) $(cflags) -I$(WSHR) -I$(MSYS) -o$@ $(WSHR)/tilemap.c
+	$(HOST_CC) $(cflags) -I$(WSHR) -I$(MSYS) -DSTATUES_LOOK_LIKE_MONSTERS -o$@ $(WSHR)/tilemap.c
 
 
 #==========================================


### PR DESCRIPTION
sys/msdos/Makefile1.cross: Add -DSTATUES_LOOK_LIKE_MONSTERS so the VESA mode can display statue glyphs. The 16 color mode already maps these back to the generic statue glyph.

src/options.c: A compile error I discovered while preparing this pull request. Remove a code fragment that appears to be a remnant of the "soundcard" option.