### PR TITLE
Allow custom increment amounts in #wizintrinsic

### DIFF
--- a/src/cmd.c
+++ b/src/cmd.c
@@ -130,7 +130,6 @@ static int NDECL(dotravel);
 static int NDECL(doterrain);
 static int NDECL(wiz_wish);
 static int NDECL(wiz_identify);
-static int NDECL(wiz_intrinsic);
 static int NDECL(wiz_map);
 static int NDECL(wiz_makemap);
 static int NDECL(wiz_genesis);
@@ -1548,6 +1547,8 @@ wiz_smell(VOID_ARGS)
     return 0;
 }
 
+#define DEFAULT_TIMEOUT_INCR 30
+
 /* #wizinstrinsic command to set some intrinsics for testing */
 static int
 wiz_intrinsic(VOID_ARGS)
@@ -1600,11 +1601,12 @@ wiz_intrinsic(VOID_ARGS)
         n = select_menu(win, PICK_ANY, &pick_list);
         destroy_nhwindow(win);
 
-        amt = 30; /* TODO: prompt for duration */
         for (j = 0; j < n; ++j) {
             i = pick_list[j].item.a_int - 1; /* -1: reverse +1 above */
             p = propertynames[i].prop_num;
             oldtimeout = u.uprops[p].intrinsic & TIMEOUT;
+            amt = (pick_list[j].count == -1L) ? DEFAULT_TIMEOUT_INCR
+                                              : (int) pick_list[j].count;
             newtimeout = oldtimeout + (long) amt;
             switch (p) {
             case SICK:


### PR DESCRIPTION
Let users of `#wizintrinsic` set a specific amount by which they want to increment each particular timeout, by entering a count/typing in numerals before selecting the item in the list.  I think doing it this way should be pretty intuitive to players who are familiar with the 'enter count -> make selection' flow of normal inventory menus in NetHack, and is simpler than using a separate prompt, as was mentioned as a possibility in a comment.

When an intrinsic is selected without entering a count, the increment will continue to default to the previous value of 30; this value is set via the `DEFAULT_TIMEOUT_INCR` macro.

I also deleted a redundant declaration of `wiz_intrinsic`; the duplicate seems to have been added by mistake in ff6139c6c5.

(Edit: merged via 77d4b4c955a9256129b601f0af70033821c3c502)

