### PR TITLE
Indicate to players that monsters are sleeping.

### DIFF
--- a/doc/fixes37.0
+++ b/doc/fixes37.0
@@ -1351,6 +1351,8 @@ drinking blessed potion of full healing heals wounded legs, either hero's or
 	steed's (when riding, wounded leg injury applies to steed, not hero)
 drinking uncursed potion of full healing or blessed potion of extra healing
 	heal hero's wounded legs when not riding; no effect on steed if riding
+looking at a monster will indicate whether it is asleep, and waking up a monster
+	yields a message
 
 
 Platform- and/or Interface-Specific New Features

--- a/include/extern.h
+++ b/include/extern.h
@@ -1494,6 +1494,7 @@ extern void maybe_mnexto(struct monst *);
 extern int mnearto(struct monst *, xchar, xchar, boolean, unsigned);
 extern void m_respond(struct monst *);
 extern void setmangry(struct monst *, boolean);
+extern void wake_msg(struct monst *, boolean);
 extern void wakeup(struct monst *, boolean);
 extern void wake_nearby(void);
 extern void wake_nearto(int, int, int);

--- a/src/hack.c
+++ b/src/hack.c
@@ -2791,8 +2791,10 @@ check_special_room(boolean newlev)
                     if (!isok(mtmp->mx,mtmp->my)
                         || roomno != (int) levl[mtmp->mx][mtmp->my].roomno)
                         continue;
-                    if (!Stealth && !rn2(3))
+                    if (!Stealth && !rn2(3)) {
+                        wake_msg(mtmp, FALSE);
                         mtmp->msleeping = 0;
+                    }
                 }
         }
     }

--- a/src/mon.c
+++ b/src/mon.c
@@ -3590,10 +3590,21 @@ setmangry(struct monst* mtmp, boolean via_attack)
     }
 }
 
+/* Indicate via message that a monster has awoken. */
+void
+wake_msg(struct monst *mtmp, boolean interesting)
+{
+    if (mtmp->msleeping && canseemon(mtmp)) {
+        pline("%s wakes up%s%s", Monnam(mtmp), interesting ? "!" : ".",
+              mtmp->data == &mons[PM_FLESH_GOLEM] ? " It's alive!" : "");
+    }
+}
+
 /* wake up a monster, possibly making it angry in the process */
 void
 wakeup(struct monst* mtmp, boolean via_attack)
 {
+    wake_msg(mtmp, via_attack);
     mtmp->msleeping = 0;
     if (M_AP_TYPE(mtmp) != M_AP_NOTHING) {
         /* mimics come out of hiding, but disguised Wizard doesn't
@@ -3629,6 +3640,7 @@ wake_nearto(int x, int y, int distance)
         if (distance == 0 || dist2(mtmp->mx, mtmp->my, x, y) < distance) {
             /* sleep for N turns uses mtmp->mfrozen, but so does paralysis
                so we leave mfrozen monsters alone */
+            wake_msg(mtmp, FALSE);
             mtmp->msleeping = 0; /* wake indeterminate sleep */
             if (!(mtmp->data->geno & G_UNIQ))
                 mtmp->mstrategy &= ~STRAT_WAITMASK; /* wake 'meditation' */

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -232,6 +232,7 @@ disturb(register struct monst* mtmp)
             || (mtmp->data->mlet == S_DOG || mtmp->data->mlet == S_HUMAN)
             || (!rn2(7) && M_AP_TYPE(mtmp) != M_AP_FURNITURE
                 && M_AP_TYPE(mtmp) != M_AP_OBJECT))) {
+        wake_msg(mtmp, !mtmp->mpeaceful);
         mtmp->msleeping = 0;
         return 1;
     }

--- a/src/pager.c
+++ b/src/pager.c
@@ -357,6 +357,8 @@ look_at_monster(char *buf,
             Strcat(buf, (Upolyd && sticks(g.youmonst.data))
                           ? ", being held" : ", holding you");
     }
+    if (mtmp->msleeping)
+        Strcat(buf, ", asleep");
     if (mtmp->mleashed)
         Strcat(buf, ", leashed to you");
 


### PR DESCRIPTION
This pull request makes the following changes:

* When a player looks at a monster, they can tell whether or not that monster is asleep.
* Display a message when a monster wakes up within sight of the player.
* Add YAFM for waking up a flesh golem.

Note that none of these changes do not consistently impact monsters put to sleep by wands of sleep, since wands of sleep alter mcanmove and mfrozen when putting a monster to sleep for a nonzero number of turns, rather than setting msleeping to 1.

The rationale for these changes is that up until this point, there has been no way to tell whether or not a monster is asleep aside from its lack of movement.