### PR TITLE
Fix: invisible pudding globs

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -651,9 +651,10 @@ make_corpse(struct monst *mtmp, unsigned int corpseflags)
             obj = obj_meld(&obj, &otmp);
         }
         free_mgivenname(mtmp);
+        newsym(x, y);
         return obj;
     default:
- default_1:
+default_1:
         if (g.mvitals[mndx].mvflags & G_NOCORPSE) {
             return (struct obj *) 0;
         } else {


### PR DESCRIPTION
When a pudding was killed by a monster (player-caused deaths were exempt
because of a 'backup' newsym call in xkilled), and the resulting glob
ended up on the pudding's square (whether because there were no adjacent
globs, or because the adjacent glob merged into the new one rather than
vice-versa), the glob wouldn't be drawn onto the map until the squre was
redrawn with ^R or similar.  This was because the early return for globs
in make_corpse skipped the typical newsym call near the end of the
function.

In this commit I just added a newsym call to the glob case in
make_corpse, but adding a newsym call to monkilled as a guard against
similar cases (equivalent to the one in xkilled) seems like a possible
extension.  I wasn't sure if there's a particular reason it's not
included in monkilled, so I didn't mess with it.

Example (using m-prefix `#wizkill` -- `#wizkill` without the m-prefix doesn't have the same problem, due to the `newsym` call in `xkilled` mentioned in the commit message):

https://user-images.githubusercontent.com/40038830/170329426-139efbf9-b538-4c81-a56d-ec5deab43449.mp4