### PR TITLE
Fix: lua exposes incorrect room width and height to contents function

### DIFF
--- a/dat/themerms.lua
+++ b/dat/themerms.lua
@@ -80,8 +80,8 @@ themerooms = {
    function()
       des.room({ type = "themed",
                  contents = function(rm)
-                    for x = 0, rm.width do
-                       for y = 0, rm.height do
+                    for x = 0, rm.width - 1 do
+                       for y = 0, rm.height - 1 do
                           if (percent(30)) then
                              if (percent(50)) then
                                 des.object("boulder");
@@ -99,8 +99,8 @@ themerooms = {
    function()
       des.room({ type = "themed",
                  contents = function(rm)
-                    for x = 0, rm.width do
-                       for y = 0, rm.height do
+                    for x = 0, rm.width - 1 do
+                       for y = 0, rm.height - 1 do
                           if (percent(30)) then
                              des.trap("web", x, y);
                           end
@@ -118,8 +118,8 @@ themerooms = {
                                     "land mine", "sleep gas", "rust",
                                     "anti magic" };
                     shuffle(traps);
-                    for x = 0, rm.width do
-                       for y = 0, rm.height do
+                    for x = 0, rm.width - 1 do
+                       for y = 0, rm.height - 1 do
                           if (percent(30)) then
                              des.trap(traps[1], x, y);
                           end
@@ -169,8 +169,8 @@ themerooms = {
                  contents = function(rm)
                     local terr = { "-", "-", "-", "-", "L", "P", "T" };
                     shuffle(terr);
-                    for x = 0, (rm.width - 3) / 4 do
-                       for y = 0, (rm.height - 3) / 4 do
+                    for x = 0, (rm.width / 4) - 1 do
+                       for y = 0, (rm.height / 4) - 1 do
                           des.terrain({ x = x * 4 + 2, y = y * 4 + 2, typ = terr[1], lit = -2 });
                           des.terrain({ x = x * 4 + 3, y = y * 4 + 2, typ = terr[1], lit = -2 });
                           des.terrain({ x = x * 4 + 2, y = y * 4 + 3, typ = terr[1], lit = -2 });
@@ -219,7 +219,7 @@ themerooms = {
    function()
       des.room({ type = "themed", w = 5 + nh.rn2(3)*2, h = 5 + nh.rn2(3)*2,
                  contents = function(rm)
-                    des.room({ type = "themed", x = (rm.width / 2), y = (rm.height / 2), w = 1, h = 1, joined = 0,
+                    des.room({ type = "themed", x = (rm.width - 1)/ 2, y = (rm.height - 1) / 2, w = 1, h = 1, joined = 0,
                                contents = function()
                                   if (percent(50)) then
                                      local mons = { "M", "V", "L", "Z" };
@@ -245,7 +245,7 @@ themerooms = {
                  contents = function(rm)
                     local feature = { "C", "L", "I", "P", "T" };
                     shuffle(feature);
-                    des.terrain(rm.width / 2, rm.height / 2, feature[1]);
+                    des.terrain((rm.width - 1) / 2, (rm.height - 1) / 2, feature[1]);
                  end
       });
    end,

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -3844,7 +3844,7 @@ lua_State *L;
                 lua_getfield(L, 1, "contents");
                 if (lua_type(L, -1) == LUA_TFUNCTION) {
                     lua_remove(L, -2);
-                    l_push_wid_hei_table(L, tmpcr->hx - tmpcr->lx, tmpcr->hy - tmpcr->ly);
+                    l_push_wid_hei_table(L, 1 + tmpcr->hx - tmpcr->lx, 1 + tmpcr->hy - tmpcr->ly);
                     lua_call(L, 1, 0);
                 } else
                     lua_pop(L, 1);


### PR DESCRIPTION
When a room was created using des.room, with w and h specified, I
noticed that the rm.width and rm.height exposed to its contents function
were smaller than they should be by 1. For instance, if I created a room
with w = 5, h = 5, and contents = function(rm), rm.width and rm.height
would both be 4.

This seems to be because the calculations for width and height were
(hx-lx) and (hy-ly), which is 1 too small. In this commit, I adjusted
those up by 1, and adjusted the uses of rm.width and rm.height in
themerms.lua to account for this change.

This does not affect the width and height exposed to the contents
function of a des.map() call; those appear to be accurate measures of
the map's width and height.