### PR TITLE
Don't describe sleep explosion as a "ray"

### DIFF
--- a/src/explode.c
+++ b/src/explode.c
@@ -156,7 +156,7 @@ explode(
             break;
         case 4:
             adstr = (olet == WAND_CLASS) ? "death field"
-                                       : "disintegration field";
+                                         : "disintegration field";
             adtyp = AD_DISN;
             break;
         case 5:

--- a/src/zap.c
+++ b/src/zap.c
@@ -2633,7 +2633,10 @@ zapyourself(struct obj *obj, boolean ordinary)
             You("don't feel sleepy!");
             monstseesu(M_SEEN_SLEEP);
         } else {
-            pline_The("sleep ray hits you!");
+            if (ordinary)
+                pline_The("sleep ray hits you!");
+            else
+                You("fall alseep!");
             fall_asleep(-rnd(50), TRUE);
         }
         break;


### PR DESCRIPTION
When breaking a wand of sleep, don't print the message "the sleep ray
hits you!" since it produces an area effect/explosion rather than a ray.
For a couple other wands, !ordinary (wand breakage) effects don't
produce a message (I assume because the do_break_wand feedback is
considered sufficient), but I put in an alternative message for the
explosion since I think it's important to inform the player the hero has
fallen asleep.
