### PR TITLE
Tie door-kick prompts to autounlock

### DIFF
--- a/src/lock.c
+++ b/src/lock.c
@@ -780,7 +780,6 @@ doopen_indir(int x, int y)
     if (!(door->doormask & D_CLOSED)) {
         const char *mesg;
         boolean locked = FALSE;
-        struct obj* unlocktool;
 
         switch (door->doormask) {
         case D_BROKEN:
@@ -798,8 +797,9 @@ doopen_indir(int x, int y)
             break;
         }
         pline("This door%s.", mesg);
-        if (locked) {
-            if (flags.autounlock && (unlocktool = autokey(TRUE)) != 0) {
+        if (locked && flags.autounlock) {
+            struct obj *unlocktool = autokey(TRUE);
+            if (unlocktool) {
                 res = pick_lock(unlocktool, cc.x, cc.y,
                                 (struct obj *) 0) ? ECMD_TIME : ECMD_OK;
             } else if (!u.usteed && ynq("Kick it?") == 'y') {

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1872,7 +1872,6 @@ do_loot_cont(struct obj **cobjp,
     if (!cobj)
         return ECMD_OK;
     if (cobj->olocked) {
-        struct obj *unlocktool;
 
         if (ccount < 2 && (g.level.objects[cobj->ox][cobj->oy] == cobj))
             pline("%s locked.",
@@ -1884,7 +1883,8 @@ do_loot_cont(struct obj **cobjp,
         cobj->lknown = 1;
 
         if (flags.autounlock) {
-            if ((unlocktool = autokey(TRUE)) != 0) {
+            struct obj *unlocktool = autokey(TRUE);
+            if (unlocktool) {
                 /* pass ox and oy to avoid direction prompt */
                 return (pick_lock(unlocktool, cobj->ox, cobj->oy, cobj) != 0);
             } else if (ccount == 1 && u_have_forceable_weapon()) {


### PR DESCRIPTION
Similar to the prompt to automatically #force a box when you have no
unlocking tool, toggling off 'autounlock' should disable the prompt to
kick down a locked door.

As it was, players with autounlock turned off would be prompted to kick
down every locked door they walked into, even when they had an unlocking
tool.

Also, reduce scope of unlocktool variables for autounlocking doors and
containers.