### PR TITLE
Hole/trap door destination fixes

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2796,6 +2796,7 @@ extern boolean burnarmor(struct monst *);
 extern int erode_obj(struct obj *, const char *, int, int);
 extern boolean grease_protect(struct obj *, const char *, struct monst *);
 extern struct trap *maketrap(coordxy, coordxy, int);
+extern d_level *clamp_hole_destination(d_level *);
 extern void fall_through(boolean, unsigned);
 extern struct monst *animate_statue(struct obj *, coordxy, coordxy, int, int *);
 extern struct monst *activate_statue_trap(struct trap *, coordxy, coordxy,

--- a/include/patchlevel.h
+++ b/include/patchlevel.h
@@ -17,7 +17,7 @@
  * Incrementing EDITLEVEL can be used to force invalidation of old bones
  * and save files.
  */
-#define EDITLEVEL 64
+#define EDITLEVEL 65
 
 /*
  * Development status possibilities.

--- a/src/do.c
+++ b/src/do.c
@@ -1145,8 +1145,11 @@ dodown(void)
     }
     if (trap && Is_stronghold(&u.uz)) {
         goto_hell(FALSE, TRUE);
-    } else if (trap) {
-        goto_level(&(trap->dst), FALSE, FALSE, FALSE);
+    } else if (trap && trap->dst.dlevel != -1) {
+        d_level tdst;
+        assign_level(&tdst, &(trap->dst));
+        (void) clamp_hole_destination(&tdst);
+        goto_level(&tdst, FALSE, FALSE, FALSE);
     } else {
         g.at_ladder = (boolean) (levl[u.ux][u.uy].typ == LADDER);
         next_level(!trap);

--- a/src/do.c
+++ b/src/do.c
@@ -1822,7 +1822,7 @@ goto_level(
 
     /* fall damage? */
     if (do_fall_dmg) {
-        int dmg = d(dist, 6);
+        int dmg = d(max(dist, 1), 6);
 
         dmg = Maybe_Half_Phys(dmg);
         losehp(dmg, "falling down a mine shaft", KILLED_BY);

--- a/src/restore.c
+++ b/src/restore.c
@@ -1093,6 +1093,11 @@ getlev(NHFILE* nhfp, int pid, xint8 lev)
         if (nhfp->structlevel)
             mread(nhfp->fd, (genericptr_t)trap, sizeof(struct trap));
         if (trap->tx != 0) {
+            if (g.program_state.restoring != REST_GSTATE
+                && trap->dst.dnum == u.uz.dnum) {
+                /* convert relative destination to absolute */
+                trap->dst.dlevel += u.uz.dlevel;
+            }
             trap->ntrap = g.ftrap;
             g.ftrap = trap;
         } else

--- a/src/save.c
+++ b/src/save.c
@@ -985,11 +985,17 @@ savetrapchn(NHFILE* nhfp, register struct trap* trap)
     register struct trap *trap2;
 
     while (trap) {
+        boolean use_relative = (g.program_state.restoring != REST_GSTATE
+                                && trap->dst.dnum == u.uz.dnum);
         trap2 = trap->ntrap;
+        if (use_relative)
+            trap->dst.dlevel -= u.uz.dlevel; /* make it relative */
         if (perform_bwrite(nhfp)) {
             if (nhfp->structlevel)
                 bwrite(nhfp->fd, (genericptr_t) trap, sizeof *trap);
         }
+        if (use_relative)
+            trap->dst.dlevel += u.uz.dlevel; /* reset back to absolute */
         if (release_data(nhfp))
             dealloc_trap(trap);
         trap = trap2;

--- a/src/teleport.c
+++ b/src/teleport.c
@@ -1540,6 +1540,7 @@ mlevel_tele_trap(
                 return Trap_Effect_Finished;
             } else {
                 assign_level(&tolevel, &trap->dst);
+                (void) clamp_hole_destination(&tolevel);
             }
         } else if (tt == MAGIC_PORTAL) {
             if (In_endgame(&u.uz) && (mon_has_amulet(mtmp)

--- a/src/teleport.c
+++ b/src/teleport.c
@@ -1539,7 +1539,7 @@ mlevel_tele_trap(
                           (tt == HOLE) ? "hole" : "trap");
                 return Trap_Effect_Finished;
             } else {
-                get_level(&tolevel, depth(&u.uz) + 1);
+                assign_level(&tolevel, &trap->dst);
             }
         } else if (tt == MAGIC_PORTAL) {
             if (In_endgame(&u.uz) && (mon_has_amulet(mtmp)

--- a/src/trap.c
+++ b/src/trap.c
@@ -580,15 +580,18 @@ fall_through(
     if (Is_stronghold(&u.uz)) {
         find_hell(&dtmp);
     } else {
-        int dist = newlevel - dunlev(&u.uz);
+        int dist;
 
         if (t) {
             dtmp.dnum = t->dst.dnum;
-            dtmp.dlevel = t->dst.dlevel;
+            /* don't fall beyond the bottom, in case this came from a bones
+               file with different dungeon size  */
+            dtmp.dlevel = min(t->dst.dlevel, bottom);
             dist = dtmp.dlevel - dunlev(&u.uz);
         } else {
             dtmp.dnum = u.uz.dnum;
             dtmp.dlevel = newlevel;
+            dist = newlevel - dunlev(&u.uz);
         }
         if (dist > 1)
             You("fall down a %s%sshaft!", dist > 3 ? "very " : "",


### PR DESCRIPTION
Attempted fixes for various issues stemming from 05761ba, mostly interactions
between holes/trapdoors and bones files: e.g. holes can deposit you backwards,
onto a higher level than you started on, or into the Sanctum prematurely (even
after applying ccaadaa).

- Fix: antigravity trap doors
- Have monsters' hole destination match the hero's
- Prevent hero from falling past end of dungeon
- Refine attempt to clamp trap door fall destination
- Apply dest. limit to monster trap door usage
