### PR TITLE
Use <lvl>d8 + 1 instead of <lvl>d8 for mon->mhpmax

### DIFF
--- a/src/makemon.c
+++ b/src/makemon.c
@@ -1020,7 +1020,7 @@ int mndx;
     } else if (!mon->m_lev) {
         mon->mhpmax = mon->mhp = rnd(4);
     } else {
-        mon->mhpmax = mon->mhp = d((int) mon->m_lev, 8);
+        mon->mhpmax = mon->mhp = d((int) mon->m_lev, 8) + 1;
         if (is_home_elemental(ptr))
             mon->mhpmax = (mon->mhp *= 3);
     }


### PR DESCRIPTION
Monster sanity checking now raises an error when monster max hp is less than `mon->m_lev + 1` (as of 7d7b98f), but `newmonhp` still just rolls \<level\>d8 to determine a monster's starting (max) hp. This means monsters can start with hp equal to their level, if every die rolled is a natural 1 (e.g. 1d8 can end up a 1, 5d8 can end up a 5, etc); to avoid tripping this new sanity check, this changes the formula for determining a monster's max hp to \<lvl\>d8 + 1.