### PR TITLE
Reverting to original phrasing for pet displacement

### DIFF
--- a/src/hack.c
+++ b/src/hack.c
@@ -1826,7 +1826,7 @@ domove_core()
             newsym(x, y);
             newsym(u.ux0, u.uy0);
 
-            You("%s %s.", mtmp->mtame ? "swap places with" : "frighten",
+            You("%s %s.", mtmp->mtame ? "displaced" : "frightened",
                 pnambuf);
 
             /* check for displacing it into pools and traps */


### PR DESCRIPTION
Comments:
- "displaced" was the original phrasing; no reason to change it
- more flexible for variants and future nethack versions:
  - hypothetical: perhaps a pet does not want to swap places into
    lava, but rather, be displaced to a spot of its own choosing
  - real-world: in slashem, the "displacer beast" exists because
    of the original wording
- regardless, past tense is appropriate