### PR TITLE
Add instructions to zero mextra struct pointer in mextra documentation

### DIFF
--- a/include/mextra.h
+++ b/include/mextra.h
@@ -56,6 +56,8 @@
  *          struct or data during a restore.
  *      10. Adjust savemon() in src/save.c to deal with your
  *          struct or data during a save.
+ *      11. Zero out the pointer to your struct in newmextra() in
+ *          src/makemon.c.
  */
 
 /***


### PR DESCRIPTION
It doesn't mention anywhere that newmextra() is responsible for
initializing struct mextra with null pointers to the various
sub-structs. So, when one follows the instructions and doesn't know or
remember to do this, they'll get segfaults when something tries to read
the uninitialized pointer to their new struct.