### PR TITLE
Have newcham() give messages when monsters polymorph in more cases

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -3808,7 +3808,7 @@ normal_shape(struct monst *mon)
     if (mcham >= LOW_PM) {
         unsigned mcan = mon->mcan;
 
-        (void) newcham(mon, &mons[mcham], FALSE, FALSE);
+        (void) newcham(mon, &mons[mcham], FALSE, TRUE);
         mon->cham = NON_PM;
         /* newcham() may uncancel a polymorphing monster; override that */
         if (mcan)

--- a/src/muse.c
+++ b/src/muse.c
@@ -2143,7 +2143,7 @@ use_misc(struct monst* mtmp)
         return 2;
     case MUSE_WAN_POLYMORPH:
         mzapwand(mtmp, otmp, TRUE);
-        (void) newcham(mtmp, muse_newcham_mon(mtmp), TRUE, FALSE);
+        (void) newcham(mtmp, muse_newcham_mon(mtmp), TRUE, TRUE);
         if (oseen)
             makeknown(WAN_POLYMORPH);
         return 2;
@@ -2152,7 +2152,7 @@ use_misc(struct monst* mtmp)
         m_useup(mtmp, otmp);
         if (vismon)
             pline("%s suddenly mutates!", Monnam(mtmp));
-        (void) newcham(mtmp, muse_newcham_mon(mtmp), FALSE, FALSE);
+        (void) newcham(mtmp, muse_newcham_mon(mtmp), FALSE, TRUE);
         if (oseen)
             makeknown(POT_POLYMORPH);
         return 2;
@@ -2179,7 +2179,7 @@ use_misc(struct monst* mtmp)
             worm_move(mtmp);
         newsym(g.trapx, g.trapy);
 
-        (void) newcham(mtmp, (struct permonst *) 0, FALSE, FALSE);
+        (void) newcham(mtmp, (struct permonst *) 0, FALSE, TRUE);
         return 2;
     case MUSE_BAG:
         return mloot_container(mtmp, otmp, vismon);

--- a/src/trap.c
+++ b/src/trap.c
@@ -2166,7 +2166,7 @@ trapeffect_poly_trap(
         if (resists_magm(mtmp)) {
             shieldeff(mtmp->mx, mtmp->my);
         } else if (!resist(mtmp, WAND_CLASS, 0, NOTELL)) {
-            (void) newcham(mtmp, (struct permonst *) 0, FALSE, in_sight);
+            (void) newcham(mtmp, (struct permonst *) 0, FALSE, TRUE);
             if (in_sight)
                 seetrap(trap);
         }
@@ -2617,7 +2617,7 @@ steedintrap(struct trap* trap, struct obj* otmp)
         if (!resists_magm(steed) && !resist(steed, WAND_CLASS, 0, NOTELL)) {
             struct permonst *mdat = steed->data;
 
-            (void) newcham(steed, (struct permonst *) 0, FALSE, FALSE);
+            (void) newcham(steed, (struct permonst *) 0, FALSE, TRUE);
             if (!can_saddle(steed) || !can_ride(steed)) {
                 dismount_steed(DISMOUNT_POLY);
             } else {


### PR DESCRIPTION
This is a descendent of an earlier patch I wrote. The main idea is still
to clearly communicate to the player *what* something is turning into,
without the need to farlook afterwards, and give them the opportunity to
add MSGTYPE for when something jumps on a polymorph trap and becomes an
arch-lich. If it happens out of sight, the player also might get a whiff
of the monster's smell, giving a bit of advance warning.

There is one new case in here, in normal_shape(), which came about
because I noticed a weird message sequence: "The magic-absorbing blade
cancels the python!  You kill the chameleon!" with no intervening
message indicating the python reverted to a chameleon.