### PR TITLE
Non-metallic gloves protect worn rings from AD_ELEC in destroy_one_item

### DIFF
--- a/src/zap.c
+++ b/src/zap.c
@@ -5003,7 +5003,7 @@ destroy_one_item(struct obj *obj, int osym, int dmgtyp)
         switch (osym) {
         case RING_CLASS:
             if (obj->otyp == RIN_SHOCK_RESISTANCE ||
-                    (obj->owornmask && uarmg && !is_metallic(uarmg))) {
+                    (obj->owornmask & W_RING && uarmg && !is_metallic(uarmg))) {
                 skip++;
                 break;
             }

--- a/src/zap.c
+++ b/src/zap.c
@@ -5002,16 +5002,9 @@ destroy_one_item(struct obj *obj, int osym, int dmgtyp)
         quan = obj->quan;
         switch (osym) {
         case RING_CLASS:
-            if (obj->otyp == RIN_SHOCK_RESISTANCE) {
+            if (obj->otyp == RIN_SHOCK_RESISTANCE || (obj->owornmask && uarmg && !is_metallic(uarmg))) {
                 skip++;
                 break;
-            }
-            if (obj->owornmask && uarmg) {
-                if (obj->owornmask & W_RING && !is_metallic(uarmg)) { /* metallic gloves conduct electricity */
-                    pline("Your %s is protected by the %s you're wearing !", xname(obj), xname(uarmg)); /* for debug purposes */
-                    skip++;
-                    break;
-                }
             }
             dindx = 5;
             dmg = 0;

--- a/src/zap.c
+++ b/src/zap.c
@@ -5002,9 +5002,8 @@ destroy_one_item(struct obj *obj, int osym, int dmgtyp)
         quan = obj->quan;
         switch (osym) {
         case RING_CLASS:
-            if (obj->otyp == RIN_SHOCK_RESISTANCE ||
-                    ((obj->owornmask & W_RING) && 
-                        uarmg && !is_metallic(uarmg))) {
+            if (((obj->owornmask & W_RING) && uarmg && !is_metallic(uarmg)) ||
+                    obj->otyp == RIN_SHOCK_RESISTANCE) {
                 skip++;
                 break;
             }

--- a/src/zap.c
+++ b/src/zap.c
@@ -5006,6 +5006,13 @@ destroy_one_item(struct obj *obj, int osym, int dmgtyp)
                 skip++;
                 break;
             }
+            if (obj->owornmask && uarmg) {
+                if (obj->owornmask & W_RING && !is_metallic(uarmg)) { /* metallic gloves conduct electricity */
+                    pline("Your %s is protected by the %s you're wearing !", xname(obj), xname(uarmg)); /* for debug purposes */
+                    skip++;
+                    break;
+                }
+            }
             dindx = 5;
             dmg = 0;
             break;

--- a/src/zap.c
+++ b/src/zap.c
@@ -5003,7 +5003,8 @@ destroy_one_item(struct obj *obj, int osym, int dmgtyp)
         switch (osym) {
         case RING_CLASS:
             if (obj->otyp == RIN_SHOCK_RESISTANCE ||
-                    (obj->owornmask & W_RING && uarmg && !is_metallic(uarmg))) {
+                    ((obj->owornmask & W_RING) && 
+                        uarmg && !is_metallic(uarmg))) {
                 skip++;
                 break;
             }

--- a/src/zap.c
+++ b/src/zap.c
@@ -5002,7 +5002,8 @@ destroy_one_item(struct obj *obj, int osym, int dmgtyp)
         quan = obj->quan;
         switch (osym) {
         case RING_CLASS:
-            if (obj->otyp == RIN_SHOCK_RESISTANCE || (obj->owornmask && uarmg && !is_metallic(uarmg))) {
+            if (obj->otyp == RIN_SHOCK_RESISTANCE ||
+                    (obj->owornmask && uarmg && !is_metallic(uarmg))) {
                 skip++;
                 break;
             }


### PR DESCRIPTION
Based on a suggestion by luxidream (and a bunch of other good people)

The rationale behind this is that a lot of people feel that the now properly working shocking sphere explosion is imbalanced, causing a lot of grief and bitterness due to the loss of important wands and rings it causes. Even other electrical attacks are now considered under a new, harrowing light.

This is the first and the least disruptive of a series of 3 patches I've come up with to address this apparent (and admittedly minor) imbalance, the rest will be submitted if the reception on this one is favorable.

This PR makes it so that rings worn under non-metallic gloves are protected from destruction by electrical attacks. Because, you know, metals conduct electricity and all.
Since the only metallic gloves are the Gauntlets of Power, which are almost always considered the best choice for any ascension-worthy character, this introduces a new layer of tactical choices (Do I want an easy 25 str or do I want my worn rings to be safe ?).