### PR TITLE
force_invmenu getobj listings

### DIFF
--- a/src/invent.c
+++ b/src/invent.c
@@ -1598,7 +1598,7 @@ unsigned int ctrlflags;
         else if (iflags.force_invmenu) {
             /* don't overwrite a possible quitchars */
             if (!oneloop)
-                ilet = forceprompt ? '*' : '?';
+                ilet = (*lets || *altlets) ? '?' : '*';
             if (!msggiven)
                 putmsghistory(qbuf, FALSE);
             msggiven = TRUE;
@@ -2668,7 +2668,8 @@ long *out_cnt;
             goto nextclass;
         }
     }
-    if (iflags.force_invmenu && lets && want_reply) {
+    if (iflags.force_invmenu && lets && want_reply
+        && (int) strlen(lets) < inv_cnt(TRUE)) {
         any = cg.zeroany;
         add_menu(win, &nul_glyphinfo, &any, 0, 0,
                  iflags.menu_headings, "Special", MENU_ITEMFLAGS_NONE);


### PR DESCRIPTION
Instead of listing the entire inventory when `force_invmenu` is on and `getobj` flags include `GETOBJ_PROMPT` (as described in #441), only applicable objects will be printed as long as any exist (either suggested or alternative choices).

However, a `getobj` callback that returns `GETOBJ_SUGGEST` for every item in inventory (such as `any_obj_ok`, used for the <kbd>d</kbd>rop command among other things) would produce a list of allowable objects that is in effect identical to the entire player inventory. Because of the way `display_pickinv` works, when this list is passed to it as a list instead of explicitly as the entire inventory, a useless "* - (list everything)" item is appended to it.  In order to fix this behavior, this patch would also add a test before adding the '*' item to ensure it will not be included for lists that already encompass the entire inventory.

There's more discussion of the ways `(*lets || *altlets)` is and isn't comparable to `*let` in pre-refactoring `getobj` in #441.