### PR TITLE
Fix some issues with genetic engineer attacks

### DIFF
--- a/src/mhitm.c
+++ b/src/mhitm.c
@@ -945,7 +945,7 @@ mon_poly(struct monst *magr, struct monst *mdef, int dmg)
 {
     if (mdef == &g.youmonst) {
         if (Antimagic) {
-            shieldeff(mdef->mx, mdef->my);
+            shieldeff(u.ux, u.uy);
         } else if (Unchanging) {
             ; /* just take a little damage */
         } else {

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -3082,9 +3082,7 @@ mhitm_ad_conf(struct monst *magr, struct attack *mattk, struct monst *mdef,
 }
 
 void
-mhitm_ad_poly(struct monst *magr,
-              struct attack *mattk UNUSED, /* implied */
-              struct monst *mdef,
+mhitm_ad_poly(struct monst *magr, struct attack *mattk, struct monst *mdef,
               struct mhitm_data *mhm)
 {
     if (magr == &g.youmonst) {
@@ -3097,6 +3095,7 @@ mhitm_ad_poly(struct monst *magr,
             mhm->damage = mon_poly(magr, mdef, mhm->damage);
     } else if (mdef == &g.youmonst) {
         /* mhitu */
+        hitmsg(magr, mattk);
         int armpro = magic_negation(mdef);
         boolean uncancelled = !magr->mcan && (rn2(10) >= 3 * armpro);
 


### PR DESCRIPTION
Genetic engineer attacks don't produce a "the genetic engineer hits!" message; when not magic-resistant this isn't such a big deal, because there is typically other feedback ("you are subjected to a freakish metamorphosis"), but when magic-resistant the attack does damage without any feedback at all, meaning the hero's health drops each turn without any explanation or warning.

Additionally, a `sparkle` shield effect is supposed to be shown when magic resistance protects a monster from the polymorph attack, but was not showing up correctly when the hero was targeted due to the use of `g.youmonst.mx` and `g.youmonst.my` when calling `shieldeff` instead of `u.ux` and `u.uy`.

This is a small patch to fix both these issues.