### PR TITLE
Add safeguard to catch non-table coord being given in Lua

### DIFF
--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -5373,6 +5373,13 @@ get_coord(lua_State *L, int i, lua_Integer *x, lua_Integer *y)
 
         return 1;
     }
+    if (lua_type(L, i) != LUA_TNIL) {
+        /* if coord is not supplied at all, it will be nil; however, if someone
+         * mistakenly supplies a number or other type (forgetting to put braces
+         * around {selection:rndcoord()} is one way this can easily happen),
+         * this should not quietly allow it to do so with x and y unmodified. */
+        nhl_error(L, "non-table coord specified");
+    }
     return 0;
 }
 


### PR DESCRIPTION
Frequently when working on special level lua files, I end up writing something like:
```
local antarea = selection.area(45,10,61,16)
des.monster({ id="soldier ant", coord=antarea:rndcoord(1) })
```
and then say "what the heck why are the ants spawning in random places all over the map". The correct usage is this:
```
des.monster({ id="soldier ant", coord={antarea:rndcoord(1)} })
```
because it expects a table and rndcoord does not return a coord, just a pair of ints. (I don't particularly think that behavior should change.) The problem is that it's a little too easy to miss this and wind up with a level not generating the way it was intended.

So to address that, this adds a lua error if coord is specified as something non-nil, but it is anything besides a table. (The existing get_coord code ensures that when it *is* a table, it must be a table of exactly 2 integers). In the case of forgotten braces around rndcoord, coord's type ends up as a number, so it gets caught by this.