### PR TITLE
Fix default epitaphs (and engravings, etc)

### DIFF
--- a/util/makedefs.c
+++ b/util/makedefs.c
@@ -962,6 +962,7 @@ const char *deflt_content;
        matches a regular entry (bogusmon "grue"), that entry will become
        more likely to be picked than normal but it's nothing to worry about */
     (void) fputs(xcrypt(deflt_content), ofp);
+    (void) fputc('\n', ofp);
 
     tfp = getfp(DATA_TEMPLATE, "grep.tmp", WRTMODE);
     grep0(ifp, tfp);


### PR DESCRIPTION
Because no newline was appended to the default messages for dat/epitaph, dat/bogusmon, and dat/engrave, the first line in each of those files effectively concatenated the output of `xcrypt` for `deflt_content` and the first line of each respective plaintext source file.

In addition to the two being combined into a single line, since `xcrypt` is a state cipher (I think?), the appended first line doesn't decrypt correctly and looks like random gibberish -- e.g. ```xcrypt("Om$equvaz0vjazu!K$uov((xdpa(Y!ci&Sgw|0hl$xu`aa")``` returns ```No matter where I went, here I am.Cfux8xm&|}p`c``` (as seen in #369), while `xcrypt("Om$equvaz0vjazu!K$uov((xdpa(Y!ci&")` returns `No matter where I went, here I am.` and ```xcrypt("Sgw|0hl$xu`aa")``` returns `Rest in peace`.

Would fix #369 