### PR TITLE
Fix #423: Teleportation bhitpos issue

### DIFF
--- a/src/zap.c
+++ b/src/zap.c
@@ -1922,6 +1922,8 @@ bhito(struct obj *obj, struct obj *otmp)
 {
     int res = 1; /* affected object by default */
     boolean learn_it = FALSE, maybelearnit;
+    /* rloco will modify bhitpos; make sure we can reset it */
+    coord save_bhitpos = g.bhitpos;
 
     /* fundamental: a wand effect hitting itself doesn't do anything;
        otherwise we need to guard against accessing otmp after something
@@ -2098,6 +2100,7 @@ bhito(struct obj *obj, struct obj *otmp)
         case WAN_TELEPORTATION:
         case SPE_TELEPORT_AWAY:
             (void) rloco(obj);
+            g.bhitpos = save_bhitpos;
             break;
         case WAN_MAKE_INVISIBLE:
             break;


### PR DESCRIPTION
(m)bhit uses g.bhitpos to track the current tip of a beam.  When a
teleportation beam hits an object, flooreffects eventually gets called
on the object after it has been randomly relocated (via rloco) -- this
updates g.bhitpos to the object's new location.  g.bhitpos was not being
reset to the old 'tip of the beam' location before returning control to
(m)bhit, and as a result, a teleportation beam would continue from the
object's new location instead of the place where the object teleported
from.

This caused problems in the Astral Plane especially, where a
teleportation beam could hit one of the riders if the teleported object
landed in an unlucky spot (as described in #423), but it also
effectively limited teleportation to only hit a single object before
becoming completely unpredictable.

Reset g.bhitpos before returning control to (m)bhit.

Fixes #423

An earlier explanation of the issue that may or may not be clearer is [here](https://github.com/NetHack/NetHack/issues/423#issuecomment-858843993).
