### PR TITLE
Reset justpicked only when picking up items

### DIFF
--- a/src/pickup.c
+++ b/src/pickup.c
@@ -650,7 +650,6 @@ pickup(int what) /* should be a long */
             nomul(0);
     }
 
-    reset_justpicked(g.invent);
     add_valid_menu_class(0); /* reset */
     if (!u.uswallow) {
         objchain_p = &g.level.objects[u.ux][u.uy];
@@ -691,6 +690,8 @@ pickup(int what) /* should be a long */
         }
 
  menu_pickup:
+        if (n > 0)
+            reset_justpicked(g.invent);
         n_tried = n;
         for (n_picked = i = 0; i < n; i++) {
             res = pickup_object(pick_list[i].item.a_obj, pick_list[i].count,
@@ -723,6 +724,7 @@ pickup(int what) /* should be a long */
             obj = *objchain_p;
             lcount = min(obj->quan, (long) count);
             n_tried++;
+            reset_justpicked(g.invent);
             if (pickup_object(obj, lcount, FALSE) > 0)
                 n_picked++; /* picked something */
             goto end_query;
@@ -788,6 +790,9 @@ pickup(int what) /* should be a long */
             }
             if (lcount == -1L)
                 lcount = obj->quan;
+
+            if (!n_tried) /* reset just before the first item picked */
+                reset_justpicked(g.invent);
 
             n_tried++;
             if ((res = pickup_object(obj, lcount, FALSE)) < 0)


### PR DESCRIPTION
With reset_justpicked called unconditionally near the top of pickup, it
was impossible to pick up some items, walk over to a chest, and use 'P'
to deposit the items with autopickup on: pickup is called with every
move, and autopickup allowed execution to reach the reset_justpicked
call whenever the hero stepped on a square with an item in it.  As a
result, stepping onto a square with a container would clear all the
justpicked flags in inventory (pressing ',' and then declining to pick
anything up would have a similar effect).

Instead, call reset_justpicked only when the hero (or autopickup) has
actually selected an item to pick up.  This makes the code a bit more
complicated than before -- I don't think there's a way to do it with
just one reset_justpicked call any more, due to the structure of pickup
and the need to call reset_justpicked before actually putting any items
into inventory -- but it means that justpicked info will be much less
ephemeral and more useful when managing stashes, etc.
