### PR TITLE
Using the() with monster name

### DIFF
--- a/src/objnam.c
+++ b/src/objnam.c
@@ -1812,6 +1812,8 @@ the(const char* str)
 {
     char *buf = nextobuf();
     boolean insert_the = FALSE;
+    const char *rest;
+    int mnum;
 
     if (!str || !*str) {
         impossible("Alphabet soup: 'the(%s)'.", str ? "\"\"" : "<null>");
@@ -1824,7 +1826,11 @@ the(const char* str)
     } else if (*str < 'A' || *str > 'Z'
                /* treat named fruit as not a proper name, even if player
                   has assigned a capitalized proper name as his/her fruit */
-               || fruit_from_name(str, TRUE, (int *) 0)) {
+               || fruit_from_name(str, TRUE, (int *) 0)
+               /* some monster names, like Angel or Keystone Kop, are
+                  capitalized despite not being proper names */
+               || (((mnum = name_to_monplus(str, &rest, (int *) 0)) > NON_PM
+                    && !type_is_pname(&mons[mnum]) && !*rest))) {
         /* not a proper name, needs an article */
         insert_the = TRUE;
     } else {


### PR DESCRIPTION
the() treats most capitalized words as proper names, which caused
problems when it was used to prepend 'the' to a monster name.

Using the() with monster names is intentionally avoided in most places
for this reason, but there are still quite a few spots where it's used,
e.g., formatting killer names, applying a stethoscope to a statue,
hitting something with a monster egg, attempting to polymorph into an
invalid form...  Rather than replacing all these uses of the(), have it
check whether the string is an exact match for a non-pname monster name,
and if so, ignore capitalization.
