### PR TITLE
Additional checks to prevent "impossible" statues

### DIFF
--- a/src/mkroom.c
+++ b/src/mkroom.c
@@ -385,10 +385,17 @@ fill_zoo(struct mkroom* sroom)
                     struct obj *sobj = mk_tt_object(STATUE, sx, sy);
 
                     if (sobj) {
-                        for (i = rn2(5); i; i--)
-                            (void) add_to_container(
-                                sobj, mkobj(RANDOM_CLASS, FALSE));
-                        sobj->owt = weight(sobj);
+                        if (poly_when_stoned(&mons[sobj->corpsenm])
+                            || (mons[sobj->corpsenm].mresists & MR_STONE)) {
+                            /* remove statue of stone-resistant monster (can
+                             * be produced when high-score list is empty) */
+                            delobj(sobj);
+                        } else {
+                            for (i = rn2(5); i; i--)
+                                (void) add_to_container(
+                                        sobj, mkobj(RANDOM_CLASS, FALSE));
+                            sobj->owt = weight(sobj);
+                        }
                     }
                 }
                 break;

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -2203,10 +2203,9 @@ create_object(object* o, struct mkroom* croom)
          * setting corpsenm).
          */
         for (wastyp = otmp->corpsenm; i < 1000; i++, wastyp = rndmonnum()) {
-            /* makemon without rndmonst() might create a group */
-            was = makemon(&mons[wastyp], 0, 0, MM_NOCOUNTBIRTH);
+            was = makemon(&mons[wastyp], 0, 0, MM_NOCOUNTBIRTH | MM_NOGRP);
             if (was) {
-                if (!resists_ston(was)) {
+                if (!resists_ston(was) && !poly_when_stoned(&mons[wastyp])) {
                     (void) propagate(wastyp, TRUE, FALSE);
                     break;
                 }


### PR DESCRIPTION
Although there is already a test to ensure statues on the Medusa level (which are supposed to be erstwhile victims of Medusa) do not represent stoning-resistant monsters, no such test exists to prevent `poly_when_stoned` creatures such as golems from showing up as Medusa statues.  This patch would add a test to ensure golem statues don't appear on Medusa's level.

It would also apply similar checks to ensure the statues created in a cockatrice nest are not stoning-resistant or `poly_when_stoned` mons.  Normally these statues represent players from the high score list, but when the high score list is empty, cockatrice nests will be filled with random monster statues which currently may be "impossible" (stoning-resistant, etc) stoning victims.