### PR TITLE
Add alchemy smock text to game-end disclosure

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2182,6 +2182,7 @@ E long NDECL(random);
 
 E void FDECL(learnscroll, (struct obj *));
 E char *FDECL(tshirt_text, (struct obj *, char *));
+E char *FDECL(apron_text, (struct obj *, char *));
 E const char *FDECL(candy_wrapper_text, (struct obj *));
 E void FDECL(assign_candy_wrapper, (struct obj *));
 E int NDECL(doread);

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -755,6 +755,9 @@ unsigned cxn_flags; /* bitmask of CXN_xxx values */
         case T_SHIRT:
             Sprintf(eos(buf), " with text \"%s\"", tshirt_text(obj, tmpbuf));
             break;
+        case ALCHEMY_SMOCK:
+            Sprintf(eos(buf), " with text \"%s\"", apron_text(obj, tmpbuf));
+            break;
         case CANDY_BAR:
             lbl = candy_wrapper_text(obj);
             if (*lbl)

--- a/src/read.c
+++ b/src/read.c
@@ -18,7 +18,6 @@ static const char all_count[] = { ALLOW_COUNT, ALL_CLASSES, 0 };
 
 static boolean FDECL(learnscrolltyp, (SHORT_P));
 static char *FDECL(erode_obj_text, (struct obj *, char *));
-static char *FDECL(apron_text, (struct obj *, char *));
 static void FDECL(stripspe, (struct obj *));
 static void FDECL(p_glow1, (struct obj *));
 static void FDECL(p_glow2, (struct obj *, const char *));
@@ -157,7 +156,7 @@ char *buf;
     return erode_obj_text(tshirt, buf);
 }
 
-static char *
+char *
 apron_text(apron, buf)
 struct obj *apron;
 char *buf;


### PR DESCRIPTION
T-shirts and candy bars have their text listed in the end-of-game list of identified possessions, with the stated intent that it can give unspoiled players a hint that these objects can be read. Following the same logic, aprons/alchemy smocks should have their text listed as well.