### PR TITLE
Fix some issues with 'P'/justpicked loot category

### DIFF
--- a/src/invent.c
+++ b/src/invent.c
@@ -2115,7 +2115,8 @@ askchain(
     ininv = (*objchn == g.invent);
     bycat = (menu_class_present('u')
              || menu_class_present('B') || menu_class_present('U')
-             || menu_class_present('C') || menu_class_present('X'));
+             || menu_class_present('C') || menu_class_present('X')
+             || menu_class_present('P'));
 
     /* someday maybe we'll sort by 'olets' too (temporarily replace
        flags.packorder and pass SORTLOOT_PACK), but not yet... */

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -3047,6 +3047,7 @@ menu_loot(int retry, boolean put_in)
                 loot_justpicked = TRUE;
                 count = max(0, pick_list[i].count);
                 add_valid_menu_class(pick_list[i].item.a_int);
+                loot_everything = FALSE;
             } else if (pick_list[i].item.a_int == ALL_TYPES_SELECTED) {
                 all_categories = TRUE;
             } else {


### PR DESCRIPTION
When using 'A'/autopick with the 'items you just picked up' category,
instead of autoselecting all items within that category, it selected
every item in your inventory (like it used to work before 3.7).  Just
blew up a bag of holding because of this.

While testing the fix for that, I noticed 'P' wasn't working at all
with menustyle:traditional -- you could select it as a filter, but it
didn't actually get applied to anything, so it would end up prompting
you for every item in inventory.  Fix both those things.

Edit: I originally had these as two separate commits, but squashed them into one since they're dealing with such similar issues (and both are very small).