### PR TITLE
Fix: repeating 'free' actions with ^A takes time

### DIFF
--- a/include/hack.h
+++ b/include/hack.h
@@ -577,6 +577,7 @@ enum bodypart_types {
 #define ECMD_TIME   0x01 /* cmd took time, uses up a turn */
 #define ECMD_CANCEL 0x02 /* cmd canceled by user */
 #define ECMD_FAIL   0x04 /* cmd failed to finish, maybe with a yafm */
+#define ECMD_PASS   0x08 /* don't reset or modify cmd vars; used by ^A */
 
 /* values returned from getobj() callback functions */
 enum getobj_callback_returns {

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -2205,7 +2205,7 @@ do_repeat(void)
         rhack((char *) 0); /* read and execute command */
         g.in_doagain = FALSE;
         iflags.menu_requested = FALSE;
-        return ECMD_TIME;
+        return ECMD_PASS;
     }
     return ECMD_OK;
 }
@@ -4062,6 +4062,9 @@ rhack(char *cmd)
                 reset_cmd_vars(TRUE);
             } else if ((res & ECMD_TIME) != 0) {
                 g.context.move = TRUE;
+            } else if ((res & ECMD_PASS) != 0) {
+                /* do nothing, don't modify cmd vars: used for ^A/do_repeat to
+                   preserve the values from the repeated command */ 
             } else { /* ECMD_OK */
                 reset_cmd_vars(FALSE);
             }


### PR DESCRIPTION
The do_repeat function returned ECMD_TIME whenever it found something to
try to repeat, including 'free' actions like checking inventory, or
even pressing a key that's not bound to any function.  Returning ECMD_OK
has the opposite problem; repeating an action never takes time, even if
it otherwise would.

Add a new return value, ECMD_PASS, which preserves the relevant
variables set by the actual action being repeated rather than resetting
or modifying them, so that actions which take time will still take time
when repeated and 'free' actions won't.
