### PR TITLE
Fix: itemized billing and perm_invent

### DIFF
--- a/src/shk.c
+++ b/src/shk.c
@@ -1621,6 +1621,7 @@ dopayobj(
                   ltmp, "");
     obj->quan = save_quan; /* restore original count */
     /* quan => amount just bought, save_quan => remaining unpaid count */
+    iflags.suppress_price--;
     if (consumed) {
         if (quan != bp->bquan) {
             /* eliminate used-up portion; remainder is still unpaid */
@@ -1636,7 +1637,6 @@ dopayobj(
         }
     } else if (itemize)
         update_inventory(); /* Done just once in dopay() if !itemize. */
-    iflags.suppress_price--;
     return buy;
 }
 


### PR DESCRIPTION
When buying multiple items from a shop via itemized billing with
perm_invent enabled, paying for any single item would immediately
conceal the prices of all the remaining unpaid items in the inventory
pane, even those that the player declined to purchase.  In other words,
if holding three items from a shop, paying for one of them via itemized
billing would cause the other two items to be listed in the perminvent
pane as though they had already been paid for as well.

Deactivate iflags.suppress_price before the call to update_inventory in
dopayobj(shk.c) so that the inventory pane's item names accurately
reflect which items are still unpaid.
