### PR TITLE
Fix: impossible from eating zombifying corpse

### DIFF
--- a/src/do.c
+++ b/src/do.c
@@ -1969,6 +1969,11 @@ zombify_mon(anything *arg, long timeout)
         if (has_omonst(body))
             free_omonst(body);
 
+        /* Ensure we get a new oeaten proportional to the new zombie form's
+         * total possible nutrition, so that the ratio stays the same and can
+         * be used by eaten_stat to determine the zombie's HP. */
+        body->oeaten = (unsigned) (body->oeaten * mons[zmon].cnutrit
+                                   / mons[body->corpsenm].cnutrit);
         body->corpsenm = zmon;
         revive_mon(arg, timeout);
     } else {


### PR DESCRIPTION
When eating a monster that then was revived as a zombie as you were chowing down, the total possible nutrition would be changed based on the new `corpsenm`, but `oeaten` stayed the same.  As a result, if you hadn't eaten much of the corpse when the revival happened and the zombie form had a lower nutritional value than the original form (as is the case for a frost giant turning into a giant zombie, for example), this could result in `oeaten` being higher than the total possible nutrition, triggering an impossible in `eaten_stat()`.  Set the corpse's `oeaten` to be proportional to the new total possible nutrition to fix this.