### PR TITLE
Add missing `const`

### DIFF
--- a/include/artilist.h
+++ b/include/artilist.h
@@ -9,7 +9,7 @@
 #define A(nam, typ, s1, s2, mt, atk, dfn, cry, inv, al, cl, rac, \
           cost, clr, bn) nam
 
-static const char *artifact_names[] = {
+static const char *const artifact_names[] = {
 
 #elif defined(ARTI_ENUM)
 #define A(nam, typ, s1, s2, mt, atk, dfn, cry, inv, al, cl, rac, \

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -1003,7 +1003,7 @@ dump_enums(void)
         objects_misc_enum,
         NUM_ENUM_DUMPS
     };
-    static const char *titles[NUM_ENUM_DUMPS] =
+    static const char *const titles[NUM_ENUM_DUMPS] =
         { "monnums", "objects_nums" , "misc_object_nums" };
     struct enum_dump {
         int val;
@@ -1027,7 +1027,7 @@ dump_enums(void)
             { MAXSPELL, "MAXSPELL" },
     };
     struct enum_dump *ed[NUM_ENUM_DUMPS] = { monsdump, objdump, omdump };
-    static const char *pfx[NUM_ENUM_DUMPS] = { "PM_", "", "" };
+    static const char *const pfx[NUM_ENUM_DUMPS] = { "PM_", "", "" };
     int szd[NUM_ENUM_DUMPS] = { SIZE(monsdump), SIZE(objdump), SIZE(omdump) };
 
     for (i = 0; i < NUM_ENUM_DUMPS; ++ i) {

--- a/src/apply.c
+++ b/src/apply.c
@@ -4042,7 +4042,7 @@ flip_through_book(struct obj *obj)
     } else if (obj->otyp == SPE_NOVEL) {
         pline("This looks like it might be interesting to read.");
     } else {
-        static const char *fadeness[] = {
+        static const char *const fadeness[] = {
             "fresh",
             "slightly faded",
             "very faded",

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -1841,7 +1841,7 @@ glow_color(int arti_indx)
 }
 
 /* glow verb; [0] holds the value used when blind */
-static const char *glow_verbs[] = {
+static const char *const glow_verbs[] = {
     "quiver", "flicker", "glimmer", "gleam"
 };
 

--- a/src/ball.c
+++ b/src/ball.c
@@ -885,7 +885,7 @@ drop_ball(xchar x, xchar y)
     }
 
     if (x != u.ux || y != u.uy) {
-        static const char *pullmsg = "The ball pulls you out of the %s!";
+        static const char *const pullmsg = "The ball pulls you out of the %s!";
         struct trap *t;
         long side;
 

--- a/src/botl.c
+++ b/src/botl.c
@@ -1048,7 +1048,7 @@ parse_cond_option(boolean negated, char *opts)
 void
 cond_menu(void)
 {
-    static const char *menutitle[2] = { "alphabetically", "by ranking"};
+    static const char *const menutitle[2] = { "alphabetically", "by ranking"};
     int i, res, idx = 0;
     int sequence[CONDITION_COUNT];
     winid tmpwin;
@@ -2373,9 +2373,9 @@ parse_status_hl2(char (*s)[QBUFSZ], boolean from_configfile)
     enum statusfields fld = BL_FLUSH;
     struct hilite_s hilite;
     char tmpbuf[BUFSZ];
-    static const char *aligntxt[] = { "chaotic", "neutral", "lawful" };
+    static const char *const aligntxt[] = { "chaotic", "neutral", "lawful" };
     /* hu_stat[] from eat.c has trailing spaces which foul up comparisons */
-    static const char *hutxt[] = { "Satiated", "", "Hungry", "Weak",
+    static const char *const hutxt[] = { "Satiated", "", "Hungry", "Weak",
                                    "Fainting", "Fainted", "Starved" };
 
     /* Examples:
@@ -3654,7 +3654,7 @@ status_hilite_menu_add(int origfld)
             hilite.rel = TXT_VALUE;
             Strcpy(hilite.textmatch, enc_stat[rv]);
         } else if (fld == BL_ALIGN) {
-            static const char *aligntxt[] = {
+            static const char *const aligntxt[] = {
                 "chaotic", "neutral", "lawful"
             };
             int rv = query_arrayvalue(qry_buf,
@@ -3666,7 +3666,7 @@ status_hilite_menu_add(int origfld)
             hilite.rel = TXT_VALUE;
             Strcpy(hilite.textmatch, aligntxt[rv]);
         } else if (fld == BL_HUNGER) {
-            static const char *hutxt[] = { "Satiated", (char *) 0, "Hungry",
+            static const char *const hutxt[] = { "Satiated", (char *) 0, "Hungry",
                                            "Weak", "Fainting", "Fainted",
                                            "Starved" };
             int rv = query_arrayvalue(qry_buf,

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -449,7 +449,7 @@ doextlist(void)
     int n, pass;
     int menumode = 0, menushown[2], onelist = 0;
     boolean redisplay = TRUE, search = FALSE;
-    static const char *headings[] = { "Extended commands",
+    static const char *const headings[] = { "Extended commands",
                                       "Debugging Extended Commands" };
 
     searchbuf[0] = '\0';

--- a/src/dig.c
+++ b/src/dig.c
@@ -1368,7 +1368,7 @@ draft_message(boolean unexpected)
         } else {
             /* "marching" is deliberately ambiguous; it might mean drills
                 after entering military service or mean engaging in protests */
-            static const char *draft_reaction[] = {
+            static const char *const draft_reaction[] = {
                 "enlisting", "marching", "protesting", "fleeing",
             };
             int dridx;

--- a/src/display.c
+++ b/src/display.c
@@ -2686,7 +2686,7 @@ static const char *type_to_name(int);
 static void error4(int, int, int, int, int, int);
 
 static int bad_count[MAX_TYPE]; /* count of positions flagged as bad */
-static const char *type_names[MAX_TYPE] = {
+static const char *const type_names[MAX_TYPE] = {
     "STONE", "VWALL", "HWALL", "TLCORNER", "TRCORNER", "BLCORNER", "BRCORNER",
     "CROSSWALL", "TUWALL", "TDWALL", "TLWALL", "TRWALL", "DBWALL", "TREE",
     "SDOOR", "SCORR", "POOL", "MOAT", "WATER", "DRAWBRIDGE_UP", "LAVAPOOL",

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -477,7 +477,7 @@ dxdy_to_dist_descr(int dx, int dy, boolean fulldir)
         /* explicit direction; 'one step' is implicit */
         Sprintf(buf, "%s", directionname(dst));
     } else {
-        static const char *dirnames[4][2] = {
+        static const char *const dirnames[4][2] = {
             { "n", "north" },
             { "s", "south" },
             { "w", "west" },
@@ -2372,8 +2372,8 @@ coyotename(struct monst *mtmp, char *buf)
 char *
 rndorcname(char *s)
 {
-    static const char *v[] = { "a", "ai", "og", "u" };
-    static const char *snd[] = { "gor", "gris", "un", "bane", "ruk",
+    static const char *const v[] = { "a", "ai", "og", "u" };
+    static const char *const snd[] = { "gor", "gris", "un", "bane", "ruk",
                                  "oth","ul", "z", "thos","akh","hai" };
     int i, iend = rn1(2, 3), vstart = rn2(2);
 

--- a/src/eat.c
+++ b/src/eat.c
@@ -2198,7 +2198,7 @@ eatspecial(void)
 
 /* NOTE: the order of these words exactly corresponds to the
    order of oc_material values #define'd in objclass.h. */
-static const char *foodwords[] = {
+static const char *const foodwords[] = {
     "meal",    "liquid",  "wax",       "food", "meat",     "paper",
     "cloth",   "leather", "wood",      "bone", "scale",    "metal",
     "metal",   "metal",   "silver",    "gold", "platinum", "mithril",

--- a/src/lock.c
+++ b/src/lock.c
@@ -37,7 +37,7 @@ static const char *
 lock_action(void)
 {
     /* "unlocking"+2 == "locking" */
-    static const char *actions[] = {
+    static const char *const actions[] = {
         "unlocking the door",   /* [0] */
         "unlocking the chest",  /* [1] */
         "unlocking the box",    /* [2] */

--- a/src/mail.c
+++ b/src/mail.c
@@ -461,7 +461,7 @@ DISABLE_WARNING_FORMAT_NONLITERAL
 void
 readmail(struct obj *otmp UNUSED)
 {
-    static const char *junk[] = {
+    static const char *const junk[] = {
         "Report bugs to <%s>.", /*** must be first entry ***/
         "Please disregard previous letter.",
         "Welcome to NetHack.",

--- a/src/mdlib.c
+++ b/src/mdlib.c
@@ -422,7 +422,7 @@ build_savebones_compat_string(void)
                 VERSION_MAJOR, VERSION_MINOR, PATCHLEVEL);
 }
 
-static const char *build_opts[] = {
+static const char *const build_opts[] = {
 #ifdef AMIGA_WBENCH
     "Amiga WorkBench support",
 #endif
@@ -755,7 +755,7 @@ build_options(void)
 
 #if defined(MAKEDEFS_C) || defined(FOR_RUNTIME)
     {
-        static const char *lua_info[] = {
+        static const char *const lua_info[] = {
  "", "NetHack 3.7.* uses the 'Lua' interpreter to process some data:", "",
  "    :LUACOPYRIGHT:", "",
  /*        1         2         3         4         5         6         7

--- a/src/mkmaze.c
+++ b/src/mkmaze.c
@@ -589,7 +589,7 @@ check_ransacked(char * s)
 }
 
 #define ORC_LEADER 1
-static const char *orcfruit[] = { "paddle cactus", "dwarven root" };
+static const char *const orcfruit[] = { "paddle cactus", "dwarven root" };
 
 static void
 migrate_orc(struct monst* mtmp, unsigned long mflags)

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -1135,13 +1135,13 @@ raceptr(struct monst* mtmp)
         return mtmp->data;
 }
 
-static const char *levitate[4] = { "float", "Float", "wobble", "Wobble" };
-static const char *flys[4] = { "fly", "Fly", "flutter", "Flutter" };
-static const char *flyl[4] = { "fly", "Fly", "stagger", "Stagger" };
-static const char *slither[4] = { "slither", "Slither", "falter", "Falter" };
-static const char *ooze[4] = { "ooze", "Ooze", "tremble", "Tremble" };
-static const char *immobile[4] = { "wiggle", "Wiggle", "pulsate", "Pulsate" };
-static const char *crawl[4] = { "crawl", "Crawl", "falter", "Falter" };
+static const char *const levitate[4] = { "float", "Float", "wobble", "Wobble" };
+static const char *const flys[4] = { "fly", "Fly", "flutter", "Flutter" };
+static const char *const flyl[4] = { "fly", "Fly", "stagger", "Stagger" };
+static const char *const slither[4] = { "slither", "Slither", "falter", "Falter" };
+static const char *const ooze[4] = { "ooze", "Ooze", "tremble", "Tremble" };
+static const char *const immobile[4] = { "wiggle", "Wiggle", "pulsate", "Pulsate" };
+static const char *const crawl[4] = { "crawl", "Crawl", "falter", "Falter" };
 
 const char *
 locomotion(const struct permonst* ptr, const char* def)

--- a/src/mplayer.c
+++ b/src/mplayer.c
@@ -14,7 +14,7 @@ static void mk_mplayer_armor(struct monst *, short);
  * Keep in alphabetical order within teams.
  * Same first name is entered once within each team.
  */
-static const char *developers[] = {
+static const char *const developers[] = {
     /* devteam */
     "Alex",    "Dave",   "Dean",    "Derek",   "Eric",    "Izchak",
     "Janet",   "Jessie", "Ken",     "Kevin",   "Michael", "Mike",

--- a/src/muse.c
+++ b/src/muse.c
@@ -55,7 +55,7 @@ precheck(struct monst* mon, struct obj* obj)
 
     if (obj->oclass == POTION_CLASS) {
         coord cc;
-        static const char *empty = "The potion turns out to be empty.";
+        static const char *const empty = "The potion turns out to be empty.";
         struct monst *mtmp;
 
         if (objdescr_is(obj, "milky")) {

--- a/src/nhlua.c
+++ b/src/nhlua.c
@@ -54,7 +54,7 @@ static void init_u_data(lua_State *);
 static int nhl_set_package_path(lua_State *, const char *);
 static int traceback_handler(lua_State *);
 
-static const char *nhcore_call_names[NUM_NHCORE_CALLS] = {
+static const char *const nhcore_call_names[NUM_NHCORE_CALLS] = {
     "start_new_game",
     "restore_old_game",
     "moveloop_turn",

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -2112,7 +2112,7 @@ bare_artifactname(struct obj* obj)
     return outbuf;
 }
 
-static const char *wrp[] = {
+static const char *const wrp[] = {
     "wand",   "ring",      "potion",     "scroll", "gem",
     "amulet", "spellbook", "spell book",
     /* for non-specific wishes */
@@ -2756,7 +2756,7 @@ ch_ksound(const char *basestr)
 {
     /* these are some *ch words/suffixes that make a k-sound. They pluralize by
        adding 's' rather than 'es' */
-    static const char *ch_k[] = {
+    static const char *const ch_k[] = {
         "monarch",     "poch",    "tech",     "mech",      "stomach", "psych",
         "amphibrach",  "anarch",  "atriarch", "azedarach", "broch",
         "gastrotrich", "isopach", "loch",     "oligarch",  "peritrich",
@@ -2783,7 +2783,7 @@ badman(
     boolean to_plural)  /* True: makeplural, False: makesingular */
 {
     /* these are all the prefixes for *man that don't have a *men plural */
-    static const char *no_men[] = {
+    static const char *const no_men[] = {
         "albu", "antihu", "anti", "ata", "auto", "bildungsro", "cai", "cay",
         "ceru", "corner", "decu", "des", "dura", "fir", "hanu", "het",
         "infrahu", "inhu", "nonhu", "otto", "out", "prehu", "protohu",
@@ -2791,7 +2791,7 @@ badman(
         "hu", "un", "le", "re", "so", "to", "at", "a",
     };
     /* these are all the prefixes for *men that don't have a *man singular */
-    static const char *no_man[] = {
+    static const char *const no_man[] = {
         "abdo", "acu", "agno", "ceru", "cogno", "cycla", "fleh", "grava",
         "hegu", "preno", "sonar", "speci", "dai", "exa", "fla", "sta", "teg",
         "tegu", "vela", "da", "hy", "lu", "no", "nu", "ra", "ru", "se", "vi",

--- a/src/options.c
+++ b/src/options.c
@@ -1787,7 +1787,7 @@ optfn_mouse_support(
 #define MOUSEFIX1 ", O/S adjusted"
 #define MOUSEFIX2 ", O/S unchanged"
 #endif
-        static const char *mousemodes[][2] = {
+        static const char *const mousemodes[][2] = {
             { "0=off", "" },
             { "1=on",  MOUSEFIX1 },
             { "2=on",  MOUSEFIX2 },
@@ -1979,7 +1979,7 @@ optfn_number_pad(int optidx, int req, boolean negated, char *opts, char *op)
         return optn_ok;
     }
     if (req == get_val) {
-        static const char *numpadmodes[] = {
+        static const char *const numpadmodes[] = {
             "0=off", "1=on", "2=on, MSDOS compatible",
             "3=on, phone-style layout",
             "4=on, phone layout, MSDOS compatible",
@@ -4356,7 +4356,7 @@ handler_disclose(void)
     char buf[BUFSZ];
     /* order of disclose_names[] must correspond to
        disclosure_options in decl.c */
-    static const char *disclosure_names[] = {
+    static const char *const disclosure_names[] = {
         "inventory", "attributes", "vanquished",
         "genocides", "conduct",    "overview",
     };
@@ -4512,7 +4512,7 @@ handler_number_pad(void)
     winid tmpwin;
     anything any;
     int i;
-    static const char *npchoices[] = {
+    static const char *const npchoices[] = {
         " 0 (off)", " 1 (on)", " 2 (on, MSDOS compatible)",
         " 3 (on, phone-style digit layout)",
         " 4 (on, phone-style layout, MSDOS compatible)",
@@ -6474,7 +6474,7 @@ query_msgtype(void)
 static boolean
 msgtype_add(int typ, char *pattern)
 {
-    static const char *re_error = "MSGTYPE regex error";
+    static const char *const re_error = "MSGTYPE regex error";
     struct plinemsg_type *tmp = (struct plinemsg_type *) alloc(sizeof *tmp);
 
     tmp->msgtype = typ;
@@ -7991,7 +7991,7 @@ static const char *opt_intro[] = {
     (char *) 0
 };
 
-static const char *opt_epilog[] = {
+static const char *const opt_epilog[] = {
     "",
     "Some of the options can only be set before the game is started;",
     "those items will not be selectable in the 'O' command's menu.",
@@ -8483,8 +8483,8 @@ wc_set_window_colors(char *op)
     int j;
     char buf[BUFSZ];
     char *wn, *tfg, *tbg, *newop;
-    static const char *wnames[] = { "menu", "message", "status", "text" };
-    static const char *shortnames[] = { "mnu", "msg", "sts", "txt" };
+    static const char *const wnames[] = { "menu", "message", "status", "text" };
+    static const char *const shortnames[] = { "mnu", "msg", "sts", "txt" };
     static char **fgp[] = { &iflags.wc_foregrnd_menu,
                             &iflags.wc_foregrnd_message,
                             &iflags.wc_foregrnd_status,

--- a/src/pray.c
+++ b/src/pray.c
@@ -41,9 +41,9 @@ static boolean blocked_boulder(int, int);
  *      responsible for the theft of the Amulet from Marduk, the Creator.
  *      Moloch is unaligned.
  */
-static const char *Moloch = "Moloch";
+static const char *const Moloch = "Moloch";
 
-static const char *godvoices[] = {
+static const char *const godvoices[] = {
     "booms out", "thunders", "rings out", "booms",
 };
 
@@ -2187,7 +2187,7 @@ align_gname(aligntyp alignment)
     return gnam;
 }
 
-static const char *hallu_gods[] = {
+static const char *const hallu_gods[] = {
     "the Flying Spaghetti Monster", /* Church of the FSM */
     "Eris",                         /* Discordianism */
     "the Martians",                 /* every science fiction ever */

--- a/src/priest.c
+++ b/src/priest.c
@@ -567,7 +567,7 @@ priest_talk(struct monst *priest)
     /* priests don't chat unless peaceful and in their own temple */
     if (!inhistemple(priest) || !priest->mpeaceful
         || !priest->mcanmove || priest->msleeping) {
-        static const char *cranky_msg[3] = {
+        static const char *const cranky_msg[3] = {
             "Thou wouldst have words, eh?  I'll give thee a word or two!",
             "Talk?  Here is what I have to say!",
             "Pilgrim, I would speak no longer with thee."

--- a/src/read.c
+++ b/src/read.c
@@ -101,7 +101,7 @@ erode_obj_text(struct obj* otmp, char* buf)
 char *
 tshirt_text(struct obj* tshirt, char* buf)
 {
-    static const char *shirt_msgs[] = {
+    static const char *const shirt_msgs[] = {
         /* Scott Bigham */
       "I explored the Dungeons of Doom and all I got was this lousy T-shirt!",
         "Is that Mjollnir in your pocket or are you just happy to see me?",
@@ -190,7 +190,7 @@ tshirt_text(struct obj* tshirt, char* buf)
 char *
 hawaiian_motif(struct obj *shirt, char *buf)
 {
-    static const char *hawaiian_motifs[] = {
+    static const char *const hawaiian_motifs[] = {
         /* birds */
         "flamingo",
         "parrot",
@@ -224,7 +224,7 @@ hawaiian_motif(struct obj *shirt, char *buf)
 static char *
 hawaiian_design(struct obj *shirt, char *buf)
 {
-    static const char *hawaiian_bgs[] = {
+    static const char *const hawaiian_bgs[] = {
         /* solid colors */
         "purple",
         "yellow",
@@ -254,7 +254,7 @@ hawaiian_design(struct obj *shirt, char *buf)
 char *
 apron_text(struct obj* apron, char* buf)
 {
-    static const char *apron_msgs[] = {
+    static const char *const apron_msgs[] = {
         "Kiss the cook",
         "I'm making SCIENCE!",
         "Don't mess with the chef",
@@ -281,7 +281,7 @@ apron_text(struct obj* apron, char* buf)
     return erode_obj_text(apron, buf);
 }
 
-static const char *candy_wrappers[] = {
+static const char *const candy_wrappers[] = {
     "",                         /* (none -- should never happen) */
     "Apollo",                   /* Lost */
     "Moon Crunchy",             /* South Park */
@@ -436,7 +436,7 @@ doread(void)
             docall(scroll);
         return 1;
     } else if (otyp == CREDIT_CARD) {
-        static const char *card_msgs[] = {
+        static const char *const card_msgs[] = {
             "Leprechaun Gold Tru$t - Shamrock Card",
             "Magic Memory Vault Charge Card",
             "Larn National Bank",                /* Larn */

--- a/src/rip.c
+++ b/src/rip.c
@@ -21,7 +21,7 @@ static void center(int, char *);
 
 #ifndef NH320_DEDICATION
 /* A normal tombstone for end of game display. */
-static const char *rip_txt[] = {
+static const char *const rip_txt[] = {
     "                       ----------",
     "                      /          \\",
     "                     /    REST    \\",
@@ -41,7 +41,7 @@ static const char *rip_txt[] = {
 #define STONE_LINE_CENT 28 /* char[] element of center of stone face */
 #else                      /* NH320_DEDICATION */
 /* NetHack 3.2.x displayed a dual tombstone as a tribute to Izchak. */
-static const char *rip_txt[] = {
+static const char *const rip_txt[] = {
     "              ----------                      ----------",
     "             /          \\                    /          \\",
     "            /    REST    \\                  /    This    \\",

--- a/src/shk.c
+++ b/src/shk.c
@@ -83,7 +83,7 @@ static const char *cad(boolean);
                     obj->quan <= bp->bquan
  */
 
-static const char *angrytexts[] = { "quite upset", "ticked off", "furious" };
+static const char *const angrytexts[] = { "quite upset", "ticked off", "furious" };
 
 /*
  *  Transfer money from inventory to monster when paying

--- a/src/spell.c
+++ b/src/spell.c
@@ -1447,7 +1447,7 @@ enum spl_sort_types {
     NUM_SPELL_SORTBY
 };
 
-static const char *spl_sortchoices[NUM_SPELL_SORTBY] = {
+static const char *const spl_sortchoices[NUM_SPELL_SORTBY] = {
     "by casting letter",
     "alphabetically",
     "by level, low to high",

--- a/src/trap.c
+++ b/src/trap.c
@@ -5942,7 +5942,7 @@ maybe_finish_sokoban(void)
 const char *
 trapname(int ttyp, boolean override)
 {
-    static const char *halu_trapnames[] = {
+    static const char *const halu_trapnames[] = {
         /* riffs on actual nethack traps */
         "bottomless pit", "polymorphism trap", "devil teleporter",
         "falling boulder trap", "anti-anti-magic field", "weeping gas trap",


### PR DESCRIPTION
If you want to declare a pointer which the address pointed to is constant,
you should declare it as like `static const char *const var = "...";`.

This commit supplies missing `const` and prevents some programming
error in the future.