### PR TITLE
Describe engulf attack by animal as "swallowing"

### DIFF
--- a/src/mhitu.c
+++ b/src/mhitu.c
@@ -1164,7 +1164,9 @@ gulpmu(struct monst *mtmp, struct attack *mattk)
                          buf);
             dismount_steed(DISMOUNT_ENGULFED);
         } else {
-            urgent_pline("%s engulfs you!", Monnam(mtmp));
+            urgent_pline("%s %s!", Monnam(mtmp),
+                         is_animal(mtmp->data) ? "swallows you whole"
+                            : "engulfs you");
         }
         stop_occupation();
         reset_occupations(); /* behave as if you had moved */


### PR DESCRIPTION
Suggested by aosdict: instead of describing all gulp attacks as
"engulfing you", say "The <monster> swallows you whole" for purple worms
(or any other animal engulfer) to visibly differentiate between
engulfing and swallowing.
