### PR TITLE
Fix underflow in free_window_info

### DIFF
--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -1769,7 +1769,8 @@ free_window_info(struct WinDesc *cw, boolean free_data)
     int i;
 
     if (cw->data) {
-        if (cw == wins[WIN_MESSAGE] && cw->rows > cw->maxrow)
+        if (WIN_MESSAGE != WIN_ERR && cw == wins[WIN_MESSAGE]
+            && cw->rows > cw->maxrow)
             cw->maxrow = cw->rows; /* topl data */
         for (i = 0; i < cw->maxrow; i++)
             if (cw->data[i]) {


### PR DESCRIPTION
At the end this is called after `WIN_MESSAGE` is reset to `-1`, so we
need a check here.

This is mostly harmless but can fail if some form of strict memory access checking is present; for example, I originally saw this with NetHack 3.6 on an experimental Arm Morello architecture machine.