### PR TITLE
Fix: "it looks very angry" on entering demon lair

### DIFF
--- a/src/minion.c
+++ b/src/minion.c
@@ -225,7 +225,8 @@ demon_talk(register struct monst *mtmp)
 
     if (uwep && (uwep->oartifact == ART_EXCALIBUR
                  || uwep->oartifact == ART_DEMONBANE)) {
-        pline("%s looks very angry.", Amonnam(mtmp));
+        if (canspotmon(mtmp))
+            pline("%s looks very angry.", Amonnam(mtmp));
         mtmp->mpeaceful = mtmp->mtame = 0;
         set_malign(mtmp);
         newsym(mtmp->mx, mtmp->my);


### PR DESCRIPTION
Getting close to certain "boss" demons while wielding Excalibur or Demonbane angers them immediately, but the message "%s looks very angry" was printed regardless of whether you could actually see the demon in question -- even if the hero was blind.

<img width="557" alt="Screen Shot 2021-04-30 at 1 17 45 PM" src="https://user-images.githubusercontent.com/40038830/116730431-7e1e7780-a9b6-11eb-8647-4955b88dd3b8.png">

