### PR TITLE
Fix: prevent traps in shops in the Tourist quest

### DIFF
--- a/dat/Tou-goal.lua
+++ b/dat/Tou-goal.lua
@@ -107,13 +107,12 @@ des.object()
 des.object()
 des.object()
 des.object()
--- Random traps
-des.trap()
-des.trap()
-des.trap()
-des.trap()
-des.trap()
-des.trap()
+-- Random traps - must avoid the 2 shops
+local validtraps = selection.area(00,00,75,19):filter_mapchar('.')
+validtraps = validtraps - selection.area(60,14,71,18)
+for i=1,6 do
+   des.trap(validtraps:rndcoord(1))
+end
 -- Random monsters.
 des.monster({ id = "Master of Thieves", x=04, y=01, peaceful = 0 })
 des.monster("giant spider")

--- a/dat/Tou-loca.lua
+++ b/dat/Tou-loca.lua
@@ -126,16 +126,12 @@ des.object()
 -- Toilet paper
 des.object("blank paper", 71, 12)
 des.object("blank paper", 71, 12)
--- Random traps
-des.trap()
-des.trap()
-des.trap()
-des.trap()
-des.trap()
-des.trap()
-des.trap()
-des.trap()
-des.trap()
+-- Random traps - must avoid the 2 shops
+local validtraps = selection.area(00,00,75,19):filter_mapchar('.')
+validtraps = validtraps - (selection.area(15,03,20,05) + selection.area(62,03,71,04))
+for i = 1,9 do
+   des.trap(validtraps:rndcoord(1))
+end
 -- Random monsters.
 des.monster("giant spider")
 des.monster("giant spider")


### PR DESCRIPTION
The Tourist locate and goal levels have 2 shops each, and also have
various traps randomly placed on the level. Unfortunately, this does not
account for placing them in the shops, so it was possible to wind up
with a magic trap or falling rock trap or whatever inside the shop,
which the shopkeeper would not clean up.

This commit makes selections that exclude the shop areas, and picks the
traps from those selections, keeping the shop floors trap-free as their
customers expect.