### PR TITLE
Allow bullwhips to grab items when flying

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -2763,7 +2763,7 @@ use_whip(struct obj *obj)
                 (void) fire_damage(uwep, FALSE, u.ux, u.uy);
             return 1;
         }
-        if (Levitation || u.usteed) {
+        if (Flying || Levitation || u.usteed) {
             /* Have a shot at snaring something on the floor */
             otmp = g.level.objects[u.ux][u.uy];
             if (otmp && otmp->otyp == CORPSE && otmp->corpsenm == PM_HORSE) {


### PR DESCRIPTION
Generally Flying is "levitation, but better", and this is reflected by it
occupying a more valuable item slot, an amulet rather than a ring. One case
where that is not yet true is when an item is submerged in water. The item
can be grabbed by a levitating player, but not a flying player.