### PR TITLE
Remove chaotic stormbringer peaceful penalty

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -2935,7 +2935,10 @@ xkilled(
             You_hear("the rumble of distant thunder...");
         else
             You_hear("the studio audience applaud!");
-    } else if (mtmp->mpeaceful)
+    } else if (mtmp->mpeaceful
+               && !(wep && wep->oartifact == ART_STORMBRINGER
+               && u.ualign.type == CHAOTIC))
+               /* it's not murder if stormbringer made you do it! */
         adjalign(-5);
 
     /* malign was already adjusted for u.ualign.type and randomization */


### PR DESCRIPTION
    Characters of all alignments, including Knights, can already remove shopkeepers
    and guards without penalty. From the wiki:
    "The simplest way to get rid of a peaceful human while avoiding the penalty for
    murder is to let your pet do the dirty work. You can also polymorph your victims
    before killing them. Note that a failed polymorph, " shudders." (system shock),
    still counts as murder."
    
    When a player is chosen to "steal souls" for the glory of whomever is concerned,
    it's a pretty big flavor glitch for stormbringer to start blasting the user for
    successfully snuffing out a soul with the artifact weapon that encourages murder
    (Not to mention the weird fantasy racism in which elf, orc, & dwarf deaths don't
    cause nearly the same level of punishment as human deaths do.)
    
    And in general, it's weird for chaotics to be god-penalized for any "crime".
    
    So the proposed change is that chaotic stormbringer users don't lose huge chunks
    of alignment for hitting peacefuls. I did not mess with the luck penalties, as
    those do not cause artifact blasting. While i find them unnecessary, they don't
    seem like a significant flavor glitch.