### PR TITLE
Fix some minor apply getobj prompt regressions

### DIFF
--- a/include/hack.h
+++ b/include/hack.h
@@ -500,13 +500,13 @@ enum getobj_callback_returns {
      * else to foo". */
     GETOBJ_EXCLUDE_INACCESS = -1,
     /* invalid for purposes of not showing a prompt if nothing is valid but
-     * psuedo-valid for selecting - identical to GETOBJ_EXCLUDE but
+     * psuedo-valid for selecting - identical to GETOBJ_EXCLUDE_INACCESS but
      * without the "else" in "You don't have anything else to foo". */
     GETOBJ_EXCLUDE_SELECTABLE = 0,
     /* valid - invlet not presented in the summary or the ? menu as a
      * recommendation, but is selectable if the player enters it anyway. Used
-     * for objects that are actually valid but unimportantly so, such as shirts
-     * for reading. */
+     * for objects that are actually valid but unimportantly so, such as
+     * shirts for reading. */
     GETOBJ_DOWNPLAY = 1,
     /* valid - will be shown in summary and ? menu */
     GETOBJ_SUGGEST  = 2,

--- a/src/apply.c
+++ b/src/apply.c
@@ -3662,11 +3662,16 @@ apply_ok(struct obj *obj)
             || obj->otyp == BULLWHIP))
         return GETOBJ_SUGGEST;
 
-    /* only applicable potion is oil, and it will only be offered as a choice
-     * when already discovered */
-    if (obj->otyp == POT_OIL && obj->dknown
-        && objects[obj->otyp].oc_name_known)
-        return GETOBJ_SUGGEST;
+    if (obj->oclass == POTION_CLASS) {
+        /* permit applying unknown potions, but don't suggest them */
+        if (!obj->dknown || !objects[obj->otyp].oc_name_known)
+            return GETOBJ_DOWNPLAY;
+
+        /* only applicable potion is oil, and it will only be suggested as a
+         * choice when already discovered */
+        if (obj->otyp == POT_OIL)
+            return GETOBJ_SUGGEST;
+    }
 
     /* certain foods */
     if (obj->otyp == CREAM_PIE || obj->otyp == EUCALYPTUS_LEAF
@@ -3682,12 +3687,12 @@ apply_ok(struct obj *obj)
         if (obj->otyp != TOUCHSTONE
             && (objects[TOUCHSTONE].oc_name_known
                 || objects[obj->otyp].oc_name_known))
-            return GETOBJ_EXCLUDE;
+            return GETOBJ_EXCLUDE_SELECTABLE;
 
         return GETOBJ_SUGGEST;
     }
 
-    return GETOBJ_EXCLUDE;
+    return GETOBJ_EXCLUDE_SELECTABLE;
 }
 
 /* the 'a' command */


### PR DESCRIPTION
Before the getobj refactor (0b638592) it was possible to identify oil by
applying an unidentified potion and seeing whether you were able to
light it successfully; because the apply_ok callback in the refactor
returned GETOBJ_EXCLUDE by default, it became impossible to apply any
potions other than a formally identified potion of oil.  Additionally,
it became impossible to 'apply' an flint stone or luckstone once it or
a touchstone had been identified.

Another change is that prior to the refactor, attempting to apply an
inappropriate object would produce the message "Sorry, I don't know how
to use that" -- because of the GETOBJ_EXCLUDE default in apply_ok, this
changed to "That is a silly thing to use or apply."

This restores the previous behavior when attempting to apply an
unidentified potion, as well as in the other cases (which are admittedly
not as important or relevant to a normal player).  It also fixes a small
error in a comment explaining the purpose of GETOBJ_EXCLUDE_SELECTABLE.