### PR TITLE
Monster looting improvements

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2098,6 +2098,7 @@ extern void observe_quantum_cat(struct obj *, boolean, boolean);
 extern boolean container_gone(int(*)(struct obj *));
 extern boolean u_handsy(void);
 extern int use_container(struct obj **, int, boolean);
+extern long boh_loss(struct monst *, struct obj *, int);
 extern int loot_mon(struct monst *, int *, boolean *);
 extern int dotip(void);
 extern struct autopickup_exception *check_autopickup_exceptions(struct obj *);

--- a/src/muse.c
+++ b/src/muse.c
@@ -1831,6 +1831,8 @@ find_misc(struct monst* mtmp)
                         }
                     }
     }
+    if (nohands(mdat))
+        return 0;
     if (OBJ_AT(mtmp->mx, mtmp->my) && !rn2(2)) {
         for (otmp = g.level.objects[mtmp->mx][mtmp->my]; otmp; otmp = otmp2) {
             otmp2 = otmp->nexthere;
@@ -1838,12 +1840,9 @@ find_misc(struct monst* mtmp)
                 && Has_contents(otmp) && !otmp->olocked && !otmp->otrapped) {
                 g.m.has_misc = MUSE_BAG;
                 g.m.misc = otmp;
-                return TRUE;
             }
         }
     }
-    if (nohands(mdat))
-        return 0;
 
     /* normally we would want to bracket a macro expansion containing
        'if' without matching 'else' with 'do { ... } while (0)' but we
@@ -2060,10 +2059,11 @@ mloot_container(
                 break; /* out of takeout_count loop */
         } /* can_carry */
     } /* takeout_count */
-    /* Monster rummaged through a bag but found nothing of interest, possibly because
-       some items vanished. */
+    /* Monster rummaged through a bag but found nothing of interest,possibly
+       because some items vanished. */
     if (!res && vismon) {
-        pline("%s %s inside %s.", Monnam(mon), mon->mcansee ? "looks" : "feels about", 
+        pline("%s %s inside %s.", Monnam(mon), 
+                                  mon->mcansee ? "looks" : "feels about",
                                   contnr_nam);
     }
     return res;

--- a/src/muse.c
+++ b/src/muse.c
@@ -2002,7 +2002,7 @@ mloot_container(
         if (!rn2(nitems + 1))
             break;
         nitems = rn2(nitems);
-        for (xobj = container->cobj; nitems > 0; xobj = xobj->nobj)about
+        for (xobj = container->cobj; nitems > 0; xobj = xobj->nobj)
             --nitems;
 
         container->cknown = 0; /* hero no longer knows container's contents

--- a/src/muse.c
+++ b/src/muse.c
@@ -1831,10 +1831,11 @@ find_misc(struct monst* mtmp)
                         }
                     }
     }
-    if (OBJ_AT(mtmp->mx, mtmp->my) && !rn2(5)) {
+    if (OBJ_AT(mtmp->mx, mtmp->my) && !rn2(2)) {
         for (otmp = g.level.objects[mtmp->mx][mtmp->my]; otmp; otmp = otmp2) {
             otmp2 = otmp->nexthere;
-            if (Is_container(otmp) && otmp->otyp != BAG_OF_TRICKS && !otmp->olocked) {
+            if (Is_container(otmp) && otmp->otyp != BAG_OF_TRICKS
+                && Has_contents(otmp) && !otmp->olocked && !otmp->otrapped) {
                 g.m.has_misc = MUSE_BAG;
                 g.m.misc = otmp;
                 return TRUE;

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -2607,7 +2607,8 @@ mbag_item_gone(struct monst *user, int held, struct obj *item, boolean silent)
             You("%s %s disappear!", Blind ? "notice" : "see", doname(item));
     }
 
-    if (*u.ushops && (shkp = shop_keeper(*u.ushops)) != 0 && user == &g.youmonst) {
+    if (*u.ushops && (shkp = shop_keeper(*u.ushops)) != 0 
+                      && user == &g.youmonst) {
         if (held ? (boolean) item->unpaid : costly_spot(u.ux, u.uy))
             loss = stolen_value(item, u.ux, u.uy, (boolean) shkp->mpeaceful,
                                 TRUE);


### PR DESCRIPTION
- Implemented cursed bag of holding behavior for when monsters loot a cursed bag of holding.
- Allow monsters to loot containers at their location instead of picking them up.

I avoided adding behavior for monsters unlocking containers. It would not be difficult to add, but the number of times we would need to iterate through a monster's inventory for such a niche behavior was difficult for me to justify.