### PR TITLE
Make enchant armor prompt for target item

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -1029,6 +1029,19 @@ display_stinking_cloud_positions(int state)
     }
 }
 
+/* getobj callback for armor object to enchant */
+static int
+armor_enchant_ok(struct obj* obj)
+{
+    if (!obj)
+        return GETOBJ_EXCLUDE;
+
+    if (obj->owornmask & W_ARMOR)
+        return GETOBJ_SUGGEST;
+
+    return GETOBJ_EXCLUDE_INACCESS;
+}
+
 static void
 seffect_enchant_armor(struct obj **sobjp)
 {
@@ -1036,11 +1049,16 @@ seffect_enchant_armor(struct obj **sobjp)
     register schar s;
     boolean special_armor;
     boolean same_color;
-    struct obj *otmp = some_armor(&g.youmonst);
     boolean sblessed = sobj->blessed;
     boolean scursed = sobj->cursed;
     boolean confused = (Confusion != 0);
     boolean old_erodeproof, new_erodeproof;
+
+    struct obj *otmp = getobj("enchant", armor_enchant_ok, GETOBJ_NOFLAGS);
+    while (otmp && !(otmp->owornmask & W_ARMOR)) {
+        You("cannot target armor that is not worn.");
+        otmp = getobj("enchant", armor_enchant_ok, GETOBJ_NOFLAGS);
+    }
 
     if (!otmp) {
         strange_feeling(sobj, !Blind

--- a/src/read.c
+++ b/src/read.c
@@ -1046,6 +1046,7 @@ static void
 seffect_enchant_armor(struct obj **sobjp)
 {
     struct obj *sobj = *sobjp;
+    int otyp = sobj->otyp;
     register schar s;
     boolean special_armor;
     boolean same_color;
@@ -1053,6 +1054,13 @@ seffect_enchant_armor(struct obj **sobjp)
     boolean scursed = sobj->cursed;
     boolean confused = (Confusion != 0);
     boolean old_erodeproof, new_erodeproof;
+    boolean already_known = (sobj->oclass == SPBOOK_CLASS /* spell */
+                             || objects[otyp].oc_name_known);
+
+    if (!already_known) {
+        pline("This is an enchant armor scroll.");
+        learnscroll(sobj);
+    }
 
     struct obj *otmp = getobj("enchant", armor_enchant_ok, GETOBJ_NOFLAGS);
     while (otmp && !(otmp->owornmask & W_ARMOR)) {
@@ -1185,7 +1193,6 @@ seffect_enchant_armor(struct obj **sobjp)
         s = otmp->spe - oldspe; /* cap_spe() might have throttled 's' */
         if (s) /* skip if it got changed to 0 */
             adj_abon(otmp, s); /* adjust armor bonus for Dex or Int+Wis */
-        g.known = otmp->known;
         /* update shop bill to reflect new higher price */
         if (s > 0 && otmp->unpaid)
             alter_cost(otmp, 0L);

--- a/src/read.c
+++ b/src/read.c
@@ -1039,7 +1039,10 @@ armor_enchant_ok(struct obj* obj)
     if (obj->owornmask & W_ARMOR)
         return GETOBJ_SUGGEST;
 
-    return GETOBJ_EXCLUDE_INACCESS;
+    if (obj->oclass == ARMOR_CLASS)
+        return GETOBJ_EXCLUDE_INACCESS;
+
+    return GETOBJ_EXCLUDE_SELECTABLE;
 }
 
 static void
@@ -1065,7 +1068,7 @@ seffect_enchant_armor(struct obj **sobjp)
 
     otmp = getobj("enchant", armor_enchant_ok, GETOBJ_NOFLAGS);
     while (otmp && !(otmp->owornmask & W_ARMOR)) {
-        You("cannot target armor that is not worn.");
+        You("can only target worn armor.");
         otmp = getobj("enchant", armor_enchant_ok, GETOBJ_NOFLAGS);
     }
 

--- a/src/read.c
+++ b/src/read.c
@@ -1056,13 +1056,14 @@ seffect_enchant_armor(struct obj **sobjp)
     boolean old_erodeproof, new_erodeproof;
     boolean already_known = (sobj->oclass == SPBOOK_CLASS /* spell */
                              || objects[otyp].oc_name_known);
+    struct obj *otmp;
 
     if (!already_known) {
         pline("This is an enchant armor scroll.");
         learnscroll(sobj);
     }
 
-    struct obj *otmp = getobj("enchant", armor_enchant_ok, GETOBJ_NOFLAGS);
+    otmp = getobj("enchant", armor_enchant_ok, GETOBJ_NOFLAGS);
     while (otmp && !(otmp->owornmask & W_ARMOR)) {
         You("cannot target armor that is not worn.");
         otmp = getobj("enchant", armor_enchant_ok, GETOBJ_NOFLAGS);


### PR DESCRIPTION
This prompts the player for a worn armor piece to enchant when reading a
scroll of enchant armor.

Although this is more flexible than before, the player must select a
worn piece of armor or opt out entirely - they cannot enchant something
that isn't currently equipped.

This should make it more ergonomic to enchant armor, without having
to derobe and shuffle armour pieces around