### PR TITLE
Handle -eaux plurals in makeplural/makesingular

### DIFF
--- a/src/objnam.c
+++ b/src/objnam.c
@@ -2359,7 +2359,8 @@ static const char *const as_is[] = {
     "tuna",    "yaki",      "-hai",      "krill",     "manes",
     "moose",   "ninja",     "sheep",     "ronin",     "roshi",
     "shito",   "tengu",     "ki-rin",    "Nazgul",    "gunyoki",
-    "piranha", "samurai",   "shuriken",  "haggis", 0,
+    "piranha", "samurai",   "shuriken",  "haggis",    "Bordeaux",
+    0,
     /* Note:  "fish" and "piranha" are collective plurals, suitable
        for "wiped out all <foo>".  For "3 <foo>", they should be
        "fishes" and "piranhas" instead.  We settle for collective
@@ -2453,7 +2454,8 @@ singplur_compound(char *str)
           " versus ", " from ",    " in ",
           " on ",     " a la ",    " with", /* " with "? */
           " de ",     " d'",       " du ",
-          "-in-",     "-at-",      0
+          " au ",     "-in-",      "-at-",
+          0
         }, /* list of first characters for all compounds[] entries */
         compound_start[] = " -";
 
@@ -2566,6 +2568,7 @@ makeplural(const char* oldstr)
     {
         static const char *const already_plural[] = {
             "ae",  /* algae, larvae, &c */
+            "eaux", /* chateaux, gateaux */
             "matzot", 0,
         };
 
@@ -2624,6 +2627,13 @@ makeplural(const char* oldstr)
         Strcasecpy(spot - 1, "es");
         goto bottom;
     }
+    /* -eau/-eaux (gateau, chapeau...) */
+    if (len >= 3 && !strcmpi(spot - 2, "eau")
+        /* 'bureaus' is the more common plural of 'bureau' */
+        && strncmpi(str, "bureau", 6)) {
+        Strcasecpy(spot + 1, "x");
+        goto bottom;
+    }
     /* matzoh/matzot, possible food name */
     if (len >= 6
         && (!strcmpi(spot - 5, "matzoh") || !strcmpi(spot - 5, "matzah"))) {
@@ -2636,7 +2646,6 @@ makeplural(const char* oldstr)
         goto bottom;
     }
 
-    /* note: -eau/-eaux (gateau, bordeau...) */
     /* note: ox/oxen, VAX/VAXen, goose/geese */
 
     lo_c = lowc(*spot);
@@ -2795,8 +2804,9 @@ makesingular(const char* oldstr)
             goto bottom;
         }
         /* matzot -> matzo, algae -> alga */
-        if (!BSTRCMPI(bp, p - 6, "matzot") || !BSTRCMPI(bp, p - 2, "ae")) {
-            *(p - 1) = '\0'; /* drop t/e */
+        if (!BSTRCMPI(bp, p - 6, "matzot") || !BSTRCMPI(bp, p - 2, "ae")
+            || !BSTRCMPI(bp, p - 4, "eaux")) {
+            *(p - 1) = '\0'; /* drop t/e/x */
             goto bottom;
         }
         /* balactheria -> balactherium */


### PR DESCRIPTION
I noticed a comment about -eau pluralizing as -eaux, e.g. "gateau" ->
"gateaux", was not consistent with the actual output of makeplural.
Same thing with "VAX" -> "VAXen" in the line below it; they're very old
comments, so maybe they were originally meant to point out some plurals
makeplural got wrong?  Since they predate the addition of "oxen" and
"geese" to one_off[] (and the array itself), it seems like the other
special cases mentioned in the comments would also have been wrong at
the time they were written.

Address this horrifying pastry-related oversight by adding handling for
'-eaux' plurals to makeplural, with an exception for 'bureau' (plural
'bureaus'; according to the dictionary, 'bureaux' is an acceptable
variant but 'bureaus' is more common, at least in American English).
There's also an exception for 'Bordeaux' (as in a bottle of the wine),
since the singular and plural are the same.

A bit surprised this wasn't already in there, since 'gateau' is a real
food item and seems like a much more likely fruit name than some of the
inedible items makeplural has special rules for.

Also add " au " to compounds[] in singplur_compound, so that 'gateau au
chocolat' will pluralize correctly to 'gateaux au chocolat'.  Without
that change, the result is 'gateau au chocolats'.