### PR TITLE
Reduce eucalyptus leaf nutrition to 1

### DIFF
--- a/include/objects.h
+++ b/include/objects.h
@@ -992,7 +992,7 @@ FOOD("glob of black pudding", 0,  2, 20, 0, FLESH,  20, CLR_BLACK,
 
 /* fruits & veggies */
 FOOD("kelp frond",            0,  1,  1, 0, VEGGY,  30, CLR_GREEN, KELP_FROND),
-FOOD("eucalyptus leaf",       3,  1,  1, 0, VEGGY,  30, CLR_GREEN,
+FOOD("eucalyptus leaf",       3,  1,  1, 0, VEGGY,   1, CLR_GREEN,
                                                              EUCALYPTUS_LEAF),
 FOOD("apple",                15,  1,  2, 0, VEGGY,  50, CLR_RED, APPLE),
 FOOD("orange",               10,  1,  2, 0, VEGGY,  80, CLR_ORANGE, ORANGE),


### PR DESCRIPTION
Eucalyptus leaves are famously inedible except by certain animals such
as koalas. I consider it very strange that a single leaf in NetHack
gives you six meatballs' worth of calories.

I considered making it 0 nutrition, but am not sure if a 0-nutrition
comestible would end up violating some assumption that all food is at
least 1 nutrition. If that's overly cautious and it's safe to do this, feel free
to make it 0 instead of 1.