### PR TITLE
Refer to non-damaging gas cloud as "steam"

### DIFF
--- a/src/region.c
+++ b/src/region.c
@@ -1175,7 +1175,8 @@ create_gas_cloud(coordxy x, coordxy y, int cloudsize, int damage)
     add_region(cloud);
 
     if (!g.in_mklev && !inside_cloud && is_hero_inside_gas_cloud())
-        You("are enveloped in a cloud of noxious gas!");
+        You("are enveloped in a cloud of %s!",
+            damage ? "noxious gas" : "steam");
 
     return cloud;
 }


### PR DESCRIPTION
You can create steam clouds that are gray and deal 0 damage when zapping
fire at or over water sources. If you happen to be in the cloud, it
produced the "You are enveloped in a cloud of noxious gas!" line, and
steam isn't noxious.

Other uses of "gas cloud" could have potentially been changed, but I
left them alone.