### PR TITLE
Don't 'fall' and self-stone when flying down

### DIFF
--- a/src/trap.c
+++ b/src/trap.c
@@ -563,7 +563,7 @@ fall_through(
         Sprintf(msgbuf, "The hole in the %s above you closes up.",
                 ceiling(u.ux, u.uy));
 
-    schedule_goto(&dtmp, UTOTYPE_FALLING, (char *) 0,
+    schedule_goto(&dtmp, !Flying ? UTOTYPE_FALLING : UTOTYPE_NONE, (char *) 0,
                   !td ? msgbuf : (char *) 0);
 }
 


### PR DESCRIPTION
When a flying hero deliberately "swoops" through a trap door or hole,
consider the movement down to the next level to be controlled flight
rather than falling, preventing the sort of inadvertent touching of a
carried cockatrice corpse that happens when falling between levels.
