### PR TITLE
Merge item stacks regardless of bknown

### DIFF
--- a/src/invent.c
+++ b/src/invent.c
@@ -716,7 +716,9 @@ merged(struct obj **potmp, struct obj **pobj)
         else if (!Is_pudding(otmp))
             otmp->owt += obj->owt;
 
-        /* update bknown */
+        /* if a stack of unknown BUC is merging with a stack of
+           known BUC, make sure the BUC of the combined stack is
+           known */
         if (otmp->oclass != COIN_CLASS)
             otmp->bknown = obj->bknown = otmp->bknown || obj->bknown;
 

--- a/src/invent.c
+++ b/src/invent.c
@@ -715,6 +715,11 @@ merged(struct obj **potmp, struct obj **pobj)
         /* and puddings!!!1!!one! */
         else if (!Is_pudding(otmp))
             otmp->owt += obj->owt;
+
+        /* update bknown */
+        if (otmp->oclass != COIN_CLASS)
+            otmp->bknown = obj->bknown = otmp->bknown || obj->bknown;
+
         if (!has_oname(otmp) && has_oname(obj))
             otmp = *potmp = oname(otmp, ONAME(obj));
         obj_extract_self(obj);
@@ -3647,7 +3652,6 @@ mergable(register struct obj *otmp, register struct obj *obj)
         return FALSE;
 
     if (obj->dknown != otmp->dknown
-        || (obj->bknown != otmp->bknown && !Role_if(PM_CLERIC))
         || obj->oeroded != otmp->oeroded || obj->oeroded2 != otmp->oeroded2
         || obj->greased != otmp->greased)
         return FALSE;


### PR DESCRIPTION
Currently, items that have been #named stack with items that have not, with the unnamed item stack acquiring the name of the named item stack as soon as the two meet each other in your inventory. This means that it's strictly better to have a stackable item _informally_ BUC-identified than it is to have it formally BUC-identified, because then other items with the same beatitude you find later will stack with it and become (informally) BUC-identified as well.

This results in strategies like dropping only _one_ dart on the altar and #naming the stack according to the results. To remove this tedium, I've tweaked the behavior so that formal BUC-identification behaves the same way as informal BUC-identification. Some variants already implement this change—I know Fourk does, but I'm not sure about 4.

A more radical possibility I considered was doing the same for the knowledge of the enchantment/fooproofing of an item, effectively removing the effect of ID status completely (except _maybe_ dknown when the player is blind) on the stackability of items, but that's a larger change, so I'm saving it for a different PR.