### PR TITLE
Add message for failed fountain monster detection

### DIFF
--- a/src/fountain.c
+++ b/src/fountain.c
@@ -332,7 +332,8 @@ drinkfountain(void)
             exercise(A_WIS, TRUE);
             break;
         case 26: /* See Monsters */
-            (void) monster_detect((struct obj *) 0, 0);
+            if (monster_detect((struct obj *) 0, 0))
+                pline_The("%s tastes like nothing.", hliquid("water"));
             exercise(A_WIS, TRUE);
             break;
         case 27: /* Find a gem in the sparkling waters. */


### PR DESCRIPTION
When the fountain quaffing monster detection effect was triggered on a
level without any monsters, no message would be printed.  I think this
was the only scenario where drinking from a fountain wouldn't print
anything, so it stood out as unusual.

Print a messsage in the case monster detection fails, to make it
consistent with other fountain effects and ensure it's clear the hero
did still drink from the fountain on that turn.  I used "the water
tastes like nothing" for the (sort of tenuous) connection to there being
nothing living on the level, but there might be a better message to put
in there.
