### PR TITLE
Additional vomit effects.

### DIFF
--- a/src/eat.c
+++ b/src/eat.c
@@ -3375,6 +3375,15 @@ vomit(void) /* A good idea from David Neves */
            reaches 0, but only if u.uhs < FAINTING (and !cantvomit()) */
         if (u.uhs >= FAINTING)
             Your("%s heaves convulsively!", body_part(STOMACH));
+         /* Vomiting on an altar is, all things considered, rather impolite. */
+        if (IS_ALTAR(levl[u.ux][u.uy].typ)) {
+            altar_wrath(u.ux, u.uy);
+        }
+        if (acidic(g.youmonst.data)) {
+            if (is_ice(u.ux, u.uy)) {
+                melt_ice(u.ux, u.uy, "Your stomach acid melts straight through the ice!");
+            }
+        }
     }
 
     /* nomul()/You_can_move_again used to be unconditional, which was

--- a/src/eat.c
+++ b/src/eat.c
@@ -3361,6 +3361,8 @@ floorfood(const char *verb,
 void
 vomit(void) /* A good idea from David Neves */
 {
+    struct attack *mattk;
+    
     if (cantvomit(g.youmonst.data)) {
         /* doesn't cure food poisoning; message assumes that we aren't
            dealing with some esoteric body_part() */
@@ -3382,6 +3384,20 @@ vomit(void) /* A good idea from David Neves */
         nomul(-2);
         g.multi_reason = "vomiting";
         g.nomovemsg = You_can_move_again;
+    }
+
+    /* Currently, only yellow dragons can breathe acid. */
+    mattk = attacktype_fordmg(g.youmonst.data, AT_BREA, AD_ACID);
+    if (mattk)
+        ubreatheu(mattk);
+    /* Vomiting on an altar is, all things considered, rather impolite. */
+    if (IS_ALTAR(levl[u.ux][u.uy].typ)) {
+        altar_wrath(u.ux, u.uy);
+    }
+    if (acidic(g.youmonst.data)) {
+        if (is_ice(u.ux, u.uy)) {
+            melt_ice(u.ux, u.uy, "Your stomach acid melts straight through the ice!");
+        }
     }
 }
 

--- a/src/eat.c
+++ b/src/eat.c
@@ -3390,15 +3390,6 @@ vomit(void) /* A good idea from David Neves */
     mattk = attacktype_fordmg(g.youmonst.data, AT_BREA, AD_ACID);
     if (mattk)
         ubreatheu(mattk);
-    /* Vomiting on an altar is, all things considered, rather impolite. */
-    if (IS_ALTAR(levl[u.ux][u.uy].typ)) {
-        altar_wrath(u.ux, u.uy);
-    }
-    if (acidic(g.youmonst.data)) {
-        if (is_ice(u.ux, u.uy)) {
-            melt_ice(u.ux, u.uy, "Your stomach acid melts straight through the ice!");
-        }
-    }
 }
 
 int


### PR DESCRIPTION
As @davidssmith mentioned in Issue #510 , vomiting on an altar currently has no effect. Given that the simple act of kicking or sitting on an altar provokes the direct intervention and wrath of a deity, this seems like an oversight. Of course, if we're adding some internal consistency to vomit, we might as well go all the way. This patch makes the following changes:

1. Vomiting on an altar provokes the wrath of a deity.
2. If the player is an acidic monster, vomiting on ice will cause the ice to melt, since they have very strong stomach acid (strong enough to reverse stoning).
3. If the player is a monster with an acidic breath weapon (i.e. a yellow dragon) they are treated as if they have used their breath weapon on themself.

This is, quite possibly, the worst thing I have ever written. I'm going to bed.