### PR TITLE
Count all poly'ing tins as potential sliming cures

### DIFF
--- a/src/eat.c
+++ b/src/eat.c
@@ -3546,7 +3546,7 @@ Popeye(int threat)
                           && (mndx == PM_LIZARD || acidic(&mons[mndx])));
     /* polymorph into a fiery monster */
     case SLIMED:
-        return (boolean) (mndx == PM_CHAMELEON);
+        return (boolean) polyfodder(otin);
     /* no tins can cure these (yet?) */
     case SICK:
     case VOMITING:


### PR DESCRIPTION
Popeye, used to check whether eating a particular tin is a potential
lifesaving action, considered tins of chameleon meat a cure for sliming
(since you can polymorph into a fiery monster), but didn't credit the
same possible curative power to other tins which can polymorph the hero.

Use the polyfodder macro (used elsewhere to check whether eating
something will polymorph a monster/pet) to determine whether a tin will
polymorph the hero.