### PR TITLE
Fix: travel from 'interesting' position

### DIFF
--- a/src/cmd.c
+++ b/src/cmd.c
@@ -4734,6 +4734,7 @@ dotravel_target(void)
     u.last_str_turn = 0;
     g.context.mv = TRUE;
 
+    domove();
     return 1;
 }
 

--- a/src/hack.c
+++ b/src/hack.c
@@ -3007,7 +3007,6 @@ end_running(boolean and_travel)
     if (flags.time && g.context.run)
         iflags.time_botl = TRUE;
     g.context.run = 0;
-    g.domove_attempting = 0;
     /* 'context.mv' isn't travel but callers who want to end travel
        all clear it too */
     if (and_travel)


### PR DESCRIPTION
(including resuming travel after being interrupted)

Attempting to travel from an 'interesting' spot that would normally
stop travel mid-attempt (next to a door, next to a monster, etc) would
fail to get off the ground, because the 'interesting thing' would halt
travel before taking the first step.

Prior to 433f0cc, initiating travel would immediately trigger a call to
domove in rhack; as part of refactoring travel, the order of events in
rhack was changed so that this didn't happen immediately as before.  Add
domove to the end of dotravel_target to produce a similar effect to the
previous arrangement.

domove also zeroes out g.domove_attempting, which I think is the reason
c0c617c seemed to mitigate some of the issues associated with this
problem (e.g. travel target selection seemingly not registering right
away).

Fixes #559

NB: This is the same thing I was talking about in a comment [here](https://github.com/NetHack/NetHack/issues/559#issuecomment-893099847) a while ago; there's some additional description of the issue and test cases in that comment thread.