### PR TITLE
Fix: levitating/flying monsters moving over liquid

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -1813,8 +1813,7 @@ mfndpos(
 
     nodiag = NODIAG(mdat - mons);
     wantpool = (mdat->mlet == S_EEL);
-    poolok = ((!Is_waterlevel(&u.uz) && IS_WATERWALL(nowtyp)
-               && !grounded(mdat))
+    poolok = ((!Is_waterlevel(&u.uz) && !grounded(mdat))
               || (is_swimmer(mdat) && !wantpool));
     /* note: floating eye is the only is_floater() so this could be
        simplified, but then adding another floater would be error prone */
@@ -1865,6 +1864,8 @@ mfndpos(
             if (IS_ROCK(ntyp)
                 && !((flag & ALLOW_WALL) && may_passwall(nx, ny))
                 && !((IS_TREE(ntyp) ? treeok : rockok) && may_dig(nx, ny)))
+                continue;
+            if (IS_WATERWALL(ntyp) && !is_swimmer(mdat))
                 continue;
             /* KMH -- Added iron bars */
             if (ntyp == IRONBARS


### PR DESCRIPTION
Commit c1a6dd4 was meant to prevent flying, levitating, and clinging
monsters from considering walls of water as acceptable movement
destinations, even outside of the Plane of Water.  However, it was
evaluating the monster's starting position instead of possible places to
move to, and the evaluation was 'backwards' (the equivalent of
IS_WATERWALL, instead of !IS_WATERWALL).

The result was that non-swimming monsters could only move onto any kind
of water or lava square if the position they were moving from was a
WATER square.  Change this so that instead of the starting position,
each potential destination spot's status as a wall of water is evaluated
in turn, and reverse the effect of the test so that it blocks walls of
water instead of allowing them.
