### PR TITLE
Add Sounds for Minotaurs

### DIFF
--- a/include/monflag.h
+++ b/include/monflag.h
@@ -45,7 +45,8 @@
 #define MS_PRIEST 36    /* ask for contribution; do cleansing */
 #define MS_SPELL 37     /* spellcaster not matching any of the above */
 #define MS_WERE 38      /* lycanthrope in human form */
-#define MS_BOAST 39     /* giants */
+#define MS_MOO 39       /* minotaurs */
+#define MS_BOAST 40     /* giants */
 
 #define MR_FIRE 0x01   /* resists fire */
 #define MR_COLD 0x02   /* resists cold */

--- a/src/monst.c
+++ b/src/monst.c
@@ -1449,7 +1449,7 @@ struct permonst _mons2[] = {
     MON("minotaur", S_GIANT, LVL(15, 15, 6, 0, 0), (G_GENO | G_NOGEN),
         A(ATTK(AT_CLAW, AD_PHYS, 3, 10), ATTK(AT_CLAW, AD_PHYS, 3, 10),
           ATTK(AT_BUTT, AD_PHYS, 2, 8), NO_ATTK, NO_ATTK, NO_ATTK),
-        SIZ(1500, 700, MS_SILENT, MZ_LARGE), 0, 0,
+        SIZ(1500, 700, MS_MOO, MZ_LARGE), 0, 0,
         M1_ANIMAL | M1_HUMANOID | M1_CARNIVORE,
         M2_HOSTILE | M2_STRONG | M2_NASTY, M3_INFRAVISIBLE | M3_INFRAVISION,
         17, CLR_BROWN),

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -339,6 +339,9 @@ register struct monst *mtmp;
     case MS_WAIL:
         ret = "wail";
         break;
+    case MS_MOO:
+        ret = "low";
+        break;
     case MS_SILENT:
         ret = "commotion";
         break;
@@ -749,6 +752,12 @@ register struct monst *mtmp;
                 verbl_msg = "??????????";
 #endif
         }
+        break;
+    case MS_MOO:
+        if (!mtmp->mpeaceful)
+            pline_msg = "bellows!";
+        else
+            pline_msg = "moos.";
         break;
     case MS_BOAST: /* giants */
         if (!mtmp->mpeaceful) {


### PR DESCRIPTION
Minotaurs, by and large, are very loud and rambunctious creatures. In NetHack, however, they are treated as silent. This pull request gives minotaurs growl sounds, as well as responses when #chatted with.
Rationale are as follows:

1. Minotaurs are generally depicted in media as being loud.

2. Minotaurs are dangerous enough that being able to identify them while blind is potentially useful.

3. Due to their high damage output and total lack of magic resistance, minotaurs are often tamed by the player. The game will be more fun if the player can interact with their pet minotaur in some way, however limited.