### PR TITLE
Refactor getobj() to use callbacks on candidate objects

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1011,7 +1011,8 @@ E boolean NDECL(wearing_armor);
 E boolean FDECL(is_worn, (struct obj *));
 E struct obj *FDECL(g_at, (int, int));
 E boolean FDECL(splittable, (struct obj *));
-E struct obj *FDECL(getobj, (const char *, const char *));
+E int FDECL(any_obj_ok, (struct obj *));
+E struct obj *FDECL(getobj, (const char *, int (*)(OBJ_P), unsigned int));
 E int FDECL(ggetobj, (const char *, int (*)(OBJ_P), int,
                       BOOLEAN_P, unsigned *));
 E int FDECL(askchain, (struct obj **, const char *, int, int (*)(OBJ_P),
@@ -2124,7 +2125,7 @@ E char *FDECL(apron_text, (struct obj *, char *));
 E const char *FDECL(candy_wrapper_text, (struct obj *));
 E void FDECL(assign_candy_wrapper, (struct obj *));
 E int NDECL(doread);
-E boolean FDECL(is_chargeable, (struct obj *));
+E int FDECL(charge_ok, (struct obj *));
 E void FDECL(recharge, (struct obj *, int));
 E int FDECL(seffects, (struct obj *));
 E void FDECL(drop_boulder_on_player,

--- a/include/hack.h
+++ b/include/hack.h
@@ -478,6 +478,40 @@ enum bodypart_types {
 #define MON_POLE_DIST 5 /* How far monsters can use pole-weapons */
 #define PET_MISSILE_RANGE2 36 /* Square of distance within which pets shoot */
 
+/* flags passed to getobj() to control how it responds to player input */
+#define GETOBJ_NOFLAGS  0x0
+#define GETOBJ_ALLOWCNT 0x1 /* is a count allowed with this command? */
+#define GETOBJ_PROMPT   0x2 /* should it force a prompt for input? (prevents it
+                               exiting early with "You don't have anything to
+                               foo" if nothing in inventory is valid) */
+
+/* values returned from getobj() callback functions */
+enum getobj_callback_returns {
+    /* generally invalid - can't be used for this purpose. will give a "silly
+     * thing" message if the player tries to pick it, unless a more specific
+     * failure message is in getobj itself - e.g. "You cannot foo gold". */
+    GETOBJ_EXCLUDE = -2,
+    /* invalid because it is an inaccessible or unwanted piece of gear, but
+     * psuedo-valid for the purposes of allowing the player to select it and
+     * getobj to return it if there is a prompt instead of getting "silly
+     * thing", in order for the getobj caller to present a specific failure
+     * message. Other than that, the only thing this does differently from
+     * GETOBJ_EXCLUDE is that it inserts an "else" in "You don't have anything
+     * else to foo". */
+    GETOBJ_EXCLUDE_INACCESS = -1,
+    /* invalid for purposes of not showing a prompt if nothing is valid but
+     * psuedo-valid for selecting - identical to GETOBJ_EXCLUDE_INACCESS but
+     * without the "else" in "You don't have anything else to foo". */
+    GETOBJ_EXCLUDE_SELECTABLE = 0,
+    /* valid - invlet not presented in the summary or the ? menu as a
+     * recommendation, but is selectable if the player enters it anyway. Used
+     * for objects that are actually valid but unimportantly so, such as shirts
+     * for reading. */
+    GETOBJ_DOWNPLAY = 1,
+    /* valid - will be shown in summary and ? menu */
+    GETOBJ_SUGGEST  = 2,
+};
+
 /*
  * option setting restrictions
  */

--- a/include/objclass.h
+++ b/include/objclass.h
@@ -166,10 +166,6 @@ enum obj_class_types {
 /* for mkobj() use ONLY! odd '-SPBOOK_CLASS' is in case of unsigned enums */
 #define SPBOOK_no_NOVEL (0 - (int) SPBOOK_CLASS)
 
-#define ALLOW_COUNT (MAXOCLASSES + 1) /* Can be used in the object class    */
-#define ALL_CLASSES (MAXOCLASSES + 2) /* input to getobj().                 */
-#define ALLOW_NONE  (MAXOCLASSES + 3)
-
 #define BURNING_OIL (MAXOCLASSES + 1) /* Can be used as input to explode.   */
 #define MON_EXPLODE (MAXOCLASSES + 2) /* Exploding monster (e.g. gas spore) */
 

--- a/src/detect.c
+++ b/src/detect.c
@@ -29,6 +29,10 @@ static int FDECL(mfind0, (struct monst *, BOOLEAN_P));
 static int FDECL(reveal_terrain_getglyph, (int, int, int,
                                                unsigned, int, int));
 
+/* wildcard class for clear_stale_map - this used to be used as a getobj() input
+ * but it's no longer used for that function */
+#define ALL_CLASSES (MAXOCLASSES + 1)
+
 /* bring hero out from underwater or underground or being engulfed;
    return True iff any change occurred */
 static boolean

--- a/src/do.c
+++ b/src/do.c
@@ -19,18 +19,15 @@ static NHFILE *NDECL(currentlevel_rewrite);
 static void NDECL(final_level);
 /* static boolean FDECL(badspot, (XCHAR_P,XCHAR_P)); */
 
-static NEARDATA const char drop_types[] = { ALLOW_COUNT, COIN_CLASS,
-                                            ALL_CLASSES, 0 };
-
 /* 'd' command: drop one inventory item */
 int
 dodrop()
 {
-    int result, i = (g.invent) ? 0 : (SIZE(drop_types) - 1);
+    int result;
 
     if (*u.ushops)
         sellobj_state(SELL_DELIBERATE);
-    result = drop(getobj(&drop_types[i], "drop"));
+    result = drop(getobj("drop", any_obj_ok, GETOBJ_PROMPT));
     if (*u.ushops)
         sellobj_state(SELL_NORMAL);
     if (result)

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -21,6 +21,8 @@ static void FDECL(auto_describe, (int, int));
 static void NDECL(do_mgivenname);
 static boolean FDECL(alreadynamed, (struct monst *, char *, char *));
 static void FDECL(do_oname, (struct obj *));
+static int FDECL(name_ok, (struct obj *));
+static int FDECL(call_ok, (struct obj *));
 static char *FDECL(docall_xname, (struct obj *));
 static void NDECL(namefloorobj);
 
@@ -1334,18 +1336,53 @@ const char *name;
     return obj;
 }
 
-static NEARDATA const char callable[] = {
-    SCROLL_CLASS, POTION_CLASS, WAND_CLASS,  RING_CLASS, AMULET_CLASS,
-    GEM_CLASS,    SPBOOK_CLASS, ARMOR_CLASS, TOOL_CLASS, VENOM_CLASS, 0
-};
-
 boolean
 objtyp_is_callable(i)
 int i;
 {
-    return (boolean) (objects[i].oc_uname
-                      || (OBJ_DESCR(objects[i])
-                          && index(callable, objects[i].oc_class)));
+    if (objects[i].oc_uname)
+        return TRUE;
+
+    switch(objects[i].oc_class) {
+    case SCROLL_CLASS:
+    case POTION_CLASS:
+    case WAND_CLASS:
+    case RING_CLASS:
+    case AMULET_CLASS:
+    case GEM_CLASS:
+    case SPBOOK_CLASS:
+    case ARMOR_CLASS:
+    case TOOL_CLASS:
+    case VENOM_CLASS:
+        if (OBJ_DESCR(objects[i]))
+            return TRUE;
+        break;
+    default:
+        break;
+    }
+    return FALSE;
+}
+
+/* getobj callback for object to name (specific item) - anything but gold */
+static int
+name_ok(obj)
+struct obj *obj;
+{
+    if (!obj || obj->oclass == COIN_CLASS)
+        return GETOBJ_EXCLUDE;
+
+    return GETOBJ_SUGGEST;
+}
+
+/* getobj callback for object to call (name its type) */
+static int
+call_ok(obj)
+struct obj *obj;
+{
+    if (!obj || !objtyp_is_callable(obj->otyp))
+        return GETOBJ_EXCLUDE;
+
+    return GETOBJ_SUGGEST;
 }
 
 /* C and #name commands - player can name monster or object or type of obj */
@@ -1356,7 +1393,7 @@ docallcmd()
     winid win;
     anything any;
     menu_item *pick_list = 0;
-    char ch, allowall[2];
+    char ch;
     /* if player wants a,b,c instead of i,o when looting, do that here too */
     boolean abc = flags.lootabc;
 
@@ -1406,14 +1443,12 @@ docallcmd()
         do_mgivenname();
         break;
     case 'i': /* name an individual object in inventory */
-        allowall[0] = ALL_CLASSES;
-        allowall[1] = '\0';
-        obj = getobj(allowall, "name");
+        obj = getobj("name", name_ok, GETOBJ_PROMPT);
         if (obj)
             do_oname(obj);
         break;
     case 'o': /* name a type of object in inventory */
-        obj = getobj(callable, "call");
+        obj = getobj("call", call_ok, GETOBJ_NOFLAGS);
         if (obj) {
             /* behave as if examining it in inventory;
                this might set dknown if it was picked up
@@ -1423,7 +1458,7 @@ docallcmd()
             if (!obj->dknown) {
                 You("would never recognize another one.");
 #if 0
-            } else if (!objtyp_is_callable(obj->otyp)) {
+            } else if (!call_ok(obj)) {
                 You("know those as well as you ever will.");
 #endif
             } else {
@@ -1591,7 +1626,7 @@ namefloorobj()
         pline("%s %s to call you \"%s.\"",
               The(buf), use_plural ? "decide" : "decides",
               unames[rn2_on_display_rng(SIZE(unames))]);
-    } else if (!objtyp_is_callable(obj->otyp)) {
+    } else if (!call_ok(obj)) {
         pline("%s %s can't be assigned a type name.",
               use_plural ? "Those" : "That", buf);
     } else if (!obj->dknown) {

--- a/src/write.c
+++ b/src/write.c
@@ -5,6 +5,7 @@
 
 static int FDECL(cost, (struct obj *));
 static boolean FDECL(label_known, (int, struct obj *));
+static int FDECL(write_ok, (struct obj *));
 static char *FDECL(new_book_description, (int, char *));
 
 /*
@@ -87,7 +88,19 @@ struct obj *objlist;
     return FALSE;
 }
 
-static NEARDATA const char write_on[] = { SCROLL_CLASS, SPBOOK_CLASS, 0 };
+/* getobj callback for object to write on */
+static int
+write_ok(obj)
+struct obj *obj;
+{
+    if (!obj || (obj->oclass != SCROLL_CLASS && obj->oclass != SPBOOK_CLASS))
+        return GETOBJ_EXCLUDE;
+
+    if (obj->otyp == SCR_BLANK_PAPER || obj->otyp == SPE_BLANK_PAPER)
+        return GETOBJ_SUGGEST;
+
+    return GETOBJ_DOWNPLAY;
+}
 
 /* write -- applying a magic marker */
 int
@@ -115,7 +128,7 @@ register struct obj *pen;
     }
 
     /* get paper to write on */
-    paper = getobj(write_on, "write on");
+    paper = getobj("write on", write_ok, GETOBJ_NOFLAGS);
     if (!paper)
         return 0;
     /* can't write on a novel (unless/until it's been converted into a blank

--- a/src/zap.c
+++ b/src/zap.c
@@ -23,6 +23,7 @@ static void FDECL(skiprange, (int, int *, int *));
 static int FDECL(zap_hit, (int, int));
 static void FDECL(disintegrate_mon, (struct monst *, int, const char *));
 static void FDECL(backfire, (struct obj *));
+static int FDECL(zap_ok, (struct obj *));
 static void FDECL(boxlock_invent, (struct obj *));
 static int FDECL(spell_hit_bonus, (int));
 static void FDECL(destroy_one_item, (struct obj *, int, int));
@@ -2302,7 +2303,15 @@ struct obj *otmp;
     useupall(otmp);
 }
 
-static NEARDATA const char zap_syms[] = { WAND_CLASS, 0 };
+/* getobj callback for object to zap */
+static int
+zap_ok(obj)
+struct obj *obj;
+{
+    if (obj && obj->oclass == WAND_CLASS)
+        return GETOBJ_SUGGEST;
+    return GETOBJ_EXCLUDE;
+}
 
 /* 'z' command (or 'y' if numbed_pad==-1) */
 int
@@ -2317,7 +2326,7 @@ dozap()
     }
     if (check_capacity((char *) 0))
         return 0;
-    obj = getobj(zap_syms, "zap");
+    obj = getobj("zap", zap_ok, GETOBJ_NOFLAGS);
     if (!obj)
         return 0;
 


### PR DESCRIPTION
This replaces the arcane system previously used by getobj where the caller would pass in a "string" whose characters were object class numbers, with the first up to four characters being special constants that effectively acted as flags and had to be in a certain order.  Because there are many places where getobj must behave more granularly than just object class filtering, this was supplemented by over a hundred lines enumerating all these special cases and "ugly checks", as well as other ugly code spread around in getobj callers that formatted the "string".

Now, getobj callers pass in a callback which will return one of five possible values for any given object in the player's inventory. The logic of determining the eligibility of a given object is handled in the caller, which greatly simplifies the code and makes it clearer to read.  Particularly since there's no real need to cram everything into one if statement.

This is related to pull request #77 by FIQ; it's largely a reimplementation of its callbacks system, without doing a bigger than necessary refactor of getobj or adding the ability to select a floor/trap/dungeon feature with getobj. Differences in implementation are mostly minor:

- using enum constants for returns instead of magic numbers
- 5 possible return values for callbacks instead of 3, due to trying to make it behave exactly as it did previously. PR #77 would sometimes outright exclude objects because it lacked semantics for invalid objects that should be selectable anyway, or give slightly different messages.
- passing a bitmask of flags to getobj rather than booleans (easier to add more flags later - such as FIQ's "allow floor features" flag, if that becomes desirable)
- renaming some of getobj's variables to clearer versions
- naming all callbacks consistently with "_ok"
- generally more comments explaining things

The callbacks use the same logic from getobj_obj_exclude, getobj_obj_exclude_too and getobj_obj_acceptable_unlisted (and in a few cases, from special cases still within getobj). In a number of them, I added comments suggesting possible further refinements to what is and isn't eligible (e.g. should a bullwhip really be presented as a candidate for readying a thrown weapon?)

This also removed ALLOW_COUNT and ALLOW_NONE, relics of the old system, and moved ALLOW_ALL's definition into detect.c which is the only place it's used now (unrelated to getobj). The ALLOW_ALL functionality still exists as the GETOBJ_PROMPT flag, because its main use is to force getobj to prompt for input even if nothing is valid.)

I did not refactor ggetobj() as part of this change.