### PR TITLE
Fix: Baalzebub's level can randomly be lit up

### DIFF
--- a/dat/baalz.lua
+++ b/dat/baalz.lua
@@ -3,7 +3,7 @@
 --	Copyright (c) 1992 by M. Stephenson and Izchak Miller
 -- NetHack may be freely redistributed.  See license for details.
 --
-des.level_init({ style = "solidfill", fg = " " });
+des.level_init({ style = "solidfill", fg = " ", lit = 0 });
 
 -- TODO FIXME: see baalz_fixup - the legs get removed currently.
 


### PR DESCRIPTION
This appears to be because unlike most other demon lairs, Baalzebub
uses a solidfill level_init, without specifying the lit state. This
means that the lit state is randomized, allowing the maze to be fully
lit, which is strange in Gehennom where usually they are dark. Force the
lit state to dark.