### PR TITLE
Fix: IS_SUBROOM_INDEX range

### DIFF
--- a/include/mkroom.h
+++ b/include/mkroom.h
@@ -100,10 +100,11 @@ enum roomtype_types {
 
 #define IS_ROOM_PTR(x)      ((x) >= g.rooms && (x) < g.rooms + MAXNROFROOMS)
 #define IS_ROOM_INDEX(x)    ((x) >= 0 && (x) < MAXNROFROOMS)
-#define IS_SUBROOM_PTR(x)   ((x) >= g.subrooms && (x) < g.subrooms + MAXNROFROOMS)
-#define IS_SUBROOM_INDEX(x) ((x) > MAXNROFROOMS && (x) < (MAXNROFROOMS * 2))
-#define ROOM_INDEX(x)       ((x) -g.rooms)
-#define SUBROOM_INDEX(x)    ((x) -g.subrooms)
+#define IS_SUBROOM_PTR(x) \
+    ((x) >= g.subrooms && (x) < g.subrooms + MAXNROFROOMS)
+#define IS_SUBROOM_INDEX(x) ((x) > MAXNROFROOMS && (x) <= (MAXNROFROOMS * 2))
+#define ROOM_INDEX(x)       ((x) - g.rooms)
+#define SUBROOM_INDEX(x)    ((x) - g.subrooms)
 #define IS_LAST_ROOM_PTR(x) (ROOM_INDEX(x) == g.nroom)
 #define IS_LAST_SUBROOM_PTR(x) (!g.nsubroom || SUBROOM_INDEX(x) == g.nsubroom)
 

--- a/src/mklev.c
+++ b/src/mklev.c
@@ -305,7 +305,7 @@ makerooms(void)
                 iflags.in_lua = g.in_mk_themerooms = TRUE;
                 g.themeroom_failed = FALSE;
                 lua_getglobal(themes, "themerooms_generate");
-                if ( nhl_pcall(themes, 0, 0)){
+                if (nhl_pcall(themes, 0, 0)) {
                     impossible("Lua error: %s", lua_tostring(themes, -1));
                 }
                 iflags.in_lua = g.in_mk_themerooms = FALSE;
@@ -911,7 +911,7 @@ makelevel(void)
             if (check_room(&g.vault_x, &w, &g.vault_y, &h, TRUE)) {
  fill_vault:
                 add_room(g.vault_x, g.vault_y, g.vault_x + w, g.vault_y + h,
-                        TRUE, VAULT, FALSE);
+                         TRUE, VAULT, FALSE);
                 g.level.flags.has_vault = 1;
                 ++room_threshold;
                 g.rooms[g.nroom - 1].needfill = FILL_NORMAL;


### PR DESCRIPTION
The macro (currently unused, I think) for checking whether a particular
index designates a subroom was off by one on the maximum allowable
value.

Because of the dedicated extra space for the g.rooms array terminator
flag (hx == -1), subroom indices in g.rooms are set out in the range
[MAXNROFROOMS+1, MAXNROFROOMS*2], inclusive.

Also some minor formatting tweaks.
