### PR TITLE
Make "joined" in Lua and level structs always take a boolean

### DIFF
--- a/dat/themerms.lua
+++ b/dat/themerms.lua
@@ -229,7 +229,7 @@ themerooms = {
                  contents = function(rm)
                     des.room({ type = "themed",
 			       x = (rm.width - 1) / 2, y = (rm.height - 1) / 2,
-			       w = 1, h = 1, joined = 0,
+			       w = 1, h = 1, joined = false,
                                contents = function()
                                   if (percent(50)) then
                                      local mons = { "M", "V", "L", "Z" };
@@ -583,12 +583,12 @@ end });
                   end
                end
                p = placements[d(#placements)]
-               des.room({ type=ltype, x=p["lx"], y=p["ly"], w=3, h=3, filled=1, joined=0,
+               des.room({ type=ltype, x=p["lx"], y=p["ly"], w=3, h=3, filled=1, joined=false,
                            contents = function()
                      des.door({ state=shopdoorstate(), wall=p["lwall"] })
                   end
                });
-               des.room({ type=rtype, x=p["rx"], y=p["ry"], w=3, h=3, filled=1, joined=0,
+               des.room({ type=rtype, x=p["rx"], y=p["ry"], w=3, h=3, filled=1, joined=false,
                            contents = function()
                      des.door({ state=shopdoorstate(), wall=p["rwall"] })
                   end

--- a/doc/lua.adoc
+++ b/doc/lua.adoc
@@ -368,7 +368,7 @@ Initialize the map with a random generator of a certain type.
 Example:
 
  des.level_init({ style = "solidfill", fg = " " });
- des.level_init({ style = "mines", fg = ".", bg = "}", smoothed=1, joined=1, lit=0 })
+ des.level_init({ style = "mines", fg = ".", bg = "}", smoothed=true, joined=true, lit=0 })
  des.level_init({ style = "maze", corrwid = 3, wallthick = 1, deadends = false });
 
 === levregion
@@ -553,7 +553,7 @@ fields:
 | yalign    | Vertical alignment on a rough 3x3 grid. Default is "random".
 | lit       | Is the room lit or unlit? Defaults to -1 (random).
 | filled    | Is the room filled as per the room type. Defaults to 1 (filled).
-| joined    | Is the room joined to the rest of the level with corridors? Default is 1 (joined).
+| joined    | Is the room joined to the rest of the level with corridors? Default is true.
 | contents  | A function called with one parameter, a table with "width" and "height", the room width and height, excluding the walls. All coordinates in the function will be relative to the room.
 |===
 

--- a/include/mkroom.h
+++ b/include/mkroom.h
@@ -14,7 +14,7 @@ struct mkroom {
     schar orig_rtype;     /* same as rtype, but not zeroed later */
     schar rlit;           /* is the room lit ? */
     schar needfill;       /* sp_lev: does the room need filling? */
-    schar needjoining;    /* sp_lev */
+    boolean needjoining;  /* sp_lev: should the room connect to others? */
     schar doorct;         /* door count */
     schar fdoor;          /* index for the first door of the room */
     schar nsubrooms;      /* number of subrooms */

--- a/include/sp_lev.h
+++ b/include/sp_lev.h
@@ -91,7 +91,7 @@ struct sp_coder {
     struct mkroom *tmproomlist[MAX_NESTED_ROOMS + 1];
     boolean failed_room[MAX_NESTED_ROOMS + 1];
     int n_subroom;
-    int lvl_is_joined;
+    boolean lvl_is_joined;
     boolean check_inaccessibles;
     int allow_flips;
 };

--- a/include/sp_lev.h
+++ b/include/sp_lev.h
@@ -185,7 +185,8 @@ typedef struct _room {
     Str_or_Len parent;
     xchar x, y, w, h;
     xchar xalign, yalign;
-    xchar rtype, chance, rlit, needfill, joined;
+    xchar rtype, chance, rlit, needfill;
+    boolean joined;
 } room;
 
 struct mapfragment {

--- a/src/mklev.c
+++ b/src/mklev.c
@@ -65,7 +65,7 @@ mkroom_cmp(const genericptr vx, const genericptr vy)
 }
 
 /* Return TRUE if a door placed at (x, y) which otherwise passes okdoor()
- * checks would be connecting into an area that was declared as joined = 0.
+ * checks would be connecting into an area that was declared as joined = false.
  * Checking for this in finddpos() enables us to have rooms with sub-areas
  * (such as shops) that will never randomly generate unwanted doors in order
  * to connect them up to other areas.

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -6103,7 +6103,7 @@ sp_level_coder_init(void)
     coder->allow_flips = 3; /* allow flipping level horiz/vert */
     coder->croom = NULL;
     coder->n_subroom = 1;
-    coder->lvl_is_joined = 0;
+    coder->lvl_is_joined = FALSE;
     coder->room_stack = 0;
 
     splev_init_present = FALSE;

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -3480,7 +3480,7 @@ lspo_level_flags(lua_State* L)
 }
 
 /* level_init({ style = "solidfill", fg = " " }); */
-/* level_init({ style = "mines", fg = ".", bg = "}", smoothed=1, joined=1, lit=0 }) */
+/* level_init({ style = "mines", fg = ".", bg = "}", smoothed=true, joined=true, lit=0 }) */
 int
 lspo_level_init(lua_State* L)
 {
@@ -3694,7 +3694,7 @@ lspo_room(lua_State* L)
         tmproom.rlit = get_table_int_opt(L, "lit", -1);
         /* theme rooms default to unfilled */
         tmproom.needfill = get_table_int_opt(L, "filled", g.in_mk_themerooms ? 0 : 1);
-        tmproom.joined = get_table_int_opt(L, "joined", 1);
+        tmproom.joined = get_table_boolean_opt(L, "joined", TRUE);
 
         if (!g.coder->failed_room[g.coder->n_subroom - 1]) {
             tmpcr = build_room(&tmproom, g.coder->croom);
@@ -5430,7 +5430,7 @@ lspo_region(lua_State* L)
          * "lvflags_only" ==> filled=2, probably in a get_table_needfill_opt */
         needfill = get_table_int_opt(L, "filled", 0);
         irregular = get_table_boolean_opt(L, "irregular", 0);
-        joined = get_table_boolean_opt(L, "joined", 1);
+        joined = get_table_boolean_opt(L, "joined", TRUE);
         do_arrival_room = get_table_boolean_opt(L, "arrival_room", 0);
         rtype = get_table_roomtype_opt(L, "type", OROOM);
         rlit = get_table_int_opt(L, "lit", -1);

--- a/test/test_des.lua
+++ b/test/test_des.lua
@@ -61,7 +61,7 @@ function test_level_init()
    des.level_init({ style = "mines", fg = ".", bg = "}", joined = true });
 
    des.reset_level();
-   des.level_init({ style = "mines", fg = ".", bg = "L", smoothed = 1, joined = 1, lit = 0 });
+   des.level_init({ style = "mines", fg = ".", bg = "L", smoothed = true, joined = true, lit = 0 });
 
    des.reset_level();
    des.level_init({ style = "mines", fg = ".", bg = " ", smoothed = true, joined = true, walled = true });


### PR DESCRIPTION
It is only ever used as a boolean, and having joined=BOOL for regions and joined=INT for rooms is confusing. So this PR changes all types of joined to booleans:

- g.coder->lvl_is_joined
- joined in struct room
- needjoining in struct mkroom
- and all places that did joined=INT in lua files are changed.