### PR TITLE
Fix: loot not drawn on map when mon dies

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -2350,9 +2350,6 @@ m_detach(
     if (mtmp->mx > 0 && emits_light(mptr))
         del_light_source(LS_MONSTER, monst_to_any(mtmp));
 
-    /* take mtmp off map but not out of fmon list yet (dmonsfree does that) */
-    mon_leaving_level(mtmp);
-
     mtmp->mhp = 0; /* simplify some tests: force mhp to 0 */
     if (mtmp->iswiz)
         wizdead();
@@ -2364,6 +2361,9 @@ m_detach(
         thiefdead();
     /* release (drop onto map) all objects carried by mtmp */
     relobj(mtmp, 0, FALSE);
+
+    /* take mtmp off map but not out of fmon list yet (dmonsfree does that) */
+    mon_leaving_level(mtmp);
 
     if (mtmp->isshk)
         shkgone(mtmp);


### PR DESCRIPTION
When a monster died, any loot it carried would not be drawn onto the map
until the square was refreshed in some other way, because the newsym
call was moved (as part of the introduction of mon_leaving_level in
6880d37b3) to before the point its inventory items are actually placed
onto the map.  Move mon_leaving_level to after the relobj call in
m_detach so the new symbol will take into consideration any items placed
onto the map from the monster's inventory.
