### PR TITLE
Prevent hero from writing Pratchett books

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -220,6 +220,11 @@ dowrite(struct obj *pen)
         You_cant("write that!");
         pline("It's obscene!");
         return ECMD_TIME;
+    } else if (i == SPE_NOVEL) {
+        You(
+         "prepare to write the Great Yendorian Novel, but lack inspiration.");
+        You("give up on the idea.");
+        return ECMD_TIME;
     } else if (i == SPE_BOOK_OF_THE_DEAD) {
         pline("No mere dungeon adventurer could write that.");
         return ECMD_TIME;


### PR DESCRIPTION
The hero's ability to channel Pratchett and write his books with a magic
marker once she had read or IDed at least one of them seemed strange,
especially cases like an illiterate hero doing it as her first
introduction to the written word.  Block the hero from writing random
novels with a marker.

The image of the hero sitting down in the dungeon to write a novel is
funny, so it feels like a good spot for a funny message.  I'm not
sure if what I have there is perfect, but it can always be changed.
