### PR TITLE
Net hack 3.7 mingw32

### DIFF
--- a/sys/windows/Makefile.mingw32
+++ b/sys/windows/Makefile.mingw32
@@ -1,0 +1,808 @@
+# NetHack 3.7	Makefile.mingw32
+# Copyright (c) 2022 by Michael Allison
+# NetHack may be freely redistributed.  See license for details.
+#
+#==============================================================================
+#
+#   Win32 Compilers Tested with this Makefile.mingw32:
+#       mingw-w64
+#   from:
+#       https://sourceforge.net/p/mingw-w64/wiki2/GeneralUsageInstructions/
+#           Toolchain for 32 and 64 bit Windows target
+#
+#==============================================================================
+#   This is used for building two versions of NetHack:
+#
+#   A tty port utilizing the Win32 Console I/O subsystem, Console
+#       NetHack.
+#
+#   A Win32 native port built on the Windows API, Graphical NetHack or
+#       NetHackW.
+#
+#   If you have any questions read the sys/windows/Install.windows file included
+#   with the distribution.
+#
+#==============================================================================
+# DECISIONS SECTION
+#
+# Build Options Decisions
+#
+#       There are currently 4 decisions that you can choose to make.
+#       None of the 4 decisions are absolutely required because defaults are in place:
+#	1. Do you have git commands in your path and NetHack in a git repository?
+#	2. Where do you want your build results to end up?
+#	3. Do you want debug information in the executable?
+#	4. Do you want to explicitly override auto-detection of a 32-bit or 64-bit target?
+#       5. Do you want to include any optional interfaces in the port?
+#          5a) console without or with pdcurses
+#          5b) Windows
+#
+# Mandatory LUA source Location
+#
+#       LUA source code or is required to build NetHack-3.7.
+#       LUATOP must point to the location of the LUA sources.
+#
+#-----------------------------------------------------------------------------------------
+#=========================================================================================
+
+#==============================================================================
+#
+# The default make target (so just typing 'mingw32-make').
+#
+
+default: install
+
+#---------------------------------------------------------------
+# 1. Where do you want the game to be built (which folder)?
+#    If not present prior to compilation it gets created.
+#
+
+GAMEDIR = ../binary
+
+#
+#---------------------------------------------------------------
+# 2. Do you want debug information in the executable?
+#
+
+DEBUGINFO = N
+
+#
+#---------------------------------------------------------------
+# 3. Do you want to explicitly override auto-detection of a 32-bit
+#    or 64-bit executable (save files do not interchange currently)?
+#
+# It depends on which MSYS2 MinGW shell you are using.
+#
+#---------------------------------------------------------------
+# 4. Do you want additional GUI interfaces in the executable?
+#    Make these Y to enable the GUIs. Win32 is always enabled,
+#    and is the default.
+#
+
+#4a Curses window port support
+#
+#
+# 4. Uncomment these and set them appropriately if you want to
+#    include curses port support alongside TTY support in your
+#    NetHack.exe binary.
+#
+#    You'll have to set PDCURSES_H to the correct location of the
+#    PDCurses header (.h) files and PDCURSES_C to the location
+#    of your PDCurses C files which must already be resident on
+#    your machine.
+#
+# ADD_CURSES=Y
+# PDCURSES_TOP=../submodules/pdcurses
+
+#---------------------------------------------------------------
+ifndef LUA_VERSION
+LUAVER=5.4.3
+else
+LUAVER=$(LUA_VERSION)
+endif
+#---------------------------------------------------------------
+# Location of LUA
+#
+# Original source needs to be obtained from:
+#    http://www.lua.org/ftp/lua-5.4.3.tar.gz
+#
+#    This build assumes that the LUA sources are located
+#    at the specified location. If they are actually elsewhere
+#    you'll need to specify the correct spot below in order to
+#    successfully build NetHack-3.7.
+#
+USE_LUADLL = Y
+WANT_LUAC = N
+LUATOP = ../submodules/lua
+#
+#==============================================================================
+# This marks the end of the BUILD DECISIONS section.
+#==============================================================================
+#
+#===============================================
+#======= End of Modification Section ===========
+#===============================================
+#
+################################################
+#                                              #
+# Nothing below here should have to be changed.#
+#                                              #
+################################################
+#
+#==============================================================================
+
+SKIP_NETHACKW = N
+
+#==============================================================================
+
+#  The version of the game this Makefile was designed for
+NETHACK_VERSION="3.7.0"
+
+# A brief version for use in macros
+NHV1=$(subst .,,$(NETHACK_VERSION))
+NHV=$(subst ",,$(NHV1))
+
+#
+#  Source directories.    Makedefs hardcodes these, don't change them.
+#
+
+# INCL    - NetHack include files
+# DAT     - NetHack data files
+# DOC     - NetHack documentation files
+# UTIL    - Utility source
+# SRC     - Main source
+# SSYS    - Shared system files
+# MSWSYS  - mswin specific files
+# TTY     - window port files (tty)
+# MSWIN   - window port files (win32)
+# WCURSES - window port files (curses)
+# WSHR    - Tile support files
+# QT      - QT window support files
+
+INCL    =../include
+DAT     =../dat
+DOC     =../doc
+UTIL    =../util
+SRC     =../src
+SSYS    =../sys/share
+MSWSYS  =../sys/windows
+TTY     =../win/tty
+MSWIN   =../win/win32
+WCURSES =../win/curses
+WSHR    =../win/share
+QT      =../win/Qt
+
+#
+#  Object directory.
+#
+
+OBJ = o
+
+#
+# Shorten up the location for some files
+#
+
+O  = $(OBJ)/
+
+U  = $(UTIL)/
+
+# To store all the level files,
+# help files, etc. in a single library file.
+# USE_DLB = Y is left uncommented
+
+USE_DLB = Y
+
+#==========================================
+#==========================================
+# Setting up the compiler and linker
+# macros. All builds include the base ones.
+#==========================================
+#==========================================
+
+ifdef TRAVIS_COMPILER
+cc = i686-w64-mingw32-gcc.exe
+ld = i686-w64-mingw32-gcc.exe
+rc = windres --target=pe-i386
+else
+cc = gcc -c
+ld = gcc
+ifeq "$(MSYSTEM)" "MINGW64"
+rc = windres --target=pe-x86-64
+else # MINGW32
+rc = windres --target=pe-i386
+endif
+endif
+
+#
+# Handle user settings
+#
+CFLAGS = -mms-bitfields -I../include -I../sys/windows
+LDFLAGS =
+ifeq "$(DEBUGINFO)" "Y"
+CFLAGS += -g -D_DEBUG
+else
+CFLAGS += -DNDEBUG
+LDFLAGS += -s
+endif
+
+ifeq "$(USE_DLB)" "Y"
+DLBFLG = -DDLB
+else
+DLBFLG =
+endif
+
+COMMONDEF = -DWIN32 -DWINVER=0x0601 -D_WIN32_WINNT=0x0601
+DLLDEF = $(COMMONDEF) -DWIN32CON -D_WINDOWS -D_USRDLL -D_WINDLL
+CONSOLEDEF = $(COMMONDEF) -D_CONSOLE
+
+# To build util targets
+CFLAGSU = $(CFLAGS) $(CONSOLEDEF) $(DLBFLG) -DWIN32CON -DMSWIN_GRAPHICS
+
+LIBS = -lcomctl32 -lgdi32 -lole32 -lshell32 -luuid -lwinmm -lbcrypt
+
+$(GAMEDIR):
+	@mkdir -p $@
+
+$(OBJ):
+	@mkdir -p $@
+
+CLEAN_DIR = $(GAMEDIR) $(OBJ)
+
+#===============-=================================================
+# LUA library
+# Source from http://www.lua.org/ftp/lua-5.4.3.tar.gz
+#=================================================================
+
+OLUA = $(O)lua
+LUASRC = $(LUATOP)
+LUAOBJS = $(addprefix $(OLUA)/, $(addsuffix .o, lapi lauxlib lbaselib lcode lcorolib lctype \
+	  ldblib ldebug ldo ldump lfunc lgc linit liolib llex lmathlib lmem \
+	  loadlib lobject lopcodes loslib lparser lstate lstring lstrlib ltable ltablib ltm \
+	  lundump lutf8lib lvm lzio))
+LUADLL = $(GAMEDIR)/lua-$(LUAVER).dll
+LUAIMP = $(OLUA)/lua-$(LUAVER).dll.a
+ULUADLL = $(U)$(notdir $(LUADLL))
+LUASTATIC = $(OLUA)/lua-$(LUAVER).a
+LUATARGETS = $(U)lua.exe
+
+ifeq "$(USE_LUADLL)" "Y"
+LUALIB = $(LUAIMP)
+LUATARGETS += $(LUADLL) $(ULUADLL) $(LUAIMP)
+else
+LUALIB = $(LUASTATIC)
+LUATARGETS += $(LUASTATIC)
+endif
+
+ifeq "$(WANT_LUAC)" "Y"
+LUATARGETS += $(U)luac.exe
+endif
+
+lua: $(LUATARGETS)
+
+$(U)lua.exe: $(OLUA)/lua.o $(LUALIB)
+	$(ld) $(LDFLAGS) $^ -o$@
+
+$(LUADLL): $(ULUADLL)
+	cp $< $@
+
+$(ULUADLL) $(LUAIMP): $(LUAOBJS) | $(OLUA)
+	$(ld) $(LDFLAGS) -fPIC -shared -Wl,--export-all-symbols -Wl,--add-stdcall-alias \
+		-Wl,--out-implib=$(LUAIMP) $^ -o$(ULUADLL)
+
+$(LUASTATIC): $(LUAOBJS) | $(OLUA)
+	ar rcs $@ $^
+
+$(OLUA)/%.o: $(LUASRC)/%.c | $(OLUA)
+	$(cc) $(CFLAGS) $< -o$@
+
+$(U)luac.exe: $(OLUA)/luac.o $(LUALIB)
+	$(ld) $(LDFLAGS) $^ -o$@
+
+$(OLUA):
+	@mkdir -p $@
+
+CLEAN_DIR += $(OLUA)
+CLEAN_FILE += $(LUATARGETS) $(LUAOBJS) $(OLUA)/lua.o $(OLUA)/luac.o
+
+#==========================================
+# nhlua.h
+#==========================================
+NHLUAH = $(INCL)/nhlua.h
+
+$(NHLUAH):
+	echo "/* nhlua.h - generated by top Makefile */" > $@
+	@echo "#include \"$(LUASRC)/lua.h\"" >> $@
+	@echo "LUA_API int (lua_error) (lua_State *L) NORETURN;" >>$@
+	@echo "#include \"$(LUASRC)/lualib.h\"" >> $@
+	@echo "#include \"$(LUASRC)/lauxlib.h\"" >> $@
+	@echo "/*nhlua.h*/" >> $@
+
+CLEAN_FILE += $(NHLUAH)
+
+#==========================================
+# Makedefs
+#==========================================
+OM = $(O)makedefs
+MOBJS = $(addprefix $(OM)/, alloc.o date.o makedefs.o monst.o objects.o panic.o)
+MTARGETS = $(U)makedefs.exe
+
+makedefs: $(MTARGETS)
+
+$(U)makedefs.exe: $(MOBJS)
+	$(ld) $(LDFLAGS) $^ -o$@
+
+$(OM)/%.o: $(SRC)/%.c $(NHLUAH) | $(OM)
+	$(cc) $(CFLAGSU) -DENUM_PM $< -o$@
+
+$(OM)/%.o: $(U)%.c $(NHLUAH) | $(OM)
+	$(cc) $(CFLAGSU) -DENUM_PM $< -o$@
+
+$(OM):
+	@mkdir -p $@
+
+CLEAN_DIR += $(OM)
+CLEAN_FILE += $(MTARGETS) $(MOBJS)
+
+#==========================================
+# Recover
+#==========================================
+OR = $(OBJ)
+ROBJS = $(OR)/recover.o
+RTARGETS = $(GAMEDIR)/recover.txt $(GAMEDIR)/recover.exe
+
+recover: $(RTARGETS)
+
+$(GAMEDIR)/recover.txt: $(DOC)/recover.txt | $(GAMEDIR)
+	cp $< $@
+
+$(GAMEDIR)/recover.exe: $(ROBJS) | $(GAMEDIR)
+	$(ld) $(LDFLAGS) $^ -o$@
+
+$(OR)/recover.o: $(U)recover.c | $(OR)
+	$(cc) $(CFLAGSU) $< -o$@
+
+# $(OR):
+#	@mkdir -p $@
+
+CLEAN_FILE += $(RTARGETS) $(ROBJS)
+
+#==========================================
+# PDCurses
+#==========================================
+ifeq "$(ADD_CURSES)" "Y"
+OP = $(O)pdcurses
+PDCOBJS = $(addprefix $(OP)/, addch.o addchstr.o addstr.o attr.o beep.o bkgd.o border.o \
+	  clear.o color.o debug.o delch.o deleteln.o getch.o getstr.o getyx.o \
+	  inch.o inchstr.o initscr.o inopts.o insch.o insstr.o \
+	  kernel.o keyname.o mouse.o move.o outopts.o overlay.o \
+	  pad.o panel.o pdcclip.o pdcdisp.o pdcgetsc.o pdckbd.o pdcscrn.o pdcsetsc.o pdcutil.o printw.o \
+	  refresh.o scanw.o scr_dump.o scroll.o slk.o termattr.o touch.o util.o window.o)
+PDCSRC = $(PDCURSES_TOP)/pdcurses
+PDCWINCON = $(PDCURSES_TOP)/wincon
+PDCINCL = -I$(PDCURSES_TOP) -I$(PDCSRC) -I$(PDCWINCON)
+PDCLIB = $(O)pdcurses.a
+
+pdcurses: $(PDCLIB)
+
+$(PDCLIB): $(PDCOBJS)
+	ar rcs $@ $^
+
+$(OP)/%.o: $(PDCSRC)/%.c | $(OP)
+	$(cc) $(CFLAGS) $(PDCINCL) -D_LIB $< -o$@
+
+$(OP)/%.o: $(PDCWINCON)/%.c | $(OP)
+	$(cc) $(CFLAGS) $(PDCINCL) -D_LIB $< -o$@
+
+$(OP):
+	@mkdir -p $@
+
+CLEAN_DIR += $(OP)
+CLEAN_FILE += $(PDCLIB) $(PDCOBJS)
+endif
+
+#==========================================
+# tile2bmp
+#==========================================
+OT = $(O)tile2bmp
+TOBJS = $(addprefix $(OT)/, drawing.o monst.o objects.o tile2bmp.o tiletext.o tiletxt.o)
+TTARGETS = $(U)tile2bmp.exe
+
+tile2bmp: $(TTARGETS)
+
+$(U)tile2bmp.exe: $(TOBJS)
+	$(ld) $(LDFLAGS) $^ -o$@
+
+$(OT)/tiletxt.o: $(WSHR)/tilemap.c $(NHLUAH) | $(OT)
+	$(cc) $(CFLAGSU) -DTILETEXT $< -o$@
+
+$(OT)/%.o: $(WSHR)/%.c $(NHLUAH) | $(OT)
+	$(cc) $(CFLAGSU) $< -o$@
+
+$(OT)/%.o: $(SRC)/%.c $(NHLUAH) | $(OT)
+	$(cc) $(CFLAGSU) $< -o$@
+
+$(OT):
+	@mkdir -p $@
+
+CLEAN_DIR += $(OT)
+CLEAN_FILE += $(TTARGETS) $(TOBJS)
+
+#==========================================
+# Optional Tile Utilities
+#==========================================
+TEXT_IO = $(addprefix $(OT)/, drawing.o monst.o objects.o tiletext.o tiletxt.o)
+TUCOMMON = $(OT)/alloc.o $(OT)/panic.o
+TUOBJS = $(TUCOMMON) $(TEXT_IO)
+
+T32OBJS = $(OT)/tilete32.o $(OT)/tiletx32.o
+TEXT_IO32 = $(addprefix $(OT)/, drawing.o monst.o objects.o) $(T32OBJS)
+TU32OBJS = $(TUCOMMON) $(TEXT_IO32)
+
+GIFOBJ = $(OT)/gifread.o
+GIF32OBJ = $(OT)/gifrd32.o
+PPMOBJ = $(OT)/ppmwrite.o
+BMP32OBJ = $(OT)/til2bm32.o
+TILEFILES32 = $(addprefix $(WSHR)/, mon32.txt obj32.txt oth32.txt)
+TUTARGETS = $(U)gif2txt.exe $(U)gif2tx32.exe $(U)txt2ppm.exe $(U)til2bm32.exe
+
+tileutil: $(TUTARGETS)
+
+$(U)gif2txt.exe: $(GIFOBJ) $(TUOBJS)
+	$(ld) $(LDFLAGS) $^ -o$@
+
+$(U)gif2tx32.exe: $(GIF32OBJ) $(TU32OBJS)
+	$(ld) $(LDFLAGS) $^ -o$@
+
+$(U)txt2ppm.exe: $(PPMOBJ) $(TUOBJS)
+	$(ld) $(LDFLAGS) $^ -o$@
+
+$(U)til2bm32.exe: $(BMP32OBJ) $(TEXT_IO32)
+	$(ld) $(LDFLAGS) $^ -o$@
+
+$(OT)/tilete32.o: $(WSHR)/tiletext.c $(NHLUAH) | $(OT)
+	$(cc) $(CFLAGSU) -DTILE_X=32 -DTILE_Y=32 $< -o$@
+
+$(OT)/tiletx32.o: $(WSHR)/tilemap.c $(NHLUAH) | $(OT)
+	$(cc) $(CFLAGSU) -DTILETEXT -DTILE_X=32 -DTILE_Y=32 $< -o$@
+
+$(GIF32OBJ): $(WSHR)/gifread.c $(NHLUAH) | $(OT)
+	$(cc) $(CFLAGSU) -DTILE_X=32 -DTILE_Y=32 $< -o$@
+
+$(BMP32OBJ): $(WSHR)/tile2bmp.c $(NHLUAH) | $(OT)
+	$(cc) $(CFLAGSU) -DTILE_X=32 -DTILE_Y=32 $< -o$@
+
+$(OT)/panic.o: $(UTIL)/panic.c $(NHLUAH) | $(OT)
+	$(cc) $(CFLAGSU) $< -o$@
+
+$(MSWIN)/tiles32.bmp: $(U)til2bm32.exe $(TILEFILES32)
+	$< $@
+
+CLEAN_FILE += $(TUTARGETS) $(GIFOBJ) $(GIF32OBJ) $(PPMOBJ) $(BMP32OBJ) \
+	      $(T32OBJS) $(TUCOMMON)
+
+#==========================================
+# tilemap
+#==========================================
+OTM = $(OBJ)/tilemap
+TMOBJS = $(addprefix $(OTM)/, drawing.o monst.o objects.o tilemap.o)
+TMTARGETS = $(SRC)/tile.c $(U)tilemap.exe
+
+tilemap: $(SRC)/tile.c
+
+$(SRC)/tile.c: $(U)tilemap.exe
+	$<
+
+$(U)tilemap.exe: $(TMOBJS)
+	$(ld) $(LDFLAGS) $^ -o$@
+
+$(OTM)/tilemap.o: $(WSHR)/tilemap.c $(NHLUAH) | $(OTM)
+	$(cc) $(CFLAGSU) $< -o$@
+
+$(OTM)/%.o: $(SRC)/%.c $(NHLUAH) | $(OTM)
+	$(cc) $(CFLAGSU) $< -o$@
+
+$(OTM):
+	@mkdir -p $@
+
+CLEAN_DIR += $(OTM)
+# tilemap.exe will create tilemappings.lst
+CLEAN_FILE += $(TMTARGETS) $(TMOBJS) $(SRC)/tilemappings.lst
+
+#==========================================
+# uudecode
+#==========================================
+OU = $(OBJ)
+UOBJS = $(OU)/uudecode.o
+UTARGETS = $(U)uudecode.exe $(MSWIN)/NetHack.ico
+
+uudecode: $(UTARGETS)
+
+$(U)uudecode.exe: $(UOBJS)
+	$(ld) $(LDFLAGS) $^ -o$@
+
+$(OU)/uudecode.o: $(SSYS)/uudecode.c | $(OU)
+	$(cc) $(CFLAGS) $(CONSOLEDEF) $< -o$@
+
+# $(OU):
+#	@mkdir -p $@
+
+$(MSWIN)/NetHack.ico: $(U)uudecode.exe $(MSWSYS)/nhico.uu
+	$^
+	mv nethack.ico $@
+
+CLEAN_FILE += $(UTARGETS) $(UOBJS)
+
+#==========================================
+# Data librarian
+#==========================================
+ODLB = $(O)dlb
+DLBOBJS = $(addprefix $(ODLB)/, alloc.o dlb.o dlb_main.o panic.o)
+DAT_CLEAN = $(addprefix $(DAT)/, data oracles options porthelp rumors engrave epitaph bogusmon)
+DAT_NOCLEAN = $(addprefix $(DAT)/, help hh cmdhelp keyhelp history opthelp optmenu \
+	      wizhelp license engrave epitaph bogusmon tribute)
+DLBLST = $(DAT)/dlb.lst
+DLB = $(GAMEDIR)/nhdat$(NHV)
+DTARGETS = $(U)dlb.exe $(DAT_CLEAN) $(DLBLST) $(DLB)
+
+dlb: $(DTARGETS)
+
+$(U)dlb.exe: $(DLBOBJS)
+	$(ld) $(LDFLAGS) $^ -o$@
+
+$(ODLB)/%.o: $(SRC)/%.c $(NHLUAH) | $(ODLB)
+	$(cc) $(CFLAGSU) $< -o$@
+
+$(ODLB)/%.o: $(U)%.c $(NHLUAH) | $(ODLB)
+	$(cc) $(CFLAGSU) $< -o$@
+
+$(ODLB):
+	@mkdir -p $@
+
+$(DAT)/data: $(U)makedefs.exe $(DAT)/data.base
+	$< -d
+
+$(DAT)/oracles: $(U)makedefs.exe $(DAT)/oracles.txt
+	$< -h
+
+$(DAT)/options $(INCL)/date.h: $(U)makedefs.exe
+	$< -v
+
+$(DAT)/porthelp: $(MSWSYS)/porthelp
+	cp $< $@
+
+$(DAT)/rumors: $(U)makedefs.exe $(DAT)/rumors.tru $(DAT)/rumors.fal
+	$< -r
+
+$(DAT)/engrave: $(DAT)/bogusmon
+
+$(DAT)/epitaph: $(DAT)/bogusmon
+
+$(DAT)/bogusmon: $(U)makedefs.exe $(DAT)/bogusmon.txt $(DAT)/engrave.txt $(DAT)/epitaph.txt
+	$< -s
+
+$(DLBLST): | $(DAT_CLEAN) $(DAT_NOCLEAN)
+	echo data > $(DLBLST)
+	echo oracles >> $(DLBLST)
+	echo options >> $(DLBLST)
+	if [ -f $(DAT)/ttyoptions ] ; then echo ttyoptions >> $(DLBLST) ; fi
+	if [ -f $(DAT)/guioptions ] ; then echo guioptions >> $(DLBLST) ; fi
+	echo porthelp >> $(DLBLST)
+	echo rumors >> $(DLBLST)
+	echo help >> $(DLBLST)
+	echo hh >> $(DLBLST)
+	echo cmdhelp >> $(DLBLST)
+	echo keyhelp >> $(DLBLST)
+	echo history >> $(DLBLST)
+	echo opthelp >> $(DLBLST)
+	echo optmenu >> $(DLBLST)
+	echo wizhelp >> $(DLBLST)
+	echo license >> $(DLBLST)
+	echo engrave >> $(DLBLST)
+	echo epitaph >> $(DLBLST)
+	echo bogusmon >> $(DLBLST)
+	echo tribute >> $(DLBLST)
+	cd $(DAT) ; ls -1 *.lua >> $(DLBLST)
+
+$(DLB): $(U)dlb.exe $(DLBLST) | $(GAMEDIR)
+	$(U)dlb.exe CcIf $(dir $(DLBLST)) $(notdir $(DLBLST)) $(SRC)/nhdat
+	mv $(SRC)/nhdat$(NHV) $@
+
+CLEAN_DIR += $(ODLB)
+CLEAN_FILE += $(DTARGETS) $(DLBOBJS) $(INCL)/date.h
+
+#==========================================
+# nethackw
+#==========================================
+COREOBJS = $(addsuffix .o, allmain alloc apply artifact attrib ball bones botl cmd cppregex \
+	   date dbridge decl detect dig display dlb do do_name do_wear \
+	   dog dogmove dokick dothrow drawing dungeon \
+	   eat end engrave exper explode extralev files fountain \
+	   hack hacklib insight invent isaac64 light lock \
+	   mail makemon mcastu mdlib mhitm mhitu minion mklev mkmap mkmaze mkobj mkroom \
+	   mon mondata monmove monst mplayer mthrowu muse music \
+	   nhlan nhlobj nhlsel nhlua ntsound o_init objects objnam options \
+	   pager pickup pline polyself potion pray priest quest questpgr \
+	   random read rect region restore rip rnd role rumors \
+	   safeproc save sfstruct shk shknam sit sounds sp_lev spell steal steed stubs symbols sys \
+	   teleport timeout topten track trap u_init uhitm vault version vision \
+	   weapon were wield windmain windows windsys wizard worm worn write zap)
+
+CFLAGSW = $(CFLAGS) $(COMMONDEF) $(DLBFLG) -DTILES -D_WINDOWS -DMSWIN_GRAPHICS -DSAFEPROCS -DNOTTYGRPHICS
+
+ONHW = $(O)nethackw
+NHWONLY = $(addsuffix .o, mhaskyn mhdlg mhfont mhinput mhmain mhmap mhmenu \
+	  mhmsgwnd mhrip mhsplash mhstatus mhtext mswproc tile NetHackW win10)
+NHWOBJS = $(addprefix $(ONHW)/, $(COREOBJS) $(NHWONLY))
+TILEFILES = $(addprefix $(WSHR)/, monsters.txt objects.txt other.txt)
+BMPS = $(addprefix $(MSWIN)/, $(addsuffix .bmp, mnsel mnselcnt mnunsel petmark pilemark rip splash tiles))
+NHWRES = $(ONHW)/winres.o
+NHWTARGETS = $(GAMEDIR)/NetHackW.exe
+
+nethackw: $(NHWTARGETS)
+
+$(GAMEDIR)/NetHackW.exe: $(NHWOBJS) $(NHWRES) $(LUALIB) | $(GAMEDIR)
+	$(ld) $(LDFLAGS) -mwindows $^ $(LIBS) -static -lstdc++ -o$@
+
+$(ONHW)/%.o: $(SRC)/%.c $(NHLUAH) | $(ONHW)
+	$(cc) $(CFLAGSW) $< -o$@
+
+$(ONHW)/cppregex.o: $(SSYS)/cppregex.cpp $(NHLUAH) | $(ONHW)
+	$(cc) $(CFLAGSW) $< -o$@
+
+$(ONHW)/%.o: $(SSYS)/%.c $(NHLUAH) | $(ONHW)
+	$(cc) $(CFLAGSW) $< -o$@
+
+$(ONHW)/stubs.o: $(MSWSYS)/stubs.c $(NHLUAH) | $(ONHW)
+	$(cc) $(CFLAGSW) -DTTYSTUB $< -o$@
+
+$(ONHW)/%.o: $(MSWSYS)/%.c $(NHLUAH) | $(ONHW)
+	$(cc) $(CFLAGSW) $< -o$@
+
+$(ONHW)/%.o: $(MSWIN)/%.c $(NHLUAH) | $(ONHW)
+	$(cc) $(CFLAGSW) $< -o$@
+
+$(ONHW)/%.o: $(WSHR)/%.c $(NHLUAH) | $(ONHW)
+	$(cc) $(CFLAGSW) $< -o$@
+
+$(NHWRES): $(MSWIN)/NetHackW.rc $(BMPS) $(MSWIN)/NetHack.ico | $(ONHW)
+	$(rc) --include-dir=$(MSWIN) --input=$< -o$@
+
+$(MSWIN)/tiles.bmp: $(U)tile2bmp.exe $(TILEFILES)
+	$< $@
+
+$(MSWIN)/%.bmp: $(U)uudecode.exe $(MSWIN)/%.uu
+	$^
+	mv $(notdir $@) $@
+
+$(ONHW):
+	@mkdir -p $@
+
+CLEAN_DIR += $(ONHW)
+CLEAN_FILE += $(NHWTARGETS) $(NHWOBJS) $(NHWRES) $(BMPS)
+
+#==========================================
+# nethack
+#==========================================
+CFLAGSNH = $(CFLAGSU) -DNO_TILE_C -DSAFEPROCS -D_LIB
+
+ONH = $(O)nethack
+
+NHONLY = consoletty.o getline.o topl.o wintty.o
+ifeq "$(ADD_CURSES)" "Y"
+CFLAGSNH += -DCURSES_GRAPHICS -DCHTYPE_32 -DPDC_NCMOUSE
+NHONLY += $(addsuffix .o, cursdial cursinit cursinvt cursmain cursmesg cursmisc cursstat curswins)
+endif
+
+NHOBJS = $(addprefix $(ONH)/, $(COREOBJS) $(NHONLY))
+NHRES = $(ONH)/conres.o
+NHTARGET = $(GAMEDIR)/NetHack.exe
+
+nethack: $(NHTARGET)
+
+$(GAMEDIR)/NetHack.exe: $(NHOBJS) $(NHRES) $(LUALIB) $(PDCLIB) | $(GAMEDIR)
+	$(ld) $(LDFLAGS) -mconsole $^ $(LIBS) -static -lstdc++ -o$@
+
+$(ONH)/%.o: $(SRC)/%.c $(NHLUAH) | $(ONH)
+	$(cc) $(CFLAGSNH) $< -o$@
+
+$(ONH)/cppregex.o: $(SSYS)/cppregex.cpp $(NHLUAH) | $(ONH)
+	$(cc) $(CFLAGSNH) $< -o$@
+
+$(ONH)/%.o: $(SSYS)/%.c $(NHLUAH) | $(ONH)
+	$(cc) $(CFLAGSNH) $< -o$@
+
+$(ONH)/stubs.o: $(MSWSYS)/stubs.c $(NHLUAH) | $(ONH)
+	$(cc) $(CFLAGSNH) -DGUISTUB $< -o$@
+
+$(ONH)/%.o: $(MSWSYS)/%.c $(NHLUAH) | $(ONH)
+	$(cc) $(CFLAGSNH) $< -o$@
+
+$(ONH)/%.o: $(MSWIN)/%.c $(NHLUAH) | $(ONH)
+	$(cc) $(CFLAGSNH) $< -o$@
+
+$(ONH)/%.o: $(WSHR)/%.c $(NHLUAH) | $(ONH)
+	$(cc) $(CFLAGSNH) $< -o$@
+
+$(ONH)/%.o: $(TTY)/%.c $(NHLUAH) | $(ONH)
+	$(cc) $(CFLAGSNH) $< -o$@
+
+$(ONH)/%.o: $(WCURSES)/%.c $(NHLUAH) | $(ONH)
+	$(cc) $(CFLAGSNH) $(PDCINCL) $< -o$@
+
+$(NHRES): $(MSWIN)/NetHack.rc $(MSWIN)/NetHack.ico | $(ONH)
+	$(rc) --include-dir=$(MSWIN) --input=$< -o$@
+
+$(ONH):
+	@mkdir -p $@
+
+CLEAN_DIR += $(ONH)
+CLEAN_FILE += $(NHTARGET) $(NHOBJS) $(NHRES)
+
+#==========================================
+#=============== TARGETS ==================
+#==========================================
+
+.PHONY: all clean default install lua makedefs recover pdcurses \
+	tile2bmp tilemap uudecode dlb nethackw nethack tileutil
+
+#
+#  Everything
+#
+
+all: install
+
+TO_INSTALL = $(GAMEDIR)/NetHack.exe $(RTARGETS) \
+	     $(addprefix $(GAMEDIR)/, $(addsuffix .template, sysconf symbols .nethackrc) \
+	     Guidebook.txt NetHack.txt license opthelp record)
+
+ifeq "$(USE_LUADLL)" "Y"
+TO_INSTALL += $(LUADLL)
+endif
+
+ifneq "$(SKIP_NETHACKW)" "Y"
+TO_INSTALL += $(GAMEDIR)/NetHackW.exe
+endif
+
+ifeq "$(USE_DLB)" "Y"
+TO_INSTALL += $(DLB)
+endif
+
+install: $(TO_INSTALL)
+ifdef TRAVIS_COMPILER
+	ls -l $(SRC)
+	ls -l $(DAT)
+	ls -l $(UTIL)
+endif
+ifneq "$(USE_DLB)" "Y"
+	cp $(DAT)/*.dat $(GAMEDIR)/
+endif
+	@echo NetHack is up to date.
+
+$(GAMEDIR)/symbols.template: $(DAT)/symbols
+	cp $< $@
+
+$(GAMEDIR)/NetHack.txt: $(DOC)/nethack.txt
+	cp $< $@
+
+$(GAMEDIR)/record:
+	touch $@
+
+$(GAMEDIR)/%: $(DAT)/%
+	cp $< $@
+
+$(GAMEDIR)/%: $(DOC)/%
+	cp $< $@
+
+$(GAMEDIR)/%: $(MSWSYS)/%
+	cp $< $@
+
+CLEAN_FILE += $(TO_INSTALL)
+
+clean:
+	@-rm -f $(CLEAN_FILE)
+	@$(foreach dir, $(CLEAN_DIR), \
+		if [ -d $(dir) ] ; then rmdir -p --ignore $(dir) ; fi ; )
+
+-include Makefile.mingw32.depend
+-include .depend
+# end of file

--- a/sys/windows/Makefile.mingw32.depend
+++ b/sys/windows/Makefile.mingw32.depend
@@ -1,6 +1,6 @@
 .PHONY: depend cleandep
 
-cce = gcc -E -MM -MT $(@:d=o)
+cce = gcc -E -MM -MT "$(@:d=o) $@"
 
 # Copy all $(cc) commands w/ their targets from Makefile.mingw32, 3rd party code unnecessary
 # Replace .o w/ .d, $(cc) w/ $(cce)
@@ -115,7 +115,6 @@ depend: $(DEP_TARGETS)
 
 cleandep:
 	@-rm -f $(DEP_TARGETS) .depend
-	@echo Done.
 
-CLEAN_FILE += .depend $(DEP_TARGETS)
+clean: cleandep
 # end of file

--- a/sys/windows/Makefile.mingw32.depend
+++ b/sys/windows/Makefile.mingw32.depend
@@ -1,0 +1,121 @@
+.PHONY: depend cleandep
+
+cce = gcc -E -MM -MT $(@:d=o)
+
+# Copy all $(cc) commands w/ their targets from Makefile.mingw32, 3rd party code unnecessary
+# Replace .o w/ .d, $(cc) w/ $(cce)
+# Check extraordinary "OBJ): " and handle them properly
+# Check all CLEAN_FILE lines, add obj files to $(OBJS4DEP)
+# Run
+# 	mingw32-make depend
+
+$(OM)/%.d: $(SRC)/%.c $(NHLUAH) | $(OM)
+	$(cce) $(CFLAGSU) -DENUM_PM $< -o$@
+
+$(OM)/%.d: $(U)%.c $(NHLUAH) | $(OM)
+	$(cce) $(CFLAGSU) -DENUM_PM $< -o$@
+
+$(OR)/recover.d: $(U)recover.c | $(OR)
+	$(cce) $(CFLAGSU) $< -o$@
+
+$(OT)/tiletxt.d: $(WSHR)/tilemap.c $(NHLUAH) | $(OT)
+	$(cce) $(CFLAGSU) -DTILETEXT $< -o$@
+
+$(OT)/%.d: $(WSHR)/%.c $(NHLUAH) | $(OT)
+	$(cce) $(CFLAGSU) $< -o$@
+
+$(OT)/%.d: $(SRC)/%.c $(NHLUAH) | $(OT)
+	$(cce) $(CFLAGSU) $< -o$@
+
+$(OT)/tilete32.d: $(WSHR)/tiletext.c $(NHLUAH) | $(OT)
+	$(cce) $(CFLAGSU) -DTILE_X=32 -DTILE_Y=32 $< -o$@
+
+$(OT)/tiletx32.d: $(WSHR)/tilemap.c $(NHLUAH) | $(OT)
+	$(cce) $(CFLAGSU) -DTILETEXT -DTILE_X=32 -DTILE_Y=32 $< -o$@
+
+$(GIF32OBJ:o=d): $(WSHR)/gifread.c $(NHLUAH) | $(OT)
+	$(cce) $(CFLAGSU) -DTILE_X=32 -DTILE_Y=32 $< -o$@
+
+$(BMP32OBJ:o=d): $(WSHR)/tile2bmp.c $(NHLUAH) | $(OT)
+	$(cce) $(CFLAGSU) -DTILE_X=32 -DTILE_Y=32 $< -o$@
+
+$(OT)/panic.d: $(UTIL)/panic.c $(NHLUAH) | $(OT)
+	$(cce) $(CFLAGSU) $< -o$@
+
+$(OTM)/tilemap.d: $(WSHR)/tilemap.c $(NHLUAH) | $(OTM)
+	$(cce) $(CFLAGSU) $< -o$@
+
+$(OTM)/%.d: $(SRC)/%.c $(NHLUAH) | $(OTM)
+	$(cce) $(CFLAGSU) $< -o$@
+
+$(OU)/uudecode.d: $(SSYS)/uudecode.c | $(OU)
+	$(cce) $(CFLAGS) $(CONSOLEDEF) $< -o$@
+
+$(ODLB)/%.d: $(SRC)/%.c $(NHLUAH) | $(ODLB)
+	$(cce) $(CFLAGSU) $< -o$@
+
+$(ODLB)/%.d: $(U)%.c $(NHLUAH) | $(ODLB)
+	$(cce) $(CFLAGSU) $< -o$@
+
+$(ONHW)/%.d: $(SRC)/%.c $(NHLUAH) | $(ONHW)
+	$(cce) $(CFLAGSW) $< -o$@
+
+$(ONHW)/cppregex.d: $(SSYS)/cppregex.cpp $(NHLUAH) | $(ONHW)
+	$(cce) $(CFLAGSW) $< -o$@
+
+$(ONHW)/%.d: $(SSYS)/%.c $(NHLUAH) | $(ONHW)
+	$(cce) $(CFLAGSW) $< -o$@
+
+$(ONHW)/stubs.d: $(MSWSYS)/stubs.c $(NHLUAH) | $(ONHW)
+	$(cce) $(CFLAGSW) -DTTYSTUB $< -o$@
+
+$(ONHW)/%.d: $(MSWSYS)/%.c $(NHLUAH) | $(ONHW)
+	$(cce) $(CFLAGSW) $< -o$@
+
+$(ONHW)/%.d: $(MSWIN)/%.c $(NHLUAH) | $(ONHW)
+	$(cce) $(CFLAGSW) $< -o$@
+
+$(ONHW)/%.d: $(WSHR)/%.c $(NHLUAH) | $(ONHW)
+	$(cce) $(CFLAGSW) $< -o$@
+
+$(ONH)/%.d: $(SRC)/%.c $(NHLUAH) | $(ONH)
+	$(cce) $(CFLAGSNH) $< -o$@
+
+$(ONH)/cppregex.d: $(SSYS)/cppregex.cpp $(NHLUAH) | $(ONH)
+	$(cce) $(CFLAGSNH) $< -o$@
+
+$(ONH)/%.d: $(SSYS)/%.c $(NHLUAH) | $(ONH)
+	$(cce) $(CFLAGSNH) $< -o$@
+
+$(ONH)/stubs.d: $(MSWSYS)/stubs.c $(NHLUAH) | $(ONH)
+	$(cce) $(CFLAGSNH) -DGUISTUB $< -o$@
+
+$(ONH)/%.d: $(MSWSYS)/%.c $(NHLUAH) | $(ONH)
+	$(cce) $(CFLAGSNH) $< -o$@
+
+$(ONH)/%.d: $(MSWIN)/%.c $(NHLUAH) | $(ONH)
+	$(cce) $(CFLAGSNH) $< -o$@
+
+$(ONH)/%.d: $(WSHR)/%.c $(NHLUAH) | $(ONH)
+	$(cce) $(CFLAGSNH) $< -o$@
+
+$(ONH)/%.d: $(TTY)/%.c $(NHLUAH) | $(ONH)
+	$(cce) $(CFLAGSNH) $< -o$@
+
+$(ONH)/%.d: $(WCURSES)/%.c $(NHLUAH) | $(ONH)
+	$(cce) $(CFLAGSNH) $(PDCINCL) $< -o$@
+
+OBJS4DEP = $(MOBJS) $(ROBJS) \
+	   $(TOBJS) $(GIFOBJ) $(GIF32OBJ) $(PPMOBJ) $(BMP32OBJ) $(T32OBJS) $(TUCOMMON) \
+	   $(TMOBJS) $(UOBJS) $(DLBOBJS) $(NHWOBJS) $(NHOBJS)
+DEP_TARGETS = $(OBJS4DEP:o=d)
+
+depend: $(DEP_TARGETS)
+	@cat $(DEP_TARGETS) > .depend
+
+cleandep:
+	@-rm -f $(DEP_TARGETS) .depend
+	@echo Done.
+
+CLEAN_FILE += .depend $(DEP_TARGETS)
+# end of file

--- a/sys/windows/stubs.c
+++ b/sys/windows/stubs.c
@@ -10,7 +10,6 @@
 #error You cannot compile this with both GUISTUB and TTYSTUB defined.
 #endif
 
-int GUILaunched;
 struct window_procs mswin_procs = { "-guistubs" };
 
 #ifdef QT_GRAPHICS
@@ -60,7 +59,6 @@ main(int argc, char *argv[])
 
 HANDLE hConIn;
 HANDLE hConOut;
-int GUILaunched;
 struct window_procs tty_procs = { "-ttystubs" };
 #ifdef CURSES_GRAPHICS
 char erase_char, kill_char;

--- a/sys/windows/win10.h
+++ b/sys/windows/win10.h
@@ -7,28 +7,6 @@
 
 #include "win32api.h"
 
-#ifdef __MINGW32__
-#ifndef DECLARE_HANDLE
-#define DECLARE_HANDLE(name) struct name##__{int unused;}; typedef struct name##__ *name
-#endif
-DECLARE_HANDLE(DPI_AWARENESS_CONTEXT);
-
-/* DPI awareness */
-typedef enum DPI_AWARENESS
-{
-    DPI_AWARENESS_INVALID = -1,
-    DPI_AWARENESS_UNAWARE = 0,
-    DPI_AWARENESS_SYSTEM_AWARE,
-    DPI_AWARENESS_PER_MONITOR_AWARE
-} DPI_AWARENESS;
-
-#define DPI_AWARENESS_CONTEXT_UNAWARE              ((DPI_AWARENESS_CONTEXT)-1)
-#define DPI_AWARENESS_CONTEXT_SYSTEM_AWARE         ((DPI_AWARENESS_CONTEXT)-2)
-#define DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE    ((DPI_AWARENESS_CONTEXT)-3)
-#define DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 ((DPI_AWARENESS_CONTEXT)-4)
-#define DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED    ((DPI_AWARENESS_CONTEXT)-5)
-#endif
-
 typedef struct {
     double  scale;  // dpi of monitor / 96
     int     width;  // in pixels

--- a/sys/windows/windsys.c
+++ b/sys/windows/windsys.c
@@ -45,7 +45,7 @@ boolean win32_cursorblink;
 HANDLE ffhandle = (HANDLE) 0;
 WIN32_FIND_DATA ffd;
 extern int GUILaunched;
-boolean getreturn_enabled;
+extern boolean getreturn_enabled;
 int redirect_stdout;
 
 typedef HWND(WINAPI *GETCONSOLEWINDOW)();

--- a/win/win32/NetHackW.c
+++ b/win/win32/NetHackW.c
@@ -63,7 +63,7 @@ _nhapply_image_transparent(HDC hDC, int x, int y, int width, int height,
 
 // Global Variables:
 NHWinApp _nethack_app;
-extern int GUILaunched;     /* We tell shared startup code in windmain.c
+int GUILaunched = TRUE;     /* We tell shared startup code in windmain.c
                                that the GUI was launched via this */
 
 #ifdef __BORLANDC__

--- a/win/win32/NetHackW.c
+++ b/win/win32/NetHackW.c
@@ -237,7 +237,12 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine,
     }
     GUILaunched = 1;
     /* let main do the argument processing */
-    (void) main(argc, argv);
+#ifndef __MINGW32__
+    main(argc, argv);
+#else
+    int mingw_main(int argc, char *argv[]);
+    mingw_main(argc, argv);
+#endif
     return 0;
 }
 


### PR DESCRIPTION
For my MSYS2/mingw32 to build properly:
```
wangfy@DESKTOP-8KQFTRT MINGW64 /d/prj/NetHack/src
$ mingw32-make -f Makefile.gcc all
----
NOTE: This build will include tile support.
----
gcc -c -mms-bitfields -I../include -I../sys/windows -I../lib/lua-5.4.3/src    -DTILES -DMSWIN_GRAPHICS -DWIN32CON -D_WIN32_IE=0x0400 -D_WIN32_WINNT=0x0601 -DWINVER=0x0601 -DDLB -DSAFEPROCS -DGUISTUB  -oo/guistub.o ../sys/windows/stubs.c
gcc -c -mms-bitfields -I../include -I../sys/windows -I../lib/lua-5.4.3/src    -DTILES -DMSWIN_GRAPHICS -DWIN32CON -D_WIN32_IE=0x0400 -D_WIN32_WINNT=0x0601 -DWINVER=0x0601 -DDLB -DSAFEPROCS -oo/windsys.o  ../sys/windows/windsys.c
In file included from D:/msys64/mingw64/x86_64-w64-mingw32/include/minwindef.h:163,
                 from D:/msys64/mingw64/x86_64-w64-mingw32/include/windef.h:9,
                 from D:/msys64/mingw64/x86_64-w64-mingw32/include/windows.h:69,
                 from ../sys/windows/win32api.h:40,
                 from ../sys/windows/win10.h:8,
                 from ../sys/windows/windsys.c:14:
../sys/windows/win10.h:14:16: error: redefinition of 'struct DPI_AWARENESS_CONTEXT__'
   14 | DECLARE_HANDLE(DPI_AWARENESS_CONTEXT);
      |                ^~~~~~~~~~~~~~~~~~~~~
D:/msys64/mingw64/x86_64-w64-mingw32/include/windef.h:155:1: note: originally defined here
```
and
```
Linking ../binary/NetHack.exe...
gcc   -o../binary/NetHack.exe o/windmain.o o/windsys.o o/win10.o o/safeproc.o o/nhlan.o o/ntsound.o o/dlb.o  o/allmain.o  o/alloc.o    o/apply.o    o/artifact.o o/attrib.o   o/ball.o     o/bones.o    o/botl.o o/cmd.o      o/dbridge.o  o/decl.o     o/detect.o o/dig.o      o/display.o  o/do.o       o/do_name.o o/do_wear.o  o/dog.o      o/dogmove.o  o/dokick.o o/dothrow.o  o/drawing.o  o/dungeon.o  o/eat.o o/end.o      o/engrave.o  o/exper.o    o/explode.o o/extralev.o o/files.o    o/fountain.o o/hack.o o/hacklib.o  o/insight.o  o/invent.o   o/isaac64.o o/light.o    o/lock.o     o/mail.o     o/makemon.o o/mdlib.o    o/mcastu.o   o/mhitm.o    o/mhitu.o o/minion.o   o/mklev.o    o/mkmap.o    o/mkmaze.o o/mkobj.o    o/mkroom.o   o/mon.o      o/mondata.o o/monmove.o  o/monst.o    o/mplayer.o  o/mthrowu.o o/muse.o     o/music.o    o/o_init.o   o/objects.o  o/objnam.o   o/options.o  o/pager.o    o/pickup.o o/pline.o    o/polyself.o o/potion.o   o/pray.o o/priest.o   o/quest.o    o/questpgr.o o/random.o o/read.o     o/rect.o     o/region.o   o/restore.o o/rip.o      o/rnd.o      o/role.o     o/rumors.o o/save.o     o/sfstruct.o o/shk.o      o/shknam.o o/sit.o      o/sounds.o   o/sp_lev.o   o/spell.o o/steal.o    o/steed.o    o/symbols.o  o/sys.o o/teleport.o o/timeout.o  o/topten.o   o/track.o o/trap.o     o/u_init.o   o/uhitm.o    o/vault.o o/vision.o   o/weapon.o   o/were.o     o/wield.o o/windows.o  o/wizard.o   o/worm.o     o/worn.o o/write.o    o/zap.o o/cppregex.o   o/version.o o/nhlua.o    o/nhlsel.o    o/nhlobj.o o/topl.o     o/getline.o  o/wintty.o o/consoletty.o o/tile.o \
        o/guistub.o o/date.o o/conres.o  o/lua-5.4.3.static.a \
        -lgdi32 -lwinmm -lshell32 -lole32 -luuid -lbcrypt -static -lstdc++
D:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/11.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: o/windsys.o:windsys.c:(.bss+0x160): multiple definition of `getreturn_enabled'; o/windmain.o:windmain.c:(.bss+0x100): first defined here
D:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/11.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: o/guistub.o:stubs.c:(.bss+0x0): multiple definition of `GUILaunched'; o/consoletty.o:consoletty.c:(.bss+0x34): first defined here
collect2.exe: error: ld returned 1 exit status
mingw32-make: *** [Makefile.gcc:895: ../binary/NetHack.exe] Error 1
```