### PR TITLE
Fix: deliberate revival of cancelled monster

### DIFF
--- a/src/zap.c
+++ b/src/zap.c
@@ -2104,6 +2104,8 @@ bhito(struct obj *obj, struct obj *otmp)
                 boolean by_u = !g.context.mon_moving;
                 int corpsenm = corpse_revive_type(obj);
                 char *corpsname = cxname_singular(obj);
+                unsigned save_norevive = obj->norevive;
+                obj->norevive = 0;  /* deliberate revival ignores norevive */
 
                 /* get corpse's location before revive() uses it up */
                 if (!get_obj_location(obj, &ox, &oy, 0))
@@ -2111,6 +2113,7 @@ bhito(struct obj *obj, struct obj *otmp)
 
                 mtmp = revive(obj, TRUE);
                 if (!mtmp) {
+                    obj->norevive = save_norevive;
                     res = 0; /* no monster implies corpse was left intact */
                 } else {
                     if (cansee(ox, oy)) {


### PR DESCRIPTION
mkcorpstat(mkobj.c) adds a norevive flag to all cancelled non-rider
monsters in order to prevent spontaneous resurrection by monsters with a
revive timer (trolls).  This shouldn't be a problem because norevive is
supposed to only block timed revival, not explicit use of undead
turning, but this rule was only applied to certain scenarios (zapping
undead turning at a monster carrying a corpse in its inventory, for
example).

The more typical use of undead turning -- zapping a corpse on the ground
to revive it -- was not clearing the norevive flag before calling
revive(zap.c), and so cancelled monsters could not be revived in this
way.  Ignore norevive for explicit undead turning of a corpse on the
floor.