### PR TITLE
Add the monstercolor system, letting players choose monster colors

### DIFF
--- a/include/color.h
+++ b/include/color.h
@@ -56,4 +56,8 @@ struct menucoloring {
     struct menucoloring *next;
 };
 
+/* For monstercolors: special value that indicates a monstercolor isn't
+ * configured for a given monster and it should use the default */
+#define MONSTERCOLOR_DEFAULT (CLR_MAX + 1)
+
 #endif /* COLOR_H */

--- a/include/decl.h
+++ b/include/decl.h
@@ -814,7 +814,7 @@ struct instance_globals {
     gbuf_entry gbuf[ROWNO][COLNO];
     xchar gbuf_start[ROWNO];
     xchar gbuf_stop[ROWNO];
-
+    uchar monstercolors[NUMMONS];
 
     /* do.c */
     boolean at_ladder;

--- a/include/extern.h
+++ b/include/extern.h
@@ -1827,6 +1827,7 @@ extern boolean msgtype_parse_add(char *);
 extern int msgtype_type(const char *, boolean);
 extern void hide_unhide_msgtypes(boolean, int);
 extern void msgtype_free(void);
+extern boolean add_monstercolor(char *);
 
 /* ### pager.c ### */
 

--- a/include/optlist.h
+++ b/include/optlist.h
@@ -306,6 +306,8 @@ opt_##a,
            No, Yes, No, NoAlias, "edit message types")
     NHOPTB(monpolycontrol, 0, opt_in, set_wizonly, Off, Yes, No, No, NoAlias,
                 &iflags.mon_polycontrol)
+    NHOPTO("monster colors", o_monstercolor, BUFSZ, opt_in, set_in_game,
+           No, Yes, No, NoAlias, "edit monster colors")
     NHOPTC(monsters, MAXMCLASSES, opt_in, set_in_config, No, Yes, No, No,
                 NoAlias, "list of symbols to use for monsters")
     NHOPTC(mouse_support, 0, opt_in, set_in_game, No, Yes, No, No, NoAlias,
@@ -412,10 +414,10 @@ opt_##a,
                 &flags.showrace)
 #ifdef SCORE_ON_BOTL
     NHOPTB(showscore, 0, opt_in, set_in_game, Off, Yes, No, No, NoAlias,
-                &flags.showscore) 
+                &flags.showscore)
 #else
     NHOPTB(showscore, 0, opt_in, set_in_config, Off, Yes, No, No, NoAlias,
-                (boolean *) 0) 
+                (boolean *) 0)
 #endif
     NHOPTB(silent, 0, opt_out, set_in_game, On, Yes, No, No, NoAlias,
                 &flags.silent)
@@ -437,7 +439,7 @@ opt_##a,
                 &iflags.status_updates)
     NHOPTO("status condition fields", o_status_cond, BUFSZ, opt_in,
            set_in_game, No, Yes, No, NoAlias, "edit status condition fields")
-#ifdef STATUS_HILITES 
+#ifdef STATUS_HILITES
     NHOPTC(statushilites, 20, opt_in, set_in_game, Yes, Yes, Yes, No, NoAlias,
                 "0=no status highlighting, N=show highlights for N turns")
     NHOPTO("status hilite rules", o_status_hilites, BUFSZ, opt_in, set_in_game,

--- a/src/decl.c
+++ b/src/decl.c
@@ -349,6 +349,7 @@ const struct instance_globals g_init = {
     UNDEFINED_VALUES, /* gbuf */
     UNDEFINED_VALUES, /* gbuf_start */
     UNDEFINED_VALUES, /* gbug_stop */
+    DUMMY, /* monstercolors */
 
     /* do.c */
     FALSE, /* at_ladder */
@@ -708,6 +709,7 @@ const glyph_info nul_glyphinfo =
 void
 decl_globals_init(void)
 {
+    int i;
     g = g_init;
 
     g.valuables[0].list = g.gems;
@@ -749,7 +751,10 @@ decl_globals_init(void)
     g.urole = urole_init_data;
     g.urace = urace_init_data;
 
-
+    /* monstercolors can't remain 0, since that's a valid color */
+    for (i = LOW_PM; i < NUMMONS; ++i) {
+        g.monstercolors[i] = MONSTERCOLOR_DEFAULT;
+    }
 }
 
 /*decl.c*/

--- a/src/display.c
+++ b/src/display.c
@@ -2069,9 +2069,14 @@ static const int explcolors[] = {
 #define zap_color(n) color = iflags.use_color ? zapcolors[n] : NO_COLOR
 #define cmap_color(n) color = iflags.use_color ? defsyms[n].color : NO_COLOR
 #define obj_color(n) color = iflags.use_color ? objects[n].oc_color : NO_COLOR
-#define mon_color(n) color = iflags.use_color ? mons[n].mcolor : NO_COLOR
+#define mon_color(n) \
+    color = iflags.use_color \
+        ? g.monstercolors[n] != MONSTERCOLOR_DEFAULT \
+            ? g.monstercolors[n] \
+            : mons[n].mcolor \
+        : NO_COLOR
 #define invis_color(n) color = NO_COLOR
-#define pet_color(n) color = iflags.use_color ? mons[n].mcolor : NO_COLOR
+#define pet_color(n) mon_color(n)
 #define warn_color(n) \
     color = iflags.use_color ? def_warnsyms[n].color : NO_COLOR
 #define explode_color(n) color = iflags.use_color ? explcolors[n] : NO_COLOR

--- a/src/files.c
+++ b/src/files.c
@@ -2382,6 +2382,9 @@ parse_config_line(char *origbuf)
     } else if (match_varname(buf, "MSGTYPE", 7)) {
         if (!msgtype_parse_add(bufp))
             retval = FALSE;
+    } else if (match_varname(buf, "MONSTERCOLOR", 12)) {
+        if (!add_monstercolor(bufp))
+            retval = FALSE;
 #ifdef NOCWD_ASSUMPTIONS
     } else if (match_varname(buf, "HACKDIR", 4)) {
         adjust_prefix(bufp, HACKPREFIX);


### PR DESCRIPTION
This existed as one of the 3.4.3-nao patches, but rather than porting that patch to the current codebase I started from scratch, because the system as I saw it had two big drawbacks:

1. Mutated mons[], which is just not a great idea in my book.
2. Colors were only settable via config file, not in-game. I envisioned monster colors working like msgtypes or autopickup exceptions, which can be modified in-game.

To that end, monstercolors are settable in-game via a submenu in the "Other settings" section of the options, like autopickup exceptions or msgtypes, as well as via "MONSTERCOLOR=monname:color" in the config. Also like those settings, they do not persist through saving and restoring, but any config lines will be loaded as normal upon restore.

Instead of directly editing mons[], it edits a new variable 'monstercolors' in instance_globals. I thought this might be unnecessary
at first, but then realized that if it changed mons[].mcolor like the NAO patch, then it would be impossible to count the number of currently set monstercolors because there would be no default to compare against.