### PR TITLE
Add liquid flow to land mine explosions

### DIFF
--- a/src/trap.c
+++ b/src/trap.c
@@ -2147,11 +2147,15 @@ unsigned trflags;
             set_wounded_legs(RIGHT_SIDE, rn1(35, 41));
             exercise(A_DEX, FALSE);
         }
+        /* add a pit before calling losehp so bones won't keep the landmine;
+         * blow_up_landmine will remove the pit afterwards if inappropriate */
+        trap->ttyp = PIT;
+        trap->madeby_u = FALSE;
+        losehp(Maybe_Half_Phys(rnd(16)), "land mine", KILLED_BY_AN);
         blow_up_landmine(trap);
         if (steed_mid && saddle && !u.usteed)
             (void) keep_saddle_with_steedcorpse(steed_mid, fobj, saddle);
         newsym(u.ux, u.uy); /* update trap symbol */
-        losehp(Maybe_Half_Phys(rnd(16)), "land mine", KILLED_BY_AN);
         /* fall recursively into the pit... */
         if ((trap = t_at(u.ux, u.uy)) != 0)
             dotrap(trap, RECURSIVETRAP);
@@ -2552,6 +2556,7 @@ struct trap *trap;
 {
     int x = trap->tx, y = trap->ty, dbx, dby;
     struct rm *lev = &levl[x][y];
+    schar typ;
 
     (void) scatter(x, y, 4,
                    MAY_DESTROY | MAY_HIT | MAY_FRACTURE | VIS_EFFECTS,
@@ -2574,9 +2579,18 @@ struct trap *trap;
             /* no pits here */
             deltrap(trap);
         } else {
-            trap->ttyp = PIT;       /* explosion creates a pit */
-            trap->madeby_u = FALSE; /* resulting pit isn't yours */
-            seetrap(trap);          /* and it isn't concealed */
+            /* fill pit with water, if applicable */
+            typ = fillholetyp(x, y, FALSE);
+            if (typ != ROOM) {
+                lev->typ = typ;
+                liquid_flow(x, y, typ, trap,
+                            cansee(x, y) ? "The hole fills with %s!"
+                                         : (char *) 0);
+            } else {
+                trap->ttyp = PIT;       /* explosion creates a pit */
+                trap->madeby_u = FALSE; /* resulting pit isn't yours */
+                seetrap(trap);          /* and it isn't concealed */
+            }
         }
     }
 }


### PR DESCRIPTION
Land mine explosions currently do not call `liquid_flow(dig.c)`, and as a result the pit created by an exploding land mine will never fill with adjacent water or lava, as pits created by other sources -- digging, breaking a wand, and earthquake -- can do.

This commit adds the appropriate calls to `liquid_flow` and `fillholetyp` to `blow_up_landmine` so that land mine explosions may fill with water like other pits do.

The call to `losehp` in `dotrap` had to be moved from after to before `blow_up_landmine`, since waiting to call `losehp` when the pit can fill with water could lead to silly messages (\`\`That was a close one. You die...'').  After this change, a land mine that killed a character would be retained unexploded in a bones file, because death would occur before the call to `blow_up_landmine`.  To avoid this issue, the land mine is converted to a pit before calling `losehp`; `blow_up_landmine` does not check whether the target trap is in fact a landmine so works as usual even if the trap is converted to a pit, and will delete the pit in cases where it should not exist.

(I closed #414 and rebased the branch after recent changes to trap.c introduced merge conflicts that needed to be resolved manually, so this is effectively the same PR as that one)