### PR TITLE
Don't erase Elbereth when monster steps into a pit or hole dug by you

### DIFF
--- a/src/trap.c
+++ b/src/trap.c
@@ -3115,7 +3115,7 @@ mintrap(register struct monst *mtmp)
            Recognizing who made the trap isn't completely
            unreasonable; everybody has their own style. */
         if (trap->madeby_u && rnl(5))
-            setmangry(mtmp, TRUE);
+            setmangry(mtmp, FALSE);
 
         return trapeffect_selector(mtmp, trap, 0);
     }


### PR DESCRIPTION
Elbereth was fading when offscreen monsters stepped into pits or holes dug elsewhere on the level. This was happening because monsters falling into traps set by you were calling setmangry() as if you had just attacked them. The behavior made it unsafe to use Elbereth if you've dug down _anywhere else_ on the level, making it a bit harder to get archeologists off the ground. This branch alters that behavior.

I don't think it makes much sense for monsters to recognize a the handiwork of a newcomer to the dungeon setting a trap (let alone _digging a hole with a wand of digging_) in the first place, but I've opted for the more conservative change. If you agree with me, feel free to just remove lines trap.c:3114-3118 altogether instead.