### PR TITLE
Remove g.monstermoves

### DIFF
--- a/include/decl.h
+++ b/include/decl.h
@@ -834,8 +834,7 @@ struct instance_globals {
     struct mkroom rooms[(MAXNROFROOMS + 1) * 2];
     struct mkroom *subrooms;
     dlevel_t level; /* level map */
-    long moves;
-    long monstermoves; /* moves and monstermoves diverge when player is Fast */
+    long moves; /* turn counter */
     long wailmsg;
     struct obj *migrating_objs; /* objects moving to another dungeon level */    
     struct obj *billobjs; /* objects not yet paid for */

--- a/include/obj.h
+++ b/include/obj.h
@@ -252,7 +252,7 @@ struct obj {
 /* Eggs and other food */
 #define MAX_EGG_HATCH_TIME 200 /* longest an egg can remain unhatched */
 #define stale_egg(egg) \
-    ((g.monstermoves - (egg)->age) > (2 * MAX_EGG_HATCH_TIME))
+    ((g.moves - (egg)->age) > (2 * MAX_EGG_HATCH_TIME))
 #define ofood(o) ((o)->otyp == CORPSE || (o)->otyp == EGG || (o)->otyp == TIN)
     /* note: sometimes eggs and tins have special corpsenm values that
        shouldn't be used as an index into mons[]                       */

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -193,7 +193,6 @@ moveloop_core(void)
                     u_calc_moveamt(mvl_wtcap);
                     settrack();
 
-                    g.monstermoves++; /* [obsolete (for a long time...)] */
                     g.moves++;
                     /*
                      * Never allow 'moves' to grow big enough to wrap.

--- a/src/apply.c
+++ b/src/apply.c
@@ -2151,7 +2151,7 @@ fig_transform(anything *arg, long timeout)
         impossible("null figurine in fig_transform()");
         return;
     }
-    silent = (timeout != g.monstermoves); /* happened while away */
+    silent = (timeout != g.moves); /* happened while away */
     okay_spot = get_obj_location(figurine, &cc.x, &cc.y, 0);
     if (figurine->where == OBJ_INVENT || figurine->where == OBJ_MINVENT)
         okay_spot = enexto(&cc, cc.x, cc.y, &mons[figurine->corpsenm]);

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -1417,7 +1417,7 @@ arti_invoke(struct obj *obj)
 
     if (oart->inv_prop > LAST_PROP) {
         /* It's a special power, not "just" a property */
-        if (obj->age > g.monstermoves) {
+        if (obj->age > g.moves) {
             /* the artifact is tired :-) */
             You_feel("that %s %s ignoring you.", the(xname(obj)),
                      otense(obj, "are"));
@@ -1425,7 +1425,7 @@ arti_invoke(struct obj *obj)
             obj->age += (long) d(3, 10);
             return 1;
         }
-        obj->age = g.monstermoves + rnz(100);
+        obj->age = g.moves + rnz(100);
 
         switch (oart->inv_prop) {
         case TAMING: {
@@ -1593,7 +1593,7 @@ arti_invoke(struct obj *obj)
              iprop = u.uprops[oart->inv_prop].intrinsic;
         boolean on = (eprop & W_ARTI) != 0; /* true if prop just set */
 
-        if (on && obj->age > g.monstermoves) {
+        if (on && obj->age > g.moves) {
             /* the artifact is tired :-) */
             u.uprops[oart->inv_prop].extrinsic ^= W_ARTI;
             You_feel("that %s %s ignoring you.", the(xname(obj)),
@@ -1604,7 +1604,7 @@ arti_invoke(struct obj *obj)
         } else if (!on) {
             /* when turning off property, determine downtime */
             /* arbitrary for now until we can tune this -dlc */
-            obj->age = g.monstermoves + rnz(100);
+            obj->age = g.moves + rnz(100);
         }
 
         if ((eprop & ~W_ARTI) || iprop) {

--- a/src/decl.c
+++ b/src/decl.c
@@ -325,7 +325,6 @@ const struct instance_globals g_init = {
     NULL, /* subrooms */
     UNDEFINED_VALUES, /* level */
     1, /* moves */
-    1, /* monstermoves */
     0, /* wailmsg */
     NULL, /* migrating_objs */
     NULL, /* billobjs */

--- a/src/do.c
+++ b/src/do.c
@@ -969,8 +969,8 @@ dodown(void)
                 for (obj = g.invent; obj; obj = obj->nobj) {
                     if (obj->oartifact
                         && artifact_has_invprop(obj, LEVITATION)) {
-                        if (obj->age < g.monstermoves)
-                            obj->age = g.monstermoves;
+                        if (obj->age < g.moves)
+                            obj->age = g.moves;
                         obj->age += rnz(100);
                     }
                 }
@@ -1963,7 +1963,7 @@ revive_mon(anything *arg, long timeout UNUSED)
         } else { /* rot this corpse away */
             You_feel("%sless hassled.", is_rider(mptr) ? "much " : "");
             action = ROT_CORPSE;
-            when = (long) d(5, 50) - (g.monstermoves - body->age);
+            when = (long) d(5, 50) - (g.moves - body->age);
             if (when < 1L)
                 when = 1L;
         }

--- a/src/dog.c
+++ b/src/dog.c
@@ -41,7 +41,7 @@ initedog(struct monst *mtmp)
     EDOG(mtmp)->dropdist = 10000;
     EDOG(mtmp)->apport = ACURR(A_CHA);
     EDOG(mtmp)->whistletime = 0;
-    EDOG(mtmp)->hungrytime = 1000 + g.monstermoves;
+    EDOG(mtmp)->hungrytime = 1000 + g.moves;
     EDOG(mtmp)->ogoal.x = -1; /* force error if used before set */
     EDOG(mtmp)->ogoal.y = -1;
     EDOG(mtmp)->abuse = 0;
@@ -212,7 +212,7 @@ update_mlstmv(void)
     for (mon = fmon; mon; mon = mon->nmon) {
         if (DEADMONSTER(mon))
             continue;
-        mon->mlstmv = g.monstermoves;
+        mon->mlstmv = g.moves;
     }
 }
 
@@ -357,12 +357,12 @@ mon_arrive(struct monst *mtmp, boolean with_you)
      * specify its final destination.
      */
 
-    if (mtmp->mlstmv < g.monstermoves - 1L) {
+    if (mtmp->mlstmv < g.moves - 1L) {
         /* heal monster for time spent in limbo */
-        long nmv = g.monstermoves - 1L - mtmp->mlstmv;
+        long nmv = g.moves - 1L - mtmp->mlstmv;
 
         mon_catchup_elapsed_time(mtmp, nmv);
-        mtmp->mlstmv = g.monstermoves - 1L;
+        mtmp->mlstmv = g.moves - 1L;
 
         /* let monster move a bit on new level (see placement code below) */
         wander = (xchar) min(nmv, 8);
@@ -556,8 +556,8 @@ mon_catchup_elapsed_time(struct monst *mtmp,
         && (carnivorous(mtmp->data) || herbivorous(mtmp->data))) {
         struct edog *edog = EDOG(mtmp);
 
-        if ((g.monstermoves > edog->hungrytime + 500 && mtmp->mhp < 3)
-            || (g.monstermoves > edog->hungrytime + 750))
+        if ((g.moves > edog->hungrytime + 500 && mtmp->mhp < 3)
+            || (g.moves > edog->hungrytime + 750))
             mtmp->mtame = mtmp->mpeaceful = 0;
     }
 
@@ -672,7 +672,7 @@ keepdogs(boolean pets_only) /* true for ascension or final escape */
             relmon(mtmp, &g.mydogs);   /* move it from map to g.mydogs */
             mtmp->mx = mtmp->my = 0; /* avoid mnexto()/MON_AT() problem */
             mtmp->wormno = num_segs;
-            mtmp->mlstmv = g.monstermoves;
+            mtmp->mlstmv = g.moves;
         } else if (mtmp->iswiz) {
             /* we want to be able to find him when his next resurrection
                chance comes up, but have him resume his present location
@@ -733,7 +733,7 @@ migrate_to_level(struct monst *mtmp,
     if (In_W_tower(mtmp->mx, mtmp->my, &u.uz))
         xyflags |= 2;
     mtmp->wormno = num_segs;
-    mtmp->mlstmv = g.monstermoves;
+    mtmp->mlstmv = g.moves;
     mtmp->mtrack[2].x = u.uz.dnum; /* migrating from this dungeon */
     mtmp->mtrack[2].y = u.uz.dlevel; /* migrating from this dungeon level */
     mtmp->mtrack[1].x = cc ? cc->x : mtmp->mx;
@@ -789,7 +789,7 @@ dogfood(struct monst *mon, struct obj *obj)
            when starving; they never eat stone-to-flesh'd meat */
         if (mptr == &mons[PM_GHOUL]) {
             if (obj->otyp == CORPSE)
-                return (peek_at_iced_corpse_age(obj) + 50L <= g.monstermoves
+                return (peek_at_iced_corpse_age(obj) + 50L <= g.moves
                         && fptr != &mons[PM_LIZARD]
                         && fptr != &mons[PM_LICHEN])
                            ? DOGFOOD
@@ -811,7 +811,7 @@ dogfood(struct monst *mon, struct obj *obj)
         case EGG:
             return carni ? CADAVER : MANFOOD;
         case CORPSE:
-            if ((peek_at_iced_corpse_age(obj) + 50L <= g.monstermoves
+            if ((peek_at_iced_corpse_age(obj) + 50L <= g.moves
                  && obj->corpsenm != PM_LIZARD && obj->corpsenm != PM_LICHEN
                  && mptr->mlet != S_FUNGUS)
                 || (acidic(fptr) && !resists_acid(mon))
@@ -927,7 +927,7 @@ tamedog(struct monst *mtmp, struct obj *obj)
         if (mtmp->mcanmove && !mtmp->mconf && !mtmp->meating
             && ((tasty = dogfood(mtmp, obj)) == DOGFOOD
                 || (tasty <= ACCFOOD
-                    && EDOG(mtmp)->hungrytime <= g.monstermoves))) {
+                    && EDOG(mtmp)->hungrytime <= g.moves))) {
             /* pet will "catch" and eat this thrown food */
             if (canseemon(mtmp)) {
                 boolean big_corpse =
@@ -1045,8 +1045,8 @@ wary_dog(struct monst *mtmp, boolean was_dead)
         edog->killed_by_u = 0;
         edog->abuse = 0;
         edog->ogoal.x = edog->ogoal.y = -1;
-        if (was_dead || edog->hungrytime < g.monstermoves + 500L)
-            edog->hungrytime = g.monstermoves + 500L;
+        if (was_dead || edog->hungrytime < g.moves + 500L)
+            edog->hungrytime = g.moves + 500L;
         if (was_dead) {
             edog->droptime = 0L;
             edog->dropdist = 10000;

--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -209,8 +209,8 @@ dog_eat(struct monst *mtmp,
     char objnambuf[BUFSZ];
 
     objnambuf[0] = '\0';
-    if (edog->hungrytime < g.monstermoves)
-        edog->hungrytime = g.monstermoves;
+    if (edog->hungrytime < g.moves)
+        edog->hungrytime = g.moves;
     nutrit = dog_nutrition(mtmp, obj);
 
     deadmimic = (obj->otyp == CORPSE && (obj->corpsenm == PM_SMALL_MIMIC
@@ -291,7 +291,7 @@ dog_eat(struct monst *mtmp,
 #ifdef LINT
         edog->apport = 0;
 #else
-        edog->apport += (int) (200L / ((long) edog->dropdist + g.monstermoves
+        edog->apport += (int) (200L / ((long) edog->dropdist + g.moves
                                        - edog->droptime));
 #endif
     if (mtmp->data == &mons[PM_RUST_MONSTER] && obj->oerodeproof) {
@@ -357,9 +357,9 @@ dog_eat(struct monst *mtmp,
 static boolean
 dog_hunger(struct monst *mtmp, struct edog *edog)
 {
-    if (g.monstermoves > edog->hungrytime + 500) {
+    if (g.moves > edog->hungrytime + 500) {
         if (!carnivorous(mtmp->data) && !herbivorous(mtmp->data)) {
-            edog->hungrytime = g.monstermoves + 500;
+            edog->hungrytime = g.moves + 500;
             /* but not too high; it might polymorph */
         } else if (!edog->mhpmax_penalty) {
             /* starving pets are limited in healing */
@@ -378,7 +378,7 @@ dog_hunger(struct monst *mtmp, struct edog *edog)
             else
                 You_feel("worried about %s.", y_monnam(mtmp));
             stop_occupation();
-        } else if (g.monstermoves > edog->hungrytime + 750
+        } else if (g.moves > edog->hungrytime + 750
                    || DEADMONSTER(mtmp)) {
  dog_died:
             if (mtmp->mleashed && mtmp != u.usteed)
@@ -421,7 +421,7 @@ dog_invent(struct monst *mtmp, struct edog *edog, int udist)
                 if (edog->apport > 1)
                     edog->apport--;
                 edog->dropdist = udist; /* hpscdi!jon */
-                edog->droptime = g.monstermoves;
+                edog->droptime = g.moves;
             }
     } else {
         if ((obj = g.level.objects[omx][omy]) != 0
@@ -549,7 +549,7 @@ dog_goal(register struct monst *mtmp, struct edog *edog,
 
     /* follow player if appropriate */
     if (g.gtyp == UNDEF || (g.gtyp != DOGFOOD && g.gtyp != APPORT
-                          && g.monstermoves < edog->hungrytime)) {
+                          && g.moves < edog->hungrytime)) {
         g.gx = u.ux;
         g.gy = u.uy;
         if (after && udist <= 4 && g.gx == u.ux && g.gy == u.uy)
@@ -909,7 +909,7 @@ dog_move(register struct monst *mtmp,
         else if (j == 1)
             goto newdogpos; /* eating something */
 
-        whappr = (g.monstermoves - edog->whistletime < 5);
+        whappr = (g.moves - edog->whistletime < 5);
     } else
         whappr = 0;
 
@@ -1009,7 +1009,7 @@ dog_move(register struct monst *mtmp,
                 return 2;
 
             if ((mstatus & MM_HIT) && !(mstatus & MM_DEF_DIED) && rn2(4)
-                && mtmp2->mlstmv != g.monstermoves
+                && mtmp2->mlstmv != g.moves
                 && !onscary(mtmp->mx, mtmp->my, mtmp2)
                 /* monnear check needed: long worms hit on tail */
                 && monnear(mtmp2, mtmp->mx, mtmp->my)) {
@@ -1062,7 +1062,7 @@ dog_move(register struct monst *mtmp,
                     cursemsg[i] = TRUE;
                 } else if ((otyp = dogfood(mtmp, obj)) < MANFOOD
                          && (otyp < ACCFOOD
-                             || edog->hungrytime <= g.monstermoves)) {
+                             || edog->hungrytime <= g.moves)) {
                     /* Note: our dog likes the food so much that he
                      * might eat it even when it conceals a cursed object */
                     nix = nx;
@@ -1118,7 +1118,7 @@ dog_move(register struct monst *mtmp,
         if (!mtmp->isminion) {
             struct edog *dog = EDOG(mtmp);
 
-            hungry = (g.monstermoves > (dog->hungrytime + 300));
+            hungry = (g.moves > (dog->hungrytime + 300));
         }
 
         /* Identify the best target in a straight line from the pet;

--- a/src/eat.c
+++ b/src/eat.c
@@ -1626,7 +1626,7 @@ eatcorpse(struct obj *otmp)
     if (!nonrotting_corpse(mnum)) {
         long age = peek_at_iced_corpse_age(otmp);
 
-        rotted = (g.monstermoves - age) / (10L + rn2(20));
+        rotted = (g.moves - age) / (10L + rn2(20));
         if (otmp->cursed)
             rotted += 2L;
         else if (otmp->blessed)
@@ -2345,7 +2345,7 @@ edibility_prompts(struct obj *otmp)
 
             /* worst case rather than random
                in this calculation to force prompt */
-            rotted = (g.monstermoves - age) / (10L + 0 /* was rn2(20) */);
+            rotted = (g.moves - age) / (10L + 0 /* was rn2(20) */);
             if (otmp->cursed)
                 rotted += 2L;
             else if (otmp->blessed)
@@ -2714,7 +2714,7 @@ doeat(void)
         g.context.victual.reqtime = objects[otmp->otyp].oc_delay;
         if (otmp->otyp != FORTUNE_COOKIE
             && (otmp->cursed || (!nonrotting_food(otmp->otyp)
-                                 && (g.monstermoves - otmp->age)
+                                 && (g.moves - otmp->age)
                                         > (otmp->blessed ? 50L : 30L)
                                  && (otmp->orotten || !rn2(7))))) {
             if (rottenfood(otmp)) {

--- a/src/lock.c
+++ b/src/lock.c
@@ -192,7 +192,7 @@ breakchestlock(struct obj *box, boolean destroyit)
                 useup(otmp);
             }
             if (box->otyp == ICE_BOX && otmp->otyp == CORPSE) {
-                otmp->age = g.monstermoves - otmp->age; /* actual age */
+                otmp->age = g.moves - otmp->age; /* actual age */
                 start_corpse_timeout(otmp);
             }
             place_object(otmp, u.ux, u.uy);

--- a/src/mhitm.c
+++ b/src/mhitm.c
@@ -341,7 +341,7 @@ mattackm(register struct monst *magr, register struct monst *mdef)
      * some cases, in which case this still counts as its move for the round
      * and it shouldn't move again.
      */
-    magr->mlstmv = g.monstermoves;
+    magr->mlstmv = g.moves;
 
     /* controls whether a mind flayer uses all of its tentacle-for-DRIN
        attacks; when fighting a headless monster, stop after the first

--- a/src/mhitu.c
+++ b/src/mhitu.c
@@ -759,7 +759,7 @@ mattacku(register struct monst *mtmp)
             bot();
         /* give player a chance of waking up before dying -kaa */
         if (sum[i] == MM_HIT) { /* successful attack */
-            if (u.usleep && u.usleep < g.monstermoves && !rn2(10)) {
+            if (u.usleep && u.usleep < g.moves && !rn2(10)) {
                 g.multi = -1;
                 g.nomovemsg = "The combat suddenly awakens you.";
             }

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -751,7 +751,7 @@ mksobj(int otyp, boolean init, boolean artif)
 
     otmp = newobj();
     *otmp = cg.zeroobj;
-    otmp->age = g.monstermoves;
+    otmp->age = g.moves;
     otmp->o_id = g.context.ident++;
     if (!otmp->o_id)
         otmp->o_id = g.context.ident++; /* ident overflowed */
@@ -1202,7 +1202,7 @@ start_corpse_timeout(struct obj *body)
 
     action = ROT_CORPSE;               /* default action: rot away */
     rot_adjust = g.in_mklev ? 25 : 10; /* give some variation */
-    age = g.monstermoves - body->age;
+    age = g.moves - body->age;
     if (age > ROT_AGE)
         when = rot_adjust;
     else
@@ -1838,12 +1838,12 @@ peek_at_iced_corpse_age(struct obj *otmp)
 
     if (otmp->otyp == CORPSE && otmp->on_ice) {
         /* Adjust the age; must be same as obj_timer_checks() for off ice*/
-        age = g.monstermoves - otmp->age;
+        age = g.moves - otmp->age;
         retval += age * (ROT_ICE_ADJUSTMENT - 1) / ROT_ICE_ADJUSTMENT;
         debugpline3(
           "The %s age has ice modifications: otmp->age = %ld, returning %ld.",
                     s_suffix(doname(otmp)), otmp->age, retval);
-        debugpline1("Effective age of corpse: %ld.", g.monstermoves - retval);
+        debugpline1("Effective age of corpse: %ld.", g.moves - retval);
     }
     return retval;
 }
@@ -1882,8 +1882,8 @@ obj_timer_checks(
                later calculations behave as if it had been on ice during
                that time (longwinded way of saying this is the inverse
                of removing it from the ice and of peeking at its age). */
-            age = g.monstermoves - otmp->age;
-            otmp->age = g.monstermoves - (age * ROT_ICE_ADJUSTMENT);
+            age = g.moves - otmp->age;
+            otmp->age = g.moves - (age * ROT_ICE_ADJUSTMENT);
         }
 
     /* Check for corpses coming off ice */
@@ -1904,7 +1904,7 @@ obj_timer_checks(
             tleft /= ROT_ICE_ADJUSTMENT;
             restart_timer = TRUE;
             /* Adjust the age */
-            age = g.monstermoves - otmp->age;
+            age = g.moves - otmp->age;
             otmp->age += age * (ROT_ICE_ADJUSTMENT - 1) / ROT_ICE_ADJUSTMENT;
         }
     }

--- a/src/mon.c
+++ b/src/mon.c
@@ -967,9 +967,9 @@ movemon(void)
            mon->isgd flag so that dmonsfree() will get rid of mon) */
         if (mtmp->isgd && !mtmp->mx) {
             /* parked at <0,0>; eventually isgd should get set to false */
-            if (g.monstermoves > mtmp->mlstmv) {
+            if (g.moves > mtmp->mlstmv) {
                 (void) gd_move(mtmp);
-                mtmp->mlstmv = g.monstermoves;
+                mtmp->mlstmv = g.moves;
             }
             continue;
         }
@@ -1273,7 +1273,7 @@ meatobj(struct monst* mtmp) /* for gelatinous cubes */
                 while ((otmp3 = otmp->cobj) != 0) {
                     obj_extract_self(otmp3);
                     if (otmp->otyp == ICE_BOX && otmp3->otyp == CORPSE) {
-                        otmp3->age = g.monstermoves - otmp3->age;
+                        otmp3->age = g.moves - otmp3->age;
                         start_corpse_timeout(otmp3);
                     }
                     (void) mpickobj(mtmp, otmp3);

--- a/src/muse.c
+++ b/src/muse.c
@@ -2598,14 +2598,14 @@ mon_consume_unstone(
     if (mon->mtame && !mon->isminion && nutrit > 0) {
         struct edog *edog = EDOG(mon);
 
-        if (edog->hungrytime < g.monstermoves)
-            edog->hungrytime = g.monstermoves;
+        if (edog->hungrytime < g.moves)
+            edog->hungrytime = g.moves;
         edog->hungrytime += nutrit;
         mon->mconf = 0;
     }
     /* use up monster's next move */
     mon->movement -= NORMAL_SPEED;
-    mon->mlstmv = g.monstermoves;
+    mon->mlstmv = g.moves;
 }
 
 /* decide whether obj can cure petrification; also used when picking up */
@@ -2867,7 +2867,7 @@ muse_unslime(
     }
     /* use up monster's next move */
     mon->movement -= NORMAL_SPEED;
-    mon->mlstmv = g.monstermoves;
+    mon->mlstmv = g.moves;
     return res;
 }
 

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -2305,7 +2305,7 @@ in_container(struct obj *obj)
         }
     }
     if (Icebox && !age_is_relative(obj)) {
-        obj->age = g.monstermoves - obj->age; /* actual age */
+        obj->age = g.moves - obj->age; /* actual age */
         /* stop any corpse timeouts when frozen */
         if (obj->otyp == CORPSE) {
             if (obj->timed) {
@@ -2445,7 +2445,7 @@ void
 removed_from_icebox(struct obj *obj)
 {
     if (!age_is_relative(obj)) {
-        obj->age = g.monstermoves - obj->age; /* actual age */
+        obj->age = g.moves - obj->age; /* actual age */
         if (obj->otyp == CORPSE) {
             struct monst *m = get_mtraits(obj, FALSE);
             boolean iceT = m ? (m->data == &mons[PM_ICE_TROLL])
@@ -2531,7 +2531,7 @@ observe_quantum_cat(struct obj *box, boolean makecat, boolean givemsg)
             /* set_corpsenm() will start the rot timer that was removed
                when makemon() created SchroedingersBox; start it from
                now rather than from when this special corpse got created */
-            deadcat->age = g.monstermoves;
+            deadcat->age = g.moves;
             set_corpsenm(deadcat, PM_HOUSECAT);
             deadcat = oname(deadcat, sc);
         }

--- a/src/pray.c
+++ b/src/pray.c
@@ -1373,7 +1373,7 @@ dosacrifice(void)
             return 1;
 
         if (otmp->corpsenm == PM_ACID_BLOB
-            || (g.monstermoves <= peek_at_iced_corpse_age(otmp) + 50)) {
+            || (g.moves <= peek_at_iced_corpse_age(otmp) + 50)) {
             value = mons[otmp->corpsenm].difficulty + 1;
             if (otmp->oeaten)
                 value = eaten_stat(value, otmp);

--- a/src/restore.c
+++ b/src/restore.c
@@ -162,7 +162,7 @@ restdamage(NHFILE* nhfp)
             mread(nhfp->fd, (genericptr_t) tmp_dam, sizeof(*tmp_dam));
 
         if (ghostly)
-            tmp_dam->when += (g.monstermoves - g.omoves);
+            tmp_dam->when += (g.moves - g.omoves);
         Strcpy(damaged_shops,
                in_rooms(tmp_dam->place.x, tmp_dam->place.y, SHOPBASE));
         if (u.uz.dlevel) {
@@ -278,7 +278,7 @@ restobjchn(NHFILE* nhfp, boolean frozen)
          * immediately after old player died.
          */
         if (ghostly && !frozen && !age_is_relative(otmp))
-            otmp->age = g.monstermoves - g.omoves + otmp->age;
+            otmp->age = g.moves - g.omoves + otmp->age;
 
         /* get contents of a container or statue */
         if (Has_contents(otmp)) {
@@ -667,7 +667,6 @@ restgamestate(NHFILE* nhfp, unsigned int* stuckid, unsigned int* steedid)
     restlevchn(nhfp);
     if (nhfp->structlevel) {
         mread(nhfp->fd, (genericptr_t) &g.moves, sizeof g.moves);
-        mread(nhfp->fd, (genericptr_t) &g.monstermoves, sizeof g.monstermoves);
         mread(nhfp->fd, (genericptr_t) &g.quest_status, sizeof (struct q_score));
         mread(nhfp->fd, (genericptr_t) g.spl_book, (MAXSPELL + 1) * sizeof (struct spell));
     }
@@ -1059,7 +1058,7 @@ getlev(NHFILE* nhfp, int pid, xchar lev)
         mread(nhfp->fd, (genericptr_t) g.lastseentyp, sizeof(g.lastseentyp));
         mread(nhfp->fd, (genericptr_t) &g.omoves, sizeof(g.omoves));
     }
-    elapsed = g.monstermoves - g.omoves;
+    elapsed = g.moves - g.omoves;
 
     if (nhfp->structlevel) {
         rest_stairs(nhfp);

--- a/src/save.c
+++ b/src/save.c
@@ -293,7 +293,6 @@ savegamestate(NHFILE* nhfp)
     savelevchn(nhfp);
     if (nhfp->structlevel) {
         bwrite(nhfp->fd, (genericptr_t) &g.moves, sizeof g.moves);
-        bwrite(nhfp->fd, (genericptr_t) &g.monstermoves, sizeof g.monstermoves);
         bwrite(nhfp->fd, (genericptr_t) &g.quest_status, sizeof g.quest_status);
         bwrite(nhfp->fd, (genericptr_t) g.spl_book,
                sizeof (struct spell) * (MAXSPELL + 1));
@@ -484,7 +483,7 @@ savelev(NHFILE* nhfp, xchar lev)
              (boolean) ((sfsaveinfo.sfi1 & SFI1_RLECOMP) == SFI1_RLECOMP));
     if (nhfp->structlevel) {
         bwrite(nhfp->fd, (genericptr_t) g.lastseentyp, sizeof g.lastseentyp);
-        bwrite(nhfp->fd, (genericptr_t) &g.monstermoves, sizeof g.monstermoves);
+        bwrite(nhfp->fd, (genericptr_t) &g.moves, sizeof g.moves);
         save_stairs(nhfp);
         bwrite(nhfp->fd, (genericptr_t) &g.updest, sizeof (dest_area));
         bwrite(nhfp->fd, (genericptr_t) &g.dndest, sizeof (dest_area));

--- a/src/shk.c
+++ b/src/shk.c
@@ -3471,12 +3471,12 @@ add_damage(
     for (tmp_dam = g.level.damagelist; tmp_dam; tmp_dam = tmp_dam->next)
         if (tmp_dam->place.x == x && tmp_dam->place.y == y) {
             tmp_dam->cost += cost;
-            tmp_dam->when = g.monstermoves; /* needed by pay_for_damage() */
+            tmp_dam->when = g.moves; /* needed by pay_for_damage() */
             return;
         }
     tmp_dam = (struct damage *) alloc((unsigned) sizeof *tmp_dam);
     (void) memset((genericptr_t) tmp_dam, 0, sizeof *tmp_dam);
-    tmp_dam->when = g.monstermoves;
+    tmp_dam->when = g.moves;
     tmp_dam->place.x = x;
     tmp_dam->place.y = y;
     tmp_dam->cost = cost;
@@ -3511,7 +3511,7 @@ repairable_damage(struct damage *dam, struct monst *shkp)
         return FALSE;
 
     /* too soon to fix it? */
-    if ((g.monstermoves - dam->when) < REPAIR_DELAY)
+    if ((g.moves - dam->when) < REPAIR_DELAY)
         return FALSE;
     /* is it a wall? don't fix if anyone is in the way */
     if (!IS_ROOM(dam->typ)) {
@@ -4115,7 +4115,7 @@ pay_for_damage(const char* dmgstr, boolean cant_mollify)
     for (tmp_dam = g.level.damagelist; tmp_dam; tmp_dam = tmp_dam->next) {
         char *shp;
 
-        if (tmp_dam->when != g.monstermoves || !tmp_dam->cost)
+        if (tmp_dam->when != g.moves || !tmp_dam->cost)
             continue;
         cost_of_damage += tmp_dam->cost;
         Strcpy(shops_affected,

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -790,7 +790,7 @@ fall_asleep(int how_long, boolean wakeup_msg)
         g.afternmv = Hear_again; /* this won't give any messages */
     }
     /* early wakeup from combat won't be possible until next monster turn */
-    u.usleep = g.monstermoves;
+    u.usleep = g.moves;
     g.nomovemsg = wakeup_msg ? "You wake up." : You_can_move_again;
 }
 
@@ -854,7 +854,7 @@ hatch_egg(anything *arg, long timeout)
     mnum = big_to_little(egg->corpsenm);
     /* The identity of one's father is learned, not innate */
     yours = (egg->spe || (!flags.female && carried(egg) && !rn2(2)));
-    silent = (timeout != g.monstermoves); /* hatched while away */
+    silent = (timeout != g.moves); /* hatched while away */
 
     /* only can hatch when in INVENT, FLOOR, MINVENT */
     if (get_obj_location(egg, &x, &y, 0)) {
@@ -1169,8 +1169,8 @@ burn_object(anything* arg, long timeout)
     many = menorah ? obj->spe > 1 : obj->quan > 1L;
 
     /* timeout while away */
-    if (timeout != g.monstermoves) {
-        long how_long = g.monstermoves - timeout;
+    if (timeout != g.moves) {
+        long how_long = g.moves - timeout;
 
         if (how_long >= obj->age) {
             obj->age = 0;
@@ -1593,7 +1593,7 @@ cleanup_burn(anything* arg, long expire_time)
     del_light_source(LS_OBJECT, obj_to_any(obj));
 
     /* restore unused time */
-    obj->age += expire_time - g.monstermoves;
+    obj->age += expire_time - g.moves;
 
     obj->lamplit = 0;
 
@@ -1657,7 +1657,7 @@ do_storms(void)
  *  boolean start_timer(long timeout,short kind,short func_index,
  *                      anything *arg)
  *      Start a timer of kind 'kind' that will expire at time
- *      g.monstermoves+'timeout'.  Call the function at 'func_index'
+ *      g.moves+'timeout'.  Call the function at 'func_index'
  *      in the timeout table using argument 'arg'.  Return TRUE if
  *      a timer was started.  This places the timer on a list ordered
  *      "sooner" to "later".  If an object, increment the object's
@@ -1801,7 +1801,7 @@ wiz_timeout_queue(void)
     if (win == WIN_ERR)
         return 0;
 
-    Sprintf(buf, "Current time = %ld.", g.monstermoves);
+    Sprintf(buf, "Current time = %ld.", g.moves);
     putstr(win, 0, buf);
     putstr(win, 0, "");
     putstr(win, 0, "Active timeout queue:");
@@ -1885,7 +1885,7 @@ run_timers(void)
      * any time.  The list is ordered, we are done when the first element
      * is in the future.
      */
-    while (g.timer_base && g.timer_base->timeout <= g.monstermoves) {
+    while (g.timer_base && g.timer_base->timeout <= g.moves) {
         curr = g.timer_base;
         g.timer_base = curr->next;
 
@@ -1934,7 +1934,7 @@ start_timer(
     (void) memset((genericptr_t) gnu, 0, sizeof *gnu);
     gnu->next = 0;
     gnu->tid = g.timer_id++;
-    gnu->timeout = g.monstermoves + when;
+    gnu->timeout = g.moves + when;
     gnu->kind = kind;
     gnu->needs_fixup = 0;
     gnu->func_index = func_index;
@@ -1966,7 +1966,7 @@ stop_timer(short func_index, anything *arg)
         if (timeout_funcs[doomed->func_index].cleanup)
             (*timeout_funcs[doomed->func_index].cleanup)(arg, timeout);
         free((genericptr_t) doomed);
-        return (timeout - g.monstermoves);
+        return (timeout - g.moves);
     }
     return 0L;
 }
@@ -2017,7 +2017,7 @@ obj_split_timers(struct obj* src, struct obj* dest)
     for (curr = g.timer_base; curr; curr = next_timer) {
         next_timer = curr->next; /* things may be inserted */
         if (curr->kind == TIMER_OBJECT && curr->arg.a_obj == src) {
-            (void) start_timer(curr->timeout - g.monstermoves, TIMER_OBJECT,
+            (void) start_timer(curr->timeout - g.moves, TIMER_OBJECT,
                                curr->func_index, obj_to_any(dest));
         }
     }
@@ -2111,7 +2111,7 @@ long
 spot_time_left(xchar x, xchar y, short func_index)
 {
     long expires = spot_time_expires(x, y, func_index);
-    return (expires > 0L) ? expires - g.monstermoves : 0L;
+    return (expires > 0L) ? expires - g.moves : 0L;
 }
 
 /* Insert timer into the global queue */

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -693,7 +693,7 @@ resurrect(void)
             if (mtmp->iswiz
                 /* if he has the Amulet, he won't bring it to you */
                 && !mon_has_amulet(mtmp)
-                && (elapsed = g.monstermoves - mtmp->mlstmv) > 0L) {
+                && (elapsed = g.moves - mtmp->mlstmv) > 0L) {
                 mon_catchup_elapsed_time(mtmp, elapsed);
                 if (elapsed >= LARGEST_INT)
                     elapsed = LARGEST_INT - 1;


### PR DESCRIPTION
It's redundant with g.moves, so there is no more need for it.

Way, way back, it looks like g.moves and g.monstermoves can and did
desync, where g.moves would track the amount of moves the player had
gotten (and would therefore increase faster if the player were hasted)
and g.monstermoves would track the amount of monster move cycles, aka
turns. But this has not been the case for a long time, and they both
increment together in the same location in allmain.c. There are no
longer any cases where they will not be the same value.

This is a save-breaking change because it changes struct
instance_globals, but I have not updated the editlevel in this commit.

Also, fixes #288 (the comment in decl.h is wrong).