### PR TITLE
Fix: gold dragon scale mail remains lit in bones

### DIFF
--- a/src/bones.c
+++ b/src/bones.c
@@ -235,10 +235,10 @@ drop_upon_death(struct monst *mtmp, /* monster if hero turned into one (other th
         if (!mtmp || is_undead(mtmp->data))
             obj_no_longer_held(otmp);
 
-        otmp->owornmask = 0L;
         /* lamps don't go out when dropped */
         if ((cont || artifact_light(otmp)) && obj_is_burning(otmp))
             end_burn(otmp, TRUE); /* smother in statue */
+        otmp->owornmask = 0L;
 
         if (otmp->otyp == SLIME_MOLD)
             goodfruit(otmp->spe);


### PR DESCRIPTION
This is caused by the bones-pile-making routine using artifact_light()
as a test for whether it needs to call end_burn. Gold dragon scale mail
uses artifact_light(), but only returns true when its owornmask is set.
But owornmask was getting zeroed right before artifact_light() is
called. Fix is to move it right after instead.

Tested that Sunsword is not affected by this (created bones while
wearing gold dragon scales and wielding Sunsword in a dark area; when
returning to them, no light was emitted from the gravesite) because it
always returns true in artifact_light() irrespective of owornmask.