### PR TITLE
Two getobj fixes

### DIFF
--- a/src/invent.c
+++ b/src/invent.c
@@ -1649,7 +1649,7 @@ getobj(const char *word,
             /* guard against the [hypothetical] chace of having more
                than one invent slot of gold and picking the non-'$' one */
             || (otmp && otmp->oclass == COIN_CLASS)) {
-            if (obj_ok(otmp) <= GETOBJ_EXCLUDE) {
+            if (otmp && obj_ok(otmp) <= GETOBJ_EXCLUDE) {
                 You("cannot %s gold.", word);
                 return (struct obj *) 0;
             }

--- a/src/invent.c
+++ b/src/invent.c
@@ -1560,7 +1560,7 @@ getobj(const char *word,
         else if (iflags.force_invmenu) {
             /* don't overwrite a possible quitchars */
             if (!oneloop)
-                ilet = forceprompt ? '*' : '?';
+                ilet = (*lets || *altlets) ? '?' : '*';
             if (!msggiven)
                 putmsghistory(qbuf, FALSE);
             msggiven = TRUE;
@@ -2614,7 +2614,8 @@ display_pickinv(
             goto nextclass;
         }
     }
-    if (iflags.force_invmenu && lets && want_reply) {
+    if (iflags.force_invmenu && lets && want_reply
+        && (int) strlen(lets) < inv_cnt(TRUE)) {
         any = cg.zeroany;
         add_menu(win, &nul_glyphinfo, &any, 0, 0,
                  iflags.menu_headings, "Special", MENU_ITEMFLAGS_NONE);

--- a/src/invent.c
+++ b/src/invent.c
@@ -1479,10 +1479,17 @@ getobj(const char *word,
     Loot *sortedinvent, *srtinv;
 
     /* is "hands"/"self" a valid thing to do this action on? */
-    if ((*obj_ok)((struct obj *) 0) == GETOBJ_SUGGEST) {
-	allownone = TRUE;
+    switch ((*obj_ok)((struct obj *) 0)) {
+    case GETOBJ_SUGGEST:
         *bp++ = HANDS_SYM;
         *bp++ = ' '; /* put a space after the '-' in the prompt */
+        /* FALLTHRU */
+    case GETOBJ_DOWNPLAY:
+        allownone = TRUE;
+        *ap++ = HANDS_SYM;
+        /* FALLTHRU */
+    default:
+        break;
     }
 
     if (!flags.invlet_constant)
@@ -2570,7 +2577,7 @@ display_pickinv(
     classcount = 0;
     for (srtinv = sortedinvent; (otmp = srtinv->obj) != 0; ++srtinv) {
         int tmpglyph;
-	glyph_info tmpglyphinfo = nul_glyphinfo;
+        glyph_info tmpglyphinfo = nul_glyphinfo;
 
         if (lets && !index(lets, otmp->invlet))
             continue;
@@ -2592,7 +2599,7 @@ display_pickinv(
             else
                 any.a_char = ilet;
             tmpglyph = obj_to_glyph(otmp, rn2_on_display_rng);
-            map_glyphinfo(0, 0, tmpglyph, 0U, &tmpglyphinfo);            
+            map_glyphinfo(0, 0, tmpglyph, 0U, &tmpglyphinfo);
             add_menu(win, &tmpglyphinfo, &any, ilet,
                      wizid ? def_oc_syms[(int) otmp->oclass].sym : 0,
                      ATR_NONE, doname(otmp), MENU_ITEMFLAGS_NONE);


### PR DESCRIPTION
Discovered a bug in my refactor of getobj a couple of months ago in which the sub-GETOBJ_SUGGEST cases didn't work for selecting '-', even though they are intended to make it selectable. This, for instance, makes it impossible to select your hands at a getobj prompt if the callback returns GETOBJ_DOWNPLAY - valid but not presented outright as an option.

I also pulled qt's fix of #441 into this pull request, at his request, because why not wrap two getobj fixes together?

Fixes #441 and #442.