### PR TITLE
Fix: encyclopedia typo of "Galadrim"

### DIFF
--- a/dat/data.base
+++ b/dat/data.base
@@ -1558,7 +1558,7 @@ elven cloak
 	The Elves next unwrapped and gave to each of the Company the
 	clothes they had brought.  For each they had provided a hood
 	and cloak, made according to his size, of the light but warm
-	silken stuff that the Galadrim wove.  It was hard to say of
+	silken stuff that the Galadhrim wove.  It was hard to say of
 	what colour they were: grey with the hue of twilight under
 	the trees they seemed to be; and yet if they were moved, or
 	set in another light, they were green as shadowed leaves, or


### PR DESCRIPTION
Should be "Galadhrim", with an h.