### PR TITLE
Fix: use correct behavior for des.line() with one coordinate

### DIFF
--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -4624,7 +4624,10 @@ struct selectionvar *ov)
 
     selection_setpoint(x1, y1, ov, 1);
 
-    if (dx > dy) {
+    if (!dx && !dy) {
+        /* it's just this one point - no line */
+        return;
+    } else if (dx > dy) {
         ai = (dy - dx) * 2;
         bi = dy * 2;
         d0 = bi - dx;


### PR DESCRIPTION
One would expect that a line from e.g. (10,10) to (10,10) would contain
only that one point, but I discovered that lspo_line doesn't know what
to do with that input and slices a big diagonal line across the whole
map in both directions from that point. This corrects the behavior to
stop after selecting the one point.

This problem is latent in vanilla NetHack because des.line is never
used.