### PR TITLE
Fix: 'Suddenly you cannot see it'

### DIFF
--- a/src/worn.c
+++ b/src/worn.c
@@ -727,7 +727,7 @@ m_dowear_type(struct monst *mon, long flag, boolean creation,
     }
     update_mon_intrinsics(mon, best, TRUE, creation);
     /* if couldn't see it but now can, or vice versa, */
-    if (!creation && (sawmon ^ !canseemon(mon))) {
+    if (!creation && (sawmon ^ canseemon(mon))) {
         if (mon->minvis && !See_invisible) {
             pline("Suddenly you cannot see %s.", nambuf);
             makeknown(best->otyp);


### PR DESCRIPTION
Updates to m_dowear_type(worn.c) in 5a09a01a13 inadvertently reversed
the effect of an xor near the end of the function, causing it to go from
testing whether a monster's status as 'seen' or 'unseen' changed over
the course of the function to testing whether it remained the same.

As a result, whenever an unseen, invisible monster donned a piece of
armor anywhere on the map, the message 'suddenly you cannot see it'
would be printed.  Fix the xor so that it goes back to testing whether
visibility changed since the start of the function.
