### PR TITLE
Fix: impossible from splitting named stack on bill

### DIFF
--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -423,11 +423,11 @@ splitobj(struct obj *obj, long num)
        be tracking the original */
     if (otmp->where == OBJ_LUAFREE)
         otmp->where = OBJ_FREE;
+    if (obj->unpaid)
+        splitbill(obj, otmp);
     copy_oextra(otmp, obj);
     if (has_omid(otmp))
         free_omid(otmp); /* only one association with m_id*/
-    if (obj->unpaid)
-        splitbill(obj, otmp);
     if (obj->timed)
         obj_split_timers(obj, otmp);
     if (obj_sheds_light(obj))


### PR DESCRIPTION
Trying to split an unpaid stack of named items in a shop, with
perm_invent enabled, would cause an impossible 'unpaid_cost: object
wasn't on any bill' because copy_oextra -> oname triggered an inventory
update while the newly created split stack was marked unpaid but before
the billing information had been split to match.  Defer the copy_oextra
call until the billing info has already been split.
