### PR TITLE
Lua enhancements

### DIFF
--- a/dat/nhlib.lua
+++ b/dat/nhlib.lua
@@ -10,3 +10,23 @@ end
 
 align = { "law", "neutral", "chaos" };
 shuffle(align);
+
+-- d(2,6) = 2d6
+-- d(20) = 1d20 (single argument = implicit 1 die)
+function d(dice, faces)
+   if (faces == nil) then
+      -- 1-arg form: argument "dice" is actually the number of faces
+      return math.random(1, dice)
+   else
+      local sum = 0
+      for i=1,dice do
+         sum = sum + math.random(1, faces)
+      end
+      return sum
+   end
+end
+
+-- percent(20) returns true 20% of the time
+function percent(threshold)
+   return math.random(0,99) < threshold
+end

--- a/include/extern.h
+++ b/include/extern.h
@@ -2498,6 +2498,8 @@ E struct selectionvar *FDECL(selection_filter_mapchar, (struct selectionvar *,
 E void FDECL(set_floodfillchk_match_under, (XCHAR_P));
 E void FDECL(selection_do_ellipse, (struct selectionvar *,
                                     int, int, int, int, int));
+E void FDECL(selection_do_gradient, (struct selectionvar *, long, long,
+                                     long, long, long, long, long, long));
 E void NDECL(update_croom);
 E const char *FDECL(get_trapname_bytype, (int));
 E void FDECL(l_register_des, (lua_State *));

--- a/include/rm.h
+++ b/include/rm.h
@@ -438,7 +438,8 @@ struct rm {
 #define SET_TYPLIT(x, y, ttyp, llit)                              \
     {                                                             \
         if ((x) >= 0 && (y) >= 0 && (x) < COLNO && (y) < ROWNO) { \
-            if ((ttyp) < MAX_TYPE)                                \
+            if ((ttyp) < MAX_TYPE && levl[(x)][(y)].typ != STAIRS \
+                && levl[(x)][(y)].typ != LADDER)                  \
                 levl[(x)][(y)].typ = (ttyp);                      \
             if ((ttyp) == LAVAPOOL)                               \
                 levl[(x)][(y)].lit = 1;                           \

--- a/src/nhlsel.c
+++ b/src/nhlsel.c
@@ -25,6 +25,7 @@ static int FDECL(l_selection_filter_mapchar, (lua_State *));
 static int FDECL(l_selection_flood, (lua_State *));
 static int FDECL(l_selection_circle, (lua_State *));
 static int FDECL(l_selection_ellipse, (lua_State *));
+static int FDECL(l_selection_gradient, (lua_State *));
 static int FDECL(l_selection_iterate, (lua_State *));
 static int FDECL(l_selection_gc, (lua_State *));
 static int FDECL(l_selection_not, (lua_State *));
@@ -39,7 +40,6 @@ static int FDECL(l_selection_not, (lua_State *));
    if ifdef'd out the prototype here and the
    function body below.
  */
-static int FDECL(l_selection_gradient, (lua_State *));
 static int FDECL(l_selection_add, (lua_State *));
 static int FDECL(l_selection_sub, (lua_State *));
 static int FDECL(l_selection_ipairs, (lua_State *));
@@ -701,6 +701,70 @@ lua_State *L;
     return 1;
 }
 
+/* Gradients are versatile enough, with so many independently optional
+ * arguments, that it doesn't seem helpful to provide a non-table form with
+ * non-obvious argument order. */
+/* selection.gradient({ type = "radial", x = 3, y = 5, x2 = 10, y2 = 12,
+ *                      mindist = 4, maxdist = 10, limited = false });    */
+static int
+l_selection_gradient(L)
+lua_State *L;
+{
+    int argc = lua_gettop(L);
+    struct selectionvar *sel = (struct selectionvar *) 0;
+    /* if x2 and y2 aren't set, the gradient has a single center point of x,y;
+     * if they are set, the gradient is centered on a (x,y) to (x2,y2) line */
+    schar x = 0, y = 0, x2 = -1, y2 = -1;
+    /* points will not be added within mindist of the center; the chance for a
+     * point between mindist and maxdist to be added to the selection starts at
+     * 0% at mindist and increases linearly to 100% at maxdist */
+    xchar mindist = 0, maxdist = 0;
+    /* if limited is true, no points farther than maxdist will be added; if
+     * false, all points farther than maxdist will be added */
+    boolean limited = FALSE;
+    long type;
+    static const char *const gradtypes[] = {
+        "radial", "square", NULL
+    };
+    static const int gradtypes2i[] = {
+        SEL_GRADIENT_RADIAL, SEL_GRADIENT_SQUARE, -1 
+    };
+
+    if (argc == 1 && lua_type(L, 1) == LUA_TTABLE) {
+        lcheck_param_table(L);
+        type = gradtypes2i[get_table_option(L, "type", "radial", gradtypes)];
+        x = (schar) get_table_int(L, "x");
+        y = (schar) get_table_int(L, "y");
+        x2 = (schar) get_table_int_opt(L, "x2", -1);
+        y2 = (schar) get_table_int_opt(L, "y2", -1);
+        /* maxdist is required because there's no obvious default value for it,
+         * whereas mindist has an obvious defalt of 0 */
+        maxdist = get_table_int(L, "maxdist");
+        mindist = get_table_int_opt(L, "mindist", 0);
+        limited = get_table_boolean_opt(L, "limited", FALSE);
+
+        lua_pop(L, 1);
+        (void) l_selection_new(L);
+        sel = l_selection_check(L, 1);
+    } else {
+        nhl_error(L, "wrong parameters");
+        /* NOTREACHED */
+    }
+
+    /* someone might conceivably want to draw a gradient somewhere off-map. So
+     * the only coordinate that's "illegal" for that is (-1,-1).
+     * If a level designer really needs to draw a gradient line using that
+     * coordinate, they can do so by setting regular x and y to -1. */
+    if (x2 == -1 && y2 == -1) {
+        x2 = x;
+        y2 = y;
+    }
+
+    selection_do_gradient(sel, x, y, x2, y2, type, mindist, maxdist, limited);
+    lua_settop(L, 1);
+    return 1;
+}
+
 /* sel:iterate(function(x,y) ... end); */
 static int
 l_selection_iterate(L)
@@ -747,10 +811,8 @@ static const struct luaL_Reg l_selection_methods[] = {
     { "floodfill", l_selection_flood },
     { "circle", l_selection_circle },
     { "ellipse", l_selection_ellipse },
+    { "gradient", l_selection_gradient },
     { "iterate", l_selection_iterate },
-    /* TODO:
-       { "gradient", l_selection_gradient },
-    */
     { NULL, NULL }
 };
 

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -4512,6 +4512,8 @@ long x, y, x2, y2, gtyp, mind, maxd, limit;
 
     switch (gtyp) {
     default:
+        impossible("Unrecognized gradient type! Defaulting to radial...");
+        /* FALLTHRU */
     case SEL_GRADIENT_RADIAL: {
         for (dx = 0; dx < COLNO; dx++)
             for (dy = 0; dy < ROWNO; dy++) {

--- a/sys/unix/Makefile.top
+++ b/sys/unix/Makefile.top
@@ -151,7 +151,7 @@ options: $(GAME)
 
 quest.lua: $(GAME)
 
-spec_levs:
+spec_levs: lua_syntax_check
 	( cd dat ; $(MAKE) spec_levs )
 	( cd dat ; $(MAKE) quest_levs )
 
@@ -260,6 +260,14 @@ fetch-Lua:
 	( mkdir -p lib ; cd lib ; \
 	  curl -R -O http://www.lua.org/ftp/lua-$(LUA_VERSION).tar.gz ; \
 	  tar zxf lua-$(LUA_VERSION).tar.gz ; rm -f lua-$(LUA_VERSION).tar.gz )
+
+# if lua is installed, luac should be as well. Leverage its ability to quietly
+# compile lua files while producing no output or other side effects in order to
+# check the basic syntax of files.
+# Note: this won't detect things like calling a function with the wrong number
+# or types of arguments.
+lua_syntax_check:
+	luac -p dat/*.lua
 
 update: $(GAME) recover $(VARDAT) spec_levs
 #	(don't yank the old version out from under people who're playing it)


### PR DESCRIPTION
This adds several enhancements to the special level parsing code:
* Lua scripts can now call d() to get dice results, or percent() to get a percent threshold, avoiding the necessity of using lots of math.random() calls.
* In order to build the game, all lua files must pass a basic lua syntax check.
* Special level functions such as terrain() or replace_terrain() cannot overwrite stairs or ladders.
* Implement selection.gradient(), re-enabling the selection gradient functionality present in 3.6.