### PR TITLE
Fix #436: writing type-named scrolls

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -108,7 +108,7 @@ dowrite(struct obj *pen)
     int basecost, actualcost;
     int curseval;
     char qbuf[QBUFSZ];
-    int first, last, i, deferred, deferralchance;
+    int first, last, i, deferred, deferralchance, real;
     boolean by_descr = FALSE;
     const char *typeword;
 
@@ -170,10 +170,11 @@ dowrite(struct obj *pen)
         (void) mungspaces(bp + 1);        /* remove the extra space */
     }
 
-    deferred = 0;       /* not any scroll or book */
-    deferralchance = 0; /* incremented for each oc_uname match */
+    deferred = real = 0; /* not any scroll or book */
+    deferralchance = 0;  /* incremented for each oc_uname match */
     first = g.bases[(int) paper->oclass];
     last = g.bases[(int) paper->oclass + 1] - 1;
+    /* first loop: look for match with name/description */
     for (i = first; i <= last; i++) {
         /* extra shufflable descr not representing a real object */
         if (!OBJ_NAME(objects[i]))
@@ -184,24 +185,30 @@ dowrite(struct obj *pen)
                 /* spellbooks can only be written by_name, so no need to
                    hold out for a 'better' by_descr match */
                 || paper->oclass == SPBOOK_CLASS) {
-                by_descr = FALSE;
                 goto found;
-            } else if (!deferralchance) {
-                /* save item in case there are no better by_descr matches;
-                   don't increment deferralchance so that the first uname
-                   match will always override this */
-                deferred = i;
+            } else {
+                /* save item in case there are no better by_descr matches */
+                real = deferred = i;
+                break;
             }
         }
+
         if (!strcmpi(OBJ_DESCR(objects[i]), nm)) {
             by_descr = TRUE;
             goto found;
         }
-        /* user-assigned name might match real name of a later
-           entry, so we don't simply use first match with it;
-           also, player might assign same name multiple times
-           and if so, we choose one of those matches randomly */
+    }
+    /* second loop: look for match with user-assigned name */
+    /* we will get here if 'nm' isn't a real scroll name/descr, or is the name
+     * of a real scroll that hasn't been formally IDed. */
+    for (i = first; i <= last; i++) {
+        /* player might assign same name multiple times and if so,
+           we choose one of those matches randomly */
         if (objects[i].oc_uname && !strcmpi(objects[i].oc_uname, nm)
+            /* prefer attempting to write the real scroll type if
+               the typename clobbers a real scroll and is known to
+               be incorrect */
+            && !(real && objects[i].oc_name_known)
             /*
              * First match: chance incremented to 1,
              *   !rn2(1) is 1, we remember i;


### PR DESCRIPTION
When using a marker, it is possible to write a scroll based on the
type-name assigned to it by the user.  Somewhat unintuitively, this
system broke down if the assigned name was identical to the real name of
a scroll type: trying to write a scroll by its previously-assigned name
'scare mon' or 'id' would be guaranteed to succeed, but this wouldn't be
the case if the user-assigned name was 'scare monster' or 'identify'.

Revise dowrite(write.c) to prefer a user-assigned type-name to the
real name of a scroll that isn't already formally known, while
continuing to prefer the real name of an identified scroll to both.

Fixes #436
