### PR TITLE
Fix counterintuitive towel wetting/drying behavior

### DIFF
--- a/src/trap.c
+++ b/src/trap.c
@@ -69,7 +69,7 @@ struct monst *victim;
     while (item) {
         if (is_wet_towel(item)) {
             oldspe = item->spe;
-            dry_a_towel(item, rn2(oldspe + 1), TRUE);
+            dry_a_towel(item, -1 * rn2(oldspe + 1), TRUE);
             if (item->spe != oldspe)
                 break; /* stop once one towel has been affected */
         }
@@ -3548,7 +3548,8 @@ boolean force;
     if (obj->otyp == CAN_OF_GREASE && obj->spe > 0) {
         return ER_NOTHING;
     } else if (obj->otyp == TOWEL && obj->spe < 7) {
-        wet_a_towel(obj, rnd(7), TRUE);
+        /* increase wetness by random amount >= 1, but never past max of 7 */
+        wet_a_towel(obj, -1 * rnd(7 - obj->spe), TRUE);
         return ER_NOTHING;
     } else if (obj->greased) {
         if (!rn2(2))


### PR DESCRIPTION
# Summary

Would allow fire traps/attacks to completely dry wet towels -- which is the original intended behavior as described in the commit message of 4b8db661dd -- and change towel wetting behavior so that dipping a towel in water would no longer have the potential to make it dryer.

# Details

Fire traps currently never fully dry out a wet towel; although a wetness level between 0 and the towel's current wetness inclusive is chosen at random and passed to `dry_a_towel(weapon.c)`, because `dry_a_towel` [interprets 0 as a no-op](https://github.com/NetHack/NetHack/blob/3e183d0c6ad0f3aac42d821b15ada2cc1173bf2c/src/weapon.c#L993) it never actually sets the dryness to that level. As a result, the towel is twice as likely to retain its existing wetness level, and can never be fully dried by a fire trap.  Passing a negative number in the same range instead decrements the result by that amount, allowing fire traps to dry out wet towels completely.

On a similar note, wetting towels by dipping them in water (or falling in) sets their wetness to a completely random level.  This means that dipping a wet towel into water can actually dry it out relative to its previous wetness, which doesn't really make a lot of sense and can be confusing in-game (for example, dipping a wet towel into a moat can visibly turn it into a moist towel).  This commit would change the behavior of towel wetting so that the current wetness is incremented by a random amount instead.