### PR TITLE
Fix: 'partly eaten' 0 nutrition item

### DIFF
--- a/src/eat.c
+++ b/src/eat.c
@@ -3398,6 +3398,8 @@ consume_oeaten(struct obj *obj, int amt)
      * huge positive value instead.  So far, no one has figured out
      * _why_ that inappropriate subtraction might sometimes happen.
      */
+    if (!obj_nutrition(obj))
+        return;
 
     if (amt > 0) {
         /* bit shift to divide the remaining amount of food */


### PR DESCRIPTION
This was noticed by @rojjaCebolla in SpliceHack, but the problem applies to NetHack too.

Wishing for a partly eaten wraith corpse or tin caused an impossible, because its nutrition is 0 but its oeaten was being set to 1 by consume_oeaten in order to make it "partly eaten", causing an impossible in eaten_stat when attempting to calculate its weight.  Prevent consume_oeaten from modifying an object's oeaten value when its total possible nutrition is 0 to begin with.

I think that the only way for this to happen in-game is to wish for these items, so preventing the call to consume_oeaten in the first place would probably be enough to fix this, but adding this test to
consume_oeaten should guard against it in general.