### PR TITLE
Fix: force-fight 'unknown obstacle' descriptions

### DIFF
--- a/src/hack.c
+++ b/src/hack.c
@@ -1889,13 +1889,16 @@ domove_fight_empty(xchar x, xchar y)
         } else if (solid) {
             /* glyph might indicate unseen terrain if hero is blind;
                unlike searching, this won't reveal what that terrain is;
-               3.7: used to say "solid rock" for the stone case, but that
-               made it be different from unmapped walls outside of rooms */
-            Strcpy(buf, (levl[x][y].typ == STONE || levl[x][y].typ == SCORR)
-                         ? "stone"
-                         : glyph_is_cmap(glyph)
-                            ? the(defsyms[glyph_to_cmap(glyph)].explanation)
-                            : (const char *) "an unknown obstacle");
+               3.7: used to say "solid rock" for STONE, but that made it be
+               different from unmapped walls outside of rooms (and was wrong
+               on arboreal levels) */
+            if (levl[x][y].seenv || IS_STWALL(levl[x][y].typ)
+                || levl[x][y].typ == SDOOR || levl[x][y].typ == SCORR) {
+                glyph = back_to_glyph(x, y);
+                Strcpy(buf, the(defsyms[glyph_to_cmap(glyph)].explanation));
+            } else {
+                Strcpy(buf, "an unknown obstacle");
+            }
             /* note: 'solid' is misleadingly named and catches pools
                of water and lava as well as rock and walls;
                3.7: furniture too */


### PR DESCRIPTION
This is intended to address a couple quirks with force-fighting an
unoccupied spot that I noticed:

 * Now that furniture is considered 'solid', an object is much more
   likely to be sitting on the square, obscuring the terrain glyph.  As
   a result, the current glyph is no longer sufficient to accurately
   describe the contents of the spot -- e.g., an altar with a corpse on
   top of it was being described as "an unknown obstacle", even when the
   hero knew exactly what furniture was there.

 * When blind and attacking an unexplored 'solid' square, the attacked
   position would always be described as 'the stone', even something
   like a fountain or sink which didn't seem likely to be confused with
   a stone wall.

 * The feedback for attacking stone was previously changed from 'solid
   rock' to 'stone' in order to be consistent with the feedback for
   attacking an unseen wall, but they still weren't quite the same
   ("stone" vs "the stone").

 * The 'stone' feedback for all STONE/SCORR spots was incorrect on
   levels flagged as arboreal, where stone is rendered and described as
   trees.

This relies on back_to_glyph for positions where the hero is aware of
the terrain and certain other spots (like stone, walls, etc) for which
back_to_glyph produces good results even if they're unseen, and falls
back to the generic "unknown terrain" in other cases.

Pretty long commit message for such a small commit, but oh well...
