### PR TITLE
libnethack compilation with TARGETPFX

### DIFF
--- a/sys/unix/hints/linux.2020
+++ b/sys/unix/hints/linux.2020
@@ -155,8 +155,9 @@ LIBNHSYSSRC = ../sys/libnh/libnhmain.c \
 		../sys/share/ioctl.c ../sys/share/unixtty.c \
 		../sys/unix/unixunix.c ../sys/unix/unixres.c \
 		../win/shim/winshim.c
-LIBNHSYSOBJ= libnhmain.o ioctl.o unixtty.o unixunix.o \
-                unixres.o winshim.o
+LIBNHSYSOBJ = libnhmain.o $(TARGETPFX)ioctl.o \
+		$(TARGETPFX)unixtty.o $(TARGETPFX)unixunix.o \
+		$(TARGETPFX)unixres.o winshim.o
 #don't bother building the game executable as it will fail
 #without winshim
 override GAME=

--- a/sys/unix/hints/linux.2020
+++ b/sys/unix/hints/linux.2020
@@ -155,13 +155,13 @@ LIBNHSYSSRC = ../sys/libnh/libnhmain.c \
 		../sys/share/ioctl.c ../sys/share/unixtty.c \
 		../sys/unix/unixunix.c ../sys/unix/unixres.c \
 		../win/shim/winshim.c
-LIBNHSYSOBJ = libnhmain.o $(TARGETPFX)ioctl.o \
+LIBNHSYSOBJ = $(TARGETPFX)libnhmain.o $(TARGETPFX)ioctl.o \
 		$(TARGETPFX)unixtty.o $(TARGETPFX)unixunix.o \
-		$(TARGETPFX)unixres.o winshim.o
+		$(TARGETPFX)unixres.o $(TARGETPFX)winshim.o
 #don't bother building the game executable as it will fail
 #without winshim
 override GAME=
-MOREALL += ( cd src ; $(MAKE) pregame ; $(MAKE) libnh.a )
+MOREALL += ( cd src ; $(MAKE) pregame ; $(MAKE) $(TARGETPFX)libnh.a )
 endif  # WANT_LIBNH
 
 #PREFIX=/usr
@@ -211,12 +211,12 @@ GAMEPERM = 0755
 #-INCLUDE cross-post.2020
 #
 ifdef WANT_LIBNH
-libnh.a: $(HOBJ) $(LIBNHSYSOBJ) ../lib/lua/liblua.a
+$(TARGETPFX)libnh.a: $(HOBJ) $(LIBNHSYSOBJ) ../lib/lua/liblua.a
 	$(AR) rcs $@ $(HOBJ) $(LIBNHSYSOBJ) ../lib/lua/liblua.a
 	@echo "$@ built."
-libnhmain.o : ../sys/libnh/libnhmain.c $(HACK_H)
+$(TARGETPFX)libnhmain.o : ../sys/libnh/libnhmain.c $(HACK_H)
 	$(CC) $(CFLAGS) -c -o$@ $<
-winshim.o : ../win/shim/winshim.c $(HACK_H)
+$(TARGETPFX)winshim.o : ../win/shim/winshim.c $(HACK_H)
 	$(CC) $(CFLAGS) -c -o$@ $<
 endif  # WANT_LIBNH
 #

--- a/sys/unix/hints/macOS.2020
+++ b/sys/unix/hints/macOS.2020
@@ -155,8 +155,9 @@ LIBNHSYSSRC = ../sys/libnh/libnhmain.c \
 		../sys/share/ioctl.c ../sys/share/unixtty.c \
 		../sys/unix/unixunix.c ../sys/unix/unixres.c \
 		../win/shim/winshim.c
-LIBNHSYSOBJ= libnhmain.o ioctl.o unixtty.o unixunix.o \
-                unixres.o winshim.o
+LIBNHSYSOBJ = libnhmain.o $(TARGETPFX)ioctl.o \
+		$(TARGETPFX)unixtty.o $(TARGETPFX)unixunix.o \
+		$(TARGETPFX)unixres.o winshim.o
 #don't bother building the game executable as it will fail
 #without winshim
 override GAME=

--- a/sys/unix/hints/macOS.2020
+++ b/sys/unix/hints/macOS.2020
@@ -155,13 +155,13 @@ LIBNHSYSSRC = ../sys/libnh/libnhmain.c \
 		../sys/share/ioctl.c ../sys/share/unixtty.c \
 		../sys/unix/unixunix.c ../sys/unix/unixres.c \
 		../win/shim/winshim.c
-LIBNHSYSOBJ = libnhmain.o $(TARGETPFX)ioctl.o \
+LIBNHSYSOBJ = $(TARGETPFX)libnhmain.o $(TARGETPFX)ioctl.o \
 		$(TARGETPFX)unixtty.o $(TARGETPFX)unixunix.o \
-		$(TARGETPFX)unixres.o winshim.o
+		$(TARGETPFX)unixres.o $(TARGETPFX)winshim.o
 #don't bother building the game executable as it will fail
 #without winshim
 override GAME=
-MOREALL += ( cd src ; $(MAKE) pregame ; $(MAKE) libnh.a )
+MOREALL += ( cd src ; $(MAKE) pregame ; $(MAKE) $(TARGETPFX)libnh.a )
 endif  # WANT_LIBNH
 
 WANT_BUNDLE=1
@@ -275,12 +275,12 @@ VARDIR=$(HACKDIR)
 #-POST
 
 ifdef WANT_LIBNH
-libnh.a: $(HOBJ) $(LIBNHSYSOBJ) ../lib/lua/liblua.a
+$(TARGETPFX)libnh.a: $(HOBJ) $(LIBNHSYSOBJ) ../lib/lua/liblua.a
 	$(AR) rcs $@ $(HOBJ) $(LIBNHSYSOBJ) ../lib/lua/liblua.a
 	@echo "$@ built."
-libnhmain.o : ../sys/libnh/libnhmain.c $(HACK_H)
+$(TARGETPFX)libnhmain.o : ../sys/libnh/libnhmain.c $(HACK_H)
 	$(CC) $(CFLAGS) -c -o$@ $<
-winshim.o : ../win/shim/winshim.c $(HACK_H)
+$(TARGETPFX)winshim.o : ../win/shim/winshim.c $(HACK_H)
 	$(CC) $(CFLAGS) -c -o$@ $<
 endif  # WANT_LIBNH
 


### PR DESCRIPTION
Found a couple issues when compiling libnh while using the `TARGETPFX` option.

I tested that these changes work when using `TARGETPFX` option and also when leaving the option unchanged.

Only the Linux hints file was tested, since I don't have access to a MacOS machine. Maybe someone else can test it. I could also remove the changes from the MacOS hints file if that's preferred.