### PR TITLE
Magical breathing helps fish survive out of water

### DIFF
--- a/src/allmain.c
+++ b/src/allmain.c
@@ -528,7 +528,8 @@ regen_hp(int wtcap)
         if (u.mh < 1) { /* shouldn't happen... */
             rehumanize();
         } else if (g.youmonst.data->mlet == S_EEL
-                   && !is_pool(u.ux, u.uy) && !Is_waterlevel(&u.uz)) {
+                   && !is_pool(u.ux, u.uy) && !Is_waterlevel(&u.uz)
+                   && !Breathless) {
             /* eel out of water loses hp, similar to monster eels;
                as hp gets lower, rate of further loss slows down */
             if (u.mh > 1 && !Regeneration && rn2(u.mh) > rn2(8)

--- a/src/mon.c
+++ b/src/mon.c
@@ -828,7 +828,8 @@ minliquid_core(struct monst* mtmp)
         }
     } else {
         /* but eels have a difficult time outside */
-        if (mtmp->data->mlet == S_EEL && !Is_waterlevel(&u.uz)) {
+        if (mtmp->data->mlet == S_EEL && !Is_waterlevel(&u.uz)
+            && !breathless(mtmp->data)) {
             /* as mhp gets lower, the rate of further loss slows down */
             if (mtmp->mhp > 1 && rn2(mtmp->mhp) > rn2(8))
                 mtmp->mhp--;


### PR DESCRIPTION
The hero in an aquatic polyform loses HP for time spent out of the
water; allow magical breathing to prevent this, just as it allows the
hero in her non-aquatic natural form to breathe underwater.

Also add a similar rule for monster fish-out-of-water HP loss, even
though currently monsters can't use amulets of magical breathing and
there's no non-breathing fish/eel -- just in case this changes at some
point.
