### PR TITLE
Fix rnd(0) in create_gas_cloud, and blasts of fire that hit bodies of water create clouds of steam.

### DIFF
--- a/src/region.c
+++ b/src/region.c
@@ -1012,6 +1012,8 @@ genericptr_t p2;
 
     reg = (NhRegion *) p1;
     dam = reg->arg.a_int;
+    if (!dam)
+        return FALSE;
     if (p2 == (genericptr_t) 0) { /* This means *YOU* Bozo! */
         if (m_poisongas_ok(&g.youmonst) == M_POISONGAS_OK)
             return FALSE;

--- a/src/zap.c
+++ b/src/zap.c
@@ -4475,6 +4475,7 @@ short exploding_wand_typ;
         if (is_ice(x, y)) {
             melt_ice(x, y, (char *) 0);
         } else if (is_pool(x, y)) {
+            create_gas_cloud(x, y, rnd(2), 0);
             const char *msgtxt = (!Deaf)
                                      ? "You hear hissing gas." /* Deaf-aware */
                                      : (type >= 0)
@@ -4498,6 +4499,7 @@ short exploding_wand_typ;
             if (lev->typ == ROOM)
                 newsym(x, y);
         } else if (IS_FOUNTAIN(lev->typ)) {
+            create_gas_cloud(x, y, rnd(3), 0);
             if (see_it)
                 pline("Steam billows from the fountain.");
             rangemod -= 1;


### PR DESCRIPTION
This is a combination bug and feature pull request:

- If create_gas_cloud() is called with a damage of zero, the game will throw a panic for calling rnd(0). This pull request fixes this.
- If a bolt of fire hits a fountain or body of water, it produces a small area of clouds that fades after a few turns.

I originally wrote this feature for SpliceHack, but upon further reflection I think that it fits in well to vanilla. The messages "you hear hissing gas" and "steam billows from the fountain" imply the creation of steam, which can be easily represented using create_gas_cloud. I feel that giving the steam a visual representation increases the sense of interacting with the environment.

Fountains produce a larger area of clouds, since the message "steam billows from the fountain" seems to imply a greater amount of steam than "you hear hissing gas."

At present, this has no gameplay effects, but this feature could be extended to allow for scalding steam or blinding clouds of fog.