### PR TITLE
Update G_IGNORE val to avoid collision with G_UNIQ

### DIFF
--- a/include/monflag.h
+++ b/include/monflag.h
@@ -201,7 +201,7 @@ enum ms_sounds {
 #define G_EXTINCT       0x0001 /* population control; create no more */
 #define G_GONE          (G_GENOD | G_EXTINCT)
 #define MV_KNOWS_EGG    0x0008 /* player recognizes egg of this monster type */
-#define G_IGNORE        0x1000 /* for mkclass(), ignore G_GENOD|G_EXTINCT */
+#define G_IGNORE        0x2000 /* for mkclass(), ignore G_GENOD|G_EXTINCT */
 
 /* *INDENT-ON* */
 /* clang-format on */


### PR DESCRIPTION
The values of `G_IGNORE` and `G_UNIQ` (defined in include/monflag.h) have both been 0x1000 since the commit in which `G_IGNORE` was introduced (f18b5bb).

https://github.com/NetHack/NetHack/blob/4e677294b3e5a3cf1ea258fd90f83323c48b4984/include/monflag.h#L187-L204

Ultimately, by way of how `mkclass_aligned` uses these macros, this interferes with the code in `mk_gen_ok` that tests for extinction, so that extinct monsters are pronounced valid targets for generation regardless of the `spc` bitmask value provided to `mkclass`.

The value of `gmask` is defined in `mkclass_aligned` to be `((G_NOGEN | G_UNIQ) & ~spc) | (G_IGNORE & spc)` (where `spc` is an optional caller-provided bitmask for ignoring certain requirements):
https://github.com/NetHack/NetHack/blob/4e677294b3e5a3cf1ea258fd90f83323c48b4984/src/makemon.c#L1699-L1705

Then that value is compared with `G_IGNORE` via bitwise operations, to make sure the user hasn't explicitly set the function to ignore extinction:
https://github.com/NetHack/NetHack/blob/4e677294b3e5a3cf1ea258fd90f83323c48b4984/src/makemon.c#L1624-L1632

So the full statement which must be `FALSE` to respect extinction is `(((G_NOGEN | G_UNIQ) & ~spc) | (G_IGNORE & spc)) & G_IGNORE` -- ignoring `G_NOGEN`, since any effect it has is disregarded by the final `& G_IGNORE`, and knowing that `G_UNIQ = G_IGNORE = 0x1000`, this statement can be simplified to `((G_IGNORE & ~spc) | (G_IGNORE & spc)) & G_IGNORE`, then further to `(spc | ~spc) & G_IGNORE`, which always evaluates to `TRUE`.

To avoid this, I have changed the value of `G_IGNORE` from `0x1000` (`0b01000000000000`) to `0x2000` (`0b10000000000000`). This should resolve #352, as far as I can tell: with the change applied I no longer see geno'd monsters on Quest levels.