### PR TITLE
Fix: off-by-one error in movecmd

### DIFF
--- a/src/cmd.c
+++ b/src/cmd.c
@@ -3705,7 +3705,7 @@ movecmd(char sym, int mode)
         char *mvkeys = (mode == MV_WALK) ? g.Cmd.move :
             ((mode == MV_RUN) ? g.Cmd.run : g.Cmd.rush);
 
-        for (d = N_DIRS; d > DIR_ERR; d--) {
+        for (d = N_DIRS - 1; d > DIR_ERR; d--) {
             if (mode == MV_ANY) {
                 if (sym == g.Cmd.move[d]
                     || sym == g.Cmd.rush[d]


### PR DESCRIPTION
The for loop which iterates through the list of movement keys in
movecmd(cmd.c) was updated in 5abf948116 to count down to 0 instead of
up to the end of the list.  This commit inadvertently introduced an
off-by-one error which started the loop one past the actual end of the
array.  On my system this made 'H' stop working as the 'run West' key.
