### PR TITLE
Make engraving an occupation

### DIFF
--- a/include/context.h
+++ b/include/context.h
@@ -65,6 +65,16 @@ struct victual_info {
     Bitfield(doreset, 1);  /* stop eating at end of turn */
 };
 
+struct engrave_info {
+    char text[BUFSZ];   /* actual text being engraved - doengrave() handles all
+                           the possible mutations of this */
+    char *nextc;        /* next character(s) in text[] to engrave */
+    struct obj *stylus; /* object doing the writing */
+    xchar type;         /* type of engraving (DUST, MARK, etc) */
+    coord pos;          /* location the engraving is being placed on */
+    int actionct;       /* nth turn spent engraving */
+};
+
 struct warntype_info {
     unsigned long obj;        /* object warn_of_mon monster type M2 */
     unsigned long polyd;      /* warn_of_mon monster type M2 due to poly */
@@ -142,6 +152,7 @@ struct context_info {
     boolean enhance_tip; /* player is informed about #enhance */
     struct dig_info digging;
     struct victual_info victual;
+    struct engrave_info engraving;
     struct tin_info tin;
     struct book_info spbook;
     struct takeoff_info takeoff;


### PR DESCRIPTION
Instead of inexplicably paralyzing the player for the duration of their
engraving. Many a character has died by trying to engrave something and
then sitting there diligently writing it while monsters surround and
attack them. (This was especially prominent back in the 3.4.3 era when
repeated Elbereths were viable, but it still occurs today with e.g.
using a hard stone to engrave Elbereth). There were also some other
oddities - for instance, if something teleported the player away while
they were engraving, they would continue to "engrave" (be paralyzed) on
their new location, but would not produce any text there; the full
engraving would be placed on their initial position.

In this commit, I have converted engraving to use the occupation
framework, which treats it as an interruptible activity. This
necessitated some logical restructuring, mostly involving the engraving
being written out in chunks as the player spends more uninterrupted time
on it.

I've tried to keep this free of regressions except for those inherent to
the occupation system.

What has NOT changed:
- The rate of engraving is still 10 characters per turn, or 1 character
  using slow methods.
- The formulas for determining how much a bladed weapon or marker can
  engrave before getting exhausted are kept. Though this is a bit
  convoluted, and if it's not considered important to preserve the
  existing behavior, I would recommend simplifying it by decreasing the
  maximum engraving length for weapons by 1 so that each point of
  enchantment simply gets you 2 characters' worth of engraving (e.g. a
  -2 weapon will only engrave 1 or 2 characters before dulling to -3,
  rather than giving it a third "grace character".
- The input buffer is still modified based on confusion/blindness/etc
  only at the time when the player inputs it (if they gain a
  debilitating status while engraving, it will not affect the text). My
  personal preference is to make the text affected in scenarios like
  that, but it's not strictly necessary to do here, so I didn't.
- Wand messages such as "The floor is riddled by bullet holes", and
  blinding from engraving lightning, still appear before the hero starts
  to take any time engraving. As noted above, getting blinded by the
  wand still has no effect on accurately engraving the text, unless the
  hero was already blind or impaired.

What has changed:
- Moving off the engraving or losing the object being engraved with
  causes the player to stop engraving.
- Wands can still engrave an arbitrary amount of text using a single
  charge, but if the hero is interrupted and decides to start engraving
  again, they will consume a second charge.

As it adds a new field to g.context, this is a save-breaking change.