### PR TITLE
Two unsaddled steed fixes

### DIFF
--- a/src/steal.c
+++ b/src/steal.c
@@ -671,7 +671,7 @@ mdrop_obj(
     boolean verbosely)
 {
     int omx = mon->mx, omy = mon->my;
-    boolean unwornmask = obj->owornmask;
+    long unwornmask = obj->owornmask;
 
     extract_from_minvent(mon, obj, FALSE, TRUE);
     /* don't charge for an owned saddle on dead steed (provided

--- a/src/steed.c
+++ b/src/steed.c
@@ -483,10 +483,11 @@ dismount_steed(
     struct monst *mtmp;
     struct obj *otmp;
     coord cc, steedcc;
-    const char *verb = "fall";
-    boolean repair_leg_damage = (Wounded_legs != 0L);
     unsigned save_utrap = u.utrap;
-    boolean have_spot = landing_spot(&cc, reason, 0);
+    boolean repair_leg_damage = (Wounded_legs != 0L),
+            have_spot = landing_spot(&cc, reason, 0),
+            in_air = (((HFlying || EFlying) && !BFlying) || Levitation);
+    const char *verb = in_air ? "float" : "fall";
 
     mtmp = u.usteed; /* make a copy of steed pointer */
     /* Sanity check */
@@ -503,9 +504,12 @@ dismount_steed(
         You("%s off of %s!", verb, mon_nam(mtmp));
         if (!have_spot)
             have_spot = landing_spot(&cc, reason, 1);
-        losehp(Maybe_Half_Phys(rn1(10, 10)), "riding accident", KILLED_BY_AN);
-        set_wounded_legs(BOTH_SIDES, (int) HWounded_legs + rn1(5, 5));
-        repair_leg_damage = FALSE;
+        if (!in_air) {
+            losehp(Maybe_Half_Phys(rn1(10, 10)), "riding accident",
+                   KILLED_BY_AN);
+            set_wounded_legs(BOTH_SIDES, (int) HWounded_legs + rn1(5, 5));
+            repair_leg_damage = FALSE;
+        }
         break;
     case DISMOUNT_POLY:
         You("can no longer ride %s.", mon_nam(u.usteed));


### PR DESCRIPTION
Would fix a bug/regression introduced in ee76646 that causes a hero riding a steed which becomes unsaddled to continue riding without interruption, rather than falling from the steed (as was the previous behavior).

Also would prevent a hero with levitation or flying (from a source other than their flying steed, e.g. polymorph into a flying monster, ring of levitation...) from taking fall damage when their steed becomes unsaddled or bucks them off.