### PR TITLE
Restore and expand wizmgender functionality

### DIFF
--- a/src/objnam.c
+++ b/src/objnam.c
@@ -1339,6 +1339,17 @@ doname_base(
         break;
     }
 
+    if ((obj->otyp == STATUE || obj->otyp == CORPSE || obj->otyp == FIGURINE)
+        && iflags.wizmgender) {
+        int cgend = (obj->spe & CORPSTAT_GENDER),
+            mgend = ((cgend == CORPSTAT_MALE) ? MALE
+                     : (cgend == CORPSTAT_FEMALE) ? FEMALE
+                       : NEUTRAL);
+        Sprintf(eos(bp), " (%s)",
+                cgend != CORPSTAT_RANDOM ? genders[mgend].adj
+                                         : "unspecified gender");
+    }
+
     if ((obj->owornmask & W_WEP) && !g.mrg_to_wielded) {
         boolean twoweap_primary = (obj == uwep && u.twoweap),
                 tethered = (obj->otyp == AKLYS);

--- a/win/curses/cursmain.c
+++ b/win/curses/cursmain.c
@@ -795,7 +795,12 @@ curses_print_glyph(winid wid, xchar x, xchar y,
         /* water and lava look the same except for color; when color is off,
            render lava in inverse video so that they look different */
         if ((special & (MG_BW_LAVA | MG_BW_ICE)) != 0 && iflags.use_inverse) {
-            attr = A_REVERSE; /* map_glyphinfo() only sets this if color is off */
+            /* reset_glyphmap() only sets MG_BW_foo if color is off */
+            attr = A_REVERSE; 
+        }
+        /* highlight female monsters (wizard mode option) */
+        if ((special & MG_FEMALE) && iflags.wizmgender) {
+            attr = A_REVERSE;
         }
     }
 

--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -4034,6 +4034,7 @@ tty_print_glyph(
        to see although the Valkyrie quest ends up being hard on the eyes) */
     if (((special & MG_PET) != 0 && iflags.hilite_pet)
         || ((special & MG_OBJPILE) != 0 && iflags.hilite_pile)
+        || ((special & MG_FEMALE) != 0 && iflags.wizmgender)
         || ((special & (MG_DETECT | MG_BW_LAVA | MG_BW_ICE)) != 0
             && iflags.use_inverse)) {
         term_start_attr(ATR_INVERSE);


### PR DESCRIPTION
Restore the wizmgender highlight on female monsters and statues on the map
(and expand it to curses).  Add gender to corpse/statue names when it's
enabled.
