### PR TITLE
Unidentified gem selling prices

### DIFF
--- a/src/shk.c
+++ b/src/shk.c
@@ -2330,8 +2330,9 @@ set_cost(register struct obj* obj, register struct monst* shkp)
             /* different shop keepers give different prices */
             if (objects[obj->otyp].oc_material == GEMSTONE
                 || objects[obj->otyp].oc_material == GLASS) {
-                tmp = (obj->otyp % (6 - shkp->m_id % 3));
+                tmp = ((obj->otyp - FIRST_GEM) % (6 - shkp->m_id % 3));
                 tmp = (tmp + 3) * obj->quan;
+                divisor = 1L;
             }
         } else if (tmp > 1L && !(shkp->m_id % 4))
             multiplier *= 3L, divisor *= 4L;


### PR DESCRIPTION
Make the token selling prices for unidentified gems not depend on how
many items were defined before FIRST_GEM.  Now the unidentified gem
selling prices will depend only on the number and defined order of the
types of gems, and won't inexplicably change when objects are added,
or depend on compile-time options such as MAIL.

Also don't do the regular item price reduction for unidentified gems,
since they are already not based on the actual value.  This restores
the pre-3.6 behavior, allowing players to gain a bit more information
from the nominal selling prices of unidentified gems.

Whoever first introduced this special handling for gems probably
intended for players to be able to gain information from gem prices
this way, but probably nobody has been doing it since 3.6.

----

I came across this when I was looking at the wiki:
https://nethackwiki.com/wiki/Gem#By_color

As a wiki editor, I don't want unrelated changes (like adding a new object) to automatically make the information on the wiki out of date.