### PR TITLE
Prevent obtaining multiple gold stacks

### DIFF
--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -2160,6 +2160,11 @@ throw_gold(struct obj *obj)
 
     if (!u.dx && !u.dy && !u.dz) {
         You("cannot throw gold at yourself.");
+        /* If we tried to throw part of a stack, force it to merge back
+         * together. Same as in throw_obj. */
+        if (obj->o_id == g.context.objsplit.parent_oid
+            || obj->o_id == g.context.objsplit.child_oid)
+            (void) unsplitobj(obj);
         return 0;
     }
     freeinv(obj);

--- a/src/wield.c
+++ b/src/wield.c
@@ -500,6 +500,12 @@ dowieldquiver(void)
             unsplitobj(newquiver);
             goto already_quivered;
         }
+        else if (newquiver->oclass == COIN_CLASS) {
+            /* don't allow splitting a stack of coins into quiver */
+            You("can't ready only part of your gold.");
+            unsplitobj(newquiver);
+            return 0;
+        }
         finish_splitting = TRUE;
     } else if (newquiver == uquiver) {
  already_quivered:


### PR DESCRIPTION
Two similar bugs here, both discovered with the debug fuzzer.

First split gold case is when attempting to throw a partial stack of gold at itself. throw_obj contains a similar bit of logic to re-merge a split stack for when the prompt is canceled, but it isn't canceled in the "You cannot throw gold at yourself" case.

Second split gold case is when attempting to quiver a partial stack of gold.

Solution in both cases is to call unsplitobj() after telling the player they can't do these things.