### PR TITLE
Rename update_mon_intrinsics to ...extrinsics

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -3359,7 +3359,7 @@ extern struct obj *wearmask_to_obj(long);
 extern long wearslot(struct obj *);
 extern void mon_set_minvis(struct monst *);
 extern void mon_adjust_speed(struct monst *, int, struct obj *);
-extern void update_mon_intrinsics(struct monst *, struct obj *, boolean,
+extern void update_mon_extrinsics(struct monst *, struct obj *, boolean,
                                   boolean);
 extern int find_mac(struct monst *);
 extern void m_dowear(struct monst *, boolean);

--- a/src/steal.c
+++ b/src/steal.c
@@ -703,7 +703,7 @@ mdrop_obj(
        throws rider, possibly inflicting fatal damage and producing bones; this
        is why we had to call extract_from_minvent() with do_intrinsics=FALSE */
     if (!DEADMONSTER(mon) && unwornmask)
-        update_mon_intrinsics(mon, obj, FALSE, TRUE);
+        update_mon_extrinsics(mon, obj, FALSE, TRUE);
 }
 
 /* some monsters bypass the normal rules for moving between levels or

--- a/src/steed.c
+++ b/src/steed.c
@@ -147,7 +147,7 @@ put_saddle_on_mon(struct obj* saddle, struct monst* mtmp)
     mtmp->misc_worn_check |= W_SADDLE;
     saddle->owornmask = W_SADDLE;
     saddle->leashmon = mtmp->m_id;
-    update_mon_intrinsics(mtmp, saddle, TRUE, FALSE);
+    update_mon_extrinsics(mtmp, saddle, TRUE, FALSE);
 }
 
 /*** Riding the monster ***/

--- a/src/worn.c
+++ b/src/worn.c
@@ -345,10 +345,9 @@ mon_adjust_speed(struct monst *mon,
      ? (POISON_RES + ACID_RES - objects[(o)->otyp].oc_oprop)    \
      : 0)
 
-/* armor put on or taken off; might be magical variety
-   [TODO: rename to 'update_mon_extrinsics()' and change all callers...] */
+/* armor put on or taken off; might be magical variety */
 void
-update_mon_intrinsics(
+update_mon_extrinsics(
     struct monst *mon,
     struct obj *obj,   /* armor being worn or taken off */
     boolean on,
@@ -702,7 +701,7 @@ m_dowear_type(struct monst *mon, long flag, boolean creation,
             mon->mcanmove = 0;
     }
     if (old) {
-        update_mon_intrinsics(mon, old, FALSE, creation);
+        update_mon_extrinsics(mon, old, FALSE, creation);
 
         /* owornmask was cleared above but artifact_light() expects it */
         old->owornmask = oldmask;
@@ -732,7 +731,7 @@ m_dowear_type(struct monst *mon, long flag, boolean creation,
                 pline("%s is shining %s.", Something, adesc);
         }
     }
-    update_mon_intrinsics(mon, best, TRUE, creation);
+    update_mon_extrinsics(mon, best, TRUE, creation);
     /* if couldn't see it but now can, or vice versa, */
     if (!creation && (sawmon ^ canseemon(mon))) {
         if (mon->minvis && !See_invisible) {
@@ -1114,9 +1113,9 @@ void
 extract_from_minvent(
     struct monst *mon,
     struct obj *obj,
-    boolean do_intrinsics,  /* whether to call update_mon_intrinsics */
+    boolean do_extrinsics,  /* whether to call update_mon_extrinsics */
     boolean silently)       /* doesn't affect all possible messages,
-                             * just update_mon_intrinsics's */
+                             * just update_mon_extrinsics's */
 {
     long unwornmask = obj->owornmask;
 
@@ -1139,8 +1138,8 @@ extract_from_minvent(
     obj_extract_self(obj);
     obj->owornmask = 0L;
     if (unwornmask) {
-        if (!DEADMONSTER(mon) && do_intrinsics) {
-            update_mon_intrinsics(mon, obj, FALSE, silently);
+        if (!DEADMONSTER(mon) && do_extrinsics) {
+            update_mon_extrinsics(mon, obj, FALSE, silently);
         }
         mon->misc_worn_check &= ~unwornmask;
         /* give monster a chance to wear other equipment on its next


### PR DESCRIPTION
There was a TODO about this; not exactly a great challenge but it feels
like a worthwhile change since the name was misleading.  I also updated
the name of the do_intrinsics parameter of extract_from_minvent(worn.c),
since it was in a similar situation (and directly related, since it
controls whether to call update_mon_{in/ex}trinsics).
