### PR TITLE
Fix: cursed levitation "head bump" effect

### DIFF
--- a/src/potion.c
+++ b/src/potion.c
@@ -1033,13 +1033,14 @@ peffects(struct obj *otmp)
             g.potion_nothing++;
 
         if (otmp->cursed) {
+            stairway *stway;
             /* 'already levitating' used to block the cursed effect(s)
                aside from ~I_SPECIAL; it was not clear whether that was
                intentional; either way, it no longer does (as of 3.6.1) */
             HLevitation &= ~I_SPECIAL; /* can't descend upon demand */
             if (BLevitation) {
                 ; /* rising via levitation is blocked */
-            } else if (stairway_find_dir(TRUE)) {
+            } else if ((stway = stairway_at(u.ux, u.uy)) != 0 && stway->up) {
                 (void) doup();
                 /* in case we're already Levitating, which would have
                    resulted in incrementing 'nothing' */


### PR DESCRIPTION
As of 6ec55a3, the condition leading to the "go up the stairs" effect of
a cursed potion of levitation was changed to check whether an up
staircase existed anywhere on the level, rather than checking whether
the hero was standing on the appropriate kind of staircase.  As a
result, quaffing a cursed potion of levitation on any level with an
upstairs would attempt to go up the stairs (leading to "you can't go up
here" with no further effects) rather than continuing on to the "bump
your head on the ceiling" case, etc.
