### PR TITLE
Sundry fixes for DOS 16-color VGA mode

### DIFF
--- a/sys/msdos/msdoshlp.txt
+++ b/sys/msdos/msdoshlp.txt
@@ -47,7 +47,7 @@ OPTIONS=VIDEO
 
 		ie: OPTIONS=video:autodetect
 
-		Possible values are: AUTODETECT, DEFAULT, VGA
+		Possible values are: AUTODETECT, DEFAULT, VGA, VESA
 
 		AUTODETECT Checks for a supported hi-res video
                            adaptor, and if it detects one, NetHack 
@@ -61,6 +61,9 @@ OPTIONS=VIDEO
                            Any forcing of specific video routines has
                            potential to cause machine lock-ups if 
                            the specified video hardware is not present.	
+
+		VESA       Forces use of VESA specific video routines.
+                           Reverts to TTY mode if no VESA BIOS is found.
 
 OPTIONS=VIDEOSHADES
 		(defaults.nh only)


### PR DESCRIPTION
To test 16-color mode, specify OPTIONS=video:vga explicitly; autodetect will choose a VESA mode if it can.

* Draw tiles correctly when redrawing from panning or from changing the map mode among text, tiles and overview. Previously, this would draw everything with the tile at the hero's position.

* Draw corridor walls with the stone tile.

* Map the statue colors to the nearest neutral tone among the main 16 colors. This mainly affects altars and female cats.

* Fix the code that shows statues as the generic statue tile. This code could be deleted, but the statues don't draw with the full range of gray tones.

* Document the option OPTIONS=video:vesa.