### PR TITLE
Fixes related to command counts

### DIFF
--- a/src/cmd.c
+++ b/src/cmd.c
@@ -5795,8 +5795,11 @@ get_count(
         if (inkey) {
             key = inkey;
             inkey = '\0';
-        } else
+        } else {
+            g.program_state.getting_a_command = 1; /* readchar altmeta
+                                                    * compatibility */
             key = readchar();
+        }
 
         if (digit(key)) {
             cnt = 10L * cnt + (long) (key - '0');

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -4463,7 +4463,8 @@ rhack(char *cmd)
     const struct ext_func_tab *cmdq_ec = 0, *prefix_seen = 0;
     boolean was_m_prefix = FALSE;
 
-    reset_cmd_vars(FALSE);
+    iflags.menu_requested = FALSE;
+    g.context.nopick = 0;
  got_prefix_input:
 #ifdef SAFERHANGUP
     if (g.program_state.done_hup)


### PR DESCRIPTION
Fix some regressions caused by 3.7 refactors: using a count with an altmeta
meta key command, and specifying a count greater than 2 (this would not fail
exactly but would never repeat the requested command more than twice).

- Fix: get_count and altmeta
- Fix: command counts greater than 2
