### PR TITLE
Rename "huge chunk of meat" to "giant meatball"

### DIFF
--- a/include/objects.h
+++ b/include/objects.h
@@ -970,7 +970,7 @@ FOOD("meatball",              0,  1,  1, 0, FLESH,   5, CLR_BROWN,
 FOOD("meat stick",            0,  1,  1, 0, FLESH,   5, CLR_BROWN,
                                                         MEAT_STICK),
 FOOD("giant meatball",        0, 20,400, 0, FLESH,2000, CLR_BROWN,
-                                                        HUGE_CHUNK_OF_MEAT),
+                                                        GIANT_MEATBALL),
 /* special case because it's not mergable */
 OBJECT(OBJ("meat ring", NoDes),
        BITS(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, FLESH),

--- a/include/objects.h
+++ b/include/objects.h
@@ -969,7 +969,7 @@ FOOD("meatball",              0,  1,  1, 0, FLESH,   5, CLR_BROWN,
                                                         MEATBALL),
 FOOD("meat stick",            0,  1,  1, 0, FLESH,   5, CLR_BROWN,
                                                         MEAT_STICK),
-FOOD("huge chunk of meat",    0, 20,400, 0, FLESH,2000, CLR_BROWN,
+FOOD("giant meatball",        0, 20,400, 0, FLESH,2000, CLR_BROWN,
                                                         HUGE_CHUNK_OF_MEAT),
 /* special case because it's not mergable */
 OBJECT(OBJ("meat ring", NoDes),

--- a/src/do.c
+++ b/src/do.c
@@ -735,7 +735,7 @@ engulfer_digests_food(struct obj *obj)
        corpse, glob, or meat <item> but not other types of food */
     if (is_animal(u.ustuck->data)
         && (obj->otyp == CORPSE || obj->globby
-            || obj->otyp == MEATBALL || obj->otyp == HUGE_CHUNK_OF_MEAT
+            || obj->otyp == MEATBALL || obj->otyp == GIANT_MEATBALL
             || obj->otyp == MEAT_RING || obj->otyp == MEAT_STICK)) {
         boolean could_petrify = FALSE,
                 could_poly = FALSE, could_slime = FALSE,

--- a/src/dog.c
+++ b/src/dog.c
@@ -806,7 +806,7 @@ dogfood(struct monst *mon, struct obj *obj)
         case MEATBALL:
         case MEAT_RING:
         case MEAT_STICK:
-        case HUGE_CHUNK_OF_MEAT:
+        case GIANT_MEATBALL:
             return carni ? DOGFOOD : MANFOOD;
         case EGG:
             return carni ? CADAVER : MANFOOD;

--- a/src/eat.c
+++ b/src/eat.c
@@ -1853,7 +1853,7 @@ fprefx(struct obj *otmp)
         goto give_feedback;
     case MEATBALL:
     case MEAT_STICK:
-    case HUGE_CHUNK_OF_MEAT:
+    case GIANT_MEATBALL:
     case MEAT_RING:
         goto give_feedback;
     case CLOVE_OF_GARLIC:

--- a/src/mthrowu.c
+++ b/src/mthrowu.c
@@ -1164,7 +1164,7 @@ hits_bars(
                 hits = TRUE;
             else
                 hits = (obj_type == MEAT_STICK
-                        || obj_type == HUGE_CHUNK_OF_MEAT);
+                        || obj_type == GIANT_MEATBALL);
             break;
         case SPBOOK_CLASS:
         case WAND_CLASS:

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -3045,7 +3045,7 @@ rnd_otyp_by_namedesc(
                type ooze/pudding/slime don't match glob of same since that
                ought to match "corpse/egg/figurine of type" too but won't */
             || (check_of
-                && i != BELL_OF_OPENING && i != HUGE_CHUNK_OF_MEAT
+                && i != BELL_OF_OPENING && i != GIANT_MEATBALL
                 && (i < minglob || i > maxglob)
                 && (of = strstri(zn, " of ")) != 0
                 && wishymatch(name, of + 4, FALSE)) /* partial name */

--- a/src/zap.c
+++ b/src/zap.c
@@ -1849,7 +1849,7 @@ stone_to_flesh_obj(struct obj *obj)
     case ROCK_CLASS: /* boulders and statues */
     case TOOL_CLASS: /* figurines */
         if (obj->otyp == BOULDER) {
-            obj = poly_obj(obj, HUGE_CHUNK_OF_MEAT);
+            obj = poly_obj(obj, GIANT_MEATBALL);
             smell = TRUE;
         } else if (obj->otyp == STATUE || obj->otyp == FIGURINE) {
             ptr = &mons[obj->corpsenm];


### PR DESCRIPTION
A number of reasons:
- This makes the relationship with boulders clearer. Boulders roll, so they are clearly round, and "chunk" does not suggest roundness.
- Its name parallels the names of the other items produced by the stone-to-flesh spell: rings become meat rings, wands become meat sticks, stones become meatballs, and boulders become giant meatballs.
- "Meatball" sounds more appetizing than "chunk of meat", making this more consistent with the message "You smell a delicious smell."
- The image of a giant meatball in the dungeon is amusing in a way that's consistent with NetHack's wry sense of humor.