### PR TITLE
Fix undefined behavior when exiting Curses

### DIFF
--- a/win/curses/cursmain.c
+++ b/win/curses/cursmain.c
@@ -855,7 +855,11 @@ curses_raw_print(const char *str)
 #ifdef PDCURSES
     /* WINDOW *win = curses_get_nhwin(MESSAGE_WIN); */
 
-    curses_message_win_puts(str, FALSE);
+    if (iflags.window_inited) {
+        curses_message_win_puts(str, FALSE);
+    } else {
+        puts(str);
+    }
 #else
     puts(str);
 #endif

--- a/win/curses/curswins.c
+++ b/win/curses/curswins.c
@@ -176,12 +176,18 @@ curses_refresh_nethack_windows(void)
         touchwin(stdscr);
         refresh();
     } else {
-        touchwin(status_window);
-        wnoutrefresh(status_window);
-        touchwin(map_window);
-        wnoutrefresh(map_window);
-        touchwin(message_window);
-        wnoutrefresh(message_window);
+        if (status_window != NULL) {
+            touchwin(status_window);
+            wnoutrefresh(status_window);
+        }
+        if (map_window != NULL) {
+            touchwin(map_window);
+            wnoutrefresh(map_window);
+        }
+        if (message_window != NULL) {
+            touchwin(message_window);
+            wnoutrefresh(message_window);
+        }
         if (inv_window) {
             touchwin(inv_window);
             wnoutrefresh(inv_window);


### PR DESCRIPTION
* When saving: curses_exit_nhwindows calls curses_uncurse_terminal, which calls endwin. curses_exit_nhwindows then calls raw_print, which calls more Curses functions after endwin has been called. Fix this by having curses_raw_print use puts if window_inited is false.

* When dying, quitting, etc.: really_done opens the "Goodbye" window, which refreshes the other windows when it closes. But the status window (and possibly the map and message windows) are gone by that point. The window pointers are properly NULLed, but the NULL is then passed to touchwin. Fix this by checking window pointers for NULL.

These bugs manifest as crashes on exit when the @Bill-Gray fork of PDCurses (https://github.com/Bill-Gray/PDCursesMod) is linked to a cross-compile to MS-DOS. This fork has the potential to offer a much-improved Curses port on DOS, but I also uncovered some bugs in PDCursesMod.