### PR TITLE
Avoid disorder caused by horseback #untrapping

### DIFF
--- a/src/trap.c
+++ b/src/trap.c
@@ -4036,6 +4036,10 @@ struct trap *ttmp;
         || drag_ball(x, y, &bc, &bx, &by, &cx, &cy, &unused, TRUE)) {
         u.ux0 = u.ux, u.uy0 = u.uy;
         u.ux = x, u.uy = y;
+        if (u.usteed) {
+            u.usteed->mx = u.ux,
+            u.usteed->my = u.uy;
+        }
         u.umoved = TRUE;
         newsym(u.ux0, u.uy0);
         vision_recalc(1);


### PR DESCRIPTION
`mon_sanity_check` can start spitting out error messages about contradictory steed position after a mounted hero gets ensnared by a failed `#untrap` attempt (#340). This is because
`move_into_trap` doesn't update `u.usteed->mx` and `my` like most other movement code does (e.g. `domove_core`, `u_on_newpos`), so those numbers get out of sync with the hero's new position.

https://github.com/NetHack/NetHack/blob/42ffce0e5d163754cb05c201345acc4c165bd050/src/hack.c#L1780-L1789

https://github.com/NetHack/NetHack/blob/42ffce0e5d163754cb05c201345acc4c165bd050/src/dungeon.c#L1437-L1461

Unlike the above two functions, `move_into_trap` only modifies `u.ux` and `u.uy`, which is why reported steed and player positions weren't matching after a failed `#untrap`:

https://github.com/NetHack/NetHack/blob/42ffce0e5d163754cb05c201345acc4c165bd050/src/trap.c#L4034-L4044

This commit adds a check to `move_into_trap` to explicitly handle updating a steed's position on the map just after moving the hero, making it closer to other position-modifying functions & hopefully fixing #340.