### PR TITLE
Prevent sokoban levels being flipped

### DIFF
--- a/dat/soko1-1.lua
+++ b/dat/soko1-1.lua
@@ -4,7 +4,7 @@
 --
 des.level_init({ style = "solidfill", fg = " " });
 
-des.level_flags("mazelevel", "noteleport", "premapped", "solidify");
+des.level_flags("mazelevel", "noteleport", "premapped", "solidify", "noflip");
 des.map([[
 --------------------------
 |........................|

--- a/dat/soko1-2.lua
+++ b/dat/soko1-2.lua
@@ -4,7 +4,7 @@
 --
 des.level_init({ style = "solidfill", fg = " " });
 
-des.level_flags("mazelevel", "noteleport", "premapped", "solidify");
+des.level_flags("mazelevel", "noteleport", "premapped", "solidify", "noflip");
 
 des.map([[
   ------------------------

--- a/dat/soko2-1.lua
+++ b/dat/soko2-1.lua
@@ -4,7 +4,7 @@
 --
 des.level_init({ style = "solidfill", fg = " " });
 
-des.level_flags("mazelevel", "noteleport", "premapped", "solidify");
+des.level_flags("mazelevel", "noteleport", "premapped", "solidify", "noflip");
 
 des.map([[
 --------------------

--- a/dat/soko2-2.lua
+++ b/dat/soko2-2.lua
@@ -4,7 +4,7 @@
 --
 des.level_init({ style = "solidfill", fg = " " });
 
-des.level_flags("mazelevel", "noteleport", "premapped", "solidify");
+des.level_flags("mazelevel", "noteleport", "premapped", "solidify", "noflip");
 
 des.map([[
   --------          

--- a/dat/soko3-1.lua
+++ b/dat/soko3-1.lua
@@ -4,7 +4,7 @@
 --
 des.level_init({ style = "solidfill", fg = " " });
 
-des.level_flags("mazelevel", "noteleport", "premapped", "solidify");
+des.level_flags("mazelevel", "noteleport", "premapped", "solidify", "noflip");
 
 des.map([[
 -----------       -----------

--- a/dat/soko3-2.lua
+++ b/dat/soko3-2.lua
@@ -4,7 +4,7 @@
 --
 des.level_init({ style = "solidfill", fg = " " });
 
-des.level_flags("mazelevel", "noteleport", "premapped", "solidify");
+des.level_flags("mazelevel", "noteleport", "premapped", "solidify", "noflip");
 
 des.map([[
  ----          -----------

--- a/dat/soko4-1.lua
+++ b/dat/soko4-1.lua
@@ -35,7 +35,7 @@
 --## Bottom (first) level of Sokoban ###
 des.level_init({ style = "solidfill", fg = " " });
 
-des.level_flags("mazelevel", "noteleport", "hardfloor", "premapped", "solidify");
+des.level_flags("mazelevel", "noteleport", "hardfloor", "premapped", "solidify", "noflip");
 
 des.map([[
 ------  ----- 

--- a/dat/soko4-2.lua
+++ b/dat/soko4-2.lua
@@ -4,7 +4,7 @@
 --
 des.level_init({ style = "solidfill", fg = " " });
 
-des.level_flags("mazelevel", "noteleport", "hardfloor", "premapped", "solidify");
+des.level_flags("mazelevel", "noteleport", "hardfloor", "premapped", "solidify", "noflip");
 
 des.map([[
 -------- ------


### PR DESCRIPTION
Sokoban levels in particular being flipped is a cause of a frustration,
particularly for long-time players whose muscle memory gets confused.

Note that the player confusion is different from if there were new levels
instead (my preferred solution) that must be done.

To a lesser extent it affects new players attempting to follow a guide,
though guides can be independently updated.