### PR TITLE
remove redundant condition on tty_add_menu()

### DIFF
--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -3036,7 +3036,7 @@ tty_add_menu(winid window,  /* window to use, must be of type NHW_MENU */
     item->selector = ch;
     item->gselector = gch;
     item->attr = attr;
-    item->str = dupstr(newstr ? newstr : "");
+    item->str = dupstr(newstr);
 
     item->next = cw->mlist;
     cw->mlist = item;


### PR DESCRIPTION
`newstr` is assigned to `str` or `buf`.
`buf` is an address of an array, and `str` is guarded,
so both are non-NULL.