### PR TITLE
Fix: 'weaken target' spell vs poly'd hero can leave hero with negative health

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -976,7 +976,7 @@ extern int monster_nearby(void);
 extern void end_running(boolean);
 extern void nomul(int);
 extern void unmul(const char *);
-extern void losehp(int, const char *, boolean);
+extern void losehp(int, const char *, schar);
 extern int weight_cap(void);
 extern int inv_weight(void);
 extern int near_capacity(void);

--- a/include/extern.h
+++ b/include/extern.h
@@ -114,7 +114,7 @@ extern struct obj *has_magic_key(struct monst *);
 
 extern boolean adjattrib(int, int, int);
 extern void gainstr(struct obj *, int, boolean);
-extern void losestr(int);
+extern void losestr(int, const char *, schar);
 extern void poisontell(int, boolean);
 extern void poisoned(const char *, int, const char *, int, boolean);
 extern void change_luck(schar);

--- a/include/extern.h
+++ b/include/extern.h
@@ -115,6 +115,7 @@ extern struct obj *has_magic_key(struct monst *);
 extern boolean adjattrib(int, int, int);
 extern void gainstr(struct obj *, int, boolean);
 extern void losestr(int, const char *, schar);
+extern void poison_strdmg(int, int, const char *, schar);
 extern void poisontell(int, boolean);
 extern void poisoned(const char *, int, const char *, int, boolean);
 extern void change_luck(schar);

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -222,7 +222,7 @@ losestr(int num, const char *knam, schar k_format)
         k_format = KILLED_BY;
     }
 
-    while (ustr < 3) {
+    while (ustr < ATTRMIN(A_STR)) {
         ++ustr;
         --num;
         losehp(6, knam, k_format);

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -241,6 +241,14 @@ losestr(int num, const char *knam, schar k_format)
     (void) adjattrib(A_STR, -num, 1);
 }
 
+/* combined strength loss and damage from some poisons */
+void
+poison_strdmg(int strloss, int dmg, const char *knam, schar k_format)
+{
+    losestr(strloss, knam, k_format);
+    losehp(dmg, knam, k_format);
+}
+
 static const struct poison_effect_message {
     void (*delivery_func)(const char *, ...);
     const char *effect_msg;

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -211,19 +211,24 @@ gainstr(struct obj *otmp, int incr, boolean givemsg)
 
 /* may kill you; cause may be poison or monster like 'a' */
 void
-losestr(int num)
+losestr(int num, const char *knam, schar k_format)
 {
     int uhpmin = minuhpmax(1), olduhpmax = u.uhpmax;
     int ustr = ABASE(A_STR) - num;
 
+    /* in case HP loss kills the hero once Str hits the minimum */
+    if (!knam || !*knam) {
+        knam = "terminal frailty";
+        k_format = KILLED_BY;
+    }
+
     while (ustr < 3) {
         ++ustr;
         --num;
+        losehp(6, knam, k_format);
         if (Upolyd) {
-            u.mh -= 6;
             u.mhmax -= 6;
         } else {
-            u.uhp -= 6;
             setuhpmax(u.uhpmax - 6);
         }
         g.context.botl = TRUE;

--- a/src/eat.c
+++ b/src/eat.c
@@ -1815,9 +1815,9 @@ eatcorpse(struct obj *otmp)
         tp++;
         pline("Ecch - that must have been poisonous!");
         if (!Poison_resistance) {
-            losestr(rnd(4));
-            losehp(rnd(15), !glob ? "poisonous corpse" : "poisonous glob",
-                   KILLED_BY_AN);
+            const char *knam = !glob ? "poisonous corpse" : "poisonous glob";
+            losestr(rnd(4), knam, KILLED_BY_AN);
+            losehp(rnd(15), knam, KILLED_BY_AN);
         } else
             You("seem unaffected by the poison.");
 
@@ -2753,8 +2753,9 @@ doeat(void)
         if (otmp->oclass == WEAPON_CLASS && otmp->opoisoned) {
             pline("Ecch - that must have been poisonous!");
             if (!Poison_resistance) {
-                losestr(rnd(4));
-                losehp(rnd(15), xname(otmp), KILLED_BY_AN);
+                const char *knam = xname(otmp);
+                losestr(rnd(4), knam, KILLED_BY_AN);
+                losehp(rnd(15), knam, KILLED_BY_AN);
             } else
                 You("seem unaffected by the poison.");
         } else if (!nodelicious) {

--- a/src/eat.c
+++ b/src/eat.c
@@ -1815,9 +1815,9 @@ eatcorpse(struct obj *otmp)
         tp++;
         pline("Ecch - that must have been poisonous!");
         if (!Poison_resistance) {
-            const char *knam = !glob ? "poisonous corpse" : "poisonous glob";
-            losestr(rnd(4), knam, KILLED_BY_AN);
-            losehp(rnd(15), knam, KILLED_BY_AN);
+            poison_strdmg(rnd(4), rnd(15),
+                          !glob ? "poisonous corpse" : "poisonous glob",
+                          KILLED_BY_AN);
         } else
             You("seem unaffected by the poison.");
 
@@ -2753,9 +2753,7 @@ doeat(void)
         if (otmp->oclass == WEAPON_CLASS && otmp->opoisoned) {
             pline("Ecch - that must have been poisonous!");
             if (!Poison_resistance) {
-                const char *knam = xname(otmp);
-                losestr(rnd(4), knam, KILLED_BY_AN);
-                losehp(rnd(15), knam, KILLED_BY_AN);
+                poison_strdmg(rnd(4), rnd(15), xname(otmp), KILLED_BY_AN);
             } else
                 You("seem unaffected by the poison.");
         } else if (!nodelicious) {

--- a/src/fountain.c
+++ b/src/fountain.c
@@ -292,7 +292,7 @@ drinkfountain(void)
                 losehp(rnd(4), "unrefrigerated sip of juice", KILLED_BY_AN);
                 break;
             }
-            losestr(rn1(4, 3));
+            losestr(rn1(4, 3), "contaminated water", KILLED_BY);
             losehp(rnd(10), "contaminated water", KILLED_BY);
             exercise(A_CON, FALSE);
             break;

--- a/src/fountain.c
+++ b/src/fountain.c
@@ -292,8 +292,8 @@ drinkfountain(void)
                 losehp(rnd(4), "unrefrigerated sip of juice", KILLED_BY_AN);
                 break;
             }
-            losestr(rn1(4, 3), "contaminated water", KILLED_BY);
-            losehp(rnd(10), "contaminated water", KILLED_BY);
+            poison_strdmg(rn1(4, 3), rnd(10), "contaminated water",
+                          KILLED_BY);
             exercise(A_CON, FALSE);
             break;
         case 22: /* Fountain of snakes! */

--- a/src/hack.c
+++ b/src/hack.c
@@ -3646,7 +3646,7 @@ maybe_wail(void)
 }
 
 void
-losehp(int n, const char *knam, boolean k_format)
+losehp(int n, const char *knam, schar k_format)
 {
 #if 0   /* code below is prepared to handle negative 'loss' so don't add this
          * until we've verified that no callers intentionally rely on that */

--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -465,11 +465,7 @@ cast_wizard_spell(struct monst *mtmp, int dmg, int spellnum)
             dmg = mtmp->m_lev - 6;
             if (Half_spell_damage)
                 dmg = (dmg + 1) / 2;
-            losestr(rnd(dmg));
-            if (u.uhp < 1)
-                done_in_by(mtmp, DIED);
-            else if (Upolyd && u.mh < 1)
-                rehumanize();
+            losestr(rnd(dmg), (const char *) 0, 0);
         }
         dmg = 0;
         break;

--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -468,6 +468,8 @@ cast_wizard_spell(struct monst *mtmp, int dmg, int spellnum)
             losestr(rnd(dmg));
             if (u.uhp < 1)
                 done_in_by(mtmp, DIED);
+            else if (Upolyd && u.mh < 1)
+                rehumanize();
         }
         dmg = 0;
         break;

--- a/src/spell.c
+++ b/src/spell.c
@@ -152,7 +152,8 @@ cursed_book(struct obj* bp)
         /* temp disable in_use; death should not destroy the book */
         was_in_use = bp->in_use;
         bp->in_use = FALSE;
-        losestr(Poison_resistance ? rn1(2, 1) : rn1(4, 3));
+        losestr(Poison_resistance ? rn1(2, 1) : rn1(4, 3),
+                "contact-poisoned spellbook", KILLED_BY_AN);
         losehp(rnd(Poison_resistance ? 6 : 10), "contact-poisoned spellbook",
                KILLED_BY_AN);
         bp->in_use = was_in_use;

--- a/src/spell.c
+++ b/src/spell.c
@@ -152,10 +152,9 @@ cursed_book(struct obj* bp)
         /* temp disable in_use; death should not destroy the book */
         was_in_use = bp->in_use;
         bp->in_use = FALSE;
-        losestr(Poison_resistance ? rn1(2, 1) : rn1(4, 3),
-                "contact-poisoned spellbook", KILLED_BY_AN);
-        losehp(rnd(Poison_resistance ? 6 : 10), "contact-poisoned spellbook",
-               KILLED_BY_AN);
+        poison_strdmg(Poison_resistance ? rn1(2, 1) : rn1(4, 3),
+                      rnd(Poison_resistance ? 6 : 10),
+                      "contact-poisoned spellbook", KILLED_BY_AN);
         bp->in_use = was_in_use;
         break;
     case 6:


### PR DESCRIPTION
losestr can subtract HP, but doesn't directly kill its target.  The
caller is responsible for possibly killing the hero if losestr reduces
her HP to 0 or lower; most callers do this by combining losestr with a
losehp call, which can kill off the hero if necessary.

MGC_WEAKEN_YOU calls done_in_by if u.uhp < 1 after losestr, but didn't
handle the Upolyd u.mh case, so could leave a polymorphed hero with
negative health.

The simple fix to this is in the first commit (I don't think the second 
would do any harm, either), and it may be that is really all that's 
wanted/needed.  The ones after that ended up turning into another 
approach which I think is more robust in some ways, but also has some 
downsides.  It moves the responsibility of handling death/rehumanization 
from the caller to losestr, so reduces the potential for error there, 
but messes somewhat with how death from the 'weaken target' spell 
works/is described.