### PR TITLE
Fix some dismount loopholes

### DIFF
--- a/src/steed.c
+++ b/src/steed.c
@@ -452,7 +452,8 @@ int forceit;
                 if (!isok(x, y) || (x == u.ux && y == u.uy))
                     continue;
 
-                if (accessible(x, y) && !MON_AT(x, y)) {
+                if (accessible(x, y) && !MON_AT(x, y)
+                    && test_move(u.ux, u.uy, x - u.ux, y - u.uy, TEST_MOVE)) {
                     distance = distu(x, y);
                     if (min_distance < 0 || distance < min_distance
                         || (distance == min_distance && rn2(2))) {

--- a/src/steed.c
+++ b/src/steed.c
@@ -648,6 +648,8 @@ int reason; /* Player was thrown off etc. */
                  */
                 g.in_steed_dismounting = TRUE;
                 teleds(cc.x, cc.y, TELEDS_ALLOW_DRAG);
+                if (sobj_at(BOULDER, cc.x, cc.y))
+                    sokoban_guilt();
                 g.in_steed_dismounting = FALSE;
 
                 /* Put your steed in your trap */


### PR DESCRIPTION
Dismounting doesn't currently test whether the destination spot could be moved to normally, so can be used to squeeze diagonally into a space that would normally be blocked because "you are carrying too much to get through". This can be abused in Sokoban to pass through gaps that are normally inaccessible, and even in normal levels can leave the hero in a spot from which they can't escape without dropping items or using a pick-axe. This patch would block dismounting through diagonals which are normally impassible by adding a successful result from `test_move` as a condition of choosing a dismount location.

Additionally, dismounting will opt to place the hero onto a boulder if no other appropriate spots are available. This too can be abused in Sokoban, so these changes would also add the standard luck penalty for using this behavior to pass over boulders on an unsolved Sokoban level.