### PR TITLE
Fix: whipping peaceful, unarmed monster

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -2951,10 +2951,11 @@ use_whip(struct obj *obj)
             else
                 You("flick your bullwhip towards %s.", mon_nam(mtmp));
             if (proficient) {
-                if (do_attack(mtmp))
-                    return 1;
-                else
+                boolean save_forcefight = g.context.forcefight;
+                g.context.forcefight = TRUE;
+                if (!do_attack(mtmp))
                     pline1(msg_snap);
+                g.context.forcefight = save_forcefight;
             }
         }
 


### PR DESCRIPTION
With the 'safedog' option enabled, applying a whip towards a peaceful
monster without a weapon wouldn't attack it, and would produce odd
messages ("You flick your whip towards Malasgirt.  You stop.  Malasgirt
is in the way!") if the monster was undisplaceable (sleeping, in a shop,
hero is punished, etc).  Use g.context.forcefight to skip the
displacement checks if attacking with a whip, since applying a whip is a
deliberate attack already.
