### PR TITLE
Have neutral sacrifices disappear in a puff, not a cloud, of smoke.

### DIFF
--- a/src/pray.c
+++ b/src/pray.c
@@ -1319,7 +1319,7 @@ consume_offering(struct obj *otmp)
              u.ualign.type == A_LAWFUL
                 ? "flash of light"
                 : u.ualign.type == A_NEUTRAL
-                    ? "cloud of smoke"
+                    ? "puff of smoke"
                     : "burst of flame");
     if (carried(otmp))
         useup(otmp);


### PR DESCRIPTION
The other two messages, "flash of light" and "burst of flame", each have an evocative onomatopoetic noun describing a sharp, abrupt release of light and flame, respectively. If law is represented by light, chaos by flame, and balance by smoke, the natural word is _puff,_ not _cloud._