### PR TITLE
Add initializer on use_tinning_kit()

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -1940,6 +1940,7 @@ use_tinning_kit(struct obj *obj)
 
         if (poly_when_stoned(g.youmonst.data)) {
             You("tin %s without wearing gloves.", corpse_name);
+            kbuf[0] = '\0';
         } else {
             pline("Tinning %s without wearing gloves is a fatal mistake...",
                   corpse_name);


### PR DESCRIPTION
If poly_when_stoned() is true, an uninitialized buffer kbuf[] is passed to instapetrify().
Although instapetrify() doesn't access it in that situation for now,
it should be initialized anyway for readability.