### PR TITLE
Allow intrinsic gain from pet's digestion attack

### DIFF
--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -3909,6 +3909,7 @@ mhitm_ad_dgst(struct monst *magr, struct attack *mattk UNUSED,
             if (nutrit > 1)
                 nutrit /= 2;
             EDOG(magr)->hungrytime += nutrit;
+            mon_givit(magr, pd);
         }
     }
 }


### PR DESCRIPTION
Add possible pet intrinsic gain from swallowing a monster in one gulp
(in situations where a corpse is created and eaten by the engulfer),
making it equivalent in this regard to eating the corpse off the floor.

One possible extension or modification would be to reduce the chance of
receiving an intrinsic when the corpse is consumed via digestion attack,
similar to how the corpse nutrition is 50% of its normal value.  I
didn't incorporate that into this commit since the chance of receiving
an intrinsic is tied to monster level rather than nutrition, so I wasn't
sure if it made sense.
