### PR TITLE
Don't repeatedly print "skates!" during ice travel

### DIFF
--- a/src/hack.c
+++ b/src/hack.c
@@ -2065,7 +2065,6 @@ slippery_ice_fumbling(void)
             || resists_cold(&g.youmonst) || Flying
             || is_floater(g.youmonst.data) || is_clinger(g.youmonst.data)
             || is_whirly(g.youmonst.data)) {
-            pline("skates!");
             on_ice = FALSE;
         } else if (!rn2(Cold_resistance ? 3 : 2)) {
             HFumbling |= FROMOUTSIDE;


### PR DESCRIPTION
This is presumably a debug pline that got left in by mistake.  It would
print repeatedly when a Valkyrie tried to travel over ice (e.g. in her
quest), or other circumstances in which the hero was considered to
be 'wearing skates' on ice.
