### PR TITLE
Fix player rendering as slime one turn early

### DIFF
--- a/src/timeout.c
+++ b/src/timeout.c
@@ -318,12 +318,13 @@ slime_dialogue()
 {
     register long i = (Slimed & TIMEOUT) / 2L;
 
-    if (i == 1L) {
+    if ((Slimed & TIMEOUT) == 1L) {
         /* display as green slime during "You have become green slime."
            but don't worry about not being able to see self; if already
            mimicking something else at the time, implicitly be revealed */
         g.youmonst.m_ap_type = M_AP_MONSTER;
         g.youmonst.mappearance = PM_GREEN_SLIME;
+        newsym(u.ux, u.uy);
     }
     if (((Slimed & TIMEOUT) % 2L) && i >= 0L && i < SIZE(slime_texts)) {
         char buf[BUFSZ];
@@ -2403,7 +2404,7 @@ long adjust;     /* how much to adjust timeout */
     /* restore elements */
     if (nhfp->structlevel)
         mread(nhfp->fd, (genericptr_t) &count, sizeof count);
-       
+
     while (count-- > 0) {
         curr = (timer_element *) alloc(sizeof(timer_element));
         if (nhfp->structlevel)


### PR DESCRIPTION
This bug can be reproduced by getting Slimed, then waiting around until
the message "You are turning into a green slime", then moving. The
player renders as a green slime even though they have not yet become a
green slime and have one more action that could be used to negate the
sliming.

This is caused by the slime_dialogue() function causing the player to
appear as a green slime when the counter ticks down to 2, rather than 1
(which is the point at which "You have become a green slime." is shown
and the slime transformation actually happens). I *think* the original
purpose of doing it this way was because the next newsym() normally
wouldn't happen until the turn on which the timer ticks down to 1 - but
if the player forces a newsym by other means (such as moving) the bug is
exposed.

The fix here changes it so that the hero only starts rendering as a
green slime on that tick down to 1, then immediately calls newsym() to
show them as a slime during the "You have become a green slime" message
as originally intended.