### PR TITLE
Fix: engraving with non-blade dulled the weapon anyway

### DIFF
--- a/src/engrave.c
+++ b/src/engrave.c
@@ -1133,15 +1133,15 @@ engrave(void)
         }
     }
 
-    dulling_wep = (stylus && stylus->oclass == WEAPON_CLASS
+    dulling_wep = (carving && stylus && stylus->oclass == WEAPON_CLASS
                    && (stylus->otyp != ATHAME || stylus->cursed));
     marker = (stylus && stylus->otyp == MAGIC_MARKER);
 
     g.context.engraving.actionct++;
 
     /* sanity checks */
-    if (dulling_wep && !carving) {
-        impossible("using weapon for non-carve engraving");
+    if (dulling_wep && !is_blade(stylus)) {
+        impossible("carving with non-bladed weapon");
     }
     else if (g.context.engraving.type == MARK && !marker) {
         impossible("making graffiti with non-marker stylus");


### PR DESCRIPTION
Due to a logic bug introduced when engraving became an occupation - the
code that tests to see whether the player is writing with a weapon that
will get dulled wasn't correctly checking that they were actually
carving an engraving.

Fixes an impossible that occurs when someone writes with a non-blade.