### PR TITLE
Fix: m-prefix movement into warning symbol

### DIFF
--- a/src/hack.c
+++ b/src/hack.c
@@ -1391,7 +1391,7 @@ domove_core(void)
     register struct rm *tmpr;
     register xchar x, y;
     struct trap *trap = NULL;
-    int wtcap;
+    int wtcap, glyph;
     boolean on_ice;
     xchar chainx = 0, chainy = 0,
           ballx = 0, bally = 0;         /* ball&chain new positions */
@@ -1609,6 +1609,7 @@ domove_core(void)
     g.bhitpos.x = x;
     g.bhitpos.y = y;
     tmpr = &levl[x][y];
+    glyph = glyph_at(x, y);
 
     /* attack monster */
     if (mtmp) {
@@ -1633,7 +1634,8 @@ domove_core(void)
          * different message and makes the player remember the monster.
          */
         if (g.context.nopick && !g.context.travel
-            && (canspotmon(mtmp) || glyph_is_invisible(levl[x][y].glyph))) {
+            && (canspotmon(mtmp) || glyph_is_invisible(glyph)
+                || glyph_is_warning(glyph))) {
             if (M_AP_TYPE(mtmp) && !Protection_from_shape_changers
                 && !sensemon(mtmp))
                 stumble_onto_mimic(mtmp);
@@ -1686,11 +1688,10 @@ domove_core(void)
     /* specifying 'F' with no monster wastes a turn */
     if (g.context.forcefight
         /* remembered an 'I' && didn't use a move command */
-        || (glyph_is_invisible(levl[x][y].glyph) && !g.context.nopick)) {
+        || (glyph_is_invisible(glyph) && !g.context.nopick)) {
         struct obj *boulder = 0;
         boolean explo = (Upolyd && attacktype(g.youmonst.data, AT_EXPL)),
                 solid = !accessible(x, y);
-        int glyph = glyph_at(x, y); /* might be monster */
         char buf[BUFSZ];
 
         if (!Underwater) {


### PR DESCRIPTION
Moving into a position containing a warning symbol with m-\<direction\> to
'safely' move would still attack as though the 'm' prefix was not
specified.  Ensure warning symbols are counted as 'detected' monsters
for this purpose, to avoid falling through to do_attack().
