### PR TITLE
Prevent amorphous mon from carrying hero into door

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -3164,7 +3164,7 @@ find_poleable_mon(coord *pos, int min_range, int max_range)
                 && (mtmp->mtame || (mtmp->mpeaceful && flags.confirm)))
                 continue;
             if (glyph_is_poleable(glyph)
-                    && (!glyph_is_statue(glyph) || impaired)) {
+                && (!glyph_is_statue(glyph) || impaired)) {
                 if (mpos.x)
                     return FALSE; /* more than one candidate location */
                 mpos.x = x, mpos.y = y;

--- a/src/mhitu.c
+++ b/src/mhitu.c
@@ -653,7 +653,7 @@ mattacku(register struct monst *mtmp)
         if (i > 0 && foundyou /* previous attack might have moved hero */
             && (mtmp->mux != u.ux || mtmp->muy != u.uy))
             continue; /* fill in sum[] with 'miss' but skip other actions */
-        mon_currwep = (struct obj *)0;
+        mon_currwep = (struct obj *) 0;
         mattk = getmattk(mtmp, &g.youmonst, i, sum, &alt_attk);
         if ((u.uswallow && mattk->aatyp != AT_ENGL)
             || (skipnonmagc && mattk->aatyp != AT_MAGC)

--- a/src/mon.c
+++ b/src/mon.c
@@ -1885,7 +1885,9 @@ mfndpos(
                         && (dmgtype(mdat, AD_RUST)
                             || dmgtype(mdat, AD_CORR)))))
                 continue;
-            if (IS_DOOR(ntyp) && !(amorphous(mdat) || can_fog(mon))
+            if (IS_DOOR(ntyp)
+                && !((amorphous(mdat) || can_fog(mon))
+                     && !(u.uswallow && mon == u.ustuck))
                 && (((levl[nx][ny].doormask & D_CLOSED) && !(flag & OPENDOOR))
                     || ((levl[nx][ny].doormask & D_LOCKED)
                         && !(flag & UNLOCKDOOR))) && !thrudoor)


### PR DESCRIPTION
An amorphous engulfer like a fog cloud could engulf the hero, then carry
him into a closed door.  If it was killed or decided to spit out the
hero, he would be left occupying the same spot as a closed/locked door.
Make an amorphous monster unable to move into a door if currently
engulfing the hero.

Something more complicated could be done along the lines of allowing the
move if the hero is himself in an amorphous polyform, but that verges on
being a little too silly, maybe.

I also included fixes to a couple miscellaneous, unrelated formatting
issues that I noticed recently.
