### PR TITLE
Make #attributes gold info match #showgold

### DIFF
--- a/src/insight.c
+++ b/src/insight.c
@@ -716,18 +716,25 @@ basics_enlightenment(int mode UNUSED, int final)
                 (u.uac < 0) ? "best" : "worst");
     enl_msg("Your armor class ", "is ", "was ", buf, "");
 
-    /* gold; similar to doprgold(#seegold) but without shop billing info;
-       same amount as shown on status line which ignores container contents */
+    /* gold; similar to doprgold (#showgold) but without shop billing info;
+       includes container contents, unlike status line but like doprgold */
     {
-        static const char Your_wallet[] = "Your wallet ";
-        long umoney = money_cnt(g.invent);
+        long umoney = money_cnt(g.invent), hmoney = hidden_gold(final);
 
         if (!umoney) {
-            enl_msg(Your_wallet, "is ", "was ", "empty", "");
+            Sprintf(buf, " Your wallet %s empty", !final ? "is" : "was");
         } else {
-            Sprintf(buf, "%ld %s", umoney, currency(umoney));
-            enl_msg(Your_wallet, "contains ", "contained ", buf, "");
+            Sprintf(buf, " Your wallet contain%s %ld %s", !final ? "s" : "ed",
+                    umoney, currency(umoney));
         }
+        if (hmoney) {
+            Sprintf(eos(buf),
+                    ", %s you %s %ld %s stashed away in your pack",
+                    umoney ? "and" : "but", !final ? "have" : "had",
+                    hmoney, umoney ? "more" : currency(hmoney));
+        }
+        Strcat(buf, ".");
+        enlght_out(buf);
     }
 
     if (flags.pickup) {

--- a/src/insight.c
+++ b/src/insight.c
@@ -727,14 +727,15 @@ basics_enlightenment(int mode UNUSED, int final)
             Sprintf(buf, " Your wallet contain%s %ld %s", !final ? "s" : "ed",
                     umoney, currency(umoney));
         }
-        if (hmoney) {
-            Sprintf(eos(buf),
-                    ", %s you %s %ld %s stashed away in your pack",
-                    umoney ? "and" : "but", !final ? "have" : "had",
-                    hmoney, umoney ? "more" : currency(hmoney));
-        }
-        Strcat(buf, ".");
+        Strcat(buf, hmoney ? "," : ".");
         enlght_out(buf);
+
+        if (hmoney) {
+            Sprintf(buf, "%ld %s stashed away in your pack",
+                    hmoney, umoney ? "more" : currency(hmoney));
+            enl_msg(umoney ? "and you " : "but you ", "have ", "had ", buf,
+                    "");
+        }
     }
 
     if (flags.pickup) {

--- a/src/invent.c
+++ b/src/invent.c
@@ -4496,20 +4496,21 @@ doprgold(void)
     long hmoney = hidden_gold(FALSE);
 
     if (Verbose(1, doprgold)) {
-        if (!umoney && !hmoney)
-            Your("wallet is empty.");
-        else if (umoney && !hmoney)
-            Your("wallet contains %ld %s.", umoney, currency(umoney));
-        else if (!umoney && hmoney)
-            Your("wallet is empty, but there %s %ld %s stashed away in "
-                 "your pack.",
-                 (hmoney == 1) ?  "is" : "are",
-                 hmoney, currency(hmoney));
-        else if (umoney && hmoney)
-            Your("wallet contains %ld %s, and there %s %ld more stashed "
-                 "away in your pack.", umoney, currency(umoney),
-                 (hmoney == 1) ? "is" : "are",
-                 hmoney);
+        char buf[BUFSZ];
+
+        if (!umoney) {
+            Strcpy(buf, "Your wallet is empty");
+        } else {
+            Sprintf(buf, "Your wallet contains %ld %s",
+                    umoney, currency(umoney));
+        }
+        if (hmoney) {
+            Sprintf(eos(buf),
+                    ", %s you have %ld %s stashed away in your pack",
+                    umoney ? "and" : "but", hmoney,
+                    umoney ? "more" : currency(hmoney));
+        }
+        pline("%s.", buf);
     } else {
         long total = umoney + hmoney;
         if (total)


### PR DESCRIPTION
The #showgold command now mentions (known) gold socked away in
containers in your inventory as of 706b1a9.  Since the gold info in the
attributes display and dumplog matches the output of #showgold
otherwise\*, update it to do the same thing.  Also refactored doprgold a
bit to be a little more compact, as opposed to enumerating all the
different combinations of gold/no gold in open inventory/containers.
This eliminated some string constants that were broken up into multiple
constants/lines (like "line 1 " "line 2"), which NetHack code style
seems to prefer to avoid.

Maybe there's a reason this is not wanted in #attributes, but since it 
acts basically like a version of the statusline info with additional 
supplementary information, it doesn't seem too out of place to me (that 
seems to be a model used by other #attributes lines as well).  And it 
does match the new and improved #showgold, too.

\* Other than shop billing info.

