### PR TITLE
Fix: 'you owe It for goods lost'

### DIFF
--- a/src/dig.c
+++ b/src/dig.c
@@ -1912,7 +1912,7 @@ bury_objs(int x, int y)
     newsym(x, y);
 
     if (costly && loss) {
-        You("owe %s %ld %s for burying merchandise.", mon_nam(shkp), loss,
+        You("owe %s %ld %s for burying merchandise.", shkname(shkp), loss,
             currency(loss));
     }
 }

--- a/src/dokick.c
+++ b/src/dokick.c
@@ -434,7 +434,7 @@ container_impact_dmg(struct obj *obj, xchar x,
             You("caused %ld %s worth of damage!", loss, currency(loss));
             make_angry_shk(shkp, x, y);
         } else {
-            You("owe %s %ld %s for objects destroyed.", mon_nam(shkp), loss,
+            You("owe %s %ld %s for objects destroyed.", shkname(shkp), loss,
                 currency(loss));
         }
     }
@@ -1459,7 +1459,7 @@ impact_drop(struct obj *missile, /* caused impact, won't drop itself */
                 if (ESHK(shkp)->customer[0] == 0)
                     (void) strncpy(ESHK(shkp)->customer, g.plname, PL_NSIZ);
                 if (angry)
-                    pline("%s is infuriated!", Monnam(shkp));
+                    pline("%s is infuriated!", Shknam(shkp));
                 else
                     pline("\"%s, you are a thief!\"", g.plname);
             } else
@@ -1470,7 +1470,7 @@ impact_drop(struct obj *missile, /* caused impact, won't drop itself */
         }
         if (ESHK(shkp)->debit > debit) {
             long amt = (ESHK(shkp)->debit - debit);
-            You("owe %s %ld %s for goods lost.", Monnam(shkp), amt,
+            You("owe %s %ld %s for goods lost.", shkname(shkp), amt,
                 currency(amt));
         }
     }

--- a/src/zap.c
+++ b/src/zap.c
@@ -1814,11 +1814,11 @@ poly_obj(struct obj *obj, int id)
                     && !costly_spot(u.ux, u.uy)) {
                     make_angry_shk(shkp, ox, oy);
                 } else {
-                    pline("%s gets angry!", Monnam(shkp));
+                    pline("%s gets angry!", Shknam(shkp));
                     hot_pursuit(shkp);
                 }
             } else
-                Norep("%s is furious!", Monnam(shkp));
+                Norep("%s is furious!", Shknam(shkp));
         }
     }
     delobj(obj);


### PR DESCRIPTION
Some messages about owing a shopkeeper money would use 'it' when blind,
with weird results such as "You owe It 267 zorkmids for goods lost."  It
seems maybe like these were missed in 6591f8b since they were outside of
shk.c/shknam.c.  Bring those messages into alignment with most other
shopkeeper-related messages, which use the shopkeeper's name even if the
hero is blind or can't see them at the moment.

Some of the 'it gets angry' ones don't seem so bad, but similar 'gets angry' messages in shk.c use Shknam so I changed those as well for consistency's sake.