### PR TITLE
Fix inaccessible spaces and shop backdoors in Bustling Town

### DIFF
--- a/dat/minetn-6.lua
+++ b/dat/minetn-6.lua
@@ -11,55 +11,62 @@ des.level_flags("mazelevel", "inaccessibles")
 
 des.level_init({ style="mines", fg=".", bg="-", smoothed=true, joined=true,lit=1,walled=true })
 
+-- Map extends the full height of the playable area in order to prevent any of
+-- the cavern fill from getting cut off by walls of the town buildings and
+-- creating inaccessible spaces. The inaccessibles flag does compensate for
+-- this, but it does so by doing things like creating backdoors into adjacent
+-- shops which we don't want.
 des.map({ halign = "center", valign = "top", map = [[
-.-----................----------------.-
+x--------xxxxxxxxxxx-------------------x
+x------xxxxxxxxxxxxxx-----------------xx
+.-----................----------------.x
 .|...|................|...|..|...|...|..
 .|...+..--+--.........|...|..|...|...|..
 .|...|..|...|..-----..|...|..|-+---+--..
-.-----..|...|--|...|..--+---+-.........|
+.-----..|...|--|...|..--+---+-.........x
 ........|...|..|...+.............-----..
 ........-----..|...|......--+-...|...|..
-.----...|...|+------..{...|..|...+...|..
-.|..+...|...|.............|..|...|...|..
-.|..|...|...|-+-.....---+-------------.|
-.----...--+--..|..-+-|..................
-...|........|..|..|..|----....---------.
-...|..T.....----..|..|...+....|......|-.
-...|-....{........|..|...|....+......|-.
-...--..-....T.....--------....|......|-.
+x----...|...|+------..{...|..|...+...|..
+x|..+...|...|.............|..|...|...|..
+x|..|...|...|-+-.....---+-------------.x
+x----...--+--..|..-+-|..................
+...|........|..|..|..|----....--------x.
+...|..T.....----..|..|...+....|......|x.
+...|-....{........|..|...|....+......|x.
+...--..-....T.....--------....|......|x.
 .......--.....................----------
+xxxxx-----xxxxxxxxxxxxxxxxxx------------
+xxxx-------xxxxxxxxxxxxxxx--------------
 ]] });
 
-des.region(selection.area(00,00,38,15),"lit")
-des.levregion({ type="stair-up", region={01,03,20,19}, region_islev=1, exclude={0,0,39,15} })
-des.levregion({ type="stair-down", region={61,03,75,19}, region_islev=1, exclude={0,0,39,15} })
-des.feature("fountain" ,22,07)
-des.feature("fountain", 09,13)
-des.region(selection.area(13,5,14,6),"unlit")
-des.region({ region={09,07, 11,09}, lit=1, type="candle shop", filled=1 })
-des.region({ region={16,04, 18,06}, lit=1, type="tool shop", filled=1 })
-des.region({ region={23,01, 25,03}, lit=1, type="shop", filled=1 })
-des.region({ region={22,12, 24,13}, lit=1, type=monkfoodshop(), filled=1 })
-des.region({ region={31,12, 36,14}, lit=1, type="temple", filled=1 })
-des.altar({ x=35,y=13,align=align[1],type="shrine"})
+des.region(selection.area(00,00,39,19),"lit")
+des.levregion({ type="stair-up", region={01,03,20,19}, region_islev=1, exclude={0,0,39,19} })
+des.levregion({ type="stair-down", region={61,03,75,19}, region_islev=1, exclude={0,0,39,19} })
+des.region(selection.area(13,7,14,8),"unlit")
+des.region({ region={09,09, 11,11}, lit=1, type="candle shop", filled=1 })
+des.region({ region={16,06, 18,08}, lit=1, type="tool shop", filled=1 })
+des.region({ region={23,03, 25,05}, lit=1, type="shop", filled=1 })
+des.region({ region={22,14, 24,15}, lit=1, type=monkfoodshop(), filled=1 })
+des.region({ region={31,14, 36,16}, lit=1, type="temple", filled=1 })
+des.altar({ x=35,y=15,align=align[1],type="shrine"})
 
-des.door("closed",5,2)
-des.door("locked",4,8)
-des.door("closed",10,2)
-des.door("closed",10,10)
-des.door("locked",13,7)
-des.door("locked",14,9)
-des.door("closed",19,5)
-des.door("closed",19,10)
-des.door("closed",24,4)
-des.door("closed",24,9)
-des.door("closed",25,12)
-des.door("closed",28,4)
-des.door("locked",28,6)
-des.door("closed",30,13)
-des.door("closed",31,3)
-des.door("closed",35,3)
-des.door("closed",33,7)
+des.door("closed",5,4)
+des.door("locked",4,10)
+des.door("closed",10,4)
+des.door("closed",10,12)
+des.door("locked",13,9)
+des.door("locked",14,11)
+des.door("closed",19,7)
+des.door("closed",19,12)
+des.door("closed",24,6)
+des.door("closed",24,11)
+des.door("closed",25,14)
+des.door("closed",28,6)
+des.door("locked",28,8)
+des.door("closed",30,15)
+des.door("closed",31,5)
+des.door("closed",35,5)
+des.door("closed",33,9)
 
 des.monster("gnome")
 des.monster("gnome")
@@ -67,9 +74,9 @@ des.monster("gnome")
 des.monster("gnome")
 des.monster("gnome")
 des.monster("gnome")
-des.monster("gnome", 14, 6)
-des.monster("gnome lord", 14, 5)
-des.monster("gnome", 27, 8)
+des.monster("gnome", 14, 8)
+des.monster("gnome lord", 14, 7)
+des.monster("gnome", 27, 10)
 des.monster("gnome lord")
 des.monster("gnome lord")
 des.monster("dwarf")


### PR DESCRIPTION
Perennial problem: since Bustling Town consists of a fixed map which was
shorter than the moveable area overlaid onto a cavern fill, sometimes
the cavern fill made spaces above or below the walled edges of the town,
which then got cut off when the town was placed. Since one of the valid
ways to generate a way out of an inaccessible space is to create a door
connecting it to an accessible space, this meant rooms in Minetown,
including shops, could get a second door leading into that tiny space.
And if it was a shop, the shopkeeper could not block exit from the
second door.

This fixes that issue by expanding the map vertically so that it will
overwrite the whole cavern fill in the town area of the map segment
where it might create cut-off spaces like this. (Not the whole area -
since we now have the 'x' mapchar to leave existing terrain in place,
areas adjoining open space where inaccessible pockets won't get
created can retain any existing fill to keep the town from being exactly
the same every time).