### PR TITLE
Move levitation potion headache false rumor into true rumors

### DIFF
--- a/dat/rumors.fal
+++ b/dat/rumors.fal
@@ -289,7 +289,6 @@ They say that only big spenders carry gold.
 They say that orc shamans are healthy, wealthy and wise.
 They say that playing NetHack is like walking into a death trap.
 They say that problem breathing is best treated by a proper diet.
-They say that quaffing many potions of levitation can give you a headache.
 They say that queen bees get that way by eating royal jelly.
 They say that reading a scare monster scroll is the same as saying Elbereth.
 They say that real hackers always are controlled.

--- a/dat/rumors.tru
+++ b/dat/rumors.tru
@@ -367,3 +367,4 @@ You're going into the morgue at midnight???
 Your dog knows what to eat; maybe you should take lessons.
 Zap yourself and see what happens...
 Zapping a wand of undead turning might bring your dog back to life.
+They say that quaffing many potions of levitation can give you a headache.


### PR DESCRIPTION
Quaffing a cursed potion of levitation does indeed cause a headache, up to d10 damage.  Assuming one was quaffing 'many' unidentified potions, it's possible one of them is indeed cursed when the player hits their head on the ceiling.

https://github.com/NetHack/NetHack/blob/f5a9901db1d9e7ebc97f4ad1fdffebb695ca2b79/src/potion.c#L1182