### PR TITLE
Mark high altars in altarmask, fix display of unaligned temple altars

### DIFF
--- a/include/align.h
+++ b/include/align.h
@@ -34,11 +34,13 @@ typedef struct align { /* alignment & record */
 /* Some altars are considered shrines, add a flag for that
    for the altarmask field of struct rm. */
 #define AM_SHRINE       0x08
+/* High altar on Astral plane or Moloch's sanctum */
+#define AM_SANCTUM      0x10
 
 /* special level flags, gone by the time the level has been loaded */
-#define AM_SPLEV_CO     0x10 /* co-aligned: force alignment to match hero's  */
-#define AM_SPLEV_NONCO  0x20 /* non-co-aligned: force alignment to not match */
-#define AM_SPLEV_RANDOM 0x40
+#define AM_SPLEV_CO     0x20 /* co-aligned: force alignment to match hero's  */
+#define AM_SPLEV_NONCO  0x40 /* non-co-aligned: force alignment to not match */
+#define AM_SPLEV_RANDOM 0x80
 
 #define Amask2align(x) \
     ((aligntyp) ((((x) & AM_MASK) == 0) ? A_NONE                \

--- a/include/display.h
+++ b/include/display.h
@@ -544,10 +544,9 @@ enum glyph_offsets {
             (((mon)->female == 0) ? GLYPH_PET_MALE_OFF : GLYPH_PET_FEM_OFF))
 
 #define altar_to_glyph(amsk) \
-    (((amsk & (AM_MASK | AM_SHRINE)) == AM_NONE)               \
+    (((amsk & (AM_MASK | AM_SHRINE | AM_SANCTUM)) == AM_NONE)  \
        ? (GLYPH_ALTAR_OFF + altar_unaligned)                   \
-       : (((amsk & AM_SHRINE) == AM_SHRINE)                    \
-          && (Is_astralevel(&u.uz) || Is_sanctum(&u.uz)))      \
+       : ((amsk & AM_SANCTUM) == AM_SANCTUM)                   \
           ? (GLYPH_ALTAR_OFF + altar_other)                    \
           : ((amsk & AM_MASK) == AM_CHAOTIC)                   \
             ? (GLYPH_ALTAR_OFF + altar_chaotic)                \

--- a/include/display.h
+++ b/include/display.h
@@ -544,17 +544,17 @@ enum glyph_offsets {
             (((mon)->female == 0) ? GLYPH_PET_MALE_OFF : GLYPH_PET_FEM_OFF))
 
 #define altar_to_glyph(amsk) \
-    (((amsk & (AM_MASK | AM_SHRINE | AM_SANCTUM)) == AM_NONE)  \
-       ? (GLYPH_ALTAR_OFF + altar_unaligned)                   \
-       : ((amsk & AM_SANCTUM) == AM_SANCTUM)                   \
-          ? (GLYPH_ALTAR_OFF + altar_other)                    \
-          : ((amsk & AM_MASK) == AM_CHAOTIC)                   \
-            ? (GLYPH_ALTAR_OFF + altar_chaotic)                \
-            : ((amsk & AM_MASK) == AM_NEUTRAL)                 \
-              ? (GLYPH_ALTAR_OFF + altar_neutral)              \
-              : ((amsk & AM_MASK) == AM_LAWFUL)                \
-                ? (GLYPH_ALTAR_OFF + altar_lawful)             \
-                : (GLYPH_ALTAR_OFF + altar_neutral))
+    ((((amsk) & AM_SANCTUM) == AM_SANCTUM)                \
+      ? (GLYPH_ALTAR_OFF + altar_other)                   \
+      : (((amsk) & AM_MASK) == AM_LAWFUL)                 \
+         ? (GLYPH_ALTAR_OFF + altar_lawful)               \
+         : (((amsk) & AM_MASK) == AM_NEUTRAL)             \
+            ? (GLYPH_ALTAR_OFF + altar_neutral)           \
+            : (((amsk) & AM_MASK) == AM_CHAOTIC)          \
+               ? (GLYPH_ALTAR_OFF + altar_chaotic)        \
+               : (((amsk) & AM_MASK) == AM_NONE)          \
+                  ? (GLYPH_ALTAR_OFF + altar_unaligned)   \
+                  : (GLYPH_ALTAR_OFF + altar_neutral))
 
 /* not used, nor is it correct
 #define zap_to_glyph(zaptype, cmap_idx) \

--- a/src/invent.c
+++ b/src/invent.c
@@ -3989,10 +3989,7 @@ dfeature_at(int x, int y, char *buf)
         cmap = S_sink; /* "sink" */
     else if (IS_ALTAR(ltyp)) {
         Sprintf(altbuf, "%saltar to %s (%s)",
-                ((lev->altarmask & AM_SHRINE)
-                 && (Is_astralevel(&u.uz) || Is_sanctum(&u.uz)))
-                    ? "high "
-                    : "",
+                (lev->altarmask & AM_SANCTUM) ? "high " : "",
                 a_gname(),
                 align_str(Amask2align(lev->altarmask & ~AM_SHRINE)));
         dfeature = altbuf;

--- a/src/music.c
+++ b/src/music.c
@@ -292,12 +292,10 @@ do_earthquake(int force)
                     pline_The("kitchen sink falls%s.", into_a_chasm);
                 goto do_pit;
             case ALTAR:
-                /* always preserve the high altars */
-                if (Is_astralevel(&u.uz) || Is_sanctum(&u.uz))
-                    break;
-                /* no need to check for high altar here; we've just
-                   excluded those */
                 amsk = altarmask_at(x, y);
+                /* always preserve the high altars */
+                if ((amsk & AM_SANCTUM) != 0)
+                    break;
                 algn = Amask2align(amsk & AM_MASK);
                 if (cansee(x, y))
                     pline_The("%s altar falls%s.",

--- a/src/pager.c
+++ b/src/pager.c
@@ -619,13 +619,11 @@ lookat(int x, int y, char *buf, char *monbuf)
             Sprintf(buf, "%s %saltar",
                     /* like endgame high priests, endgame high altars
                        are only recognizable when immediately adjacent */
-                    (Is_astralevel(&u.uz) && !next2u(x, y))
+                    (Is_astralevel(&u.uz) && !next2u(x, y)
+                     && (amsk & AM_SANCTUM))
                         ? "aligned"
                         : align_str(algn),
-                    ((amsk & AM_SHRINE) != 0
-                     && (Is_astralevel(&u.uz) || Is_sanctum(&u.uz)))
-                        ? "high "
-                        : "");
+                    (amsk & AM_SANCTUM) ? "high " : "");
             break;
         case S_ndoor:
             if (is_drawbridge_wall(x, y) >= 0)

--- a/src/pray.c
+++ b/src/pray.c
@@ -1468,8 +1468,7 @@ dosacrifice(void)
         You("are not standing on an altar.");
         return ECMD_OK;
     }
-    highaltar = ((Is_astralevel(&u.uz) || Is_sanctum(&u.uz))
-                 && (levl[u.ux][u.uy].altarmask & AM_SHRINE));
+    highaltar = (levl[u.ux][u.uy].altarmask & AM_SANCTUM);
 
     otmp = floorfood("sacrifice", 1);
     if (!otmp)

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -2330,6 +2330,8 @@ create_altar(altar* a, struct mkroom* croom)
     if (a->shrine) { /* Is it a shrine  or sanctum? */
         priestini(&u.uz, croom, x, y, (a->shrine > 1));
         levl[x][y].altarmask |= AM_SHRINE;
+        if (a->shrine == 2) /* high altar or sanctum */
+            levl[x][y].altarmask |= AM_SANCTUM;
         g.level.flags.has_temple = TRUE;
     }
 }


### PR DESCRIPTION
I noticed I had a branch from a few months ago with this change to altarmask,
which I don't *think* I ever submitted to the devteam (my apologies if I did
and just forgot about it!).  I looked it over and it seemed like a decent idea
to me, so I thought I may as well send it in now -- and if there's some big
mistake or other reason I never submitted it that I've since forgotten,
hopefully that will become apparent. :)

While testing that commit, I also noticed that altars in unaligned temples
(like the one in the Valley) weren't being displayed as the right color.

- Designate high altars with dedicated altarmask bit
- Fix coloring of unaligned temple altars
