### PR TITLE
Digestion attack can grant hero intrinsics

### DIFF
--- a/include/decl.h
+++ b/include/decl.h
@@ -1257,6 +1257,7 @@ struct instance_globals {
     /* uhitm.c */
     boolean override_confirmation; /* Used to flag attacks caused by
                                     * Stormbringer's maliciousness. */
+    short corpsenm_digested; /* monster type being digested, set by gulpum */
 
     /* vision.c */
     seenV **viz_array; /* used in cansee() and couldsee() macros */

--- a/include/extern.h
+++ b/include/extern.h
@@ -775,6 +775,7 @@ extern void set_tin_variety(struct obj *, int);
 extern int tin_variety_txt(char *, int *);
 extern void tin_details(struct obj *, int, char *);
 extern boolean Popeye(int);
+extern int Finish_digestion(void);
 
 /* ### end.c ### */
 

--- a/src/decl.c
+++ b/src/decl.c
@@ -674,6 +674,7 @@ const struct instance_globals g_init = {
 
     /* uhitm.c */
     FALSE, /* override_confirmation */
+    NON_PM, /* corpsenm_digested */
 
     /* vision.c */
     UNDEFINED_PTR, /* viz_array */

--- a/src/eat.c
+++ b/src/eat.c
@@ -3791,4 +3791,16 @@ Popeye(int threat)
     return FALSE;
 }
 
+/* the hero has swallowed a monster whole as a purple worm or similar, and has
+   finished digesting its corpse (called via g.afternmv) */
+int
+Finish_digestion(void)
+{
+    if (g.corpsenm_digested != NON_PM) {
+        cpostfx(g.corpsenm_digested);
+        g.corpsenm_digested = NON_PM;
+    }
+    return 0;
+}
+
 /*eat.c*/

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -4449,8 +4449,9 @@ gulpum(struct monst *mdef, struct attack *mattk)
                         && !(g.mvitals[monsndx(pd)].mvflags & G_NOCORPSE)) {
                         /* nutrition only if there can be a corpse */
                         u.uhunger += (pd->cnutrit + 1) / 2;
-                    } else
+                    } else {
                         tmp = 0;
+                    }
                     Sprintf(msgbuf, "You totally digest %s.", mon_nam(mdef));
                     if (tmp != 0) {
                         /* setting afternmv = end_engulf is tempting,
@@ -4464,6 +4465,9 @@ gulpum(struct monst *mdef, struct attack *mattk)
                         nomul(-tmp);
                         g.multi_reason = "digesting something";
                         g.nomovemsg = msgbuf;
+                        /* possible intrinsic once totally digested */
+                        g.corpsenm_digested = monsndx(pd);
+                        g.afternmv = Finish_digestion;
                     } else
                         pline1(msgbuf);
                     if (pd == &mons[PM_GREEN_SLIME]) {


### PR DESCRIPTION
Monster purple worms can now gain intrinsics from swallowing foes whole,
so maybe the hero should be able to do so too.  Intrinsics aren't
granted immediately upon swallowing (that would probably have been
easier), but only once a corpse is created and then entirely digested.

I'm not sure if this is too powerful and was being avoided deliberately
for that reason, since it includes potential level gain from wraith
corpses in addition to other intrinsics.  That's consistent with monster
purple worms but may be a bit too much in the hands of the hero, though
it is limited by needing the corpse creation roll to succeed.  Putting 
it out here to see what people think about it.
