### PR TITLE
Disambiguate blunt weapons

### DIFF
--- a/include/objclass.h
+++ b/include/objclass.h
@@ -65,16 +65,16 @@ struct objclass {
 #define oc_bulky oc_big    /* for armor */
     Bitfield(oc_tough, 1); /* hard gems/rings */
 
-    Bitfield(oc_dir, 2);
+    Bitfield(oc_dir, 3);
 #define NODIR 1     /* for wands/spells: non-directional */
 #define IMMEDIATE 2 /*               directional */
 #define RAY 3       /*               zap beams */
 
 #define PIERCE 1 /* for weapons & tools used as weapons */
 #define SLASH 2  /* (latter includes iron ball & chain) */
-#define WHACK 0
+#define WHACK 4
 
-    /* 4 free bits */
+    /* 3 free bits */
 
     Bitfield(oc_material, 5); /* one of obj_material_types */
 


### PR DESCRIPTION
Currently weapons are set up as piercing, slashing, or whacking, using
their object's oc_dir field, with the intention that certain weapons
can classify as both. However, since oc_dir is only 2 bits and WHACK is
0, there's no way to unambiguously express some of these combinations.
Certain weapons such as the lucern hammer are defined as combination
piercing/blunt weapons, but the game just sees it as a piercing weapon.

This commit adds a third bit to oc_dir and promotes the WHACK constant
to its own bit. Nothing should be affected by this (wand directions and
the like should remain working as usual) other than the
blunt-and-something-else weapons being defined properly.