### PR TITLE
Encyclopedia fixes

### DIFF
--- a/dat/data.base
+++ b/dat/data.base
@@ -124,7 +124,7 @@ maud
 	If ever I should forget,
 	May God make me more wretched
 	Than ever I have been yet!
-		[ Maud, And Other Poems by Alfred, Lord Tennyson ]
+		[ Maud, And Other Poems, by Alfred, Lord Tennyson ]
 ~amulet of yendor
 ~amulet of restful sleep
 *amulet
@@ -217,7 +217,7 @@ apelike creature
 	the apes have the forelimbs much better developed than
 	the hind limbs.  Tail entirely absent.  Growth is slow
 	and sexual maturity reached at quite an advanced age.
-	  [ A Field Guide to the Larger Mammals of Africa by Dorst ]
+	  [ A Field Guide to the Larger Mammals of Africa, by Dorst ]
 
 	Aldo the gorilla had a plan.  It was a good plan.  It was
 	right.  He knew it.  He smacked his lips in anticipation as
@@ -656,7 +656,7 @@ brigit
 	And clear understanding.
 	Bring me my cross of gold,
 	As a talisman.
-		[ "Broadsword" (refrain) by Ian Anderson ]
+		[ "Broadsword" (refrain), by Ian Anderson ]
 bugbear
 	Bugbears are relatives of goblins, although they tend to be
 	larger and more hairy.  They are aggressive carnivores and
@@ -972,7 +972,7 @@ c*ckatrice
 	But even a dead basilisk is dangerous, for it is said that
 	merely touching its lifeless body can cause a person to
 	sicken and die.
-	  [ Mythical Beasts by Deirdre Headon (The Leprechaun Library)
+	  [ Mythical Beasts, by Deirdre Headon (The Leprechaun Library)
 	      and other sources ]
 *coin
 ~creeping coins
@@ -1084,7 +1084,7 @@ crom
 	aura of evil magic in the air.  Without thought, he readies
 	his weapon, and mutters under his breath:
 	"By Crom, there will be blood spilt today."
-	    [ Conan the Avenger by Robert E. Howard, Bjorn Nyberg,
+	    [ Conan the Avenger, by Robert E. Howard, Bjorn Nyberg,
 		and L. Sprague de Camp ]
 crossbow*
 	"God save thee, ancient Mariner!
@@ -1360,7 +1360,7 @@ doppelganger
 	not only with clouds of sulphurous fumes pouring from its fire
 	breathing nostrils, but also with the thrashings of its tail,
 	the most deadly part of its serpent-like body.
-	  [ Mythical Beasts by Deirdre Headon (The Leprechaun Library) ]
+	  [ Mythical Beasts, by Deirdre Headon (The Leprechaun Library) ]
 
 	"One whom the dragons will speak with," he said, "that is a
 	dragonlord, or at least that is the center of the matter.  It's
@@ -2191,7 +2191,7 @@ heart of ahriman
 	"Bring that thing back?" muttered the small dark man who
 	stood on the right, with a short, sardonic laugh.  "It is
 	ready to crumble at a touch.  We are fools ---"
-		[ Conan The Conqueror, by Robert E. Howard ]
+		[ Conan the Conqueror, by Robert E. Howard ]
 hell hound*
 	But suddenly they started forward in a rigid, fixed stare,
 	and his lips parted in amazement.  At the same instant Lestrade
@@ -2207,7 +2207,7 @@ hell hound*
 	savage, more appalling, more hellish be conceived than that
 	dark form and savage face which broke upon us out of the wall
 	of fog.
-	  [ The Hound of the Baskervilles, by Sir Arthur Conan Doyle. ]
+	  [ The Hound of the Baskervilles, by Sir Arthur Conan Doyle ]
 hermes
 	Messenger and herald of the Olympians.  Being required to do
 	a great deal of travelling and speaking in public, he became
@@ -2407,7 +2407,7 @@ minion of huhetotl
 	associated with paternalism and one of the group classed
 	as the Xiuhtecuhtli complex.  He is known to send his
 	minions to wreak havoc upon ordinary humans.
-	     [ after the Encyclopedia of Gods, by Michael Jordan ]
+	     [ Encyclopedia of Gods, by Michael Jordan ]
 humanoid
 	Humanoids are all approximately the size of a human, and may
 	be mistaken for one at a distance.  They are usually of a
@@ -2909,7 +2909,7 @@ lava
 	of its own, which lends an additional infernal splendor to the
 	already hellish scene.  A dark, forboding passage exits to the
 	south.
-		[ Adventure, by Will Crowther and Don Woods. ]
+		[ Adventure, by Will Crowther and Don Woods ]
 leash
 	They had splendid heads, fine shoulders, strong legs, and
 	straight tails.  The spots on their bodies were jet-black and
@@ -3633,7 +3633,7 @@ ninja-to
 	good condition by placing fresh earth around it daily.  In her
 	fury, Skuld often spoiled the work of her sisters by tearing
 	the web to shreds.
-	    [ The Encyclopedia of Myths and Legends of All Nations
+	    [ The Encyclopaedia of Myths and Legends of All Nations,
 		by Herbert Spencer Robinson and Knox Wilson ]
 nunchaku
 	A nunchaku is two sections of wood (or metal in modern
@@ -4063,8 +4063,8 @@ poseido*n
 	shake the earth, a power which makes him the god of
 	earthquakes as well.  Physically, he is shown as a strong and
 	powerful ruler, every inch a king.
-	    [ The Encyclopedia of Myths and Legends of All Nations,
-		by Herbert Robinson and Knox Wilson ]
+	    [ The Encyclopaedia of Myths and Legends of All Nations,
+		by Herbert Spencer Robinson and Knox Wilson ]
 ~*sleeping
 ~*booze
 *potion*
@@ -4116,7 +4116,7 @@ acolyte
 	but who can look at those millions of worlds and not feel that
 	there may well be wonderful universes above us where reason is
 	utterly unreasonable?"
-		[ The Innocence of Father Brown, by G.K. Chesterton ]
+		[ The Innocence of Father Brown, by G. K. Chesterton ]
 paddle cactus
 	Opuntia, commonly called prickly pear, is a genus in the cactus
 	family, Cactaceae. Prickly pears are also known as tuna (fruit),
@@ -4938,7 +4938,7 @@ statue*
 	lion.  And as soon as he had thought of that he noticed that
 	the lion's back and the top of its head were covered with
 	snow.  Of course it must be only a statue!
-		[ The Lion, the Witch and the Wardrobe by C.S. Lewis ]
+		[ The Lion, the Witch and the Wardrobe, by C.S. Lewis ]
 sting
 	There was the usual dim grey light of the forest-day about
 	him when he came to his senses.  The spider lay dead beside
@@ -5361,7 +5361,7 @@ valkyrie
 	which they died and in which they had won their deathless
 	fame.
 	    [ The Encyclopaedia of Myths and Legends of All Nations,
-		by Herbert Robinson and Knox Wilson ]
+		by Herbert Spencer Robinson and Knox Wilson ]
 vampire
 ~vampire bat
 vampire lord

--- a/dat/data.base
+++ b/dat/data.base
@@ -34,6 +34,10 @@ ac
 armor*
 armour*
 suit or piece of armor
+~*dragon*scale*
+~scroll of mail
+*mail
+*leather armor
 	"The last spot on the school jousting team came down to another
 	boy and me.  He was poor, and his only armor was a blanket his
 	mother had made him from her hair.  I, on the other hand, had
@@ -531,6 +535,7 @@ ooze
 	kind had swept so evilly free of all litter.
 		[ At the Mountains of Madness, by H.P. Lovecraft ]
 blue jelly
+ochre jelly
 spotted jelly
 	I'd planned how to prevent the lock from sealing behind me; it
 	required a temporary sacrifice, not cleverness.  I used the door
@@ -2651,6 +2656,7 @@ jubilex
 	alive, spits acidic secretions, and causes disease in his
 	victims which can be almost instantly fatal.
 k?ration
+c?ration
 	The K ration was the [ Quartermaster Subsistence Research
 	and Development Laboratory's ] answer to the demand for an
 	individual, easy-to-carry ration that could be used in
@@ -2766,6 +2772,7 @@ knight
 	Elven race, and will go out of their way to cause trouble
 	for Elves at any time.
 *kop*
+rubber hose
 	The Kops are a brilliant concept.  To take a gaggle of inept
 	policemen and display them over and over again in a series of
 	riotously funny physical punishments plays equally well to the
@@ -3084,6 +3091,7 @@ lord surt*
 			[ The Prose Edda, by Snorri Sturluson ]
 # if a quote for good luck gets added, make this one exclusively bad luck
 luck
+luckstone
 bad luck
 	"[...]  We'll succeed and you'll get all the fortune you came
 	seeking."
@@ -3296,6 +3304,7 @@ huge chunk of meat
 		[ Grace Before Meat, by Robert Burns ]
 medusa
 perseus
+shield of reflection
 	Medusa, one of the three Gorgons or Graeae, is the only one
 	of her sisters to have assumed mortal form and inhabited the
 	dungeon world.
@@ -5527,13 +5536,19 @@ water troll
 	across its chest.
 	    [ The Colour of Magic, by Terry Pratchett ]
 weapon
+battle axe
+club
+flail
+~*broadsword
+~sunsword
+*sword
 	A weapon is a device for making your enemy change his mind.
 		[ The Vor Game, by Lois McMaster Bujold ]
 web
 	Oh what a tangled web we weave,
 	When first we practise to deceive!
 		[ Marmion, by Sir Walter Scott ]
-whistle
+*whistle
 	There were legends both on the front and on the back of the
 	whistle. The one read thus:
 


### PR DESCRIPTION
While going through the NetHack encyclopedia, I've gone through and fixed some consistency issues with cited sources' authors. I've also added a few entries where it makes sense (c-ration -> k-ration, shield of reflection -> perseus, ochre jelly, tin and magic whistle -> whistle, rubber hose -> kops, club, flail, etc -> weapon, most armors -> armor).

Note there are still a few monsters and items that don't have encyclopedia entries associated with them that I couldn't find a good match for:

* stalker
* all gauntlets
* all helms
* all shields
* all worthless glass
* some foods (pancake, eucalyptus leaf)
* some gems (amethyst, aquamarine, black opal, fluorite, garnet, opal)
* some tools (bell, credit card, lenses, lock pick, stethoscope, skeleton key)
* T-shirt
* alchemy smock
* corpse
* ice box
* iron shoes
* loadstone
* novel
 