### PR TITLE
Fix: running on ice sent hero in weird directions

### DIFF
--- a/src/hack.c
+++ b/src/hack.c
@@ -2831,7 +2831,7 @@ lookaround(void)
 
             /* more uninteresting terrain */
             if (IS_ROCK(levl[x][y].typ) || levl[x][y].typ == ROOM
-                || IS_AIR(levl[x][y].typ)) {
+                || IS_AIR(levl[x][y].typ) || levl[x][y].typ == ICE) {
                 continue;
             } else if (closed_door(x, y) || (mtmp && is_door_mappear(mtmp))) {
                 /* a closed door? */


### PR DESCRIPTION
It's because ice was being treated as a type of
corridor rather than a ROOM space, and running has rules for following
similar terrain. In reality it's not a corridor and should behave like
normal room for running purposes.

This was obvious in the valkyrie quest upper levels with ice fields, in
which running into the edges of the map obliquely, or into the corners
of the map, would send the hero flying around the edge in a different,
probably unintended direction.