### PR TITLE
Fix: getpos cmap vs typ/glyph confusion

### DIFF
--- a/src/do_name.c
+++ b/src/do_name.c
@@ -926,10 +926,11 @@ getpos(coord *ccp, boolean force, const char *goal)
                 int pass, lo_x, lo_y, hi_x, hi_y, k = 0;
 
                 (void) memset((genericptr_t) matching, 0, sizeof matching);
-                for (sidx = 1; sidx < MAXPCHARS; sidx++) { /* [0] left as 0 */
-                    /* don't even try to match some terrain: walls, room... */
-                    if (sidx <= S_hcdoor
-                        || sidx == S_room || sidx == S_darkroom
+                /* start the loop one past the block of doors, walls, etc,
+                   because we aren't interested in trying to match them */
+                for (sidx = S_hcdoor + 1; sidx < MAXPCHARS; sidx++) {
+                    /* some additional cmap types that should be skipped */
+                    if (sidx == S_room || sidx == S_darkroom
                         || sidx == S_corr || sidx == S_litcorr)
                         continue;
                     if (c == defsyms[sidx].sym

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -927,12 +927,10 @@ getpos(coord *ccp, boolean force, const char *goal)
 
                 (void) memset((genericptr_t) matching, 0, sizeof matching);
                 for (sidx = 1; sidx < MAXPCHARS; sidx++) { /* [0] left as 0 */
-                    if (IS_DOOR(sidx) || IS_WALL(sidx)
-                        || sidx == SDOOR || sidx == SCORR
-                        || glyph_to_cmap(k) == S_room
-                        || glyph_to_cmap(k) == S_darkroom
-                        || glyph_to_cmap(k) == S_corr
-                        || glyph_to_cmap(k) == S_litcorr)
+                    /* don't even try to match some terrain: walls, room... */
+                    if (sidx <= S_hcdoor
+                        || sidx == S_room || sidx == S_darkroom
+                        || sidx == S_corr || sidx == S_litcorr)
                         continue;
                     if (c == defsyms[sidx].sym
                         || c == (int) g.showsyms[sidx]

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -926,12 +926,11 @@ getpos(coord *ccp, boolean force, const char *goal)
                 int pass, lo_x, lo_y, hi_x, hi_y, k = 0;
 
                 (void) memset((genericptr_t) matching, 0, sizeof matching);
-                /* start the loop one past the block of doors, walls, etc,
-                   because we aren't interested in trying to match them */
-                for (sidx = S_hcdoor + 1; sidx < MAXPCHARS; sidx++) {
-                    /* some additional cmap types that should be skipped */
-                    if (sidx == S_room || sidx == S_darkroom
-                        || sidx == S_corr || sidx == S_litcorr)
+                for (sidx = 0; sidx < MAXPCHARS; sidx++) {
+                    /* don't even try to match some terrain: walls, room... */
+                    if (is_cmap_wall(sidx) || is_cmap_room(sidx)
+                        || is_cmap_corr(sidx) || is_cmap_door(sidx)
+                        || sidx == S_ndoor)
                         continue;
                     if (c == defsyms[sidx].sym
                         || c == (int) g.showsyms[sidx]

--- a/src/mkroom.c
+++ b/src/mkroom.c
@@ -942,6 +942,7 @@ cmap_to_type(int sym)
         typ = TREE;
         break;
     case S_room:
+    case S_darkroom:
         typ = ROOM;
         break;
     case S_corr:


### PR DESCRIPTION
When some parts of getpos were rearranged in 7404597, tests of terrain
types and glyphs were moved to a loop which iterated through the defsyms
array without being updated to handle cmap values instead.  Consequently
they weren't excluding certain terrain types from being 'jumped to' as
intended.  (Though it seems as though they actually worked by chance to
some extent, just because there's some overlap between terrain types and
defsyms in terms of where the 'walls/doors' blocks start and end.)

I also noticed that cmap_to_type was missing S_darkroom (it fell through
to the default case so that the function returned STONE), so I added it.
