### PR TITLE
Avoid revealing mimics with mind flayer lock-on

### DIFF
--- a/src/monmove.c
+++ b/src/monmove.c
@@ -587,7 +587,7 @@ register struct monst *mtmp;
                 continue;
             if ((telepathic(m2->data) && (rn2(2) || m2->mblinded))
                 || !rn2(10)) {
-                if (cansee(m2->mx, m2->my))
+                if (canseemon(m2))
                     pline("It locks on to %s.", mon_nam(m2));
                 m2->mhp -= rnd(15);
                 if (DEADMONSTER(m2))


### PR DESCRIPTION
Using `cansee` for feedback on the mind flayer psychic attack means that the message identifies the target by name, even if it's a cloaked mimic or other hiding monster, as long as you can see the square it's on. Using `canseemon` instead will skip printing the message if the target is concealed in some way.