### PR TITLE
Use simple_typename when trying to repair a broken lock

### DIFF
--- a/src/lock.c
+++ b/src/lock.c
@@ -480,7 +480,7 @@ struct obj *container; /* container, for autounlock */
                 }
 
                 if (otmp->obroken) {
-                    You_cant("fix its broken lock with %s.", an(xname(pick)));
+                    You_cant("fix its broken lock with %s.", an(simple_typename(picktyp)));
                     return PICKLOCK_LEARNED_SOMETHING;
                 } else if (picktyp == CREDIT_CARD && !otmp->olocked) {
                     /* credit cards are only good for unlocking */

--- a/src/lock.c
+++ b/src/lock.c
@@ -480,7 +480,7 @@ struct obj *container; /* container, for autounlock */
                 }
 
                 if (otmp->obroken) {
-                    You_cant("fix its broken lock with %s.", doname(pick));
+                    You_cant("fix its broken lock with %s.", an(xname(pick)));
                     return PICKLOCK_LEARNED_SOMETHING;
                 } else if (picktyp == CREDIT_CARD && !otmp->olocked) {
                     /* credit cards are only good for unlocking */


### PR DESCRIPTION
Using `doname` includes information like BUC level, so that the resulting message when <kbd>a</kbd>pplying a key on a broken box is something like \`\`You can't fix its broken lock with an uncursed key.'' -- this makes me feel like \`\`uncursed'' is being stressed, as if a blessed key *would* fix the lock (and so on for any other attributes `doname` can include). I think it's clearer to just say ``You can't fix the lock with a [skeleton key|credit card|lock pick].''