### PR TITLE
Level teleporters always print "momentarily disoriented" message

### DIFF
--- a/src/teleport.c
+++ b/src/teleport.c
@@ -1191,10 +1191,7 @@ level_tele_trap(struct trap* trap, unsigned int trflags)
         You_feel("a wrenching sensation.");
         return;
     }
-    if (!Blind)
-        You("are momentarily blinded by a flash of light.");
-    else
-        You("are momentarily disoriented.");
+    You("are momentarily disoriented.");
     deltrap(trap);
     newsym(u.ux, u.uy); /* get rid of trap symbol */
     level_tele();


### PR DESCRIPTION
Removing the message "You are momentarily blinded by a flash of light"
and keeping the alternate message that was formerly shown only when
blind. There are three reasons:
1. This effect doesn't actually blind you.
2. This effect *does* momentarily disorient you (i.e. confuse you.)
3. This is the exact same message as the summoning/blinding effect of a
   magic trap, and it's easy to conflate the two.