### PR TITLE
remove unnecessary code

### DIFF
--- a/src/botl.c
+++ b/src/botl.c
@@ -3958,14 +3958,10 @@ status_hilite_menu_fld(int fld)
 
             if (idx == -1) {
                 /* delete selected hilites */
-                if (mode)
-                    goto shlmenu_free;
                 mode = -1;
                 break;
             } else if (idx == -2) {
                 /* create a new hilite */
-                if (mode)
-                    goto shlmenu_free;
                 mode = -2;
                 break;
             }


### PR DESCRIPTION
`mode` is initialized to 0, and the codes changing it are always breaking the loop.
So, the conditions of these `if` statements are always false.