### PR TITLE
Add 'ec2' to default GENERIC_USERS

### DIFF
--- a/sys/unix/sysconf
+++ b/sys/unix/sysconf
@@ -35,7 +35,7 @@ EXPLORERS=*
 # If the user name is found in this list, prompt for username instead.
 # Uses the same syntax as the WIZARDS option above.
 # A public server should probably disable this.
-GENERICUSERS=play player game games nethack nethacker
+GENERICUSERS=play player game games nethack nethacker ec2
 
 # Use the player name for matching WIZARDS, EXPLORERS and SHELLERS,
 # instead of the user's login name.


### PR DESCRIPTION
On Amazon Linux (1 and 2), the default user is "ec2-user", which due to
how NetHack will filter out dashes from usernames gets shortened to
'ec2'. The GENERIC_USERS filter is applied *after* this filtering (see
unixmain.c snippet below):

    set_playmode(); /* sets plname to "wizard" for wizard mode */
    if (exact_username) {
	< filter out dash >
    }
    plnamesuffix();

So, if we add 'ec2' to the list, the net effect is that you'd be asked
for your name if launching as the generic user. This is probably better
than applying the filter twice or changing the logic of when the
filtering is done.

Signed-off-by: Stewart Smith <trawets@amazon.com>