### PR TITLE
Fix: tty map weirdness after 'full-screen' menu

### DIFF
--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -1573,6 +1573,7 @@ erase_menu_or_text(winid window, struct WinDesc *cw, boolean clear)
             clear_screen();
         } else {
             docrt();
+            flush_screen(1);
         }
     } else {
         docorner((int) cw->offx, cw->maxrow + 1);


### PR DESCRIPTION
When a 'full-screen' (cw->offx and cw->offy both 0) menu was immediately
followed by an offset menu -- as in the case of selecting certain
options from the options menu, or using loot to take out/put in items
after using ':' to describe the contents of a very full container --
there were some odd interactions with the map.

Only certain parts of the map near/under the menu window would be
redrawn if the first offset menu was followed by another one, while
a getlin prompt would cause the entire map to be redrawn, with parts
intersecting the window being drawn on top of it and obscuring it.
Flushing the display immediately after the docrt call when closing a
full-screen menu seems to fix both these issues.

It's a little hard to describe the 'weirdness' so here are some illustrative videos:
Before:

https://user-images.githubusercontent.com/40038830/153090341-45180ef1-09a3-44fa-9225-c20f976fb072.mp4

After:

https://user-images.githubusercontent.com/40038830/153090352-0646ae37-2730-4b0f-9a10-ad04519fe7c4.mp4



