### PR TITLE
Remove gendered mons indices from roles, races

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -622,11 +622,8 @@ enum glyph_offsets {
 /* The hero's glyph when seen as a monster.
  */
 #define hero_glyph                                                      \
-    monnum_to_glyph((Upolyd || !flags.showrace)                         \
-                        ? u.umonnum                                     \
-                        : (flags.female && g.urace.femalenum != NON_PM) \
-                              ? g.urace.femalenum                       \
-                              : g.urace.malenum, (Ugender))
+    monnum_to_glyph((Upolyd || !flags.showrace) ? u.umonnum : g.urace.mnum, \
+                    (Ugender))
 
 /*
  * Change the given glyph into it's given type.  Note:

--- a/include/you.h
+++ b/include/you.h
@@ -175,8 +175,7 @@ struct Role {
     const char *intermed; /* quest intermediate goal (from questpgr.c) */
 
     /*** Indices of important monsters and objects ***/
-    short malenum, /* index (PM_) as a male (botl.c) */
-        femalenum, /* ...or as a female (NON_PM == same) */
+    short mnum,    /* index (PM_) of role (botl.c) */
         petnum,    /* PM_ of preferred pet (NON_PM == random) */
         ldrnum,    /* PM_ of quest leader (questpgr.c) */
         guardnum,  /* PM_ of quest guardians (questpgr.c) */
@@ -230,8 +229,8 @@ struct Role {
 };
 
 extern const struct Role roles[]; /* table of available roles */
-#define Role_if(X) (g.urole.malenum == (X))
-#define Role_switch (g.urole.malenum)
+#define Role_if(X) (g.urole.mnum == (X))
+#define Role_switch (g.urole.mnum)
 
 /* used during initialization for race, gender, and alignment
    as well as for character class */
@@ -249,8 +248,7 @@ struct Race {
     struct RoleName individual; /* individual as a noun ("man", "elf") */
 
     /*** Indices of important monsters and objects ***/
-    short malenum, /* PM_ as a male monster */
-        femalenum, /* ...or as a female (NON_PM == same) */
+    short mnum,    /* PM_ as a monster */
         mummynum,  /* PM_ as a mummy */
         zombienum; /* PM_ as a zombie */
 
@@ -281,8 +279,8 @@ struct Race {
 };
 
 extern const struct Race races[]; /* Table of available races */
-#define Race_if(X) (g.urace.malenum == (X))
-#define Race_switch (g.urace.malenum)
+#define Race_if(X) (g.urace.mnum == (X))
+#define Race_switch (g.urace.mnum)
 
 /*** Unified structure specifying gender information ***/
 struct Gender {

--- a/outdated/win/Qt3/qt3_win.cpp
+++ b/outdated/win/Qt3/qt3_win.cpp
@@ -929,7 +929,7 @@ public:
 #endif
 	)
     {
-	setGlyph(monnum_to_glyph(roles[id].malenum));
+	setGlyph(monnum_to_glyph(roles[id].mnum));
     }
 };
 
@@ -944,7 +944,7 @@ public:
 #endif
 	)
     {
-	setGlyph(monnum_to_glyph(races[id].malenum));
+	setGlyph(monnum_to_glyph(races[id].mnum));
     }
 };
 

--- a/outdated/win/gem/wingem.c
+++ b/outdated/win/gem/wingem.c
@@ -250,7 +250,7 @@ Gem_player_selection()
                     currch = lowc(roles[i].name.m[0]);
                     if (currch == lastch)
                         currch = highc(currch);
-                    add_menu(win, roles[i].malenum, &any, currch, 0, ATR_NONE,
+                    add_menu(win, roles[i].mnum, &any, currch, 0, ATR_NONE,
                              an(roles[i].name.m), MENU_ITEMFLAGS_NONE);
                     lastch = currch;
                 }

--- a/src/botl.c
+++ b/src/botl.c
@@ -327,7 +327,7 @@ rank_of(int lev, short monnum, boolean female)
 
     /* Find the role */
     for (role = roles; role->name.m; role++)
-        if (monnum == role->malenum || monnum == role->femalenum)
+        if (monnum == role->mnum)
             break;
     if (!role->name.m)
         role = &g.urole;
@@ -370,7 +370,7 @@ title_to_mon(const char *str, int *rank_indx, int *title_length)
                     *rank_indx = j;
                 if (title_length)
                     *title_length = strlen(roles[i].rank[j].m);
-                return roles[i].malenum;
+                return roles[i].mnum;
             }
             if (roles[i].rank[j].f
                 && !strncmpi(str, roles[i].rank[j].f,
@@ -379,8 +379,7 @@ title_to_mon(const char *str, int *rank_indx, int *title_length)
                     *rank_indx = j;
                 if (title_length)
                     *title_length = strlen(roles[i].rank[j].f);
-                return (roles[i].femalenum != NON_PM) ? roles[i].femalenum
-                                                      : roles[i].malenum;
+                return roles[i].mnum;
             }
         }
     }

--- a/src/decl.c
+++ b/src/decl.c
@@ -150,7 +150,7 @@ const struct Role urole_init_data = {
       { 0, 0 }, { 0, 0 }, { 0, 0 }, { 0, 0 } },
     "L", "N", "C",
     "Xxx", "home", "locate",
-    NON_PM, NON_PM, NON_PM, NON_PM, NON_PM, NON_PM, NON_PM, NON_PM,
+    NON_PM, NON_PM, NON_PM, NON_PM, NON_PM, NON_PM, NON_PM,
     0, 0, 0, 0,
     /* Str Int Wis Dex Con Cha */
     { 7, 7, 7, 7, 7, 7 },
@@ -175,7 +175,6 @@ const struct Race urace_init_data = {
     "something",
     "Xxx",
     { 0, 0 },
-    NON_PM,
     NON_PM,
     NON_PM,
     NON_PM,

--- a/src/end.c
+++ b/src/end.c
@@ -1404,15 +1404,10 @@ really_done(int how)
        this grave in the current level's features for #overview */
     if (bones_ok && u.ugrave_arise == NON_PM
         && !(g.mvitals[u.umonnum].mvflags & G_NOCORPSE)) {
-        int mnum = u.umonnum;
+        /* Base corpse on race when not poly'd since original u.umonnum
+           is based on role, and all role monsters are human. */
+        int mnum = !Upolyd ? g.urace.mnum : u.umonnum;
 
-        if (!Upolyd) {
-            /* Base corpse on race when not poly'd since original u.umonnum
-               is based on role, and all role monsters are human. */
-            mnum = (flags.female && g.urace.femalenum != NON_PM)
-                       ? g.urace.femalenum
-                       : g.urace.malenum;
-        }
         corpse = mk_named_object(CORPSE, &mons[mnum], u.ux, u.uy, g.plname);
         Sprintf(pbuf, "%s, ", g.plname);
         formatkiller(eos(pbuf), sizeof pbuf - strlen(pbuf), how, TRUE);

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -1090,7 +1090,7 @@ mksobj(int otyp, boolean init, boolean artif)
         if (otmp->corpsenm == NON_PM) {
             otmp->corpsenm = undead_to_corpse(rndmonnum());
             if (g.mvitals[otmp->corpsenm].mvflags & (G_NOCORPSE | G_GONE))
-                otmp->corpsenm = g.urole.malenum;
+                otmp->corpsenm = g.urole.mnum;
         }
         /*FALLTHRU*/
     case STATUE:

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -1166,7 +1166,7 @@ const struct permonst *
 raceptr(struct monst* mtmp)
 {
     if (mtmp == &g.youmonst && !Upolyd)
-        return &mons[g.urace.malenum];
+        return &mons[g.urace.mnum];
     else
         return mtmp->data;
 }

--- a/src/mplayer.c
+++ b/src/mplayer.c
@@ -366,8 +366,7 @@ mplayer_talk(register struct monst* mtmp)
     if (mtmp->mpeaceful)
         return; /* will drop to humanoid talk */
 
-    pline("Talk? -- %s", (mtmp->data == &mons[g.urole.malenum]
-                          || mtmp->data == &mons[g.urole.femalenum])
+    pline("Talk? -- %s", mtmp->data == &mons[g.urole.mnum]
                              ? same_class_msg[rn2(3)]
                              : other_class_msg[rn2(3)]);
 }

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -87,7 +87,7 @@ set_uasmon(void)
     PROPSET(SEE_INVIS, perceives(mdat));
     PROPSET(TELEPAT, telepathic(mdat));
     /* note that Infravision uses mons[race] rather than usual mons[role] */
-    PROPSET(INFRAVISION, infravision(Upolyd ? mdat : &mons[g.urace.malenum]));
+    PROPSET(INFRAVISION, infravision(Upolyd ? mdat : &mons[g.urace.mnum]));
     PROPSET(INVIS, pm_invisible(mdat));
     PROPSET(TELEPORT, can_teleport(mdat));
     PROPSET(TELEPORT_CONTROL, control_teleport(mdat));
@@ -240,32 +240,24 @@ RESTORE_WARNING_FORMAT_NONLITERAL
 void
 change_sex(void)
 {
-    /* setting u.umonster for caveman/cavewoman or priest/priestess
-       swap unintentionally makes `Upolyd' appear to be true */
-    boolean already_polyd = (boolean) Upolyd;
-
     /* Some monsters are always of one sex and their sex can't be changed;
      * Succubi/incubi can change, but are handled below.
      *
-     * !already_polyd check necessary because is_male() and is_female()
-     * are true if the player is a priest/priestess.
+     * !Upolyd check necessary because is_male() and is_female()
+     * may be true for certain roles
      */
-    if (!already_polyd
+    if (!Upolyd
         || (!is_male(g.youmonst.data) && !is_female(g.youmonst.data)
             && !is_neuter(g.youmonst.data)))
         flags.female = !flags.female;
-    if (already_polyd) /* poly'd: also change saved sex */
+    if (Upolyd) /* poly'd: also change saved sex */
         u.mfemale = !u.mfemale;
     max_rank_sz(); /* [this appears to be superfluous] */
-    if ((already_polyd ? u.mfemale : flags.female) && g.urole.name.f)
+    if ((Upolyd ? u.mfemale : flags.female) && g.urole.name.f)
         Strcpy(g.pl_character, g.urole.name.f);
     else
         Strcpy(g.pl_character, g.urole.name.m);
-    u.umonster = ((already_polyd ? u.mfemale : flags.female)
-                  && g.urole.femalenum != NON_PM)
-                     ? g.urole.femalenum
-                     : g.urole.malenum;
-    if (!already_polyd) {
+    if (!Upolyd) {
         u.umonnum = u.umonster;
     } else if (u.umonnum == PM_AMOROUS_DEMON) {
         flags.female = !flags.female;
@@ -499,8 +491,7 @@ polyself(int psflags)
                        && !(mntmp == PM_HUMAN
                             || (your_race(&mons[mntmp])
                                 && (mons[mntmp].geno & G_UNIQ) == 0)
-                            || mntmp == g.urole.malenum
-                            || mntmp == g.urole.femalenum)) {
+                            || mntmp == g.urole.mnum)) {
                 const char *pm_name;
 
                 /* mkclass_poly() can pick a !polyok()
@@ -1983,12 +1974,8 @@ polysense(void)
 boolean
 ugenocided(void)
 {
-    return ((g.mvitals[g.urole.malenum].mvflags & G_GENOD)
-            || (g.urole.femalenum != NON_PM
-                && (g.mvitals[g.urole.femalenum].mvflags & G_GENOD))
-            || (g.mvitals[g.urace.malenum].mvflags & G_GENOD)
-            || (g.urace.femalenum != NON_PM
-                && (g.mvitals[g.urace.femalenum].mvflags & G_GENOD)));
+    return ((g.mvitals[g.urole.mnum].mvflags & G_GENOD)
+            || (g.mvitals[g.urace.mnum].mvflags & G_GENOD));
 }
 
 /* how hero feels "inside" after self-genocide of role or race */

--- a/src/read.c
+++ b/src/read.c
@@ -5,12 +5,8 @@
 
 #include "hack.h"
 
-#define Your_Own_Role(mndx)  \
-    ((mndx) == g.urole.malenum \
-     || (g.urole.femalenum != NON_PM && (mndx) == g.urole.femalenum))
-#define Your_Own_Race(mndx)  \
-    ((mndx) == g.urace.malenum \
-     || (g.urace.femalenum != NON_PM && (mndx) == g.urace.femalenum))
+#define Your_Own_Role(mndx)  ((mndx) == g.urole.mnum)
+#define Your_Own_Race(mndx)  ((mndx) == g.urace.mnum)
 
 static boolean learnscrolltyp(short);
 static void cap_spe(struct obj *);
@@ -2420,8 +2416,8 @@ do_class_genocide(void)
                     goodcnt++;
             }
         }
-        if (!goodcnt && class != mons[g.urole.malenum].mlet
-            && class != mons[g.urace.malenum].mlet) {
+        if (!goodcnt && class != mons[g.urole.mnum].mlet
+            && class != mons[g.urace.mnum].mlet) {
             if (gonecnt)
                 pline("All such monsters are already nonexistent.");
             else if (immunecnt || class == S_invisible)
@@ -2481,7 +2477,7 @@ do_class_genocide(void)
                     /* Self-genocide if it matches either your race
                        or role.  Assumption:  male and female forms
                        share same monster class. */
-                    if (i == g.urole.malenum || i == g.urace.malenum) {
+                    if (i == g.urole.mnum || i == g.urace.mnum) {
                         u.uhp = -1;
                         if (Upolyd) {
                             if (!feel_dead++)
@@ -2642,16 +2638,6 @@ do_genocide(int how)
               (*which != 'a') ? buf : makeplural(buf));
 
         if (killplayer) {
-            /* might need to wipe out dual role */
-            if (g.urole.femalenum != NON_PM && mndx == g.urole.malenum)
-                g.mvitals[g.urole.femalenum].mvflags |= (G_GENOD | G_NOCORPSE);
-            if (g.urole.femalenum != NON_PM && mndx == g.urole.femalenum)
-                g.mvitals[g.urole.malenum].mvflags |= (G_GENOD | G_NOCORPSE);
-            if (g.urace.femalenum != NON_PM && mndx == g.urace.malenum)
-                g.mvitals[g.urace.femalenum].mvflags |= (G_GENOD | G_NOCORPSE);
-            if (g.urace.femalenum != NON_PM && mndx == g.urace.femalenum)
-                g.mvitals[g.urace.malenum].mvflags |= (G_GENOD | G_NOCORPSE);
-
             u.uhp = -1;
             if (how & PLAYER) {
                 g.killer.format = KILLED_BY;
@@ -2821,7 +2807,7 @@ create_particular_parse(char* str, struct _create_particular_data* d)
 
     d->quan = 1 + ((g.multi > 0) ? g.multi : 0);
     d->monclass = MAXMCLASSES;
-    d->which = g.urole.malenum; /* an arbitrary index into mons[] */
+    d->which = g.urole.mnum; /* an arbitrary index into mons[] */
     d->fem = -1;     /* gender not specified */
     d->genderconf = -1;  /* no confusion on which gender to assign */
     d->randmonst = FALSE;
@@ -2919,7 +2905,7 @@ create_particular_parse(char* str, struct _create_particular_data* d)
         d->monclass = MAXMCLASSES;
         return TRUE;
     } else if (d->monclass > 0) {
-        d->which = g.urole.malenum; /* reset from NON_PM */
+        d->which = g.urole.mnum; /* reset from NON_PM */
         return TRUE;
     }
     return FALSE;

--- a/src/role.c
+++ b/src/role.c
@@ -41,7 +41,6 @@ const struct Role roles[NUM_ROLES+1] = {
       "the Tomb of the Toltec Kings",
       PM_ARCHEOLOGIST,
       NON_PM,
-      NON_PM,
       PM_LORD_CARNARVON,
       PM_STUDENT,
       PM_MINION_OF_HUHETOTL,
@@ -83,7 +82,6 @@ const struct Role roles[NUM_ROLES+1] = {
       "the Duali Oasis",
       PM_BARBARIAN,
       NON_PM,
-      NON_PM,
       PM_PELIAS,
       PM_CHIEFTAIN,
       PM_THOTH_AMON,
@@ -124,7 +122,6 @@ const struct Role roles[NUM_ROLES+1] = {
       "the Caves of the Ancestors",
       "the Dragon's Lair",
       PM_CAVE_DWELLER,
-      NON_PM,
       PM_LITTLE_DOG,
       PM_SHAMAN_KARNOV,
       PM_NEANDERTHAL,
@@ -167,7 +164,6 @@ const struct Role roles[NUM_ROLES+1] = {
       "the Temple of Coeus",
       PM_HEALER,
       NON_PM,
-      NON_PM,
       PM_HIPPOCRATES,
       PM_ATTENDANT,
       PM_CYCLOPS,
@@ -207,7 +203,6 @@ const struct Role roles[NUM_ROLES+1] = {
       "Camelot Castle",
       "the Isle of Glass",
       PM_KNIGHT,
-      NON_PM,
       PM_PONY,
       PM_KING_ARTHUR,
       PM_PAGE,
@@ -249,7 +244,6 @@ const struct Role roles[NUM_ROLES+1] = {
       "the Monastery of the Earth-Lord",
       PM_MONK,
       NON_PM,
-      NON_PM,
       PM_GRAND_MASTER,
       PM_ABBOT,
       PM_MASTER_KAEN,
@@ -290,7 +284,6 @@ const struct Role roles[NUM_ROLES+1] = {
       "the Great Temple",
       "the Temple of Nalzok",
       PM_CLERIC,
-      NON_PM,
       NON_PM,
       PM_ARCH_PRIEST,
       PM_ACOLYTE,
@@ -334,7 +327,6 @@ const struct Role roles[NUM_ROLES+1] = {
       "the Thieves' Guild Hall",
       "the Assassins' Guild Hall",
       PM_ROGUE,
-      NON_PM,
       NON_PM,
       PM_MASTER_OF_THIEVES,
       PM_THUG,
@@ -389,7 +381,6 @@ const struct Role roles[NUM_ROLES+1] = {
       "Orion's camp",
       "the cave of the wumpus",
       PM_RANGER,
-      NON_PM,
       PM_LITTLE_DOG /* Orion & canis major */,
       PM_ORION,
       PM_HUNTER,
@@ -431,7 +422,6 @@ const struct Role roles[NUM_ROLES+1] = {
       "the Castle of the Taro Clan",
       "the Shogun's Castle",
       PM_SAMURAI,
-      NON_PM,
       PM_LITTLE_DOG,
       PM_LORD_SATO,
       PM_ROSHI,
@@ -473,7 +463,6 @@ const struct Role roles[NUM_ROLES+1] = {
       "the Thieves' Guild Hall",
       PM_TOURIST,
       NON_PM,
-      NON_PM,
       PM_TWOFLOWER,
       PM_GUIDE,
       PM_MASTER_OF_THIEVES,
@@ -513,7 +502,6 @@ const struct Role roles[NUM_ROLES+1] = {
       "the Shrine of Destiny",
       "the cave of Surtur",
       PM_VALKYRIE,
-      NON_PM,
       NON_PM /*PM_WINTER_WOLF_CUB*/,
       PM_NORN,
       PM_WARRIOR,
@@ -554,7 +542,6 @@ const struct Role roles[NUM_ROLES+1] = {
       "the Lonely Tower",
       "the Tower of Darkness",
       PM_WIZARD,
-      NON_PM,
       PM_KITTEN,
       PM_NEFERET_THE_GREEN,
       PM_APPRENTICE,
@@ -594,7 +581,6 @@ const struct Race races[] = {
         "Hum",
         { "man", "woman" },
         PM_HUMAN,
-        NON_PM,
         PM_HUMAN_MUMMY,
         PM_HUMAN_ZOMBIE,
         MH_HUMAN | ROLE_MALE | ROLE_FEMALE | ROLE_LAWFUL | ROLE_NEUTRAL
@@ -616,7 +602,6 @@ const struct Race races[] = {
         "Elf",
         { 0, 0 },
         PM_ELF,
-        NON_PM,
         PM_ELF_MUMMY,
         PM_ELF_ZOMBIE,
         MH_ELF | ROLE_MALE | ROLE_FEMALE | ROLE_CHAOTIC,
@@ -637,7 +622,6 @@ const struct Race races[] = {
         "Dwa",
         { 0, 0 },
         PM_DWARF,
-        NON_PM,
         PM_DWARF_MUMMY,
         PM_DWARF_ZOMBIE,
         MH_DWARF | ROLE_MALE | ROLE_FEMALE | ROLE_LAWFUL,
@@ -658,7 +642,6 @@ const struct Race races[] = {
         "Gno",
         { 0, 0 },
         PM_GNOME,
-        NON_PM,
         PM_GNOME_MUMMY,
         PM_GNOME_ZOMBIE,
         MH_GNOME | ROLE_MALE | ROLE_FEMALE | ROLE_NEUTRAL,
@@ -679,7 +662,6 @@ const struct Race races[] = {
         "Orc",
         { 0, 0 },
         PM_ORC,
-        NON_PM,
         PM_ORC_MUMMY,
         PM_ORC_ZOMBIE,
         MH_ORC | ROLE_MALE | ROLE_FEMALE | ROLE_CHAOTIC,
@@ -2034,7 +2016,7 @@ role_init(void)
  * needed--via instrinsic 'Infravision' which set_uasmon() manages.
  */
     /* Fix up infravision */
-    if (mons[g.urace.malenum].mflags3 & M3_INFRAVISION) {
+    if (mons[g.urace.mnum].mflags3 & M3_INFRAVISION) {
         /* although an infravision intrinsic is possible, infravision
          * is purely a property of the physical race.  This means that we
          * must put the infravision flag in the player's current race
@@ -2044,9 +2026,7 @@ role_init(void)
          * but since infravision has no effect for NPCs anyway we can
          * ignore this.
          */
-        mons[g.urole.malenum].mflags3 |= M3_INFRAVISION;
-        if (g.urole.femalenum != NON_PM)
-            mons[g.urole.femalenum].mflags3 |= M3_INFRAVISION;
+        mons[g.urole.mnum].mflags3 |= M3_INFRAVISION;
     }
 #endif /*0*/
 

--- a/src/topten.c
+++ b/src/topten.c
@@ -76,7 +76,7 @@ static char *encode_extended_achievements(void);
 static char *encode_extended_conducts(void);
 #endif
 static void free_ttlist(struct toptenentry *);
-static int classmon(char *, boolean);
+static int classmon(char *);
 static int score_wanted(boolean, int, struct toptenentry *, int,
                         const char **, int);
 #ifdef NO_SCAN_BRACK
@@ -1273,20 +1273,19 @@ prscore(int argc, char **argv)
 }
 
 static int
-classmon(char *plch, boolean fem)
+classmon(char *plch)
 {
     int i;
 
     /* Look for this role in the role table */
-    for (i = 0; roles[i].name.m; i++)
+    for (i = 0; roles[i].name.m; i++) {
         if (!strncmp(plch, roles[i].filecode, ROLESZ)) {
-            if (fem && roles[i].femalenum != NON_PM)
-                return roles[i].femalenum;
-            else if (roles[i].malenum != NON_PM)
-                return roles[i].malenum;
+            if (roles[i].mnum != NON_PM)
+                return roles[i].mnum;
             else
                 return PM_HUMAN;
         }
+    }
     /* this might be from a 3.2.x score for former Elf class */
     if (!strcmp(plch, "E"))
         return PM_RANGER;
@@ -1351,7 +1350,11 @@ tt_oname(struct obj* otmp)
     if (!tt)
         return (struct obj *) 0;
 
-    set_corpsenm(otmp, classmon(tt->plrole, (tt->plgend[0] == 'F')));
+    set_corpsenm(otmp, classmon(tt->plrole));
+    if (tt->plgend[0] == 'F')
+        otmp->spe = CORPSTAT_FEMALE;
+    else if (tt->plgend[0] == 'M')
+        otmp->spe = CORPSTAT_MALE;
     otmp = oname(otmp, tt->name);
 
     return otmp;

--- a/src/u_init.c
+++ b/src/u_init.c
@@ -654,9 +654,7 @@ u_init(void)
     u.umortality = 0;
     u.ugrave_arise = NON_PM;
 
-    u.umonnum = u.umonster = (flags.female && g.urole.femalenum != NON_PM)
-                                 ? g.urole.femalenum
-                                 : g.urole.malenum;
+    u.umonnum = u.umonster = g.urole.mnum;
     u.ulycn = NON_PM;
     set_uasmon();
 
@@ -1080,13 +1078,13 @@ ini_inv(struct trobj *trop)
                 g.nocreate4 = otyp;
         }
 
-        if (g.urace.malenum != PM_HUMAN) {
+        if (g.urace.mnum != PM_HUMAN) {
             /* substitute race-specific items; this used to be in
                the 'if (otyp != UNDEF_TYP) { }' block above, but then
                substitutions didn't occur for randomly generated items
                (particularly food) which have racial substitutes */
             for (i = 0; inv_subs[i].race_pm != NON_PM; ++i)
-                if (inv_subs[i].race_pm == g.urace.malenum
+                if (inv_subs[i].race_pm == g.urace.mnum
                     && otyp == inv_subs[i].item_otyp) {
                     debugpline3("ini_inv: substituting %s for %s%s",
                                 OBJ_NAME(objects[inv_subs[i].subs_otyp]),

--- a/win/Qt/qt_plsel.cpp
+++ b/win/Qt/qt_plsel.cpp
@@ -134,7 +134,7 @@ public:
 	)
     {
 	glyph_info gi;
-	int glyph = monnum_to_glyph(roles[id].malenum, MALE);
+	int glyph = monnum_to_glyph(roles[id].mnum, MALE);
 	map_glyphinfo(0, 0, glyph, 0, &gi);
 	setGlyph(glyph, gi.gm.tileidx);
     }
@@ -152,7 +152,7 @@ public:
 	)
     {
 	glyph_info gi;
-	int glyph = monnum_to_glyph(races[id].malenum, MALE);
+	int glyph = monnum_to_glyph(races[id].mnum, MALE);
 	map_glyphinfo(0, 0, glyph, 0, &gi);
 	setGlyph(glyph, gi.gm.tileidx);
     }


### PR DESCRIPTION
There are no longer distinct gendered versions of monsters, so femalenum
is unused (i.e. set to NON_PM) for all roles and races. Take a pass at
removing all uses of/references to femalenum, and rename 'malenum' to
'mnum' since it no longer has any particular association with
gender or sex.
