### PR TITLE
Fix: zoo monsters spawning in hallways

### DIFF
--- a/src/mkroom.c
+++ b/src/mkroom.c
@@ -340,7 +340,7 @@ fill_zoo(struct mkroom* sroom)
                                              : (type == ANTHOLE)
                                                  ? antholemon()
                                                  : (struct permonst *) 0,
-                          sx, sy, MM_ASLEEP);
+                          sx, sy, MM_ASLEEP | MM_NOGRP);
             if (mon) {
                 mon->msleeping = 1;
                 if (type == COURT && mon->mpeaceful) {


### PR DESCRIPTION
If a random G_[SL]GROUP monster was generated in a zoo, the resulting
group of monsters could spill out into nearby hallways and other
surrounding areas.  Disregard G_GROUP flags when filling a zoo with
monsters to avoid this problem.

Example of the issue:
<img width="170" alt="Screen Shot 2021-11-30 at 1 42 51 PM" src="https://user-images.githubusercontent.com/40038830/144124748-9e719b82-39a5-48ce-bc1c-c647d88aa9dd.png">

