### PR TITLE
Fix several issues with monster interruption checks, and an info leak

### DIFF
--- a/src/hack.c
+++ b/src/hack.c
@@ -2971,10 +2971,10 @@ monster_nearby()
                 continue;
             if ((mtmp = m_at(x, y)) && M_AP_TYPE(mtmp) != M_AP_FURNITURE
                 && M_AP_TYPE(mtmp) != M_AP_OBJECT
-                && (!mtmp->mpeaceful || Hallucination)
+                && (Hallucination
+                    || (!mtmp->mpeaceful && !noattacks(mtmp->data)))
                 && (!is_hider(mtmp->data) || !mtmp->mundetected)
-                && !noattacks(mtmp->data) && mtmp->mcanmove
-                && !mtmp->msleeping  /* aplvax!jcn */
+                && mtmp->mcanmove && !mtmp->msleeping  /* aplvax!jcn */
                 && !onscary(u.ux, u.uy, mtmp) && canspotmon(mtmp))
                 return 1;
         }

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -114,16 +114,18 @@ register struct monst *mtmp;
 
     /* a similar check is in monster_nearby() in hack.c */
     /* check whether hero notices monster and stops current activity */
-    if (g.occupation && !rd && !Confusion && (!mtmp->mpeaceful || Hallucination)
+    if (g.occupation && !rd
+        /* monster is hostile and can attack (or hallu distorts knowledge) */
+        && (Hallucination || (!mtmp->mpeaceful && !noattacks(mtmp->data)))
         /* it's close enough to be a threat */
-        && distu(x, y) <= (BOLT_LIM + 1) * (BOLT_LIM + 1)
+        && distu(mtmp->mx, mtmp->my) <= (BOLT_LIM + 1) * (BOLT_LIM + 1)
         /* and either couldn't see it before, or it was too far away */
         && (!already_saw_mon || !couldsee(x, y)
             || distu(x, y) > (BOLT_LIM + 1) * (BOLT_LIM + 1))
         /* can see it now, or sense it and would normally see it */
-        && (canseemon(mtmp) || (sensemon(mtmp) && couldsee(x, y)))
-        && mtmp->mcanmove && !noattacks(mtmp->data)
-        && !onscary(u.ux, u.uy, mtmp))
+        && canspotmon(mtmp) && couldsee(mtmp->mx, mtmp->my)
+        /* monster isn't paralyzed or afraid (scare monster/Elbereth) */
+        && mtmp->mcanmove && !onscary(u.ux, u.uy, mtmp))
         stop_occupation();
 
     return rd;


### PR DESCRIPTION
The automatic interruption system for approaching monsters was comparing
the old tile in cases where new tile was intended. Also, the way the checks
were constructed caused monsters seen by astral vision to constantly interrupt
you. There was also an information leak where the game would reveal monsters
without any attacks even if you were hallucinating. The game also stopped
interrupting you if you were confused, which was not only confusing to the
player, but also a pointless UI screw.

The interruption conditionals was changed. This is how the new system works:
Monsters interrupt you if:
* they are within 9 tiles (ball radius), can be spotted (vision or detection),
  and within LOS, and...
* it was outside 9 tiles ball radius, outside LOS or wasn't previously spotted.
* monster is hostile, has attacks, or you're hallucinating (since it conceals
  the information)