### PR TITLE
Give different messages for flipping through a novel

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -3952,12 +3952,14 @@ unfixable_trouble_count(boolean is_horn)
 static int
 flip_through_book(struct obj *obj)
 {
+    boolean normal_book = (obj->otyp == SPE_NOVEL);
     if (Underwater) {
         pline("You don't want to get the pages even more soggy, do you?");
         return 0;
     }
 
-    You("flip through the pages of the spellbook.");
+    You("flip through the pages of the %sbook.",
+        normal_book ? "" : "spell");
 
     if (obj->otyp == SPE_BOOK_OF_THE_DEAD) {
         if (Deaf) {
@@ -3967,22 +3969,19 @@ flip_through_book(struct obj *obj)
                     Hallucination ? "chuckling"
                                   : "rustling");
         }
-        return 1;
     } else if (Blind) {
         pline("The pages feel %s.",
               Hallucination ? "freshly picked"
                             : "rough and dry");
-        return 1;
     } else if (obj->otyp == SPE_BLANK_PAPER) {
         pline("This spellbook %s.",
               Hallucination ? "doesn't have much of a plot"
                             : "has nothing written in it");
         makeknown(obj->otyp);
-        return 1;
-    }
-
-    if (Hallucination) {
+    } else if (Hallucination) {
         You("enjoy the animated initials.");
+    } else if (normal_book) {
+        pline("This looks like it might be interesting to read.");
     } else {
         static const char* fadeness[] = {
             "fresh",


### PR DESCRIPTION
Current behavior is when you flip through a novel, you get the standard
messages: "You flip through the pages of the spellbook. The ink in this
spellbook is fresh." But a novel is not a spellbook, and its ink doesn't
wear out with repeated reading.

This alters the "flip" message to refer to it as just a "book", and adds
a second novel-specific message. Attempting to flip through a novel
while hallucinating will give the same message as with regular
spellbooks.

There is also a possible minor bug I noticed here: flipping through the
Book of the Dead while blind and deaf produces "You sense the pages glow
faintly red", which seems wrong.