### PR TITLE
Make replace_terrain respect fromterrain='w'

### DIFF
--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -5559,7 +5559,9 @@ lspo_replace_terrain(lua_State *L)
                     if (mapfrag_match(mf, x, y) && (rn2(100)) < chance)
                         (void) set_levltyp_lit(x, y, totyp, tolit);
                 } else {
-                    if (levl[x][y].typ == fromtyp && rn2(100) < chance)
+                    if (((fromtyp == MATCH_WALL && IS_STWALL(levl[x][y].typ))
+                         || levl[x][y].typ == fromtyp)
+                        && rn2(100) < chance)
                         (void) set_levltyp_lit(x, y, totyp, tolit);
                 }
             }


### PR DESCRIPTION
Noticed that an attempted terrain replacement wasn't taking hold even
though 'w' is supposed to mean "match any stone or wall"; this was
because w converts into non-terrain-type MATCH_WALL and replace_terrain
was doing a simple comparison on whether the potentially replaced
terrain matches that type. Add a special check here for w so it will
match the terrain types it's supposed to.

Note that using replace_terrain with 'w' now WILL match stone, since
this is the documented behavior of w, to match IS_STWALL rather than
just IS_WALL. If a level designer really wants to exclude stone, they
can work around this by either making a selection and filter out stone
terrain, or doing two replace_terrains with '-' and '|'.

Tested this by turning 40% of bigrm-1 walls to lava.