### PR TITLE
Add option to link to Homebrew ncurses for macOS hints file

### DIFF
--- a/sys/unix/hints/macOS.370
+++ b/sys/unix/hints/macOS.370
@@ -117,6 +117,10 @@ CURSESLIB = -lncurses
 endif
 
 ifdef CURSESLIB
+# Newer versions of ncurses are commonly installed via homebrew, but intentionally unlinked.
+# Uncommenting the following two lines will compile nethack with it.
+# LFLAGS += -L$(shell brew --prefix)/opt/ncurses/lib
+# WINLIB += -I$(shell brew --prefix)/opt/ncurses/include
 WINLIB += $(CURSESLIB)
 endif
 
@@ -136,7 +140,7 @@ WINX11LIB += -lXpm
 VARDATND0 += rip.xpm
 endif
 WINLIB += $(WINX11LIB)
-LFLAGS=-L/opt/X11/lib
+LFLAGS += -L/opt/X11/lib
 endif	# WANT_WIN_X11
 
 ifdef WANT_WIN_QT


### PR DESCRIPTION
It's probably possible to conditionally check if the directory where Homebrew curses lives exists, but that feels a bit iffy for me, and also isn't very easy to do in a Makefile. This solution is simpler, albeit a bit harder to find.