### PR TITLE
Fix aborted worm placement failing sanity check

### DIFF
--- a/src/worm.c
+++ b/src/worm.c
@@ -728,6 +728,7 @@ xchar x, y;
         return;
     }
 
+    wheads[wnum]->wx = 0, wheads[wnum]->wy = 0;
     wheads[wnum] = new_tail = curr;
     curr = curr->nseg;
     new_tail->nseg = (struct wseg *) 0;


### PR DESCRIPTION
`initworm(worm.c)` sets `wx` and `wy` of `wheads[worm->wormno]` to `worm->mx` and `worm->my`. Because `place_worm_tail_randomly` reverses all the segments of the worm in the process of placing them, however, this segment with a `wx` and `wy` matching the worm ends up being the final tail segment rather than the head.

When `place_worm_tail_randomly` is forced to abort early, it calls `toss_wsegs`, which removes the `g.level.monsters` entry for each segment's `wx` and `wy` (based on the assumption that a segment having a `wx` and `wy` means it has been placed on the map). Since the final tail piece has a `wx` and `wy` that matches the worm itself, the worm ends up being removed from the map, and therefore causes `mon_sanity_check(mon.c)` to fail -- the worm is still in the list of monsters, but nothing exists on the map where it's supposed to be.

This problem can be avoided by preemptively setting the `wx` and `wy` of `wheads[worm->wormno]` to `0` in `place_worm_tail_randomly` before starting to reverse the worm's segments/place the worm.