### PR TITLE
Fix: uninitialized buffer in mhitm theft feedback

### DIFF
--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -2284,8 +2284,8 @@ mhitm_ad_sgld(struct monst *magr, struct attack *mattk, struct monst *mdef,
             add_to_minv(magr, gold);
         }
         mdef->mstrategy &= ~STRAT_WAITFORU;
+        Strcpy(buf, Monnam(magr));
         if (g.vis && canseemon(mdef)) {
-            Strcpy(buf, Monnam(magr));
             pline("%s steals some gold from %s.", buf, mon_nam(mdef));
         }
         if (!tele_restrict(magr)) {
@@ -3965,8 +3965,8 @@ mhitm_ad_sedu(struct monst *magr, struct attack *mattk, struct monst *mdef,
             if (g.vis)
                 Strcpy(onambuf, doname(obj));
             (void) add_to_minv(magr, obj);
+            Strcpy(buf, Monnam(magr));
             if (g.vis && canseemon(mdef)) {
-                Strcpy(buf, Monnam(magr));
                 pline("%s steals %s from %s!", buf, onambuf, mdefnambuf);
             }
             possibly_unwield(mdef, FALSE);


### PR DESCRIPTION
If a monster with a theft attack (nymph or leprechaun) stole something from an invisible monster (e.g. while under the influence of conflict), and the attacking monster was not itself invisible, the monster name buffer used when printing the "\<foo\> suddenly disappears!" message would be used while still uninitialized.  The attacking monster's name was only copied into the buffer if the defending monster was visible, but would be used regardless to print the pline if the attacking monster was visible and teleported away successfully after the attack.

![uninitialized-buffer-use](https://user-images.githubusercontent.com/40038830/117215828-d0073900-adcc-11eb-83f9-0d6b34a068c8.png)

