### PR TITLE
Fix: engulf/digest intrinsic granting

### DIFF
--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -3957,7 +3957,6 @@ mhitm_ad_dgst(struct monst *magr, struct attack *mattk UNUSED,
             if (nutrit > 1)
                 nutrit /= 2;
             EDOG(magr)->hungrytime += nutrit;
-            mon_givit(magr, pd);
         }
     }
 }


### PR DESCRIPTION
Engulfing pets were getting a double chance to get an intrinsic from a
digestion attack, because they got the mon_givit call in mhitm_ad_dgst
and then also the one in mdamagem.

There is a bit of inconsistency here, in that mhitm_ad_dgst requires
corpse creation to grant nutrition, but the non-nutrition effects of
eating a corpse like polymorph, extra health, etc, in mdamagem don't
have any such requirement.  As a result, one of the mon_givit calls
required a corpse to be "created" before granting an intrinsic, and the
other didn't.   In choosing which one to remove, I figured intrinsic
granting is probably closer to those special effects than providing
nutrition (and also putting it in mhitm_ad_dgst is not ideal w/r/t
message ordering: it causes the 'intrinsic granted' message to appear
before the monster kill message).
