### PR TITLE
remove unnecessary null-check on parsesymbols()

### DIFF
--- a/src/symbols.c
+++ b/src/symbols.c
@@ -704,7 +704,7 @@ parsesymbols(register char *opts, int which_set)
 #endif
 
             if ((g.symset[which_set].handling == H_UTF8)
-                || (strval && (lowc(strval[0]) == 'u') && (strval[1] == '+'))) {
+                || (lowc(strval[0]) == 'u') && (strval[1] == '+')) {
 #ifdef ENHANCED_SYMBOLS
                 char buf[BUFSZ];
 


### PR DESCRIPTION
`strval` here is always non-null,
because the null-check is done in earlier code.