### PR TITLE
Fix: some converted altars did not change color

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -1593,9 +1593,10 @@ show_glyph(int x, int y, int glyph)
 
     if (g.gbuf[y][x].glyph != glyph
 #ifndef UNBUFFERED_GLYPHINFO
-           /* I don't think we have to test for changes in TTYCHAR or COLOR
-              because they typically only change if the glyph changed */
+           /* I don't think we have to test for changes in TTYCHAR
+              because it typically only changes if the glyph changed */
             || g.gbuf[y][x].glyphinfo.glyphflags != glyphinfo.glyphflags
+            || g.gbuf[y][x].glyphinfo.color != glyphinfo.color
 #endif
             || iflags.use_background_glyph ) {
         g.gbuf[y][x].glyph = glyph;


### PR DESCRIPTION
A comment in display.c said it was not necessary to check for the color of a glyph changing, because typically the color won't change unless the glyph itself changes as well.  This is true in most cases.

However, there is an exception to the rule: when the hero is invisible and converts an unaligned altar (which is colored red), the glyph itself doesn't change even though its color does.  When this happened, the color wouldn't be updated until the symbol was redrawn for some other reason.  This problem is even more common in versions of NetHack with a patch applied to color altars according to their alignment (this is the case on several public servers), where it could happen for any altar conversion by an invisible hero.

Check whether the color of a glyph has changed in `show_glyph` even if the glyph itself hasn't been updated, so that an (unaligned) altar converted by an invisible hero will change color appropriately, in line with the "the altar glows white", etc, altar conversion messages.