### PR TITLE
Move check for starting L1 spellbook to include non-random spellbooks

### DIFF
--- a/src/u_init.c
+++ b/src/u_init.c
@@ -1082,9 +1082,6 @@ ini_inv(struct trobj *trop)
             /* Don't have 2 of the same ring or spellbook */
             if (obj->oclass == RING_CLASS || obj->oclass == SPBOOK_CLASS)
                 g.nocreate4 = otyp;
-            /* First spellbook should be level 1 - did we get it? */
-            if (obj->oclass == SPBOOK_CLASS && objects[obj->otyp].oc_level == 1)
-                got_sp1 = TRUE;
         }
 
         if (g.urace.mnum != PM_HUMAN) {
@@ -1182,6 +1179,10 @@ ini_inv(struct trobj *trop)
         }
         if (obj->oclass == SPBOOK_CLASS && obj->otyp != SPE_BLANK_PAPER)
             initialspell(obj);
+
+        /* First spellbook should be level 1 - did we get it? */
+        if (obj->oclass == SPBOOK_CLASS && objects[obj->otyp].oc_level == 1)
+            got_sp1 = TRUE;
 
         if (--trop->trquan)
             continue; /* make a similar object */


### PR DESCRIPTION
A wizard's starting equipment should include a blessed spellbook of force bolt and a random non-force bolt spellbook of level 3 or lower.

Currently, a wizard's second spellbook is always level 1. A previous change ensures that any character's first (random) spellbook is always level 1. Since a wizard's first spellbook is non-random, however, the got_sp1 flag is not set, and the second spellbook is always level 1 as well.

The proposed change moves the level 1 spellbook check so that it is performed on both random and non-random spellbooks, so the second spellbook is level 3 or lower as intended.