### PR TITLE
Remove "danger sense" message for a monster you can already see

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -1751,7 +1751,7 @@ mfind0(struct monst *mtmp, boolean via_warning)
         if (mtmp->mundetected && (is_hider(mtmp->data)
                                   || hides_under(mtmp->data)
                                   || mtmp->data->mlet == S_EEL)) {
-            if (via_warning) {
+            if (via_warning && found_something) {
                 Your("danger sense causes you to take a second %s.",
                      Blind ? "to check nearby" : "look close by");
                 display_nhwindow(WIN_MESSAGE, FALSE); /* flush messages */


### PR DESCRIPTION
If you had both warning and ESP, you would get the message "Your danger
sense causes you to take a second look close by" when moving next to a
monster that is technically "undetected" (according to mundetected) but
was actually apparent to the player via ESP. For instance, moving next
to an eel hiding in the water would produce this.

Since there was no follow-up message ("You find a <monster>".) and no
new information being given to the player, the "danger sense" message
was pointless, and so I removed it in this case when the warning doesn't
lead you to find anything new.