### PR TITLE
Fixes related to running and traps

### DIFF
--- a/src/hack.c
+++ b/src/hack.c
@@ -3361,6 +3361,14 @@ lookaround(void)
             if (x == u.ux - u.dx && y == u.uy - u.dy)
                 continue;
 
+            /* stop for traps, sometimes */
+            if (avoid_moving_on_trap(x, y, (infront && g.context.run > 1))) {
+                if (g.context.run == 1)
+                    goto bcorr; /* if you must */
+                if (infront)
+                    goto stop;
+            }
+
             /* more uninteresting terrain */
             if (IS_ROCK(levl[x][y].typ) || levl[x][y].typ == ROOM
                 || IS_AIR(levl[x][y].typ) || levl[x][y].typ == ICE) {
@@ -3405,12 +3413,6 @@ lookaround(void)
                     }
                     corrct++;
                 }
-                continue;
-            } else if (avoid_moving_on_trap(x, y, infront)) {
-                if (g.context.run == 1)
-                    goto bcorr; /* if you must */
-                if (infront)
-                    goto stop;
                 continue;
             } else if (is_pool_or_lava(x, y)) {
                 if (infront && avoid_moving_on_liquid(x, y, TRUE))

--- a/src/hack.c
+++ b/src/hack.c
@@ -2149,18 +2149,16 @@ avoid_moving_on_liquid(
 static boolean
 avoid_running_into_trap_or_liquid(coordxy x, coordxy y)
 {
+    boolean would_stop = (g.context.run >= 2);
     if (!g.context.run)
         return FALSE;
 
-    if (avoid_moving_on_trap(x,y, TRUE)) {
+    if (avoid_moving_on_trap(x,y, would_stop)
+        || (Blind && avoid_moving_on_liquid(x,y, would_stop))) {
         nomul(0);
-        g.context.move = 0;
-        return TRUE;
-    }
-    if (Blind && avoid_moving_on_liquid(x,y, TRUE)) {
-        nomul(0);
-        g.context.move = 0;
-        return TRUE;
+        if (would_stop)
+            g.context.move = 0;
+        return would_stop;
     }
     return FALSE;
 }


### PR DESCRIPTION
I noticed some issues(?) with how traps interact with running: one recent-ish
change to behavior when running which removed an existing way for players to
override the normal run-stopping (using runmode 1), and a problem that
prevented the trap check from being evaluated most of the time in lookaround.

- Restore old behavior for running onto trap
- Fix: lookaround trap detection
