### PR TITLE
Add a guard for corpsenm in polyfodder macro

### DIFF
--- a/include/obj.h
+++ b/include/obj.h
@@ -249,7 +249,7 @@ struct obj {
 #define ofood(o) ((o)->otyp == CORPSE || (o)->otyp == EGG || (o)->otyp == TIN)
 #define polyfodder(obj) \
     (ofood(obj) && (pm_to_cham((obj)->corpsenm) != NON_PM       \
-                    || dmgtype(&mons[(obj)->corpsenm], AD_POLY)))
+                    || ((obj)->corpsenm >= LOW_PM && dmgtype(&mons[(obj)->corpsenm], AD_POLY))))
 #define mlevelgain(obj) (ofood(obj) && (obj)->corpsenm == PM_WRAITH)
 #define mhealup(obj) (ofood(obj) && (obj)->corpsenm == PM_NURSE)
 #define Is_pudding(o)                                                 \


### PR DESCRIPTION
If for example a dog eats a generic egg or a metallivore eats a
tin of spinach this will attempt to index into the mons array with a
negative index

Spotted whilst fuzzing with address sanitizer