### PR TITLE
Improve feedback for unseen boulder traps

### DIFF
--- a/src/trap.c
+++ b/src/trap.c
@@ -2239,7 +2239,8 @@ trapeffect_rolling_boulder_trap(
         int style = ROLL | (trap->tseen ? LAUNCH_KNOWN : 0);
 
         feeltrap(trap);
-        pline("Click!  You trigger a rolling boulder trap!");
+        pline("%sYou trigger a rolling boulder trap!",
+              Deaf ? "" : "Click!  ");
         if (!launch_obj(BOULDER, trap->launch.x, trap->launch.y,
                         trap->launch2.x, trap->launch2.y, style)) {
             deltrap(trap);
@@ -2250,13 +2251,16 @@ trapeffect_rolling_boulder_trap(
         struct permonst *mptr = mtmp->data;
 
         if (!is_flyer(mptr)) {
-            boolean in_sight = canseemon(mtmp) || (mtmp == u.usteed);
+            boolean in_sight = (mtmp == u.usteed
+                                || (canspotmon(mtmp)
+                                    && cansee(mtmp->mx, mtmp->my)));
             int style = ROLL | (in_sight ? 0 : LAUNCH_UNSEEN);
             boolean trapkilled = FALSE;
 
             newsym(mtmp->mx, mtmp->my);
             if (in_sight)
-                pline("Click!  %s triggers %s.", Monnam(mtmp),
+                pline("%s%s triggers %s.",
+                      Deaf ? "" : "Click!  ", Monnam(mtmp),
                       trap->tseen ? "a rolling boulder trap" : something);
             if (launch_obj(BOULDER, trap->launch.x, trap->launch.y,
                            trap->launch2.x, trap->launch2.y, style)) {
@@ -2697,8 +2701,16 @@ launch_obj(
     switch (style) {
     case ROLL | LAUNCH_UNSEEN:
         if (otyp == BOULDER) {
-            You_hear(Hallucination ? "someone bowling."
-                                   : "rumbling in the distance.");
+            if (cansee(x1, y1)) {
+                You_see("%s start to roll.", an(xname(singleobj)));
+            } else if (Hallucination) {
+                You_hear("someone bowling.");
+            } else {
+                You_hear("rumbling %s.",
+                         (distu(x1, y1) <= 4 * 4) ? "nearby"
+                                                  : "in the distance");
+            }
+
         }
         style &= ~LAUNCH_UNSEEN;
         goto roll;


### PR DESCRIPTION
When an unseen monster triggers a boulder trap, the only feedback given is "you hear rumbling in the distance."  This doesn't depend on whether the boulder itself is seen, or its distance from the hero, but only on whether the monster that triggered the trap can be seen.  Because a boulder can block line of sight, this means that a character standing immediately behind a boulder when the trap is triggered gets the "you hear rumbling in the distance" feedback.  This "rumbling in the distance" pline is also printed if a character sees the trap triggered by an invisible monster that is sensed via ESP/monster detection.

This commit would improve this feedback so that actually seeing the boulder launched would take precedence over "hearing rumbling", and so that the rumbling of a totally unseen boulder trap could be described as "nearby" or "in the distance" depending on how close to the hero the boulder is.  It would also change the criteria for monsters being 'seen', so that an invisible monster that is detected by other means and triggers the trap on a square that is visible to the hero would be considered 'seen'.

Also would adjust the "Click! The foo triggers something." message so that the "Click!" is only printed when the hero is not deaf.



### Examples of some questionable situations where "rumbling in the distance" is currently used:

When the boulder itself blocks line of sight to the trap:

https://user-images.githubusercontent.com/40038830/114747394-caaf5500-9d1e-11eb-8946-d46fb1953437.mp4

When a monster is invisible but detected by some other means:

https://user-images.githubusercontent.com/40038830/114747460-dc90f800-9d1e-11eb-92d7-cfaa7ed292df.mp4


