### PR TITLE
docs: fix simple typo, accomodate -> accommodate

### DIFF
--- a/include/patchlevel.h
+++ b/include/patchlevel.h
@@ -98,7 +98,7 @@
  *  fix the article used in the message when your steed encounters a polymorph
  *      trap
  *  allow teleporting onto the vibrating square
- *  message "your knapsack can't accomodate any more items" when picking stuff
+ *  message "your knapsack can't accommodate any more items" when picking stuff
  *      up or removing such from container was inaccurate if there was some
  *      gold pending; vary the message rather than add more convoluted pickup
  *      code

--- a/outdated/sys/wince/mhmsgwnd.c
+++ b/outdated/sys/wince/mhmsgwnd.c
@@ -609,7 +609,7 @@ mswin_message_window_size(HWND hWnd, LPSIZE sz)
 
     data = (PNHMessageWindow) GetWindowLong(hWnd, GWL_USERDATA);
     if (data) {
-        /* set size to accomodate MSG_VISIBLE_LINES, highligh rectangle and
+        /* set size to accommodate MSG_VISIBLE_LINES, highligh rectangle and
            horizontal scroll bar (difference between window rect and client
            rect */
         GetClientRect(hWnd, &client_rt);

--- a/win/win32/mhmsgwnd.c
+++ b/win/win32/mhmsgwnd.c
@@ -769,7 +769,7 @@ mswin_message_window_size(HWND hWnd, LPSIZE sz)
     sz->cx = rt.right - rt.left;
     sz->cy = rt.bottom - rt.top;
 
-    /* set size to accomodate MSG_VISIBLE_LINES and
+    /* set size to accommodate MSG_VISIBLE_LINES and
        horizontal scroll bar (difference between window rect and client rect
        */
     GetClientRect(hWnd, &client_rt);


### PR DESCRIPTION
There is a small typo in include/patchlevel.h, outdated/sys/wince/mhmsgwnd.c, win/win32/mhmsgwnd.c.

Should read `accommodate` rather than `accomodate`.

