### PR TITLE
Fix: missing filled flags in various levels

### DIFF
--- a/dat/Hea-loca.lua
+++ b/dat/Hea-loca.lua
@@ -23,7 +23,7 @@ PPPPPPPPPPP........PPPPPPPPPPPP
 ]]);
 -- Dungeon Description
 des.region(selection.area(00,00,30,09), "lit")
-des.region({ region={12,03, 20,06}, lit=1, type="temple" })
+des.region({ region={12,03, 20,06}, lit=1, type="temple", filled=1 })
 -- Doors
 des.door("closed",09,04)
 des.door("closed",09,05)

--- a/dat/Kni-loca.lua
+++ b/dat/Kni-loca.lua
@@ -27,7 +27,7 @@ xxxxxxxxx.......xxxxxx.....xxxxxxxxxxxxx
 -- The Isle of Glass is a Tor rising out of the swamps surrounding it.
 des.region(selection.area(00,00,39,11), "lit")
 -- The top area of the Tor is a holy site.
-des.region({ region={09,02, 27,09}, lit=1, type="temple" })
+des.region({ region={09,02, 27,09}, lit=1, type="temple", filled=2 })
 -- Stairs
 des.stair("up", 38,0)
 des.stair("down", 18,05)

--- a/dat/Pri-strt.lua
+++ b/dat/Pri-strt.lua
@@ -37,7 +37,7 @@ des.map([[
 ]]);
 -- Dungeon Description
 des.region(selection.area(00,00,75,19), "lit")
-des.region({ region={24,06, 33,13}, lit=1, type="temple" })
+des.region({ region={24,06, 33,13}, lit=1, type="temple", filled=2 })
 
 des.replace_terrain({ region={00,00, 10,19}, fromterrain=".", toterrain="T", chance=10 })
 des.replace_terrain({ region={65,00, 75,19}, fromterrain=".", toterrain="T", chance=10 })

--- a/dat/Tou-goal.lua
+++ b/dat/Tou-goal.lua
@@ -33,7 +33,7 @@ des.map([[
 des.region(selection.area(00,00,75,19), "lit")
 -- The Inn
 des.region(selection.area(01,01,09,02), "lit")
-des.region({ region = {01,04,09,05}, lit=1, type = "barracks" })
+des.region({ region = {01,04,09,05}, lit=1, type = "barracks", filled = 1 })
 des.region(selection.area(01,07,02,10), "unlit")
 des.region(selection.area(07,07,09,10), "unlit")
 des.region(selection.area(01,14,02,15), "unlit")
@@ -41,9 +41,9 @@ des.region(selection.area(07,14,09,15), "unlit")
 des.region(selection.area(01,17,02,18), "unlit")
 des.region(selection.area(07,17,09,18), "unlit")
 --
-des.region({ region = {11,01,19,02}, lit = 0, type = "barracks" })
+des.region({ region = {11,01,19,02}, lit = 0, type = "barracks", filled = 1 })
 des.region(selection.area(21,01,30,02), "unlit")
-des.region({ region = {11,17,19,18}, lit = 0, type = "barracks" })
+des.region({ region = {11,17,19,18}, lit = 0, type = "barracks", filled = 1 })
 des.region(selection.area(21,17,30,18), "unlit")
 -- Police Station
 des.region(selection.area(18,07,25,11), "lit")
@@ -53,12 +53,12 @@ des.region(selection.area(24,13,25,13), "unlit")
 -- The town itself
 des.region(selection.area(42,03,47,06), "unlit")
 des.region(selection.area(42,08,50,11), "unlit")
-des.region({ region = {37,16,41,18}, lit = 0, type = "morgue" })
+des.region({ region = {37,16,41,18}, lit = 0, type = "morgue", filled = 1 })
 des.region(selection.area(47,16,55,18), "unlit")
 des.region(selection.area(55,01,62,03), "unlit")
 des.region(selection.area(64,01,71,03), "unlit")
-des.region({ region = {60,14,71,15}, lit = 1, type = "shop" })
-des.region({ region = {60,17,71,18}, lit = 1, type = "shop" })
+des.region({ region = {60,14,71,15}, lit = 1, type = "shop", filled = 1 })
+des.region({ region = {60,17,71,18}, lit = 1, type = "shop", filled = 1 })
 -- Non diggable walls
 des.non_diggable(selection.area(00,00,75,19))
 -- Stairs

--- a/dat/Wiz-goal.lua
+++ b/dat/Wiz-goal.lua
@@ -29,7 +29,7 @@ des.map([[
                                                                             
 ]]);
 -- Dungeon Description
-des.region({ region={13,10,18,12}, lit=0, type="temple" })
+des.region({ region={13,10,18,12}, lit=0, type="temple", filled=2 })
 des.region(selection.area(13,06,18,08), "lit")
 des.region(selection.area(20,04,30,14), "unlit")
 des.region(selection.area(32,06,33,07), "unlit")

--- a/dat/astral.lua
+++ b/dat/astral.lua
@@ -82,9 +82,9 @@ des.region({ region={61,05,74,14},lit=1,type="ordinary",irregular=1 })
 -- A Sanctum for each alignment
 -- The shrines' alignments are shuffled for
 -- each game
-des.region({ region={04,07,10,11},lit=1,type="temple" })
-des.region({ region={34,03,40,07},lit=1,type="temple" })
-des.region({ region={64,07,70,11},lit=1,type="temple" })
+des.region({ region={04,07,10,11},lit=1,type="temple",filled=2 })
+des.region({ region={34,03,40,07},lit=1,type="temple",filled=2 })
+des.region({ region={64,07,70,11},lit=1,type="temple",filled=2 })
 
 des.altar({ x=07, y=09, align=align[1],type="sanctum" })
 des.altar({ x=37, y=05, align=align[2],type="sanctum" })

--- a/dat/juiblex.lua
+++ b/dat/juiblex.lua
@@ -56,7 +56,7 @@ place:set(04,15);
 place:set(46,15);
 
 -- Dungeon description
-des.region({ region={00,00,50,17}, lit=0, type="swamp" })
+des.region({ region={00,00,50,17}, lit=0, type="swamp", filled=2 })
 des.levregion({ region = {01,00,11,20}, region_islev=1, exclude={0,0,50,17}, type="stair-down" });
 des.levregion({ region = {69,00,79,20}, region_islev=1, exclude={0,0,50,17}, type="stair-up" });
 des.levregion({ region = {01,00,11,20}, region_islev=1, exclude={0,0,50,17}, type="branch" });

--- a/dat/minetn-5.lua
+++ b/dat/minetn-5.lua
@@ -132,6 +132,6 @@ des.door("locked",50,06)
 des.object("(", 50, 03)
 des.object({ id = "statue", x=38, y=15, montype="gnome king", historic=1 })
 -- Temple
-des.region({ region={29,02, 33,04}, lit=1, type="temple" })
+des.region({ region={29,02, 33,04}, lit=1, type="temple", filled=1 })
 des.door("closed",31,05)
 des.altar({ x=31,y=03, align=align[1], type="shrine" })

--- a/dat/sanctum.lua
+++ b/dat/sanctum.lua
@@ -32,7 +32,7 @@ des.map([[
 |             -------------                  -----          -------        |
 ----------------------------------------------------------------------------
 ]]);
-des.region({ region={15,07, 21,10}, lit=1, type="temple", contents = function()
+des.region({ region={15,07, 21,10}, lit=1, type="temple", filled=2, contents = function()
                 des.door({ wall = "random", state = "secret" });
 end })
 des.altar({ x=18, y=08, align="noalign", type="sanctum" })

--- a/dat/valley.lua
+++ b/dat/valley.lua
@@ -51,7 +51,7 @@ end
 
 -- Dungeon Description
 -- The shrine to Moloch.
-des.region({ region={01,06, 05,14},lit=1,type="temple" })
+des.region({ region={01,06, 05,14},lit=1,type="temple",filled=2 })
 -- The Morgues
 des.region({ region={19,01, 24,08},lit=0,type="morgue",filled=1,irregular=1 })
 des.region({ region={09,14, 16,18},lit=0,type="morgue",filled=1,irregular=1 })

--- a/dat/wizard3.lua
+++ b/dat/wizard3.lua
@@ -28,7 +28,7 @@ des.teleport_region({ region={01,00,79,20}, region_islev=1, exclude={0,0,27,12} 
 des.levregion({ region={25,11,25,11}, type="portal", name="fakewiz1" });
 des.mazewalk(28,09,"east")
 des.region({ region={07,03, 15,11}, lit=0 ,type="morgue", filled=2 })
-des.region({ region={17,06, 18,11}, lit=0, type="beehive" })
+des.region({ region={17,06, 18,11}, lit=0, type="beehive", filled=1 })
 -- make the entry chamber a real room; it affects monster arrival
 des.region({ region={20,06,26,11},lit=0,type="ordinary",arrival_room=true,
              contents = function()


### PR DESCRIPTION
This is an omission in the filled/prefilled unification. The default for
filled on regions now being 0 meant that regions that had previously had
no need for any fill declaration at all (regions' prefilled defaulted to
0 before this, the effect being to fill them) now failed to get filled.

The rule of thumb is that all des.regions with a type for which filled
is meaningful (e.g. special rooms) should declare the fill status. I
added it to a bunch of temples even though this doesn't really seem to
affect anything there (the priest and altar come with the altar
definition). I assigned temples filled=1 and filled=2 loosely based on
if there is ever being some other generation that would put other
furniture or items in a temple, but the distinction should not affect
anything right now.

Cases fixed where non-temple regions weren't getting filled:
- Barracks, a graveyard, and shops in Tou-goal
- The beehive in the Wizard's Tower