### PR TITLE
Fix: segfault after in_lua flag was left set

### DIFF
--- a/src/mklev.c
+++ b/src/mklev.c
@@ -318,6 +318,9 @@ makerooms(void)
         wallification(1, 0, COLNO - 1, ROWNO - 1);
         free(g.coder);
         g.coder = NULL;
+        /* Exiting lua code now, so this needs to be unset, but nhl_done() can't
+         * be used because that would free g.luathemes */
+        iflags.in_lua = FALSE;
     }
 }
 


### PR DESCRIPTION
If the in_lua flag is set during normal gameplay, and the player sets
some invalid option, the config_erradd function goes into a different
block that assumes *config_error_data is valid, which is not true in
playerspace.

The proper solution is to avoid leaving is_lua set, and the place it
should be unset and currently isn't is at the end of makerooms() after
loading themed rooms for a new branch. (Reproducing this required
setting !legacy, since otherwise the com_pager call for the legacy text
will set and unset is_lua.)