### PR TITLE
Some lit corridor display tweaks

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -1981,8 +1981,11 @@ reveal_terrain_getglyph(coordxy x, coordxy y, int full, unsigned swallowed,
             }
         }
     }
+    /* FIXME: dirty hack */
     if (glyph == cmap_to_glyph(S_darkroom))
-        glyph = cmap_to_glyph(S_room); /* FIXME: dirty hack */
+        glyph = cmap_to_glyph(S_room);
+    else if (glyph == cmap_to_glyph(S_litcorr))
+        glyph = cmap_to_glyph(S_corr);
     return glyph;
 }
 

--- a/src/display.c
+++ b/src/display.c
@@ -1606,6 +1606,16 @@ reglyph_darkroom(void)
         for (y = 0; y < ROWNO; y++) {
             struct rm *lev = &levl[x][y];
 
+            if (!flags.dark_room) {
+                if (lev->glyph == cmap_to_glyph(S_corr)
+                    && lev->waslit)
+                    lev->glyph = cmap_to_glyph(S_litcorr);
+            } else {
+                if (lev->glyph == cmap_to_glyph(S_litcorr)
+                    && !cansee(x, y))
+                    lev->glyph = cmap_to_glyph(S_corr);
+            }
+
             if (!flags.dark_room || !iflags.use_color
                 || Is_rogue_level(&u.uz)) {
                 if (lev->glyph == cmap_to_glyph(S_darkroom))


### PR DESCRIPTION
A couple small tweaks to how lit corridors are displayed in various scenarios,
intended to address some minor issues I've noticed recently.

- Don't show corridors as lit in #terrain
- Update lit corridor display if dark_room toggled
