### PR TITLE
Move 'major events' section in dumplog

### DIFF
--- a/src/end.c
+++ b/src/end.c
@@ -786,6 +786,7 @@ dump_everything(
     putstr(0, 0, pbuf);
     putstr(0, 0, "");
 
+    /* info about current game state */
     dump_map();
     putstr(0, 0, do_statusline1());
     putstr(0, 0, do_statusline2());
@@ -793,13 +794,15 @@ dump_everything(
 
     dump_plines();
     putstr(0, 0, "");
-    show_gamelog((how >= PANICKED) ? ENL_GAMEOVERALIVE : ENL_GAMEOVERDEAD);
-    putstr(0, 0, "");
     putstr(0, 0, "Inventory:");
     (void) display_inventory((char *) 0, TRUE);
     container_contents(g.invent, TRUE, TRUE, FALSE);
     enlightenment((BASICENLIGHTENMENT | MAGICENLIGHTENMENT),
                   (how >= PANICKED) ? ENL_GAMEOVERALIVE : ENL_GAMEOVERDEAD);
+    putstr(0, 0, "");
+
+    /* overview of the game up to this point */
+    show_gamelog((how >= PANICKED) ? ENL_GAMEOVERALIVE : ENL_GAMEOVERDEAD);
     putstr(0, 0, "");
     list_vanquished('d', FALSE); /* 'd' => 'y' */
     putstr(0, 0, "");


### PR DESCRIPTION
The sections of the dumplog can be broadly organized into two
categories: 'current state' and 'game overview'.  Current state includes
information about what exactly was happening when the game ended: the
map, recent messages, current inventory, and current attributes.  Game
overview is more like a history of the game up to that point: vanquished
monsters, extinct species, conducts, and dungeon overview.

All the current state sections are listed first, followed by the game
overview sections -- I'm not sure if this was a deliberate move to break
the dumplog into two distinct 'chapters', but it's convenient for
readers who may only want to know the circumstances of a death without
seeing the nitty-gritty details of the entire game up to that point.

The one section that wasn't ordered with its category was major events,
which was positioned near the top of the 'current state' group, above
the inventory listing.  This commit moves it into the 'game overview'
group.  I put it at the top, since it can serve as a sort of summary of
the game for those who are interested but don't care about some of the
details of monsters killed, etc.
