### PR TITLE
Fix: "in the the purple worm's entrails"

### DIFF
--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -2402,9 +2402,11 @@ throw_gold(struct obj *obj)
     }
     freeinv(obj);
     if (u.uswallow) {
-        pline(is_animal(u.ustuck->data) ? "%s in the %s's entrails."
-                                        : "%s into %s.",
-              "The gold disappears", mon_nam(u.ustuck));
+        const char *swallower = mon_nam(u.ustuck);
+        if (is_animal(u.ustuck->data))
+            swallower = s_suffix(swallower);
+        pline_The("gold disappears into %s%s.", swallower,
+                  is_animal(u.ustuck->data) ? " entrails" : "");
         add_to_minv(u.ustuck, obj);
         return ECMD_TIME;
     }


### PR DESCRIPTION
The message printed if the hero threw gold while swallowed by an animal
used "the <mon_nam>'s entrails", which produced a doubled 'the'.  It
could also use the wrong possessive form, since it doesn't take
advantage of any of the special case handling in s_suffix.  I think the
only way that could ever be a problem with the current cast of engulfers
is if the hero was swallowed by a purple worm while hallucinating, but I
changed it to use s_suffix anyway.
