### PR TITLE
Fix: contradictory series of encumbrance messages

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -673,7 +673,6 @@ redist_attr(void)
         if (ABASE(i) < ATTRMIN(i))
             ABASE(i) = ATTRMIN(i);
     }
-    (void) encumber_msg();
 }
 
 static

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -365,6 +365,7 @@ newman(void)
             Strcpy(g.killer.name, "unsuccessful polymorph");
             done(DIED);
             newuhs(FALSE);
+            (void) encumber_msg();
             return; /* lifesaved */
         }
     }


### PR DESCRIPTION
...when polymorphing into your base form and "feeling like a new man".

The use of encumber_msg in redist_attr, which is only called from
newman(polyself.c), was positioned after the hero's stats were
reconfigured but before their polyform was reset to their original race
(this may also restore attributes to the values they had before
modification by redist_attr).  Because the inventory weight cap is based
on the hero's CON and STR as well as current polyform, checking for
encumbrance immediately after changing hero attributes, then again after
resetting polyform, could cause sequences of messages like this:

    You can barely move a handspan with this load!  You feel like a new
    woman!  Your movements are now unencumbered.

Remove the initial encumber_msg from redist_attr and instead only call
it at the end of newman once all the steps involved in changing form are
complete.

A short video of the issue:

https://user-images.githubusercontent.com/40038830/125368429-31f19b00-e348-11eb-9b31-5f04093790c2.mp4