### PR TITLE
Make player explosion attack wake monsters

### DIFF
--- a/src/hack.c
+++ b/src/hack.c
@@ -1751,7 +1751,7 @@ domove_core(void)
 
         nomul(0);
         if (explo) {
-            wake_nearby();
+            wake_nearto(u.ux, u.uy, 7 * 7);
             u.mh = -1; /* dead in the current form */
             rehumanize();
         }

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -4109,6 +4109,7 @@ explum(struct monst *mdef, struct attack *mattk)
     default:
         break;
     }
+    wake_nearto(u.ux, u.uy, 7 * 7);
     return MM_HIT;
 }
 


### PR DESCRIPTION
This brings a polyselfed player's AT_EXPL attacks into line with
monsters' attacks, in terms of making noise. Previously, exploding at a
monster was entirely silent, and exploding at thin air called
wake_nearby which is an XL-dependent radius (usually much larger than
monsters' sound radius of 7).

Now, both exploding at a monster and exploding at thin air wake monsters
in the same 7 sound radius as monster explosions use.