### PR TITLE
Avoid null dereference in VESA initialization

### DIFF
--- a/sys/msdos/vidvesa.c
+++ b/sys/msdos/vidvesa.c
@@ -1047,7 +1047,7 @@ vesa_Init(void)
 
     vesa_mode = 0xFFFF; /* might want an 8 bit mode after loading tiles */
     vesa_detect();
-    if (vesa_mode == 0xFFFF) {
+    if (vesa_mode == 0xFFFF || (vesa_pixel_size == 8 && get_palette() == NULL)) {
         raw_printf("%s (%d)", "Reverting to TTY mode, no VESA mode available.",
                    tilefailure);
         wait_synch();


### PR DESCRIPTION
If the VESA mode chooses a mode with 8 bit pixels, but the tile set has too many colors for that, a null dereference can result when trying to set up the nonexistent palette. Catch this condition and refuse to set VESA mode instead.