### PR TITLE
implement realtime/wallclock statusline timer

### DIFF
--- a/include/botl.h
+++ b/include/botl.h
@@ -39,9 +39,9 @@ enum statusfields {
     BL_TITLE = 0,
     BL_STR, BL_DX, BL_CO, BL_IN, BL_WI, BL_CH,  /* 1..6 */
     BL_ALIGN, BL_SCORE, BL_CAP, BL_GOLD, BL_ENE, BL_ENEMAX, /* 7..12 */
-    BL_XP, BL_AC, BL_HD, BL_TIME, BL_HUNGER, BL_HP, /* 13..18 */
-    BL_HPMAX, BL_LEVELDESC, BL_EXP, BL_CONDITION, /* 19..22 */
-    MAXBLSTATS /* [23] */
+    BL_XP, BL_AC, BL_HD, BL_TIME, BL_REALTIME, BL_HUNGER, /* 13..18 */
+    BL_HP, BL_HPMAX, BL_LEVELDESC, BL_EXP, BL_CONDITION, /* 19..23 */
+    MAXBLSTATS /* [24] */
 };
 
 enum relationships { NO_LTEQGT = -1,

--- a/include/botl.h
+++ b/include/botl.h
@@ -265,4 +265,8 @@ struct istat_s {
 
 extern const char *status_fieldnames[]; /* in botl.c */
 
+#ifdef REALTIME_ON_BOTL
+void stat_update_time(void);
+#endif
+
 #endif /* BOTL_H */

--- a/include/config.h
+++ b/include/config.h
@@ -568,6 +568,9 @@ typedef unsigned char uchar;
 /* #define SCORE_ON_BOTL */         /* enable the 'showscore' option to
                                        show estimated score on status line */
 
+#define REALTIME_ON_BOTL            /* enable the 'showrealtime' option to
+   show elapsed time */
+
 /* FREE_ALL_MEMORY is neither experimental nor inadequately tested,
    but it isn't necessary for successful operation of the program */
 #define FREE_ALL_MEMORY             /* free all memory at exit */

--- a/include/extern.h
+++ b/include/extern.h
@@ -173,6 +173,9 @@ extern void max_rank_sz(void);
 #ifdef SCORE_ON_BOTL
 extern long botl_score(void);
 #endif
+#ifdef REALTIME_ON_BOTL
+extern const char *botl_realtime(void);
+#endif
 extern int describe_level(char *);
 extern void status_initialize(boolean);
 extern void status_finish(void);

--- a/include/flag.h
+++ b/include/flag.h
@@ -255,6 +255,10 @@ struct instance_flags {
     uchar bouldersym;         /* symbol for boulder display */
     char prevmsg_window;      /* type of old message window to use */
     boolean extmenu;          /* extended commands use menu interface */
+#ifdef REALTIME_ON_BOTL
+    char show_realtime;       /* type of time to show in status display */
+    char realtime_format;     /* format of time shown */
+#endif
 #ifdef MICRO
     boolean BIOS; /* use IBM or ST BIOS calls when appropriate */
 #endif

--- a/include/optlist.h
+++ b/include/optlist.h
@@ -390,6 +390,12 @@ opt_##a,
     NHOPTB(rawio, 0, opt_in, set_in_config, Off, No, No, No, NoAlias,
                 (boolean *) 0)
 #endif
+#ifdef REALTIME_ON_BOTL
+    NHOPTC(realtime, 5, opt_in, set_in_game, Yes, Yes, No, Yes, NoAlias,
+           "show realtime in status line")
+    NHOPTC(realtime_format, 5, opt_in, set_in_game, No, Yes, No, Yes, NoAlias,
+           "format of realtime in status line")
+#endif
     NHOPTB(rest_on_space, 0, opt_in, set_in_game, Off, Yes, No, No, NoAlias,
                 &flags.rest_on_space)
     NHOPTC(roguesymset, 70, opt_in, set_in_game, No, Yes, No, Yes, NoAlias,

--- a/src/botl.c
+++ b/src/botl.c
@@ -409,6 +409,48 @@ botl_score(void)
 }
 #endif /* SCORE_ON_BOTL */
 
+#ifdef REALTIME_ON_BOTL
+const char *
+botl_realtime(void)
+{
+    time_t currenttime;
+
+    if (iflags.show_realtime == 'p') {
+        /* play time */
+        currenttime = urealtime.realtime + (getnow() - urealtime.start_timing);
+    } else if (iflags.show_realtime == 'w') {
+        /* wallclock time */
+        currenttime = getnow() - ubirthday;
+    } else {
+        return "";
+    }
+
+    static char buf[BUFSZ] = { 0 };
+    switch (iflags.realtime_format) {
+    case 's':
+        Sprintf(buf, "%ld", currenttime);
+        break;
+
+    case 'c':
+        Sprintf(buf, "%ld:%2.2ld", currenttime / 3600, (currenttime % 3600) / 60);
+        break;
+
+    case 'u':
+    default: {
+        long ss, mm, hh;
+        ss = currenttime % 60;
+        currenttime /= 60;
+        mm = currenttime % 60;
+        currenttime /= 60;
+        hh = currenttime;
+        Sprintf(buf, "%02ld:%02ld:%02ld", hh, mm, ss);
+    }
+    }
+    return buf;
+}
+
+#endif
+
 /* provide the name of the current level for display by various ports */
 int
 describe_level(char *buf)
@@ -524,6 +566,7 @@ static struct istat_s initblstats[MAXBLSTATS] = {
     INIT_BLSTAT("armor-class", " AC:%s", ANY_INT, 10, BL_AC),
     INIT_BLSTAT("HD", " HD:%s", ANY_INT, 10, BL_HD),
     INIT_BLSTAT("time", " T:%s", ANY_LONG, 20, BL_TIME),
+    INIT_BLSTAT("realtime", " %s", ANY_STR, 10, BL_REALTIME),
     /* hunger used to be 'ANY_UINT'; see note below in bot_via_windowport() */
     INIT_BLSTAT("hunger", " %s", ANY_INT, 40, BL_HUNGER),
     INIT_BLSTATP("hitpoints", " HP:%s", ANY_INT, 10, BL_HPMAX, BL_HP),
@@ -811,6 +854,9 @@ bot_via_windowport(void)
     /* Time (moves) */
     g.blstats[idx][BL_TIME].a.a_long = g.moves;
 
+    /* Realtime */
+    Strcpy(g.blstats[idx][BL_REALTIME].val, botl_realtime());
+
     /* Hunger */
     /* note: u.uhs is unsigned, and 3.6.1's STATUS_HILITE defined
        BL_HUNGER to be ANY_UINT, but that was the only non-int/non-long
@@ -939,18 +985,25 @@ bot_via_windowport(void)
 }
 
 
-/* update just the status lines' 'time' field */
+/* update just the status lines' 'time' and 'realtime' fields */
 static void
 stat_update_time(void)
 {
     int idx = g.now_or_before_idx; /* no 0/1 toggle */
-    int fld = BL_TIME;
+    int fld;
 
     /* Time (moves) */
+    fld = BL_TIME;
     g.blstats[idx][fld].a.a_long = g.moves;
     g.valset[fld] = FALSE;
-
     eval_notify_windowport_field(fld, g.valset, idx);
+
+    /* Realtime */
+    fld = BL_REALTIME;
+    Strcpy(g.blstats[idx][fld].val, botl_realtime());
+    g.valset[fld] = FALSE;
+    eval_notify_windowport_field(fld, g.valset, idx);
+
     if ((windowprocs.wincap2 & WC2_FLUSH_STATUS) != 0L)
         status_update(BL_FLUSH, (genericptr_t) 0, 0, 0,
                       NO_COLOR, (unsigned long *) 0);
@@ -1241,6 +1294,7 @@ evaluate_and_notify_windowport(boolean *valsetlist, int idx)
         if (((i == BL_SCORE) && !flags.showscore)
             || ((i == BL_EXP) && !flags.showexp)
             || ((i == BL_TIME) && !flags.time)
+            || ((i == BL_REALTIME) && !iflags.show_realtime)
             || ((i == BL_HD) && !Upolyd)
             || ((i == BL_XP || i == BL_EXP) && Upolyd)) {
             notpresent++;
@@ -1308,7 +1362,8 @@ status_initialize(boolean reassessment) /* TRUE: just recheck fields w/o other i
                      : (fld == BL_EXP) ? (boolean) (flags.showexp && !Upolyd)
                        : (fld == BL_XP) ? (boolean) !Upolyd
                          : (fld == BL_HD) ? (boolean) Upolyd
-                           : TRUE;
+                           : (fld == BL_REALTIME) ? (boolean) iflags.show_realtime
+                             : TRUE;
 
         fieldname = initblstats[i].fldname;
         fieldfmt = (fld == BL_TITLE && iflags.wc2_hitpointbar) ? "%-30.30s"
@@ -1768,6 +1823,7 @@ static struct fieldid_t {
     { "ac",       BL_AC },
     { "hit-dice", BL_HD },
     { "turns",    BL_TIME },
+    { "realtime", BL_REALTIME },
     { "hp",       BL_HP },
     { "hp-max",   BL_HPMAX },
     { "dgn",      BL_LEVELDESC },

--- a/src/botl.c
+++ b/src/botl.c
@@ -15,7 +15,9 @@ const char *const enc_stat[] = { "",         "Burdened",  "Stressed",
 
 static const char *rank(void);
 static void bot_via_windowport(void);
+#ifndef REALTIME_ON_BOTL
 static void stat_update_time(void);
+#endif
 #ifdef STATUS_HILITES
 static unsigned long query_conditions(void);
 static boolean status_hilite_remove(int);
@@ -986,7 +988,11 @@ bot_via_windowport(void)
 
 
 /* update just the status lines' 'time' and 'realtime' fields */
+#ifdef REALTIME_ON_BOTL
+void
+#else
 static void
+#endif
 stat_update_time(void)
 {
     int idx = g.now_or_before_idx; /* no 0/1 toggle */

--- a/src/windows.c
+++ b/src/windows.c
@@ -902,16 +902,16 @@ genl_status_update(int idx, genericptr_t ptr, int chg UNUSED,
     enum statusfields idx1, idx2, *fieldlist;
     char *nb, *text = (char *) ptr;
 
-    static enum statusfields fieldorder[][15] = {
+    static enum statusfields fieldorder[][16] = {
         /* line one */
         { BL_TITLE, BL_STR, BL_DX, BL_CO, BL_IN, BL_WI, BL_CH, BL_ALIGN,
           BL_SCORE, BL_FLUSH, BL_FLUSH, BL_FLUSH, BL_FLUSH, BL_FLUSH,
-          BL_FLUSH },
+          BL_FLUSH, BL_FLUSH },
         /* line two, default order */
         { BL_LEVELDESC, BL_GOLD,
           BL_HP, BL_HPMAX, BL_ENE, BL_ENEMAX, BL_AC,
           BL_XP, BL_EXP, BL_HD,
-          BL_TIME,
+          BL_TIME, BL_REALTIME,
           BL_HUNGER, BL_CAP, BL_CONDITION,
           BL_FLUSH },
         /* move time to the end */
@@ -919,16 +919,16 @@ genl_status_update(int idx, genericptr_t ptr, int chg UNUSED,
           BL_HP, BL_HPMAX, BL_ENE, BL_ENEMAX, BL_AC,
           BL_XP, BL_EXP, BL_HD,
           BL_HUNGER, BL_CAP, BL_CONDITION,
-          BL_TIME, BL_FLUSH },
+          BL_TIME, BL_REALTIME, BL_FLUSH },
         /* move experience and time to the end */
         { BL_LEVELDESC, BL_GOLD,
           BL_HP, BL_HPMAX, BL_ENE, BL_ENEMAX, BL_AC,
           BL_HUNGER, BL_CAP, BL_CONDITION,
-          BL_XP, BL_EXP, BL_HD, BL_TIME, BL_FLUSH },
+          BL_XP, BL_EXP, BL_HD, BL_TIME, BL_REALTIME, BL_FLUSH },
         /* move level description plus gold and experience and time to end */
         { BL_HP, BL_HPMAX, BL_ENE, BL_ENEMAX, BL_AC,
           BL_HUNGER, BL_CAP, BL_CONDITION,
-          BL_LEVELDESC, BL_GOLD, BL_XP, BL_EXP, BL_HD, BL_TIME, BL_FLUSH },
+          BL_LEVELDESC, BL_GOLD, BL_XP, BL_EXP, BL_HD, BL_TIME, BL_REALTIME, BL_FLUSH },
     };
 
     /* in case interface is using genl_status_update() but has not
@@ -1016,7 +1016,7 @@ genl_status_update(int idx, genericptr_t ptr, int chg UNUSED,
                 case BL_HP: /* for pass 4, Hp comes first; mungspaces()
                                will strip the unwanted leading spaces */
                 case BL_XP: case BL_HD:
-                case BL_TIME:
+                case BL_TIME: case BL_REALTIME:
                     Strcpy(nb = eos(nb), " ");
                     break;
                 case BL_LEVELDESC:

--- a/win/curses/cursdial.c
+++ b/win/curses/cursdial.c
@@ -289,10 +289,18 @@ curses_character_input_dialog(const char *prompt, const char *choices,
 
     curs_set(1);
     while (1) {
+#ifdef REALTIME_ON_BOTL
+#ifdef PDCURSES
+        answer = wgetch_timeout(message_window);
+#else
+        answer = getch_timeout();
+#endif
+#else
 #ifdef PDCURSES
         answer = wgetch(message_window);
 #else
         answer = getch();
+#endif
 #endif
         if (answer == ERR) {
             answer = def;
@@ -430,7 +438,12 @@ curses_ext_cmd(void)
 
         curs_set(1);
         wrefresh(extwin);
+#ifdef REALTIME_ON_BOTL
+        letter = getch_timeout();
+#else
         letter = getch();
+#endif
+
         curs_set(0);
         prompt_width = (int) strlen(cur_choice);
         matches = 0;
@@ -1452,7 +1465,11 @@ menu_get_selections(WINDOW *win, nhmenu *menu, int how)
     menu_display_page(menu, win, curpage, selectors);
 
     while (!dismiss) {
+#ifdef REALTIME_ON_BOTL
+        curletter = getch_timeout();
+#else
         curletter = getch();
+#endif
 
         if (curletter == ERR) {
             num_selected = -1;
@@ -1505,7 +1522,11 @@ menu_get_selections(WINDOW *win, nhmenu *menu, int how)
             if (isdigit(curletter)) {
                 count = curses_get_count(curletter);
                 /* after count, we know some non-digit is already pending */
+#ifdef REALTIME_ON_BOTL
+                curletter = getch_timeout();
+#else
                 curletter = getch();
+#endif
                 count_letter = (count > 0L) ? curletter : '\0';
 
                 /* remove the count wind (erases last line of message wind) */

--- a/win/curses/cursinvt.c
+++ b/win/curses/cursinvt.c
@@ -151,7 +151,11 @@ curs_scroll_invt(WINDOW *win UNUSED)
              menukeys, *menukeys ? " " : "", "Ret Esc");
 
     curses_count_window(qbuf);
+#ifdef REALTIME_ON_BOTL
+    ch = getch_timeout();
+#else
     ch = getch();
+#endif
     curses_count_window((char *) 0);
     curses_clear_unhighlight_message_window();
 

--- a/win/curses/cursmain.c
+++ b/win/curses/cursmain.c
@@ -816,7 +816,6 @@ curses_nhgetch(void)
     curses_prehousekeeping();
     ch = curses_read_char();
     curses_posthousekeeping();
-
     return ch;
 }
 

--- a/win/curses/cursmesg.c
+++ b/win/curses/cursmesg.c
@@ -213,6 +213,7 @@ curses_block(boolean noscroll) /* noscroll - blocking because of msgtype
         mvwprintw(win, my, mx, ">>"), mx += 2;
     }
     curses_toggle_color_attr(win, MORECOLOR, moreattr, OFF);
+    curses_alert_main_borders(FALSE);
     wrefresh(win);
 
     /* cancel mesg suppression; all messages will have had chance to be read */
@@ -220,8 +221,13 @@ curses_block(boolean noscroll) /* noscroll - blocking because of msgtype
 
     oldcrsr = curs_set(1);
     do {
+#ifdef REALTIME_ON_BOTL
+        ret = wgetch_timeout(win);
+        if (ret == '\0')
+#else
         ret = wgetch(win);
         if (ret == ERR || ret == '\0')
+#endif
             ret = '\n';
         /* msgtype=stop should require space/enter rather than any key,
            as we want to prevent YASD from direction keys. */
@@ -598,10 +604,18 @@ curses_message_win_getline(const char *prompt, char *answer, int buffer)
         curs_set(1);
         wrefresh(win);
         curses_got_input(); /* despite its name, before rather than after... */
+#ifdef REALTIME_ON_BOTL
+#ifdef PDCURSES
+        ch = wgetch_timeout(win);
+#else
+        ch = getch_timeout();
+#endif
+#else
 #ifdef PDCURSES
         ch = wgetch(win);
 #else
         ch = getch();
+#endif
 #endif
         curs_set(0);
 

--- a/win/curses/cursstat.c
+++ b/win/curses/cursstat.c
@@ -89,8 +89,8 @@ curses_status_finish(void)
  *      -- fldindex could be any one of the following from botl.h:
  *         BL_TITLE, BL_STR, BL_DX, BL_CO, BL_IN, BL_WI, BL_CH,
  *         BL_ALIGN, BL_SCORE, BL_CAP, BL_GOLD, BL_ENE, BL_ENEMAX,
- *         BL_XP, BL_AC, BL_HD, BL_TIME, BL_HUNGER, BL_HP, BL_HPMAX,
- *         BL_LEVELDESC, BL_EXP, BL_CONDITION
+ *         BL_XP, BL_AC, BL_HD, BL_TIME, BL_REALTIME, BL_HUNGER, BL_HP,
+ *         BL_HPMAX, BL_LEVELDESC, BL_EXP, BL_CONDITION
  *      -- fldindex could also be BL_FLUSH (-1), which is not really
  *         a field index, but is a special trigger to tell the
  *         windowport that it should redisplay all its status fields,
@@ -251,12 +251,12 @@ draw_horizontal(boolean border)
     /* almost all fields already come with a leading space;
        "xspace" indicates places where we'll generate an extra one */
     static const enum statusfields
-    twolineorder[3][15] = {
+    twolineorder[3][16] = {
         { BL_TITLE,
           /*xspace*/ BL_STR, BL_DX, BL_CO, BL_IN, BL_WI, BL_CH,
           /*xspace*/ BL_ALIGN,
           /*xspace*/ BL_SCORE,
-          BL_FLUSH, blPAD, blPAD, blPAD, blPAD, blPAD },
+          BL_FLUSH, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD },
         { BL_LEVELDESC,
           /*xspace*/ BL_GOLD,
           /*xspace*/ BL_HP, BL_HPMAX,
@@ -264,16 +264,17 @@ draw_horizontal(boolean border)
           /*xspace*/ BL_AC,
           /*xspace*/ BL_XP, BL_EXP, BL_HD,
           /*xspace*/ BL_TIME,
+          /*xspace*/ BL_REALTIME,
           /*xspace*/ BL_HUNGER, BL_CAP, BL_CONDITION,
           BL_FLUSH },
         { BL_FLUSH, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD,
-          blPAD, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD }
+          blPAD, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD }
     },
-    threelineorder[3][15] = { /* moves align to line 2, leveldesc+ to 3 */
+    threelineorder[3][16] = { /* moves align to line 2, leveldesc+ to 3 */
         { BL_TITLE,
           /*xspace*/ BL_STR, BL_DX, BL_CO, BL_IN, BL_WI, BL_CH,
           /*xspace*/ BL_SCORE,
-          BL_FLUSH, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD },
+          BL_FLUSH, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD },
         { BL_ALIGN,
           /*xspace*/ BL_GOLD,
           /*xspace*/ BL_HP, BL_HPMAX,
@@ -281,14 +282,15 @@ draw_horizontal(boolean border)
           /*xspace*/ BL_AC,
           /*xspace*/ BL_XP, BL_EXP, BL_HD,
           /*xspace*/ BL_HUNGER, BL_CAP,
-          BL_FLUSH, blPAD, blPAD },
+          BL_FLUSH, blPAD, blPAD, blPAD },
         { BL_LEVELDESC,
           /*xspace*/ BL_TIME,
+          /*xspace*/ BL_REALTIME,
           /*xspecial*/ BL_CONDITION,
-          BL_FLUSH, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD,
-          blPAD, blPAD, blPAD, blPAD }
+          BL_FLUSH, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD,
+          blPAD, blPAD, blPAD, blPAD, blPAD }
     };
-    const enum statusfields (*fieldorder)[15];
+    const enum statusfields (*fieldorder)[16];
     xchar spacing[MAXBLSTATS], valline[MAXBLSTATS];
     enum statusfields fld, prev_fld;
     char *text, *p, cbuf[BUFSZ], ebuf[STATVAL_WIDTH];
@@ -431,6 +433,7 @@ draw_horizontal(boolean border)
             case BL_XP:
             case BL_HD:
             case BL_TIME:
+            case BL_REALTIME:
                 spacing[fld] = status_activefields[fld] ? 1 : 0;
                 break;
             case BL_SCORE:
@@ -1914,6 +1917,11 @@ draw_horizontal(int x, int y, int hp, int hpmax)
     if (flags.time)
         print_statdiff(" T:", &prevtime, g.moves, STAT_TIME);
 
+#ifdef REALTIME_ON_BOTL
+    if (iflags.show_realtime)
+        printw(win, " %s", botl_realtime());
+#endif
+
     curses_add_statuses(win, FALSE, FALSE, NULL, NULL);
 }
 
@@ -1994,6 +2002,11 @@ draw_horizontal_new(int x, int y, int hp, int hpmax)
 
     if (flags.time)
         print_statdiff(" T:", &prevtime, g.moves, STAT_TIME);
+
+#ifdef REALTIME_ON_BOTL
+    if (iflags.show_realtime)
+        printw(win, " %s", botl_realtime());
+#endif
 
     curses_add_statuses(win, TRUE, FALSE, &x, &y);
 
@@ -2148,6 +2161,11 @@ draw_vertical(int x, int y, int hp, int hpmax)
         print_statdiff("Time:          ", &prevtime, g.moves, STAT_TIME);
         wmove(win, y++, x);
     }
+
+#ifdef REALTIME_ON_BOTL
+    if (iflags.show_realtime)
+        printw(win,   "Realtime:       %s", botl_realtime());
+#endif
 
 #ifdef SCORE_ON_BOTL
     if (flags.showscore) {

--- a/win/curses/cursstat.c
+++ b/win/curses/cursstat.c
@@ -30,7 +30,11 @@ static int curses_status_colors[MAXBLSTATS];
 static int hpbar_percent, hpbar_color;
 static int vert_status_dirty;
 
+#ifdef REALTIME_ON_BOTL
+void draw_status(void);
+#else
 static void draw_status(void);
+#endif
 static void draw_vertical(boolean);
 static void draw_horizontal(boolean);
 static void curs_HPbar(char *, int);
@@ -206,7 +210,11 @@ curses_status_update(int fldidx, genericptr_t ptr, int chg UNUSED, int percent,
 
 RESTORE_WARNING_FORMAT_NONLITERAL
 
+#ifdef REALTIME_ON_BOTL
+void
+#else
 static void
+#endif
 draw_status(void)
 {
     WINDOW *win = curses_get_nhwin(STATUS_WIN);

--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -3677,27 +3677,28 @@ static const char *encvals[3][6] = {
     { "", "Brd",      "Strs",     "Strn",     "Ovtx",      "Ovld"       }
 };
 #define blPAD BL_FLUSH
-#define MAX_PER_ROW 15
+#define MAX_PER_ROW 16
 /* 2 or 3 status lines */
 static const enum statusfields
     twolineorder[3][MAX_PER_ROW] = {
     { BL_TITLE, BL_STR, BL_DX, BL_CO, BL_IN, BL_WI, BL_CH, BL_ALIGN,
-      BL_SCORE, BL_FLUSH, blPAD, blPAD, blPAD, blPAD, blPAD },
+      BL_SCORE, BL_FLUSH, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD },
     { BL_LEVELDESC, BL_GOLD, BL_HP, BL_HPMAX, BL_ENE, BL_ENEMAX,
-      BL_AC, BL_XP, BL_EXP, BL_HD, BL_TIME, BL_HUNGER,
+      BL_AC, BL_XP, BL_EXP, BL_HD, BL_TIME, BL_REALTIME, BL_HUNGER,
       BL_CAP, BL_CONDITION, BL_FLUSH },
     /* third row of array isn't used for twolineorder */
     { BL_FLUSH, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD,
-      blPAD, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD }
+      blPAD, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD }
 },
     /* Align moved from 1 to 2, Leveldesc+Time+Condition moved from 2 to 3 */
     threelineorder[3][MAX_PER_ROW] = {
     { BL_TITLE, BL_STR, BL_DX, BL_CO, BL_IN, BL_WI, BL_CH,
-      BL_SCORE, BL_FLUSH, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD },
+      BL_SCORE, BL_FLUSH, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD,
+      blPAD },
     { BL_ALIGN, BL_GOLD, BL_HP, BL_HPMAX, BL_ENE, BL_ENEMAX,
       BL_AC, BL_XP, BL_EXP, BL_HD, BL_HUNGER,
-      BL_CAP, BL_FLUSH, blPAD, blPAD },
-    { BL_LEVELDESC, BL_TIME, BL_CONDITION, BL_FLUSH, blPAD, blPAD,
+      BL_CAP, BL_FLUSH, blPAD, blPAD, blPAD },
+    { BL_LEVELDESC, BL_TIME, BL_REALTIME, BL_CONDITION, BL_FLUSH, blPAD,
       blPAD, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD, blPAD }
 };
 static const enum statusfields (*fieldorder)[MAX_PER_ROW];
@@ -3778,8 +3779,8 @@ tty_status_enablefield(int fieldidx, const char *nm, const char *fmt,
  *      -- fldindex could be any one of the following from botl.h:
  *         BL_TITLE, BL_STR, BL_DX, BL_CO, BL_IN, BL_WI, BL_CH,
  *         BL_ALIGN, BL_SCORE, BL_CAP, BL_GOLD, BL_ENE, BL_ENEMAX,
- *         BL_XP, BL_AC, BL_HD, BL_TIME, BL_HUNGER, BL_HP, BL_HPMAX,
- *         BL_LEVELDESC, BL_EXP, BL_CONDITION
+ *         BL_XP, BL_AC, BL_HD, BL_TIME, BL_REALTIME, BL_HUNGER, BL_HP,
+ *         BL_HPMAX, BL_LEVELDESC, BL_EXP, BL_CONDITION
  *      -- fldindex could also be BL_FLUSH (-1), which is not really
  *         a field index, but is a special trigger to tell the
  *         windowport that it should output all changes received
@@ -4142,9 +4143,9 @@ status_sanity_check(void)
     static const char *const idxtext[] = {
         "BL_TITLE", "BL_STR", "BL_DX", "BL_CO", "BL_IN", "BL_WI", /* 0.. 5   */
         "BL_CH","BL_ALIGN", "BL_SCORE", "BL_CAP", "BL_GOLD",     /* 6.. 10  */
-        "BL_ENE", "BL_ENEMAX", "BL_XP", "BL_AC", "BL_HD",       /* 11.. 15 */
-        "BL_TIME", "BL_HUNGER", "BL_HP", "BL_HPMAX",           /* 16.. 19 */
-        "BL_LEVELDESC", "BL_EXP", "BL_CONDITION"              /* 20.. 22 */
+        "BL_ENE", "BL_ENEMAX", "BL_XP", "BL_AC", "BL_HD",        /* 11.. 15 */
+        "BL_TIME", "BL_REALTIME", "BL_HUNGER", "BL_HP",          /* 16.. 19 */
+        "BL_HPMAX", "BL_LEVELDESC", "BL_EXP", "BL_CONDITION"     /* 20.. 23 */
     };
    
     if (in_sanity_check)


### PR DESCRIPTION
this pr implements the ui clock developed by @bhaak in such a way that it can update independently of user input

for tty it uses pselect(), for curses they have their own timeout functionality

i am unsure about the portability of this, only tested on Ubuntu 20.04 with Linux kernel 5.8.0-59-generic