### PR TITLE
Fix: lantern-specific message called it a "lamp"

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -1452,7 +1452,7 @@ use_lamp(struct obj *obj)
     if ((!Is_candle(obj) && obj->age == 0)
         || (obj->otyp == MAGIC_LAMP && obj->spe == 0)) {
         if (obj->otyp == BRASS_LANTERN)
-            Your("lamp has run out of power.");
+            Your("lantern has run out of power.");
         else
             pline("This %s has no oil.", xname(obj));
         return;


### PR DESCRIPTION
Running out of power only happens and is only printed for lanterns. Call
it a lantern in the message.