### PR TITLE
Make homemade tins never give more nutrition than the corpse does

### DIFF
--- a/src/eat.c
+++ b/src/eat.c
@@ -1354,6 +1354,10 @@ consume_tin(const char *mesg)
 
         if (tintxts[r].nut < 0) /* rotten */
             make_vomiting((long) rn1(15, 10), FALSE);
+        else if (r == HOMEMADE_TIN)
+            /* presume a homemade tin is made from a single corpse; it can't
+             * contain more nutrition than the corpse did */
+            lesshungry(min(tintxts[HOMEMADE_TIN].nut, mons[mnum].cnutrit));
         else
             lesshungry(tintxts[r].nut);
 


### PR DESCRIPTION
This fixes an oddity in how tins work - homemade tins always gave 50
nutrition points, so if you tinned a bunch of low-nutrition monsters
such as killer bees (5 nutrition points per corpse), the resulting tins
all suddenly give 50 nutrition. Where did the extra nutrition come from?

If the corpse provided >= 50 nutrition, a homemade tin of it still gives
50. Other tins still give their regular amounts of nutrition (a tin of
pureed killer bee is not necessarily made from just one killer bee
corpse, so there's no reason why the corpse nutrition of 5 has to
constrain that).