### PR TITLE
Fix: replace_terrain used wrong y2 coordinate

### DIFF
--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -5122,7 +5122,7 @@ lspo_replace_terrain(lua_State *L)
             (void) selection_not(sel);
         } else {
             xchar rx1, ry1, rx2, ry2;
-            rx1 = x1, ry1 = y1, rx2 = x2, ry2 = x2;
+            rx1 = x1, ry1 = y1, rx2 = x2, ry2 = y2;
             get_location(&rx1, &ry1, ANY_LOC, g.coder->croom);
             get_location(&rx2, &ry2, ANY_LOC, g.coder->croom);
             for (x = max(rx1, 0); x <= min(rx2, COLNO - 1); x++)


### PR DESCRIPTION
It erroneously uses x2 again instead of the y2 value. It looks like in most cases where replace_terrain is specified with a region, the region goes to the bottom of the screen, and this effect wasn't noticed; but there are some cases like in Orcish Town where it might have been knocking down the wrong walls.