### PR TITLE
Externify trycall() and replace many docall() calls with it

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -435,6 +435,7 @@ extern int dodrop(void);
 extern boolean boulder_hits_pool(struct obj *, int, int, boolean);
 extern boolean flooreffects(struct obj *, int, int, const char *);
 extern void doaltarobj(struct obj *);
+extern void trycall(struct obj *);
 extern boolean canletgo(struct obj *, const char *);
 extern void dropx(struct obj *);
 extern void dropy(struct obj *);

--- a/src/do.c
+++ b/src/do.c
@@ -7,7 +7,6 @@
 
 #include "hack.h"
 
-static void trycall(struct obj *);
 static void polymorph_sink(void);
 static boolean teleport_sink(void);
 static void dosinkring(struct obj *);
@@ -315,7 +314,9 @@ doaltarobj(struct obj *obj)
     }
 }
 
-static void
+/* If obj is neither formally identified nor informally called something
+ * already, prompt the player to call its object type. */
+void
 trycall(struct obj *obj)
 {
     if (!objects[obj->otyp].oc_name_known && !objects[obj->otyp].oc_uname)

--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -888,10 +888,8 @@ Amulet_on(void)
         }
         livelog_newform(FALSE, orig_sex, new_sex);
         pline_The("amulet disintegrates!");
-        if (orig_sex == poly_gender() && uamul->dknown
-            && !objects[AMULET_OF_CHANGE].oc_name_known
-            && !objects[AMULET_OF_CHANGE].oc_uname)
-            docall(uamul);
+        if (orig_sex == poly_gender() && uamul->dknown)
+            trycall(uamul);
         useup(uamul);
         break;
     }

--- a/src/eat.c
+++ b/src/eat.c
@@ -2620,9 +2620,8 @@ doeat(void)
     if (otmp->otyp == RIN_SLOW_DIGESTION) {
         pline("This ring is indigestible!");
         (void) rottenfood(otmp);
-        if (otmp->dknown && !objects[otmp->otyp].oc_name_known
-            && !objects[otmp->otyp].oc_uname)
-            docall(otmp);
+        if (otmp->dknown)
+            trycall(otmp);
         return ECMD_TIME;
     }
     if (otmp->oclass != FOOD_CLASS) {

--- a/src/muse.c
+++ b/src/muse.c
@@ -857,9 +857,8 @@ use_defensive(struct monst* mtmp)
          */
         if (known)
             makeknown(SCR_CREATE_MONSTER);
-        else if (!objects[SCR_CREATE_MONSTER].oc_name_known
-                 && !objects[SCR_CREATE_MONSTER].oc_uname)
-            docall(otmp);
+        else
+            trycall(otmp);
         m_useup(mtmp, otmp);
         return 2;
     }
@@ -2076,9 +2075,7 @@ use_misc(struct monst* mtmp)
                 if (vismon) {
                     pline("%s rises up, through the %s!", Monnam(mtmp),
                           ceiling(mtmp->mx, mtmp->my));
-                    if (!objects[POT_GAIN_LEVEL].oc_name_known
-                        && !objects[POT_GAIN_LEVEL].oc_uname)
-                        docall(otmp);
+                    trycall(otmp);
                 }
                 m_useup(mtmp, otmp);
                 migrate_to_level(mtmp, ledger_no(&tolevel), MIGR_RANDOM,
@@ -2088,9 +2085,7 @@ use_misc(struct monst* mtmp)
  skipmsg:
                 if (vismon) {
                     pline("%s looks uneasy.", Monnam(mtmp));
-                    if (!objects[POT_GAIN_LEVEL].oc_name_known
-                        && !objects[POT_GAIN_LEVEL].oc_uname)
-                        docall(otmp);
+                    trycall(otmp);
                 }
                 m_useup(mtmp, otmp);
                 return 2;
@@ -2789,10 +2784,9 @@ muse_unslime(
         if (mon->mconf) {
             if (cansee(mon->mx, mon->my))
                 pline("Oh, what a pretty fire!");
-            if (vis && !objects[otyp].oc_name_known
-                && !objects[otyp].oc_uname)
-                docall(obj);
-            m_useup(mon, obj); /* after docall() */
+            if (vis)
+                trycall(obj);
+            m_useup(mon, obj); /* after trycall() */
             vis = FALSE;       /* skip makeknown() below */
             res = FALSE;       /* failed to cure sliming */
         } else {

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1666,9 +1666,7 @@ pickup_object(struct obj *obj, long count,
             pline_The("scroll%s %s to dust as you %s %s up.", plur(obj->quan),
                       otense(obj, "turn"), telekinesis ? "raise" : "pick",
                       (obj->quan == 1L) ? "it" : "them");
-            if (!objects[SCR_SCARE_MONSTER].oc_name_known
-                && !objects[SCR_SCARE_MONSTER].oc_uname)
-                docall(obj);
+            trycall(obj);
             useupf(obj, obj->quan);
             return 1; /* tried to pick something up and failed, but
                          don't want to terminate pickup loop yet   */

--- a/src/potion.c
+++ b/src/potion.c
@@ -591,8 +591,8 @@ dopotion(struct obj *otmp)
         if (!g.potion_unkn) {
             makeknown(otmp->otyp);
             more_experienced(0, 10);
-        } else if (!objects[otmp->otyp].oc_uname)
-            docall(otmp);
+        } else
+            trycall(otmp);
     }
     useup(otmp);
     return ECMD_TIME;
@@ -1414,9 +1414,8 @@ strange_feeling(struct obj *obj, const char *txt)
     if (!obj) /* e.g., crystal ball finds no traps */
         return;
 
-    if (obj->dknown && !objects[obj->otyp].oc_name_known
-        && !objects[obj->otyp].oc_uname)
-        docall(obj);
+    if (obj->dknown)
+        trycall(obj);
 
     useup(obj);
 }
@@ -1837,9 +1836,8 @@ potionhit(struct monst *mon, struct obj *obj, int how)
     if ((distance == 0 || (distance < 3 && rn2(5)))
         && (!breathless(g.youmonst.data) || haseyes(g.youmonst.data)))
         potionbreathe(obj);
-    else if (obj->dknown && !objects[obj->otyp].oc_name_known
-             && !objects[obj->otyp].oc_uname && cansee(tx, ty))
-        docall(obj);
+    else if (obj->dknown && cansee(tx, ty))
+        trycall(obj);
 
     if (*u.ushops && obj->unpaid) {
         struct monst *shkp = shop_keeper(*in_rooms(u.ux, u.uy, SHOPBASE));
@@ -2040,9 +2038,8 @@ potionbreathe(struct obj *obj)
     if (obj->dknown) {
         if (kn)
             makeknown(obj->otyp);
-        else if (!objects[obj->otyp].oc_name_known
-                 && !objects[obj->otyp].oc_uname)
-            docall(obj);
+        else
+            trycall(obj);
     }
     return;
 }
@@ -2391,10 +2388,8 @@ dodip(void)
                                    : potion->odiluted ? hcolor(NH_ORANGE)
                                      : hcolor(NH_RED));
         potion->in_use = FALSE; /* didn't go poof */
-        if (potion->dknown
-            && !objects[potion->otyp].oc_name_known
-            && !objects[potion->otyp].oc_uname)
-            docall(potion);
+        if (potion->dknown)
+            trycall(potion);
         return ECMD_TIME;
     }
 
@@ -2578,10 +2573,8 @@ dodip(void)
     return ECMD_TIME;
 
  poof:
-    if (potion->dknown
-        && !objects[potion->otyp].oc_name_known
-        && !objects[potion->otyp].oc_uname)
-        docall(potion);
+    if (potion->dknown)
+        trycall(potion);
     useup(potion);
     return ECMD_TIME;
 }

--- a/src/read.c
+++ b/src/read.c
@@ -440,8 +440,7 @@ doread(void)
 
         /* yet another note: despite the fact that player will recognize
            the object type, don't make it become a discovery for hero */
-        if (!objects[otyp].oc_name_known && !objects[otyp].oc_uname)
-            docall(scroll);
+        trycall(scroll);
         return ECMD_TIME;
     } else if (otyp == CREDIT_CARD) {
         static const char *const card_msgs[] = {
@@ -631,8 +630,8 @@ doread(void)
         if (!objects[otyp].oc_name_known) {
             if (g.known)
                 learnscroll(scroll);
-            else if (!objects[otyp].oc_uname)
-                docall(scroll);
+            else
+                trycall(scroll);
         }
         scroll->in_use = FALSE;
         if (otyp != SCR_BLANK_PAPER)

--- a/src/spell.c
+++ b/src/spell.c
@@ -185,9 +185,7 @@ confused_book(struct obj* spellbook)
          "Being confused you have difficulties in controlling your actions.");
         display_nhwindow(WIN_MESSAGE, FALSE);
         You("accidentally tear the spellbook to pieces.");
-        if (!objects[spellbook->otyp].oc_name_known
-            && !objects[spellbook->otyp].oc_uname)
-            docall(spellbook);
+        trycall(spellbook);
         useup(spellbook);
         gone = TRUE;
     } else {
@@ -587,9 +585,7 @@ study_book(register struct obj* spellbook)
             if (gone || !rn2(3)) {
                 if (!gone)
                     pline_The("spellbook crumbles to dust!");
-                if (!objects[spellbook->otyp].oc_name_known
-                    && !objects[spellbook->otyp].oc_uname)
-                    docall(spellbook);
+                trycall(spellbook);
                 useup(spellbook);
             } else
                 spellbook->in_use = FALSE;


### PR DESCRIPTION
trycall() is a short docall() wrapper that is a no-op if the item is
already identified or the player has called the object type already. For
some reason, many calls to docall() did those same exact checks
beforehand.

This commit eliminates that redundancy by converting those calls into
trycall(), which is now made extern rather than local to do.c. No
behavior should be changed by this commit; I've checked that none of the
affected places could take a different code path now that the
oc_name_known and oc_uname checks are removed.