### PR TITLE
Guard lua_close()

### DIFF
--- a/src/nhlua.c
+++ b/src/nhlua.c
@@ -1375,7 +1375,8 @@ nhl_init(void)
 void
 nhl_done(lua_State *L)
 {
-    lua_close(L);
+    if (L)
+        lua_close(L);
     iflags.in_lua = FALSE;
 }
 


### PR DESCRIPTION
nhl_done() can be called with L == NULL.
So lua_close() should be guarded.