### PR TITLE
Make some quest nemeses leave poison clouds when they die.

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -2370,8 +2370,18 @@ m_detach(
     mtmp->mhp = 0; /* simplify some tests: force mhp to 0 */
     if (mtmp->iswiz)
         wizdead();
-    if (mtmp->data->msound == MS_NEMESIS)
+    if (mtmp->data->msound == MS_NEMESIS) {
+        struct permonst *mdat = mtmp->data;
         nemdead();
+        /* The Archeologist, Caveman, and Priest quest texts describe
+           the nemesis's body creating noxious fumes/gas when
+           killed. */
+        if (mdat == &mons[PM_MINION_OF_HUHETOTL]
+            || mdat == &mons[PM_CHROMATIC_DRAGON]
+            || mdat == &mons[PM_NALZOK]) {
+            create_gas_cloud(mx, my, 5, 8);
+        }
+    }
     if (mtmp->data->msound == MS_LEADER)
         leaddead();
     if (mtmp->m_id == g.stealmid)


### PR DESCRIPTION
The Archeologist, Caveman, and Priest quest texts describe the
nemesis's body producing a cloud of noxious fumes/gas when killed.

----

I could have implemented this by checking for the hero's role instead of the nemesis's permonst pointer, but I decided that somebody who changes the quest text will probably also rename the nemesis.  Referencing the specific nemesis makes it less likely that some variant author who revamps the quest accidentally leaves in the poison gas cloud when their replacement quest text doesn't call for it.

----

The relevant quest texts:
Archeologist: https://github.com/NetHack/NetHack/blob/3a0a92764a37c6465ed5251b50bdef1915cebee1/dat/quest.lua#L295-L296
Caveman: https://github.com/NetHack/NetHack/blob/3a0a92764a37c6465ed5251b50bdef1915cebee1/dat/quest.lua#L758-L760
Priest:  https://github.com/NetHack/NetHack/blob/3a0a92764a37c6465ed5251b50bdef1915cebee1/dat/quest.lua#L1634-L1638