### PR TITLE
Fix out-of-bounds access of xdir and ydir in farlook

### DIFF
--- a/src/do_name.c
+++ b/src/do_name.c
@@ -787,9 +787,8 @@ getpos(coord *ccp, boolean force, const char *goal)
                 dy = u.dy;
                 while (isok(cx + dx, cy + dy)
                        && glyph == glyph_at(cx + dx, cy + dy)
-                       && isok(cx + dx + xdir[i], cy + dy + ydir[i])
-                       && glyph == glyph_at(cx + dx + xdir[i],
-                                            cy + dy + ydir[i])) {
+                       && isok(cx + dx + u.dx, cy + dy + u.dy)
+                       && glyph == glyph_at(cx + dx + u.dx, cy + dy + u.dy)) {
                     dx += u.dx;
                     dy += u.dy;
 


### PR DESCRIPTION
In commit db68395, most of the instances of xdir and ydir here were
changed to u.dx and u.dy, but not all of them. The remaining ones are
out-of-bounds on xdir and ydir, because i is always set to 12 from an
earlier loop and is no longer involved in handling user input. They
should be u.dx and u.dy like the rest.