### PR TITLE
Fix: mdisplacem stoning and gloves

### DIFF
--- a/src/mhitm.c
+++ b/src/mhitm.c
@@ -226,13 +226,18 @@ mdisplacem(register struct monst *magr, register struct monst *mdef,
     g.vis = (canspotmon(magr) && canspotmon(mdef));
 
     if (touch_petrifies(pd) && !resists_ston(magr)) {
-        if (which_armor(magr, W_ARMG) != 0) {
+        if (!which_armor(magr, W_ARMG)) {
             if (poly_when_stoned(pa)) {
                 mon_to_stone(magr);
                 return MM_HIT; /* no damage during the polymorph */
             }
-            if (!quietly && canspotmon(magr))
+            if (!quietly && canspotmon(magr)) {
+                if (g.vis) {
+                    pline("%s tries to move %s out of %s way.", Monnam(magr),
+                          mon_nam(mdef), is_rider(pa) ? "the" : mhis(magr));
+                }
                 pline("%s turns to stone!", Monnam(magr));
+            }
             monstone(magr);
             if (!DEADMONSTER(magr))
                 return MM_HIT; /* lifesaved */


### PR DESCRIPTION
Apparently this is a bug that's existed since mon-vs-mon displacement
was introduced in 2003 (in 89c785e): if a monster displaced a footrice,
having gloves on would make it vulnerable to being stoned, while having
bare hands would protect it.  Switch it around so wearing gloves blocks
petrification, as it does under other circumstances.

Also add a message explaining why the displacing monster was stoned (if
the displacement attempt is visible to the hero), so the "Foo turns to
stone!" message has some context.
