### PR TITLE
Fix: nymph theft vs monster

### DIFF
--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -3946,7 +3946,7 @@ mhitm_ad_sedu(struct monst *magr, struct attack *mattk, struct monst *mdef,
         /* find an object to steal, non-cursed if magr is tame */
         for (obj = mdef->minvent; obj; obj = obj->nobj)
             if (!magr->mtame || !obj->cursed)
-                return;
+                break;
 
         if (obj) {
             char buf[BUFSZ];


### PR DESCRIPTION
Nymphs' item theft attack against other monsters was broken in 1696019,
when a `break` used to select a particular item in the target monster's
inventory was changed to an early return.