### PR TITLE
Properly reveal mimics targeted by mind flayer psychic blast

### DIFF
--- a/src/monmove.c
+++ b/src/monmove.c
@@ -593,7 +593,7 @@ register struct monst *mtmp;
                 if (DEADMONSTER(m2))
                     monkilled(m2, "", AD_DRIN);
                 else
-                    m2->msleeping = 0;
+                    wakeup(m2, FALSE);
             }
         }
     }


### PR DESCRIPTION
Mimics targeted with a mind flayer's psychic attack are \`revealed' by name (``it locks on to the small mimic'') if they are mimicking an object, but are not actually \`unmimicked' with `seemimic`. This results in something of a disparity of information available to the player and the hero, and differs from normal monster-on-mimic attacks.

This commit reveals hidden mimics with `wakeup` if they are targeted & identified by a mind flayer's lock-on attack. Monsters targeted by the psychic blast are woken up anyway (currently via `m2->msleeping = 0`), so this behavior seems consistent with how the attack affects non-mimics already, as well as the typical logic of mimic interactions.

P.S. -- I had submitted a previous PR (#362) intended to address this issue in sort of the opposite way -- hiding the \`\`lock-on'' message entirely when the target is a mimic -- but not only does this seem less consistent with the way the attack works for other concealed/invisible monsters, the actual changes involved were useless, if not a step backwards (they prevented invisible monsters from being mentioned, normally \`\`it locks on to it'', and didn't actually affect how mimics are handled at all).