### PR TITLE
Remove redundant null-check on christen_orc()

### DIFF
--- a/src/do_name.c
+++ b/src/do_name.c
@@ -2415,6 +2415,7 @@ christen_orc(struct monst *mtmp, const char *gang, const char *other)
     char buf[BUFSZ], buf2[BUFSZ], *orcname;
 
     orcname = rndorcname(buf2);
+    /* orcname is never NULL */
     sz = (int) strlen(orcname);
     if (gang)
         sz += (int) (strlen(gang) + sizeof " of " - sizeof "");
@@ -2425,11 +2426,11 @@ christen_orc(struct monst *mtmp, const char *gang, const char *other)
         char gbuf[BUFSZ];
         boolean nameit = FALSE;
 
-        if (gang && orcname) {
+        if (gang) {
             Sprintf(buf, "%s of %s", upstart(orcname),
                     upstart(strcpy(gbuf, gang)));
             nameit = TRUE;
-        } else if (other && orcname) {
+        } else if (other) {
             Sprintf(buf, "%s%s", upstart(orcname), other);
             nameit = TRUE;
         }


### PR DESCRIPTION
rndorcname() returns buf2 itself, so orcname is never NULL.