### PR TITLE
Fix: chameleon quickmimic not reset after eating

### DIFF
--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -1364,7 +1364,7 @@ void
 finish_meating(struct monst *mtmp)
 {
     mtmp->meating = 0;
-    if (M_AP_TYPE(mtmp) && mtmp->mappearance && mtmp->cham == NON_PM) {
+    if (M_AP_TYPE(mtmp) && mtmp->mappearance && mtmp->data->mlet != S_MIMIC) {
         /* was eating a mimic and now appearance needs resetting */
         mtmp->m_ap_type = M_AP_NOTHING;
         mtmp->mappearance = 0;


### PR DESCRIPTION
finish_meating was checking whether the monster in question was a
chameleon/shapechanger, rather than whether it was a mimic, in deciding
which monsters should be allowed to maintain their current appearance
once they finish eating.  This meant that true mimics had their
appearance reset, while a chameleon, vampire, etc, who ate a mimic
would maintain their appearance as a tripe ration even after they had
finished eating and resumed their normal behavior.  The result?  An
amazing living tripe ration which followed the hero around throughout
the level:


https://user-images.githubusercontent.com/40038830/135450633-e0245073-85a8-49f0-954f-c28ef56cfad7.mp4

