### PR TITLE
Let fleeing monsters dig pits in undiggable floor

### DIFF
--- a/src/muse.c
+++ b/src/muse.c
@@ -781,10 +781,23 @@ use_defensive(struct monst* mtmp)
             return 2;
         }
         if (!Can_dig_down(&u.uz) && !levl[mtmp->mx][mtmp->my].candig) {
-            if (canseemon(mtmp))
-                pline_The("%s here is too hard to dig in.",
-                          surface(mtmp->mx, mtmp->my));
-            return 2;
+            /* can't dig further if there's already a pit (or other trap)
+               here, or if pit creation fails for some reason */
+            if (t_at(mtmp->mx, mtmp->my)
+                || !(ttmp = maketrap(mtmp->mx, mtmp->my, PIT))) {
+                if (vismon) {
+                    pline_The("%s here is too hard to dig in.",
+                              surface(mtmp->mx, mtmp->my));
+                }
+                return 2;
+            }
+            /* pit creation succeeded */
+            if (vis) {
+                seetrap(ttmp);
+                pline("%s has made a pit in the %s.", Monnam(mtmp),
+                      surface(mtmp->mx, mtmp->my));
+            }
+            return (mintrap(mtmp, FORCEBUNGLE) == Trap_Killed_Mon) ? 1 : 2;
         }
         ttmp = maketrap(mtmp->mx, mtmp->my, HOLE);
         if (!ttmp)


### PR DESCRIPTION
When the hero zaps a wand of digging down in an undiggable level, it
creates a pit.  When a fleeing monster did the same thing, it had no
effect.  Bring this closer to the behavior experienced by the hero: if a
monster tries to use a wand of digging to create a hole in an undiggable
floor, a pit will be made (and the monster will fall into it, if not a
flyer).
