### PR TITLE
Multiple definitions of getreturn_enabled and GUILaunched

### DIFF
--- a/sys/winnt/stubs.c
+++ b/sys/winnt/stubs.c
@@ -10,7 +10,7 @@
 #error You cannot compile this with both GUISTUB and TTYSTUB defined.
 #endif
 
-int GUILaunched;
+extern int GUILaunched;
 struct window_procs mswin_procs = { "-guistubs" };
 
 #ifdef QT_GRAPHICS
@@ -62,7 +62,7 @@ char *argv[];
 
 HANDLE hConIn;
 HANDLE hConOut;
-int GUILaunched;
+extern int GUILaunched;
 struct window_procs tty_procs = { "-ttystubs" };
 #ifdef CURSES_GRAPHICS
 char erase_char, kill_char;

--- a/sys/winnt/windmain.c
+++ b/sys/winnt/windmain.c
@@ -61,7 +61,7 @@ int NDECL(tty_self_recover_prompt);
 int NDECL(other_self_recover_prompt);
 
 char orgdir[PATHLEN];
-boolean getreturn_enabled;
+boolean getreturn_enabled = TRUE;
 int windows_startup_state = 0;    /* we flag whether to continue with this */
                                   /* 0 = keep starting up, everything is good */
 

--- a/sys/winnt/winnt.c
+++ b/sys/winnt/winnt.c
@@ -45,7 +45,7 @@ boolean win32_cursorblink;
 HANDLE ffhandle = (HANDLE) 0;
 WIN32_FIND_DATA ffd;
 extern int GUILaunched;
-boolean getreturn_enabled;
+extern boolean getreturn_enabled;
 int redirect_stdout;
 
 typedef HWND(WINAPI *GETCONSOLEWINDOW)();


### PR DESCRIPTION
This patch is to fix the following linking error when I was porting NetHack to MSYS2/mingw-w64:
D:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.3.0/../../../../x86_64-w64-mingw32/bin/ld.exe: o/winnt.o:winnt.c:(.bss+0x160): multiple definition of `getreturn_enabled'; o/windmain.o:windmain.c:(.bss+0x100): first defined here
D:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.3.0/../../../../x86_64-w64-mingw32/bin/ld.exe: o/guistub.o:stubs.c:(.bss+0x0): multiple definition of `GUILaunched'; o/nttty.o:nttty.c:(.bss+0x24): first defined here