### PR TITLE
Fix: overwriting stairs in movement tests

### DIFF
--- a/test/testmove.lua
+++ b/test/testmove.lua
@@ -15,7 +15,7 @@ function initlev()
    des.teleport_region({ region = {POS.x,POS.y,POS.x,POS.y}, region_islev = true, dir="both" });
    des.finalize_level();
    for k, v in pairs(nh.stairways()) do
-      des.terrain(v.x - 1, v.y, ".");
+      des.terrain(v.x, v.y, ".");
    end
 end
 


### PR DESCRIPTION
Like some of the other coordinates in testmove.lua (addressed in
70008fc), the attempt to overwrite the stairs was targeting a spot
one space to the left of the actual position of the stairs, causing it
to have no effect (discussion suggested this may have been a result of
99715e0).  Update it so the stairs are properly erased and won't
interfere with movement tests by stopping a running/rushing hero early.

Discussed this with paxed already on IRC so it may be that a fix is 
already planned or on its way, but since it's been a day or so without 
any movement and I had already made this branch locally, I thought I'd 
open a PR in case it makes things easier.
