### PR TITLE
Make amnesia drain training to appropriate level

### DIFF
--- a/src/weapon.c
+++ b/src/weapon.c
@@ -1363,6 +1363,8 @@ drain_weapon_skill(int n) /* number of skills to drain */
 {
     int skill;
     int i;
+    int curradv;
+    int prevadv;
     int tmpskills[P_NUM_SKILLS];
 
     (void) memset((genericptr_t) tmpskills, 0, sizeof(tmpskills));
@@ -1382,9 +1384,11 @@ drain_weapon_skill(int n) /* number of skills to drain */
             P_SKILL(skill)--;   /* drop skill one level */
             /* refund slots used for skill */
             u.weapon_slots += slots_required(skill);
-            /* drain a random proportion of skill training */
-            if (P_ADVANCE(skill))
-                P_ADVANCE(skill) = rn2(P_ADVANCE(skill));
+            /* drain skill training to a value appropriate for new level */
+            curradv = practice_needed_to_advance(P_SKILL(skill));
+            prevadv = practice_needed_to_advance(P_SKILL(skill) - 1);
+            if (P_ADVANCE(skill) >= curradv)
+                P_ADVANCE(skill) = prevadv + rn2(curradv - prevadv);
         }
     }
 


### PR DESCRIPTION
When amnesia drains your skills the skill training would be set
to a random amount rather than a random valid amount for the new
level of skill.

This meant that, for example, you could have Master skill level in
martial arts but with the training amount of Basic.

Attempts to retrain to level martial arts to Grand Master would
then take an extraordinary amount of time compared to usual.

Fix taken from Evilhack