### PR TITLE
Amplify booze effect if drinking on empty stomach

### DIFF
--- a/src/potion.c
+++ b/src/potion.c
@@ -721,8 +721,10 @@ peffect_booze(struct obj *otmp)
     pline("Ooph!  This tastes like %s%s!",
           otmp->odiluted ? "watered down " : "",
           Hallucination ? "dandelion wine" : "liquid fire");
-    if (!otmp->blessed)
-        make_confused(itimeout_incr(HConfusion, d(3, 8)), FALSE);
+    if (!otmp->blessed) {
+        /* booze hits harder if drinking on an empty stomach */
+        make_confused(itimeout_incr(HConfusion, d(2 + u.uhs, 8)), FALSE);
+    }
     /* the whiskey makes us feel better */
     if (!otmp->odiluted)
         healup(1, 0, FALSE, FALSE);


### PR DESCRIPTION
Ok, this is admittedly a sort of silly idea, but has [basis in reality](https://www.nytimes.com/2005/12/06/health/the-claim-never-drink-on-an-empty-stomach.html).

Drinking booze on an empty stomach will amplify its effects
(i.e. increase the duration of the resulting confusion); stuffing
yourself before drinking will have the opposite effect.