### PR TITLE
Remove obsolete find_skates function

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1870,7 +1870,6 @@ extern void tty_ibmgraphics_fixup(void);
 extern void init_objects(void);
 extern void init_oclass_probs(void);
 extern void obj_shuffle_range(int, int *, int *);
-extern int find_skates(void);
 extern boolean objdescr_is(struct obj *, const char *);
 extern void oinit(void);
 extern void savenames(NHFILE *);

--- a/src/hack.c
+++ b/src/hack.c
@@ -2058,13 +2058,11 @@ slippery_ice_fumbling(void)
     boolean on_ice = !Levitation && is_ice(u.ux, u.uy);
 
     if (on_ice) {
-        static int skates = 0;
-
-        if (!skates)
-            skates = find_skates();
-        if ((uarmf && uarmf->otyp == skates) || resists_cold(&g.youmonst)
-            || Flying || is_floater(g.youmonst.data)
-            || is_clinger(g.youmonst.data) || is_whirly(g.youmonst.data)) {
+        if ((uarmf && objdescr_is(uarmf, "snow boots"))
+            || resists_cold(&g.youmonst) || Flying
+            || is_floater(g.youmonst.data) || is_clinger(g.youmonst.data)
+            || is_whirly(g.youmonst.data)) {
+            pline("skates!");
             on_ice = FALSE;
         } else if (!rn2(Cold_resistance ? 3 : 2)) {
             HFumbling |= FROMOUTSIDE;
@@ -3837,7 +3835,7 @@ spot_checks(coordxy x, coordxy y, schar old_typ)
         db_ice_now = ((levl[x][y].drawbridgemask & DB_UNDER) == DB_ICE);
         /*FALLTHRU*/
     case ICE:
-        if ((new_typ != old_typ) 
+        if ((new_typ != old_typ)
             || (old_typ == DRAWBRIDGE_UP && !db_ice_now)) {
             /* make sure there's no MELT_ICE_AWAY timer */
             if (spot_time_left(x, y, MELT_ICE_AWAY)) {

--- a/src/o_init.c
+++ b/src/o_init.c
@@ -341,21 +341,6 @@ objdescr_is(struct obj* obj, const char * descr)
     return !strcmp(objdescr, descr);
 }
 
-/* find the object index for snow boots; used [once] by slippery ice code */
-int
-find_skates(void)
-{
-    register int i;
-    register const char *s;
-
-    for (i = SPEED_BOOTS; i <= LEVITATION_BOOTS; i++)
-        if ((s = OBJ_DESCR(objects[i])) != 0 && !strcmp(s, "snow boots"))
-            return i;
-
-    impossible("snow boots not found?");
-    return -1; /* not 0, or caller would try again each move */
-}
-
 /* level dependent initialization */
 void
 oinit(void)
@@ -993,7 +978,7 @@ rename_disco(void)
             if (oclass != prev_class) {
                 any.a_int = 0;
                 add_menu(tmpwin, &nul_glyphinfo, &any, 0, 0,
-                         iflags.menu_headings, clr, 
+                         iflags.menu_headings, clr,
                          let_to_name(oclass, FALSE, FALSE),
                          MENU_ITEMFLAGS_NONE);
                 prev_class = oclass;


### PR DESCRIPTION
find_skates was still in use for its one intended case, but objdescr_is
has been around for a few years now and can do just as good a job
without having to hardcode the first and last boots in objects[].