### PR TITLE
Fix: object detection vs mimic statue disguise

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -726,7 +726,8 @@ object_detect(struct obj *detector, /* object doing the detecting */
             temp.quan = 1L;
             temp.ox = mtmp->mx;
             temp.oy = mtmp->my;
-            temp.corpsenm = PM_TENGU; /* if mimicing a corpse */
+            /* used for mimicking a corpse or statue */
+            temp.corpsenm = has_mcorpsenm(mtmp) ? MCORPSENM(mtmp) : PM_TENGU;
             map_object(&temp, 1);
         } else if (findgold(mtmp->minvent)
                    && (!class || class == COIN_CLASS)) {


### PR DESCRIPTION
Cursed potions of object detection were showing all mimics disguised as
statues as 'i' glyphs, because object_detect used PM_TENGU as the
corpsenm of any mimic disguise.  Instead, use MCORPSENM when available
so that hidden mimics will be mapped with glyphs corresponding to their
actual disguises.