### PR TITLE
Allow specifying a montype on figurines in lua files

### DIFF
--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -3459,7 +3459,8 @@ lua_State *L;
         tmpobj.id = -1;
 
     if (tmpobj.id == STATUE || tmpobj.id == EGG
-        || tmpobj.id == CORPSE || tmpobj.id == TIN) {
+        || tmpobj.id == CORPSE || tmpobj.id == TIN
+        || tmpobj.id == FIGURINE) {
         struct permonst *pm = NULL;
         int i, lflags = 0;
         char *montype = get_table_str_opt(L, "montype", NULL);


### PR DESCRIPTION
This was already allowed for the other montype-compatible objects like
statues, corpses, eggs and tins. I don't see a reason why figurines
shouldn't be part of this group; perhaps it was an oversight.