### PR TITLE
Improve feedback for trying to bribe the watch

### DIFF
--- a/src/dokick.c
+++ b/src/dokick.c
@@ -353,30 +353,36 @@ ghitm(register struct monst *mtmp, register struct obj *gold)
                           ? "I'll take care of that; please move along."
                           : "I'll take that; now get moving.");
         } else if (is_mercenary(mtmp->data)) {
+            boolean was_angry = !mtmp->mpeaceful;
             long goldreqd = 0L;
 
-            if (rn2(3)) {
-                if (mtmp->data == &mons[PM_SOLDIER])
-                    goldreqd = 100L;
-                else if (mtmp->data == &mons[PM_SERGEANT])
-                    goldreqd = 250L;
-                else if (mtmp->data == &mons[PM_LIEUTENANT])
-                    goldreqd = 500L;
-                else if (mtmp->data == &mons[PM_CAPTAIN])
-                    goldreqd = 750L;
+            if (mtmp->data == &mons[PM_SOLDIER])
+                goldreqd = 100L;
+            else if (mtmp->data == &mons[PM_SERGEANT])
+                goldreqd = 250L;
+            else if (mtmp->data == &mons[PM_LIEUTENANT])
+                goldreqd = 500L;
+            else if (mtmp->data == &mons[PM_CAPTAIN])
+                goldreqd = 750L;
 
-                if (goldreqd) {
-                    umoney = money_cnt(g.invent);
-                    if (value
-                        > goldreqd
-                              + (umoney + u.ulevel * rn2(5)) / ACURR(A_CHA))
-                        mtmp->mpeaceful = TRUE;
-                }
+            if (goldreqd && rn2(3)) {
+                umoney = money_cnt(g.invent);
+                goldreqd += (umoney + u.ulevel * rn2(5)) / ACURR(A_CHA);
+                if (value > goldreqd)
+                    mtmp->mpeaceful = TRUE;
             }
-            if (mtmp->mpeaceful)
+
+            if (!mtmp->mpeaceful) {
+                if (goldreqd)
+                    verbalize("That's not enough, coward!");
+                else /* unbribeable (watchman) */
+                    verbalize("I don't take bribes from scum like you!");
+            } else if (was_angry) {
                 verbalize("That should do.  Now beat it!");
-            else
-                verbalize("That's not enough, coward!");
+            } else {
+                verbalize("Thanks for the tip, %s.",
+                          flags.female ? "lady" : "buddy");
+            }
         }
         return TRUE;
     }


### PR DESCRIPTION
Members of the watch can never be bribed, no matter how much gold is
thrown at them, but when a bribe was attempted they would say "that's
not enough" (implying incorrectly some higher amount would be enough to
pacify them).  Also, an already-peaceful mercenary would take on an
unusually aggressive tone when given any amount of gold, giving the
player the same message to "beat it" as when a bribe succeeds in
pacifying them.

Adjust the mercenary bribery code a bit so that a more friendly message
is given if the monster is already peaceful, and so that unbribeable
monsters don't imply they are just not being given enough gold.  I think
the actual effects of bribery shouldn't be affected by this commit, just
the messages/feedback.
