### PR TITLE
Support Unicode on Win32

### DIFF
--- a/sys/windows/windsys.c
+++ b/sys/windows/windsys.c
@@ -543,10 +543,26 @@ winos_ascii_to_wide_str(const unsigned char * src, WCHAR * dst, size_t dstLength
     return dst;
 }
 
-WCHAR
-winos_ascii_to_wide(const unsigned char c)
+void
+winos_ascii_to_wide(WCHAR dst[3], UINT32 c)
 {
-    return cp437[c];
+#ifdef ENHANCED_SYMBOLS
+    if (SYMHANDLING(H_UTF8)) {
+        if (c <= 0xFFFF) {
+            dst[0] = (WCHAR) c;
+            dst[1] = L'\0';
+        } else {
+            /* UTF-16 surrogate pair */
+            dst[0] = (WCHAR) ((c >> 10) + 0xD7C0);
+            dst[1] = (WCHAR) ((c & 0x3FF) + 0xDC00);
+            dst[2] = L'\0';
+        }
+    } else
+#endif
+    {
+        dst[0] = cp437[c];
+        dst[1] = L'\0';
+    }
 }
 
 BOOL winos_font_support_cp437(HFONT hFont)

--- a/sys/windows/winos.h
+++ b/sys/windows/winos.h
@@ -12,8 +12,8 @@ extern const WCHAR cp437[256];
 WCHAR *
 winos_ascii_to_wide_str(const unsigned char * src, WCHAR * dst, size_t dstLength);
 
-WCHAR
-winos_ascii_to_wide(const unsigned char c);
+void
+winos_ascii_to_wide(WCHAR dst[3], UINT32 c);
 
 BOOL winos_font_support_cp437(HFONT hFont);
 

--- a/win/win32/mhmap.c
+++ b/win/win32/mhmap.c
@@ -765,6 +765,36 @@ onMSNHCommand(HWND hWnd, WPARAM wParam, LPARAM lParam)
         }
     } break;
 
+#ifdef ENHANCED_SYMBOLS
+    case MSNH_MSG_GETWIDETEXT: {
+        PMSNHMsgGetWideText msg_data = (PMSNHMsgGetWideText) lParam;
+        size_t index;
+        int col, row;
+
+        index = 0;
+        for (row = 0; row < ROWNO; row++) {
+            for (col = 0; col < COLNO; col++) {
+                glyph_info *glyphinfo;
+                uint32 ch;
+                if (index >= msg_data->max_size)
+                    break;
+                glyphinfo = &data->map[col][row];
+                if (glyphinfo->gm.u && glyphinfo->gm.u->utf8str) {
+                    ch = glyphinfo->gm.u->utf32ch;
+                } else {
+                    ch = glyphinfo->ttychar;
+                }
+                winos_ascii_to_wide(msg_data->buffer + index, ch);
+                index += wcslen(msg_data->buffer + index);
+            }
+            if (index >= msg_data->max_size - 1)
+                break;
+            msg_data->buffer[index++] = '\r';
+            msg_data->buffer[index++] = '\n';
+        }
+    } break;
+#endif
+
     case MSNH_MSG_RANDOM_INPUT:
         nhassert(0); // unexpected
         break;

--- a/win/win32/mhmap.c
+++ b/win/win32/mhmap.c
@@ -49,6 +49,7 @@ typedef struct mswin_nethack_map_window {
     POINT map_orig;             /* map origin point */
 
     HFONT hMapFont;             /* font for ASCII mode */
+    HFONT hMapFontUnicode;      /* font for Unicode mode */
     boolean bUnicodeFont;       /* font supports unicode page 437 */
 
     int tileWidth;              /* width of tile in pixels at 96 dpi */
@@ -251,6 +252,12 @@ mswin_map_layout(HWND hWnd, LPSIZE map_size)
         data->hMapFont = font;
 
         data->bUnicodeFont = winos_font_support_cp437(data->hMapFont);
+
+        // Same as above, but with ANSI_CHARSET for IBM and Unicode modes
+        lgfnt.lfCharSet = ANSI_CHARSET;
+        if (data->hMapFontUnicode)
+            DeleteObject(data->hMapFontUnicode);
+        data->hMapFontUnicode = CreateFontIndirect(&lgfnt);
 
         // set tile size to match font metrics
 
@@ -626,6 +633,8 @@ MapWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
     case WM_DESTROY:
         if (data->hMapFont)
             DeleteObject(data->hMapFont);
+        if (data->hMapFontUnicode)
+            DeleteObject(data->hMapFontUnicode);
         if (data->hBackBuffer)
             DeleteBitmap(data->hBackBuffer);
         if (data->backBufferDC)
@@ -911,9 +920,11 @@ paintGlyph(PNHMapWindow data, int i, int j, RECT * rect)
 {
     if (data->map[i][j].glyph >= 0) {
 
-        char ch;
-        WCHAR wch;
+        glyph_info *glyphinfo;
+        uint32 ch;
+        WCHAR wch[3];
         int color;
+        uint32 rgbcolor;
 //        unsigned special;
 //        int mgch;
         HBRUSH back_brush;
@@ -925,12 +936,23 @@ paintGlyph(PNHMapWindow data, int i, int j, RECT * rect)
         FillRect(data->backBufferDC, rect, blackBrush);
         DeleteObject(blackBrush);
 
-    #if (VERSION_MAJOR < 4) && (VERSION_MINOR < 4) && (PATCHLEVEL < 2)
-        nhglyph2charcolor(data->map[i][j], &ch, &color);
-        OldFg = SetTextColor(hDC, nhcolor_to_RGB(color));
-    #else
-        ch = (char) data->map[i][j].ttychar;
-        color = (int) data->map[i][j].gm.sym.color;
+        glyphinfo = &data->map[i][j];
+        ch = glyphinfo->ttychar;
+        color = (int) glyphinfo->gm.sym.color;
+        rgbcolor = nhcolor_to_RGB(color);
+#ifdef ENHANCED_SYMBOLS
+        if (SYMHANDLING(H_UTF8)
+            && glyphinfo->gm.u
+            && glyphinfo->gm.u->utf8str) {
+            ch = glyphinfo->gm.u->utf32ch;
+            if (glyphinfo->gm.u->ucolor != 0) {
+                rgbcolor = RGB(
+                        (glyphinfo->gm.u->ucolor >> 16) & 0xFF,
+                        (glyphinfo->gm.u->ucolor >>  8) & 0xFF,
+                        (glyphinfo->gm.u->ucolor >>  0) & 0xFF);
+            }
+        }
+#endif
         if (((data->map[i][j].gm.glyphflags & MG_PET) && iflags.hilite_pet)
             || ((data->map[i][j].gm.glyphflags & (MG_DETECT | MG_BW_LAVA))
                 && iflags.use_inverse)) {
@@ -946,21 +968,23 @@ paintGlyph(PNHMapWindow data, int i, int j, RECT * rect)
                 break;
             default:
                 OldFg =
-                    SetTextColor(data->backBufferDC, nhcolor_to_RGB(color));
+                    SetTextColor(data->backBufferDC, rgbcolor);
             }
         } else {
-            OldFg = SetTextColor(data->backBufferDC, nhcolor_to_RGB(color));
+            OldFg = SetTextColor(data->backBufferDC, rgbcolor);
         }
-    #endif
-        if (data->bUnicodeFont) {
-            wch = winos_ascii_to_wide(ch);
-            if (wch == 0x2591 || wch == 0x2592) {
+        if (data->bUnicodeFont || SYMHANDLING(H_UTF8)) {
+            winos_ascii_to_wide(wch, ch);
+            if (wch[0] == 0x2591 || wch[0] == 0x2592) {
                 int intensity = 80;
                 HBRUSH brush = CreateSolidBrush(RGB(intensity, intensity, intensity));
                 FillRect(data->backBufferDC, rect, brush);
                 DeleteObject(brush);
-                intensity = (wch == 0x2591 ? 100 : 200);
-                brush = CreateSolidBrush(RGB(intensity, intensity, intensity));
+                intensity = (wch[0] == 0x2591 ? 1 : 2);
+                brush = CreateSolidBrush(RGB(
+                            GetRValue(rgbcolor)*intensity/2,
+                            GetGValue(rgbcolor)*intensity/2,
+                            GetBValue(rgbcolor)*intensity/2));
                 RECT smallRect = {0};
                 smallRect.left = rect->left + 1;
                 smallRect.top = rect->top + 1;
@@ -969,12 +993,15 @@ paintGlyph(PNHMapWindow data, int i, int j, RECT * rect)
                 FillRect(data->backBufferDC, &smallRect, brush);
                 DeleteObject(brush);
             } else {
-                DrawTextW(data->backBufferDC, &wch, 1, rect,
+                SelectObject(data->backBufferDC, data->hMapFontUnicode);
+                DrawTextW(data->backBufferDC, wch, -1, rect,
                     DT_CENTER | DT_VCENTER | DT_NOPREFIX
                     | DT_SINGLELINE);
             }
         } else {
-            DrawTextA(data->backBufferDC, &ch, 1, rect,
+            char ch8 = (char) ch;
+            SelectObject(data->backBufferDC, data->hMapFont);
+            DrawTextA(data->backBufferDC, &ch8, 1, rect,
                         DT_CENTER | DT_VCENTER | DT_NOPREFIX
                             | DT_SINGLELINE);
         }

--- a/win/win32/mhmsg.h
+++ b/win/win32/mhmsg.h
@@ -22,6 +22,9 @@
 #define MSNH_MSG_GETTEXT 111
 #define MSNH_MSG_UPDATE_STATUS 112
 #define MSNH_MSG_RANDOM_INPUT 113
+#ifdef ENHANCED_SYMBOLS
+#define MSNH_MSG_GETWIDETEXT 114
+#endif
 
 typedef struct mswin_nhmsg_add_wnd {
     winid wid;
@@ -70,6 +73,13 @@ typedef struct mswin_nhmsg_get_text {
     size_t max_size;
     char buffer[TEXT_BUFFER_SIZE];
 } MSNHMsgGetText, *PMSNHMsgGetText;
+
+#ifdef ENHANCED_SYMBOLS
+typedef struct mswin_nhmsg_get_wide_text {
+    size_t max_size;
+    WCHAR buffer[TEXT_BUFFER_SIZE];
+} MSNHMsgGetWideText, *PMSNHMsgGetWideText;
+#endif
 
 typedef struct mswin_nhmsg_update_status {
     struct mswin_status_lines * status_lines;

--- a/win/win32/mhstatus.c
+++ b/win/win32/mhstatus.c
@@ -199,15 +199,17 @@ StatusWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
             size_t space_remaining = msg_data->max_size;
 
             for (int line = 0; line < NHSW_LINES; line++) {
-                mswin_status_line *status_line = data->status_lines[line].lines;
+                mswin_status_line *status_line = &data->status_lines->lines[line];
                 for (int i = 0; i < status_line->status_strings.count; i++) {
                     mswin_status_string * status_string = status_line->status_strings.status_strings[i];
-                    if (status_string->space_in_front) {
-                        strncat(msg_data->buffer, " ", space_remaining);
+                    if (status_string->str != NULL) {
+                        if (status_string->space_in_front) {
+                            strncat(msg_data->buffer, " ", space_remaining);
+                            space_remaining = msg_data->max_size - strlen(msg_data->buffer);
+                        }
+                        strncat(msg_data->buffer, status_string->str, space_remaining);
                         space_remaining = msg_data->max_size - strlen(msg_data->buffer);
                     }
-                    strncat(msg_data->buffer, status_string->str, space_remaining);
-                    space_remaining = msg_data->max_size - strlen(msg_data->buffer);
                 }
                 strncat(msg_data->buffer, "\r\n", space_remaining);
                 space_remaining = msg_data->max_size - strlen(msg_data->buffer);

--- a/win/win32/mswproc.c
+++ b/win/win32/mswproc.c
@@ -91,6 +91,9 @@ struct window_procs mswin_procs = {
 #ifdef STATUS_HILITES
     WC2_HITPOINTBAR | WC2_FLUSH_STATUS | WC2_RESET_STATUS | WC2_HILITE_STATUS |
 #endif
+#ifdef ENHANCED_SYMBOLS
+     WC2_U_UTF8STR | WC2_U_24BITCOLOR |
+#endif
     0L,
     {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},   /* color availability */
     mswin_init_nhwindows, mswin_player_selection, mswin_askname,


### PR DESCRIPTION
This change adds Unicode support, with colors, to the Win32 port. It supports copying Unicode to the clipboard and saving it to a file.

While testing the clipboard support, I found some crashes. This change fixes the crashes.