### PR TITLE
Turn cancelled bags of holding into sacks

### DIFF
--- a/src/pickup.c
+++ b/src/pickup.c
@@ -2224,14 +2224,12 @@ loot_mon(struct monst *mtmp, int *passed_info, boolean *prev_loot)
 static boolean
 mbag_explodes(struct obj *obj, int depthin)
 {
-    /* these won't cause an explosion when they're empty */
-    if ((obj->otyp == WAN_CANCELLATION || obj->otyp == BAG_OF_TRICKS)
-        && obj->spe <= 0)
+    /* won't cause an explosion when it's empty */
+    if (obj->otyp == BAG_OF_TRICKS && obj->spe <= 0)
         return FALSE;
 
     /* odds: 1/1, 2/2, 3/4, 4/8, 5/16, 6/32, 7/64, 8/128, 9/128, 10/128,... */
-    if ((Is_mbag(obj) || obj->otyp == WAN_CANCELLATION)
-        && (rn2(1 << (depthin > 7 ? 7 : depthin)) <= depthin))
+    if (Is_mbag(obj) && (rn2(1 << (depthin > 7 ? 7 : depthin)) <= depthin))
         return TRUE;
     else if (Has_contents(obj)) {
         struct obj *otmp;
@@ -2426,6 +2424,11 @@ in_container(struct obj *obj)
 
         losehp(d(6, 6), "magical explosion", KILLED_BY_AN);
         g.current_container = 0; /* baggone = TRUE; */
+    } else if (Is_mbag(g.current_container) &&
+               obj->otyp == WAN_CANCELLATION && obj->spe > 0) {
+        /* cancel bag because wand of cancellation was inserted */
+        cancel_item(g.current_container);
+        obj->spe--;
     }
 
     if (g.current_container) {

--- a/src/zap.c
+++ b/src/zap.c
@@ -1214,6 +1214,13 @@ cancel_item(struct obj *obj)
                 obj->odiluted = 0; /* same as any other water */
             }
             break;
+        case TOOL_CLASS:
+            /* A BoH turns into a sack when cancelled.  (The same thing
+               happens to the bag when a wand of cancellation is placed
+               into it.) */
+            if (otyp = BAG_OF_HOLDING)
+                obj->otyp = SACK;
+            break;
         }
     }
     /* cancelling a troll's corpse prevents it from reviving (on its own;


### PR DESCRIPTION
A wand or spell of cancellation zapped at a bag of holding now turns the bag into a sack. A wand of cancellation placed directly into a bag of holding now, instead of exploding the bag, just uses one charge and cancels the bag. This is not checked for recursively; you can put a wand of cancellation into a sack and then safely put the sack into a bag of holding.

The biggest consequence of this (other than making wands of cancellation less of a hassle to carry) has to do with looting cursed bags of holding from bones. Formerly, you could just cancel the bag and pick it up. You can still do this to safely retrieve the items, but you don't get to keep the bag of holding. If you want to keep the bag, you have empty it first and risk losing some of the contents. There is now an opportunity cost.