### PR TITLE
Fix: engraving with dry magic marker

### DIFF
--- a/src/engrave.c
+++ b/src/engrave.c
@@ -1146,7 +1146,8 @@ engrave(void)
 
     dulling_wep = (carving && stylus && stylus->oclass == WEAPON_CLASS
                    && (stylus->otyp != ATHAME || stylus->cursed));
-    marker = (stylus && stylus->otyp == MAGIC_MARKER);
+    marker = (stylus && stylus->otyp == MAGIC_MARKER
+              && g.context.engraving.type == MARK);
 
     g.context.engraving.actionct++;
 


### PR DESCRIPTION
Engraving with a marker can use up remaining charges to write
semi-permanently in ink, or--if the marker has no remaining charges--can
draw in the dust as with a normal blunt item.  Handling in engrave after
a recent refactor (9c6a5fc423) didn't fully cover this second case, and
as a result using an empty marker to engrave would deduct a charge per
attempt and cause an impossible.  This could be exploited by repeatedly
engraving with the same empty marker to underflow the marker charges.