### PR TITLE
The return value of weight_cap() should be non-zero

### DIFF
--- a/src/hack.c
+++ b/src/hack.c
@@ -3330,8 +3330,8 @@ weight_cap(void)
             if (EWounded_legs & RIGHT_SIDE)
                 carrcap -= 100;
         }
-        if (carrcap < 0)
-            carrcap = 0;
+        if (carrcap < 1)
+            carrcap = 1;
     }
 
     if (ELevitation != save_ELev || BLevitation != save_BLev) {


### PR DESCRIPTION
The return value of weight_cap() should be non-zero, because
it is used as a divisor on try_lift().