### PR TITLE
Fix impossible/panic when monster dies to self-read scroll of earth

### DIFF
--- a/src/muse.c
+++ b/src/muse.c
@@ -1578,6 +1578,7 @@ use_offensive(struct monst* mtmp)
         boolean confused = (mtmp->mconf ? TRUE : FALSE);
         int mmx = mtmp->mx, mmy = mtmp->my;
         boolean is_cursed = otmp->cursed;
+        boolean is_blessed = otmp->blessed;
 
         mreadmsg(mtmp, otmp);
         /* Identify the scroll */
@@ -1594,6 +1595,7 @@ use_offensive(struct monst* mtmp)
             if (oseen)
                 makeknown(otmp->otyp);
         }
+        m_useup(mtmp, otmp); /* otmp now gone */
 
         /* Loop through the surrounding squares */
         for (x = mmx - 1; x <= mmx + 1; x++) {
@@ -1601,14 +1603,13 @@ use_offensive(struct monst* mtmp)
                 /* Is this a suitable spot? */
                 if (isok(x, y) && !closed_door(x, y)
                     && !IS_ROCK(levl[x][y].typ) && !IS_AIR(levl[x][y].typ)
-                    && (((x == mmx) && (y == mmy)) ? !otmp->blessed
-                                                   : !otmp->cursed)
+                    && (((x == mmx) && (y == mmy)) ? !is_blessed
+                                                   : !is_cursed)
                     && (x != u.ux || y != u.uy)) {
                     (void) drop_boulder_on_monster(x, y, confused, FALSE);
                 }
             }
         }
-        m_useup(mtmp, otmp);
         /* Attack the player */
         if (distmin(mmx, mmy, u.ux, u.uy) == 1 && !is_cursed) {
             drop_boulder_on_player(confused, !is_cursed, FALSE, TRUE);
@@ -2136,12 +2137,12 @@ use_misc(struct monst* mtmp)
         return 2;
     case MUSE_POT_POLYMORPH:
         mquaffmsg(mtmp, otmp);
+        m_useup(mtmp, otmp);
         if (vismon)
             pline("%s suddenly mutates!", Monnam(mtmp));
         (void) newcham(mtmp, muse_newcham_mon(mtmp), FALSE, FALSE);
         if (oseen)
             makeknown(POT_POLYMORPH);
-        m_useup(mtmp, otmp);
         return 2;
     case MUSE_BAG:
         return mloot_container(mtmp, otmp, vismon);

--- a/src/worn.c
+++ b/src/worn.c
@@ -1051,6 +1051,7 @@ extract_from_minvent(struct monst *mon, struct obj *obj,
 
     if (obj->where != OBJ_MINVENT) {
         impossible("extract_from_minvent called on object not in minvent");
+        obj_extract_self(obj); /* free it anyway to avoid a panic */
         return;
     }
     obj_extract_self(obj);


### PR DESCRIPTION
When a monster read a scroll of earth and died to a boulder falling on
its own head, it would immediately drop the scroll to the ground. Then
when m_useup called extract_from_minvent after that, it would see that
the scroll was now at OBJ_FLOOR instead of OBJ_MINVENT and trigger the
impossible.

The panic happens following this because extract_from_minvent gave up
and did nothing when it encountered an object not at OBJ_MINVENT, and
predictably a lot of callers of extract_from_minvent want to free the
object afterwards. This commit hardens it against that case by calling
obj_extract_self even if the object is not in a monster's inventory.

To fix the problem of the scroll falling to the ground and then having
m_useup called on it, I moved the m_useup call to before the boulders
drop. This is consistent with player use of the scroll anyway,
disappearing before the effect happens.

I also did this for the case where a monster quaffs polymorph; I think
in some rare circumstances it can die indirectly after polymorphing by
falling onto a trap or unfavorable terrain.