### PR TITLE
Fix #812: recovered stair dlevel

### DIFF
--- a/src/save.c
+++ b/src/save.c
@@ -717,7 +717,8 @@ save_stairs(NHFILE* nhfp)
 
     while (stway) {
         if (perform_bwrite(nhfp)) {
-            if (stway->tolev.dnum == u.uz.dnum) {
+            boolean use_relative = (stway->tolev.dnum == u.uz.dnum);
+            if (use_relative) {
                 /* make dlevel relative to current level */
                 stway->tolev.dlevel -= u.uz.dlevel;
             }
@@ -725,7 +726,7 @@ save_stairs(NHFILE* nhfp)
                 bwrite(nhfp->fd, (genericptr_t) &buflen, sizeof buflen);
                 bwrite(nhfp->fd, (genericptr_t) stway, sizeof *stway);
             }
-            if (stway->tolev.dnum == u.uz.dnum) {
+            if (use_relative) {
                 /* reset staiway dlevel back to absolute */
                 stway->tolev.dlevel += u.uz.dlevel;
             }


### PR DESCRIPTION
Stair dlevels weren't being restored with the correct values when
recovered after the game crashed, apparently because they weren't being
reset back to their 'absolute' level from a 'relative' level.  I'm not
totally sure of why this affected only recovered games (maybe that's the
only time when the 'relative' stair values are used?) but this fix seems
to work.

Fixes #812