### PR TITLE
Don't autoquiver aklys that fails to return

### DIFF
--- a/src/invent.c
+++ b/src/invent.c
@@ -927,9 +927,11 @@ addinv_core0(struct obj *obj, struct obj *other_obj,
     if (flags.pickup_thrown && !uquiver && obj_was_thrown
         /* if Mjollnir is thrown and fails to return, we want to
            auto-pick it when we move to its spot, but not into quiver;
-           aklyses behave like Mjollnir when thrown while wielded, but
-           we lack sufficient information here make them exceptions */
+           aklyses behave like Mjollnir when thrown while wielded, so
+           treat them similarly unless hero is wielding something else
+           already. */
         && obj->oartifact != ART_MJOLLNIR
+        && (obj->otyp != AKLYS || uwep)
         && (throwing_weapon(obj) || is_ammo(obj)))
         setuqwep(obj);
  added:


### PR DESCRIPTION
Changes to the 'f' command in a71d318 have incentivized keeping an
empty quiver while wielding an aklys.  As a result, it's become more
likely that an aklys which fails to return will fall into the "quiver
is empty" case used to determine that a thrown weapon should be
automatically added to the quiver when picked up.

Instead of autoquivering an aklys whenever the quiver is empty,
autoquiver it only when the hero is already wielding another weapon.
