### PR TITLE
Revert MAX_RADIUS change

### DIFF
--- a/include/vision.h
+++ b/include/vision.h
@@ -52,7 +52,7 @@
 /*
  *  Circle information
  */
-#define MAX_RADIUS 16 /* this is in points from the source */
+#define MAX_RADIUS 15 /* this is in points from the source */
 
 /* Use this macro to get a list of distances of the edges (see vision.c). */
 #define circle_ptr(z) (&circle_data[(int) circle_start[z]])


### PR DESCRIPTION
On 59818fb, MAX_RADIUS was changed from 15 to 16 to intend to support
"radius 0".  But MAX_RADIUS doesn't means the range but outer bound of
the radius table, so it should not be changed, and this change led
possible out-of-bound access on view_from() and do_clear_area() in
vision.c.

This commit reverts the change and avoids the problem.

(from Coverity Scan)