### PR TITLE
Fix: starving herbivore pet vs polymorphing corpse

### DIFF
--- a/src/dog.c
+++ b/src/dog.c
@@ -965,17 +965,11 @@ dogfood(struct monst *mon, struct obj *obj)
                 || (acidic(fptr) && !resists_acid(mon))
                 || (poisonous(fptr) && !resists_poison(mon)))
                 return POISON;
-            /* polymorphing is preferable to starvation, and pet might also
-               want to take its chances on that if they've been mistreated */
-            else if (is_shapeshifter(fptr)) {
-                if (mon->mtame == 1) {
-                    /* A herbivore still won't eat a nonvegan corpse, but
-                       in any other circumstance a pet with tameness 1 will
-                       happily eat a shapeshifter. */
-                    return (herbi && !vegan(fptr)) ? MANFOOD : CADAVER;
-                }
-                return starving ? ACCFOOD : MANFOOD;
-            } else if (vegan(fptr))
+            /* avoid polymorph unless starving or abused (in which case the
+               pet will consider it for a chance to become more powerful) */
+            else if (is_shapeshifter(fptr) && mon->mtame > 1 && !starving)
+                return MANFOOD;
+            else if (vegan(fptr))
                 return herbi ? CADAVER : MANFOOD;
             /* most humanoids will avoid cannibalism unless starving;
                arbitrary: elves won't eat other elves even then */


### PR DESCRIPTION
The special handling of polymorphing corpses included an "is acceptable
food if starving" rule which ignored the pet's other food preferences,
so a starving herbivorous pet would become willing to eat a
non-vegetarian corpse iff the corpse would polymorph it when eaten.
Along the same lines but latent: if there were a vegan polymorphing
corpse, a carnivorous pet would eat it not only if starving, but also if
maltreated and on the verge of becoming feral.

Instead of trying to fix this by reimplementing all the herbi vs carni
rules specifically for polymorphing corpses, just have a "don't eat
polymorphing corpses if neither starving nor almost untame" rule, and
fall back to the normal palatable corpses tests once it's been
determined that the pet is willing to eat even a polymorphing corpse.

I rephrased the comment just to make it negative (about avoiding
polymorph, rather than polymorph being OK under certain circumstances)
to match the new form of the rule.
