### PR TITLE
Track number of times player has cheated at Sokoban.

### DIFF
--- a/include/you.h
+++ b/include/you.h
@@ -150,6 +150,7 @@ struct u_conduct {     /* number of times... */
     long polyselfs;    /* transformed yourself */
     long wishes;       /* used a wish */
     long wisharti;     /* wished for an artifact */
+    long cheated;      /* cheated at Sokoban */
     /* genocides already listed at end of game */
 };
 

--- a/src/insight.c
+++ b/src/insight.c
@@ -1883,7 +1883,7 @@ show_achievements(final)
 int final; /* used "behind the curtain" by enl_foo() macros */
 {
     int i, achidx, absidx, acnt;
-    char title[QBUFSZ], buf[QBUFSZ];
+    char title[QBUFSZ], buf[QBUFSZ], sokobuf[QBUFSZ];
     winid awin = WIN_ERR;
 
     /* unfortunately we can't show the achievements (at least not all of
@@ -1954,7 +1954,13 @@ int final; /* used "behind the curtain" by enl_foo() macros */
             you_have_X("entered Sokoban");
             break;
         case ACH_SOKO_PRIZE: /* hard to reach guaranteed bag or amulet */
-            you_have_X("completed Sokoban");
+            if (!u.uconduct.cheated)
+                you_have_X("completed Sokoban");
+            else {
+                Sprintf(sokobuf, "completed Sokoban... by cheating (%ld times)", 
+                    u.uconduct.cheated);
+                you_have_X(sokobuf);
+            }
             break;
         case ACH_MINE_PRIZE: /* hidden guaranteed luckstone */
             you_have_X("completed the Gnomish Mines");

--- a/src/trap.c
+++ b/src/trap.c
@@ -5457,6 +5457,7 @@ sokoban_guilt()
 {
     if (Sokoban) {
         change_luck(-1);
+        u.uconduct.cheated++;
         /* TODO: issue some feedback so that player can learn that whatever
            he/she just did is a naughty thing to do in sokoban and should
            probably be avoided in future....


### PR DESCRIPTION
Adds a conduct (u.uconduct.cheated) in order to track the number of times that the player has cheated at Sokoban. If the player receives the achievement for completing Sokoban, they are told the number of times that they cheated to do so.

Although this does not address the TODO mentioned in soko_guilt(), I think that it's a nice way of explicitly expressing that there are actions which count as cheating. Also, it feels vaguely evil, which is a plus.