### PR TITLE
Monster AI Improvements and monmove.c refactoring.

### DIFF
--- a/src/monmove.c
+++ b/src/monmove.c
@@ -1828,13 +1828,14 @@ set_apparxy(register struct monst* mtmp)
      */
 
     /* pet knows your smell; grabber still has hold of you */
-    if (mtmp->mtame || mtmp == u.ustuck)
-        goto found_you;
-
-    /* monsters which know where you are don't suddenly forget,
+    if (mtmp->mtame || mtmp == u.ustuck ||
+        /* monsters which know where you are don't suddenly forget,
        if you haven't moved away */
-    if (u_at(mx, my))
-        goto found_you;
+        u_at(mx,my)) {
+            mtmp->mux = u.ux;
+            mtmp->muy = u.uy;
+            return;
+    }
 
     notseen = (!mtmp->mcansee || (Invis && !perceives(mtmp->data)));
     notthere = (Displaced && mtmp->data != &mons[PM_DISPLACER_BEAST]);
@@ -1850,8 +1851,11 @@ set_apparxy(register struct monst* mtmp)
     } else {
         disp = 0;
     }
-    if (!disp)
-        goto found_you;
+    if (!disp) {
+        mtmp->mux = u.ux;
+        mtmp->muy = u.uy;
+        return;
+    }
 
     /* without something like the following, invisibility and displacement
        are too powerful */
@@ -1861,8 +1865,11 @@ set_apparxy(register struct monst* mtmp)
         register int try_cnt = 0;
 
         do {
-            if (++try_cnt > 200)
-                goto found_you; /* punt */
+            if (++try_cnt > 200) {
+                mx = u.ux;
+                my = u.uy;
+                break; /* punt */
+            }
             mx = u.ux - disp + rn2(2 * disp + 1);
             my = u.uy - disp + rn2(2 * disp + 1);
         } while (!isok(mx, my)
@@ -1873,7 +1880,6 @@ set_apparxy(register struct monst* mtmp)
                               && (can_ooze(mtmp) || can_fog(mtmp)))))
                  || !couldsee(mx, my));
     } else {
- found_you:
         mx = u.ux;
         my = u.uy;
     }

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -1702,7 +1702,8 @@ m_move(register struct monst* mtmp, register int after)
             }
             /* Maybe a purple worm ate a corpse */
             if (ptr == &mons[PM_PURPLE_WORM]
-                || ptr == &mons[PM_BABY_PURPLE_WORM]) {
+                || ptr == &mons[PM_BABY_PURPLE_WORM]
+                || ptr == &mons[PM_PIRANHA]) {
                 if ((etmp = meatcorpse(mtmp)) >= 2)
                     return etmp; /* it died or got forced off the level */
             }

--- a/src/muse.c
+++ b/src/muse.c
@@ -1136,7 +1136,7 @@ rnd_defensive_item(struct monst* mtmp)
 #define MUSE_FROST_HORN 12
 #define MUSE_FIRE_HORN 13
 #define MUSE_POT_ACID 14
-/*#define MUSE_WAN_TELEPORTATION 15*/
+#define MUSE_WAN_TELEPORTATION 15
 #define MUSE_POT_SLEEPING 16
 #define MUSE_SCR_EARTH 17
 /*#define MUSE_WAN_UNDEAD_TURNING 20*/ /* also a defensive item so don't
@@ -1282,7 +1282,7 @@ find_offensive(struct monst* mtmp)
             g.m.offensive = obj;
             g.m.has_offense = MUSE_WAN_STRIKING;
         }
-#if 0   /* use_offensive() has had some code to support wand of teleportation
+        /* use_offensive() has had some code to support wand of teleportation
          * for a long time, but find_offensive() never selected one;
          * so for the time being, this is still disabled */
         nomore(MUSE_WAN_TELEPORTATION);
@@ -1291,11 +1291,11 @@ find_offensive(struct monst* mtmp)
             && !Teleport_control
             /* do try to move hero to a more vulnerable spot */
             && (onscary(u.ux, u.uy, mtmp)
-                || (stairway_at(u.ux, u.uy))) {
+                || (stairway_at(u.ux, u.uy)
+                || IS_ALTAR(levl[u.ux][u.uy].typ])))) {
             g.m.offensive = obj;
             g.m.has_offense = MUSE_WAN_TELEPORTATION;
         }
-#endif
         nomore(MUSE_POT_PARALYSIS);
         if (obj->otyp == POT_PARALYSIS && g.multi >= 0) {
             g.m.offensive = obj;
@@ -1399,7 +1399,6 @@ mbhitm(register struct monst* mtmp, register struct obj* otmp)
                 makeknown(WAN_STRIKING);
         }
         break;
-#if 0   /* disabled because find_offensive() never picks WAN_TELEPORTATION */
     case WAN_TELEPORTATION:
         if (hits_you) {
             tele();
@@ -1414,7 +1413,6 @@ mbhitm(register struct monst* mtmp, register struct obj* otmp)
                 (void) rloc(mtmp, RLOC_MSG);
         }
         break;
-#endif
     case WAN_CANCELLATION:
     case SPE_CANCELLATION:
         (void) cancel_monst(mtmp, otmp, FALSE, TRUE, FALSE);

--- a/src/muse.c
+++ b/src/muse.c
@@ -1291,8 +1291,7 @@ find_offensive(struct monst* mtmp)
             && !Teleport_control
             /* do try to move hero to a more vulnerable spot */
             && (onscary(u.ux, u.uy, mtmp)
-                || (stairway_at(u.ux, u.uy)
-                || IS_ALTAR(levl[u.ux][u.uy].typ])))) {
+                || (stairway_at(u.ux, u.uy)))) {
             g.m.offensive = obj;
             g.m.has_offense = MUSE_WAN_TELEPORTATION;
         }


### PR DESCRIPTION
This pull request contains a number of minor AI tweaks and improvements:

- When the player is on a set of stairs, tame monsters acts as if the player is carrying a treat. This reduces the frustration experienced by many players when they attempt to bring their pets with them, while still allowing for intentionally leaving pets behind on other dungeon levels.
- Enable offensive use of wands of teleportation by monsters. While comments in the code indicate that this behavior was disabled simply because it never occurred, I have found that in practice, this is not the case. When this code is enabled, monsters zap wands of teleportation at players standing on staircases, exactly as intended.
- Allow piranhas to eat corpses in the same manner that purple worms do. In pop culture, piranhas are infamous for their ability to skeletonize animals remarkably quickly, and I thought this would be nice to represent in NetHack.

This pull request also contains some significant refactoring and readability improvements for monmove.c:

- Pull illithid mind blast behavior into its own function. This shouldn't create much overhead, and enormously improves the readability of dochug().
- Eliminate a number of gotos in movemon.c.
- Replace magic numbers in movemon.c with constants.

I'm far from done with refactoring movement code, but I think this pull request is a good place to start. Dochug() is arguable the worst spaghetti code in the entire codebase, and I think that addressing it starts with making it more legible.