### PR TITLE
Fix travel to diagonally adjacent square

### DIFF
--- a/src/hack.c
+++ b/src/hack.c
@@ -3000,12 +3000,13 @@ end_running(boolean and_travel)
     g.context.run = 0;
     /* 'context.mv' isn't travel but callers who want to end travel
        all clear it too */
-    if (and_travel)
+    if (and_travel) {
         g.context.travel = g.context.travel1 = g.context.mv = 0;
-    
-    // Cancel mutli
-    if (g.multi > 0) 
-        g.multi = 0;
+
+        /* Cancel multi */
+        if (g.multi > 0) 
+            g.multi = 0;
+    }
 }
 
 void


### PR DESCRIPTION
When traveling to a square that is adjacent but cannot be moved to in a
single move, for example in this situation, where `*` is the travel
destination and the hero is carrying too much to squeeze between the
diagonal:

    ..*|.
    ..|@.
    .....

The hero would move a single square and then stop:

    ..*|.
    ..|..
    ..@..

This is because when testing whether an adjacent square can be moved to
in a single move (in which case multimove travel is not necessary),
`g.multi` was being reset to 0 before confirming that the destination was
accessible.  Instead, set `g.multi` to 0 only once the adjacent target is
confirmed to be accessible in a single move.

A video of the issue:

https://user-images.githubusercontent.com/40038830/113428161-4d8df280-93a4-11eb-8620-8b3844d96bc4.mp4

