### PR TITLE
Some minor read_simplemail improvements

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1057,7 +1057,6 @@ extern void strbuf_append(strbuf_t *, const char *);
 extern void strbuf_reserve(strbuf_t *, int);
 extern void strbuf_empty(strbuf_t *);
 extern void strbuf_nl_to_crlf(strbuf_t *);
-extern char *nonconst(const char *, char *, size_t);
 extern int swapbits(int, int, int);
 extern void shuffle_int_array(int *, int);
 /* note: the snprintf CPP wrapper includes the "fmt" argument in "..."

--- a/src/hacklib.c
+++ b/src/hacklib.c
@@ -74,7 +74,6 @@
         void            strbuf_reserve  (strbuf *, int)
         void            strbuf_empty    (strbuf *)
         void            strbuf_nl_to_crlf (strbuf_t *)
-        char *          nonconst        (const char *, char *)
         int             swapbits        (int, int, int)
         void            shuffle_int_array (int *, int)
         void            nh_snprintf     (const char *, int, char *, size_t,
@@ -1269,19 +1268,6 @@ strbuf_nl_to_crlf(strbuf_t *strbuf)
                 }
         }
     }
-}
-
-char *
-nonconst(const char *str, char *buf, size_t bufsz)
-{
-    char *retval = emptystr;
-
-    if (str && buf)
-        if (strlen(str) <= (bufsz - 1)) {
-            Strcpy(buf, str);
-            retval = buf;
-        }
-    return retval;
 }
 
 /* swapbits(val, bita, bitb) swaps bit a with bit b in val */

--- a/src/mail.c
+++ b/src/mail.c
@@ -560,8 +560,6 @@ ckmailstatus(void)
 
 #if defined(SIMPLE_MAIL) || defined(SERVER_ADMIN_MSG)
 
-DISABLE_WARNING_FORMAT_NONLITERAL
-
 void
 read_simplemail(char *mbox, boolean adminmsg)
 {
@@ -571,9 +569,6 @@ read_simplemail(char *mbox, boolean adminmsg)
 #ifdef SIMPLE_MAIL
     struct flock fl = { 0 };
 #endif
-    const char *msgfrom = adminmsg
-        ? "The voice of %s booms through the caverns:"
-        : "This message is from '%s'.";
 
     if (!mb)
         goto bail;
@@ -589,34 +584,47 @@ read_simplemail(char *mbox, boolean adminmsg)
     /* Allow this call to block. */
     if (!adminmsg
 #ifdef SIMPLE_MAIL
-        && fcntl (fileno (mb), F_SETLKW, &fl) == -1
+        && fcntl(fileno(mb), F_SETLKW, &fl) == -1
 #endif
         )
         goto bail;
 
     while (fgets(curline, 128, mb) != NULL) {
+        const char *endpunct;
+        int msglen;
+
         if (!adminmsg) {
 #ifdef SIMPLE_MAIL
             fl.l_type = F_UNLCK;
-            fcntl (fileno(mb), F_UNLCK, &fl);
+            fcntl(fileno(mb), F_UNLCK, &fl);
 #endif
             pline("There is a%s message on this scroll.",
                   seen_one_already ? "nother" : "");
         }
         msg = strchr(curline, ':');
 
-        if (!msg)
+        /* if incorrectly formatted, or message is empty (':' and '\n' take
+           up 2 chars, so must have at least 3 to be nonempty), give up */
+        if (!msg || (msglen = (int) strlen(msg)) < 3)
             goto bail;
 
         *msg = '\0';
-        msg++;
-        msg[strlen(msg) - 1] = '\0'; /* kill newline */
+        msg++, msglen--;
+        msg[msglen - 1] = '\0'; /* kill newline */
 
-        pline(msgfrom, curline);
-        if (adminmsg)
-            verbalize("%s", msg);
-        else
-            pline("It reads: \"%s\".", msg);
+        /* supply ending punctuation only if the message doesn't have any */
+        endpunct = "";
+        if (!index(".!?", msg[msglen - 2]))
+            endpunct = ".";
+
+        if (adminmsg) {
+            urgent_pline("The voice of %s booms through the caverns:",
+                         curline);
+        } else {
+            pline("This message is from '%s'.", curline);
+            pline("It reads:");
+        }
+        pline("\"%s\"%s", msg, endpunct);
 
         seen_one_already = TRUE;
 #ifdef SIMPLE_MAIL
@@ -645,8 +653,6 @@ read_simplemail(char *mbox, boolean adminmsg)
     if (!adminmsg)
         pline("It appears to be all gibberish.");
 }
-
-RESTORE_WARNING_FORMAT_NONLITERAL
 
 #endif /* SIMPLE_MAIL */
 

--- a/src/mail.c
+++ b/src/mail.c
@@ -45,7 +45,7 @@ static boolean md_stop(coord *, coord *);
 static boolean md_rush(struct monst *, int, int);
 static void newmail(struct mail_info *);
 #if defined(SIMPLE_MAIL) || defined(SERVER_ADMIN_MSG)
-static void read_simplemail(char *mbox, boolean adminmsg);
+static void read_simplemail(const char *mbox, boolean adminmsg);
 #endif
 
 #if !defined(UNIX) && !defined(VMS)
@@ -561,7 +561,7 @@ ckmailstatus(void)
 #if defined(SIMPLE_MAIL) || defined(SERVER_ADMIN_MSG)
 
 void
-read_simplemail(char *mbox, boolean adminmsg)
+read_simplemail(const char *mbox, boolean adminmsg)
 {
     FILE* mb = fopen(mbox, "r");
     char curline[128], *msg;
@@ -662,15 +662,13 @@ ck_server_admin_msg(void)
 #ifdef SERVER_ADMIN_MSG
     static struct stat ost,nst;
     static long lastchk = 0;
-    char adminbuf[BUFSZ];
 
     if (g.moves < lastchk + SERVER_ADMIN_MSG_CKFREQ) return;
     lastchk = g.moves;
 
     if (!stat(SERVER_ADMIN_MSG, &nst)) {
         if (nst.st_mtime > ost.st_mtime)
-            read_simplemail(nonconst(SERVER_ADMIN_MSG, adminbuf,
-                                     sizeof adminbuf), TRUE);
+            read_simplemail(SERVER_ADMIN_MSG, TRUE);
         ost.st_mtime = nst.st_mtime;
     }
 #endif /* SERVER_ADMIN_MSG */


### PR DESCRIPTION
Make admin message use urgent_pline so it's less likely to be skipped
and inadvertently missed, make ending punctuation conditional on message
itself not containing any (similar to what's done for T-shirt messages
in read.c), guard against printing an empty message (from a line like
"name:\n"; it does mean that subsequent messages in a single batch will
be discarded, but that's true of the existing guard against malformed
lines as well, and it should make the overwriting of characters past the
'msg' ptr safer).
