### PR TITLE
Fix: levelport by name to unconnected branch

### DIFF
--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -1975,6 +1975,14 @@ level_difficulty(void)
     return res;
 }
 
+/* within same branch, or else main dungeon <-> gehennom */
+#define dlev_in_current_branch(dlev) \
+    (dlev.dnum == u.uz.dnum \
+     || (u.uz.dnum == valley_level.dnum \
+         && dlev.dnum == medusa_level.dnum) \
+     || (u.uz.dnum == medusa_level.dnum \
+         && dlev.dnum == valley_level.dnum))
+
 /* Take one word and try to match it to a level.
  * Recognized levels are as shown by print_dungeon().
  */
@@ -1982,7 +1990,7 @@ schar
 lev_by_name(const char *nam)
 {
     schar lev = 0;
-    s_level *slev = (s_level *)0;
+    s_level *slev = (s_level *) 0;
     d_level dlev;
     const char *p;
     int idx, idxtoo;
@@ -2017,12 +2025,7 @@ lev_by_name(const char *nam)
 
     if (mseen || slev) {
         idx = ledger_no(&dlev);
-        if ((dlev.dnum == u.uz.dnum
-             /* within same branch, or else main dungeon <-> gehennom */
-             || (u.uz.dnum == valley_level.dnum
-                 && dlev.dnum == medusa_level.dnum)
-             || (u.uz.dnum == medusa_level.dnum
-                 && dlev.dnum == valley_level.dnum))
+        if (dlev_in_current_branch(dlev)
             && (/* either wizard mode or else seen and not forgotten */
                 wizard
                 || (g.level_info[idx].flags & (VISITED))
@@ -2048,12 +2051,15 @@ lev_by_name(const char *nam)
                     idx = idxtoo;
                 dlev.dnum = ledger_to_dnum(idx);
                 dlev.dlevel = ledger_to_dlev(idx);
-                lev = depth(&dlev);
+                if (dlev_in_current_branch(dlev))
+                    lev = depth(&dlev);
             }
         }
     }
     return lev;
 }
+
+#undef dlev_in_current_branch
 
 static boolean
 unplaced_floater(struct dungeon *dptr)


### PR DESCRIPTION
(unconnected to the current dungeon branch, that is)

Level teleporting allows you to type in the name of a level instead of
its number.  This normally only works for levels within your current
dungeon branch (main dungeon <-> Gehennom levelports are the exception):
entering "medusa" as a destination won't work while the hero is in the
Gnomish Mines, but it will work fine to get to the Medusa level from
elsewhere in the main dungeon.

Teleporting to a particular branch entrance didn't apply the same
restriction.  The teleport would still happen even if the destination
branch was unreachable from the current branch, and in such a case the
game would just try to get the hero to the depth of the branch entrance,
within the current branch.  For example, entering "quest" as a
destination within the Gnomish Mines would bring the hero to Mines' End,
since that's the closest depth-wise it's possible to get to the quest
portal level.  Apply the same heuristics to branch entrances as exist
for named levels, excluding destinations that are unreachable from the
current branch.

I'm not sure if this commit is the best way to apply the rule
consistently; an alternative option would be to just place one test at
the end, with structure somewhat along the lines of this diff (against
the commit in this PR):

```diff
diff --git a/src/dungeon.c b/src/dungeon.c
index 95e40bfe8..792930543 100644
--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -2025,11 +2025,9 @@ lev_by_name(const char *nam)
 
     if (mseen || slev) {
         idx = ledger_no(&dlev);
-        if (dlev_in_current_branch(dlev)
-            && (/* either wizard mode or else seen and not forgotten */
-                wizard
-                || (g.level_info[idx].flags & (VISITED))
-                       == VISITED)) {
+        /* either wizard mode or else seen and not forgotten */
+        if (wizard
+            || (g.level_info[idx].flags & (VISITED)) == VISITED) {
             lev = depth(&dlev);
         }
     } else { /* not a specific level; try branch names */
@@ -2051,12 +2049,11 @@ lev_by_name(const char *nam)
                     idx = idxtoo;
                 dlev.dnum = ledger_to_dnum(idx);
                 dlev.dlevel = ledger_to_dlev(idx);
-                if (dlev_in_current_branch(dlev))
-                    lev = depth(&dlev);
+                lev = depth(&dlev);
             }
         }
     }
-    return lev;
+    return (lev && dlev_in_current_branch(dlev)) ? lev : (schar) 0;
 }
 
 #undef dlev_in_current_branch
```

It made me a little nervous to use 'lev' as a proxy for whether 'dlev'
has been initialized, though, since I'm not sure if they'd necessarily
always have to be so tightly coupled in the future.  That might be
(and probably is) pointless and unnecessary fretting...
