### PR TITLE
Fix: artifacts silently removed from the game 

### DIFF
--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -273,7 +273,7 @@ mkbox_cnts(struct obj *box)
 
     for (n = rn2(n + 1); n > 0; n--) {
         if (box->otyp == ICE_BOX) {
-            otmp = mksobj(CORPSE, TRUE, TRUE);
+            otmp = mksobj(CORPSE, TRUE, FALSE);
             /* Note: setting age to 0 is correct.  Age has a different
              * from usual meaning for objects stored in ice boxes. -KAA
              */
@@ -288,7 +288,7 @@ mkbox_cnts(struct obj *box)
 
             for (tprob = rnd(100); (tprob -= iprobs->iprob) > 0; iprobs++)
                 ;
-            if (!(otmp = mkobj(iprobs->iclass, TRUE)))
+            if (!(otmp = mkobj(iprobs->iclass, FALSE)))
                 continue;
 
             /* handle a couple of special cases */

--- a/src/mon.c
+++ b/src/mon.c
@@ -2954,6 +2954,8 @@ xkilled(
             if (mdat->msize < MZ_HUMAN && otyp != FIGURINE
                 /* oc_big is also oc_bimanual and oc_bulky */
                 && (otmp->owt > 30 || objects[otyp].oc_big)) {
+                if (otmp->oartifact)
+                    artifact_exists(otmp, safe_oname(otmp), FALSE);
                 delobj(otmp);
             } else if (!flooreffects(otmp, x, y, nomsg ? "" : "fall")) {
                 place_object(otmp, x, y);

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -2214,6 +2214,8 @@ create_object(object* o, struct mkroom* croom)
                 cobj->owt = weight(cobj);
             } else {
                 obj_extract_self(otmp);
+                if (otmp->oartifact)
+                    artifact_exists(otmp, safe_oname(otmp), FALSE);
                 obfree(otmp, NULL);
                 return;
             }


### PR DESCRIPTION
Prevent some cases where artifacts may be generated and then immediately deleted, with the effect that they are permanently removed from the game (as pointed out by @copperwater).  Use `artifact_exists(..., FALSE)` to "unmake" artifacts in these scenarios, and formally prevent artifacts from showing up randomly in boxes (has effectively been the case already, but was not explicitly blocked).  This should prevent situations where an artifact is counted as "generated" without actually being added to the game.