### PR TITLE
Unify code for extracting an object from a monster's inventory

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -3101,6 +3101,8 @@ extern void bypass_objlist(struct obj *, boolean);
 extern struct obj *nxt_unbypassed_obj(struct obj *);
 extern struct obj *nxt_unbypassed_loot(Loot *, struct obj *);
 extern int racial_exception(struct monst *, struct obj *);
+extern void extract_from_minvent(struct monst *, struct obj *, boolean,
+                                 boolean);
 
 /* ### write.c ### */
 

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -1878,21 +1878,11 @@ remove_object(struct obj* otmp)
 void
 discard_minvent(struct monst* mtmp, boolean uncreate_artifacts)
 {
-    struct obj *otmp, *mwep = MON_WEP(mtmp);
-    boolean keeping_mon = !DEADMONSTER(mtmp);
+    struct obj *otmp;
 
     while ((otmp = mtmp->minvent) != 0) {
         /* this has now become very similar to m_useupall()... */
-        obj_extract_self(otmp);
-        if (otmp->owornmask) {
-            if (keeping_mon) {
-                if (otmp == mwep)
-                    mwepgone(mtmp), mwep = 0;
-                mtmp->misc_worn_check &= ~otmp->owornmask;
-                update_mon_intrinsics(mtmp, otmp, FALSE, TRUE);
-            }
-            otmp->owornmask = 0L; /* obfree() expects this */
-        }
+        extract_from_minvent(mtmp, otmp, TRUE, TRUE);
         if (uncreate_artifacts && otmp->oartifact)
             artifact_exists(otmp, safe_oname(otmp), FALSE);
         obfree(otmp, (struct obj *) 0); /* dealloc_obj() isn't sufficient */

--- a/src/mon.c
+++ b/src/mon.c
@@ -2597,13 +2597,7 @@ monstone(struct monst* mdef)
         oldminvent = 0;
         /* some objects may end up outside the statue */
         while ((obj = mdef->minvent) != 0) {
-            obj_extract_self(obj);
-            if (obj->owornmask)
-                update_mon_intrinsics(mdef, obj, FALSE, TRUE);
-            obj_no_longer_held(obj);
-            if (obj->owornmask & W_WEP)
-                setmnotwielded(mdef, obj);
-            obj->owornmask = 0L;
+            extract_from_minvent(mdef, obj, TRUE, TRUE);
             if (obj->otyp == BOULDER
 #if 0 /* monsters don't carry statues */
                 ||  (obj->otyp == STATUE

--- a/src/mthrowu.c
+++ b/src/mthrowu.c
@@ -842,20 +842,11 @@ breamm(struct monst* mtmp, struct attack* mattk, struct monst* mtarg)
     return MM_HIT;
 }
 
-
-
 /* remove an entire item from a monster's inventory; destroy that item */
 void
 m_useupall(struct monst* mon, struct obj* obj)
 {
-    obj_extract_self(obj);
-    if (obj->owornmask) {
-        if (obj == MON_WEP(mon))
-            mwepgone(mon);
-        mon->misc_worn_check &= ~obj->owornmask;
-        update_mon_intrinsics(mon, obj, FALSE, FALSE);
-        obj->owornmask = 0L;
-    }
+    extract_from_minvent(mon, obj, TRUE, FALSE);
     obfree(obj, (struct obj *) 0);
 }
 

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -2104,8 +2104,6 @@ loot_mon(struct monst *mtmp, int *passed_info, boolean *prev_loot)
      *  *prev_loot is set to TRUE if something was actually acquired in here.
      */
     if (mtmp && mtmp != u.usteed && (otmp = which_armor(mtmp, W_SADDLE))) {
-        long unwornmask;
-
         if (passed_info)
             *passed_info = 1;
         Sprintf(qbuf, "Do you want to remove the saddle from %s?",
@@ -2123,12 +2121,7 @@ loot_mon(struct monst *mtmp, int *passed_info, boolean *prev_loot)
                 /* the attempt costs you time */
                 return 1;
             }
-            obj_extract_self(otmp);
-            if ((unwornmask = otmp->owornmask) != 0L) {
-                mtmp->misc_worn_check &= ~unwornmask;
-                otmp->owornmask = 0L;
-                update_mon_intrinsics(mtmp, otmp, FALSE, FALSE);
-            }
+            extract_from_minvent(mtmp, otmp, TRUE, FALSE);
             otmp = hold_another_object(otmp, "You drop %s!", doname(otmp),
                                        (const char *) 0);
             nhUse(otmp);

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -1626,22 +1626,14 @@ steal_it(struct monst *mdef, struct attack *mattk)
             mpickobj(mdef, gold), gold = 0;
         if (!Upolyd)
             break; /* no longer have ability to steal */
+        unwornmask = otmp->owornmask;
         /* take the object away from the monster */
-        obj_extract_self(otmp);
-        if ((unwornmask = otmp->owornmask) != 0L) {
-            mdef->misc_worn_check &= ~unwornmask;
-            if (otmp->owornmask & W_WEP)
-                setmnotwielded(mdef, otmp);
-            otmp->owornmask = 0L;
-            update_mon_intrinsics(mdef, otmp, FALSE, FALSE);
-            /* give monster a chance to wear other equipment on its next
-               move instead of waiting until it picks something up */
-            mdef->misc_worn_check |= I_SPECIAL;
-
-            if (otmp == ustealo) /* special message for final item */
-                pline("%s finishes taking off %s suit.", Monnam(mdef),
-                      mhis(mdef));
-        }
+        extract_from_minvent(mdef, otmp, TRUE, FALSE);
+        /* special message for final item; no need to check owornmask because
+         * ustealo is only set on objects with (owornmask & W_ARM) */
+        if (otmp == ustealo)
+            pline("%s finishes taking off %s suit.", Monnam(mdef),
+                  mhis(mdef));
         /* give the object to the character */
         otmp = hold_another_object(otmp, "You snatched but dropped %s.",
                                    doname(otmp), "You steal: ");
@@ -3917,17 +3909,7 @@ mhitm_ad_sedu(struct monst *magr, struct attack *mattk, struct monst *mdef,
             if (u.usteed == mdef && obj == which_armor(mdef, W_SADDLE))
                 /* "You can no longer ride <steed>." */
                 dismount_steed(DISMOUNT_POLY);
-            obj_extract_self(obj);
-            if (obj->owornmask) {
-                mdef->misc_worn_check &= ~obj->owornmask;
-                if (obj->owornmask & W_WEP)
-                    mwepgone(mdef);
-                obj->owornmask = 0L;
-                update_mon_intrinsics(mdef, obj, FALSE, FALSE);
-                /* give monster a chance to wear other equipment on its next
-                   move instead of waiting until it picks something up */
-                mdef->misc_worn_check |= I_SPECIAL;
-            }
+            extract_from_minvent(mdef, obj, TRUE, FALSE);
             /* add_to_minv() might free 'obj' [if it merges] */
             if (g.vis)
                 Strcpy(onambuf, doname(obj));

--- a/src/zap.c
+++ b/src/zap.c
@@ -347,7 +347,6 @@ bhitm(struct monst *mtmp, struct obj *otmp)
             } else if (canspotmon(mtmp)) {
                 pline("%s falls off.", buf);
             }
-            obj_extract_self(obj);
             mdrop_obj(mtmp, obj, FALSE);
         }
         break;
@@ -4052,16 +4051,7 @@ disintegrate_mon(struct monst *mon,
     for (otmp = mon->minvent; otmp; otmp = otmp2) {
         otmp2 = otmp->nobj;
         if (!oresist_disintegration(otmp)) {
-            if (otmp->owornmask) {
-                /* in case monster's life gets saved */
-                mon->misc_worn_check &= ~otmp->owornmask;
-                if (otmp->owornmask & W_WEP)
-                    setmnotwielded(mon, otmp);
-                /* also dismounts hero if this object is steed's saddle */
-                update_mon_intrinsics(mon, otmp, FALSE, TRUE);
-                otmp->owornmask = 0L;
-            }
-            obj_extract_self(otmp);
+            extract_from_minvent(mon, otmp, TRUE, TRUE);
             obfree(otmp, (struct obj *) 0);
         }
     }


### PR DESCRIPTION
The code for doing this (basically an obj_extract_self() call plus
handling if the object was worn or wielded) was duplicated all over, and
inconsistent - for instance, though all of them updated the monster's
misc_worn_check to indicate it was no longer wearing something in
whatever slot, only one call also set the bit that flags the monster to
consider putting on other gear afterwards.

Under a new function, extract_from_minvent, all this extra handling is
checked in one function, which can simply replace the obj_extract_self
call.

A few callers (such as stealing) have some common code *after* the
object is extracted and some other things happen such as message
printing, such as calling mselftouch if the object was worn
gloves. extract_from_minvent does not handle these cases.