### PR TITLE
Remove urace test from is_elf, etc, macros

### DIFF
--- a/include/mondata.h
+++ b/include/mondata.h
@@ -112,21 +112,11 @@
 #define is_shapeshifter(ptr) (((ptr)->mflags2 & M2_SHAPESHIFTER) != 0L)
 #define is_undead(ptr) (((ptr)->mflags2 & M2_UNDEAD) != 0L)
 #define is_were(ptr) (((ptr)->mflags2 & M2_WERE) != 0L)
-#define is_elf(ptr) ((((ptr)->mflags2 & M2_ELF) != 0L)     \
-                     || ((ptr) == g.youmonst.data &&       \
-                         !Upolyd && Race_if(PM_ELF)))
-#define is_dwarf(ptr) ((((ptr)->mflags2 & M2_DWARF) != 0L) \
-                     || ((ptr) == g.youmonst.data &&       \
-                         !Upolyd && Race_if(PM_DWARF)))
-#define is_gnome(ptr) ((((ptr)->mflags2 & M2_GNOME) != 0L) \
-                     || ((ptr) == g.youmonst.data &&       \
-                         !Upolyd && Race_if(PM_GNOME)))
-#define is_orc(ptr) ((((ptr)->mflags2 & M2_ORC) != 0L)     \
-                     || ((ptr) == g.youmonst.data &&       \
-                         !Upolyd && Race_if(PM_ORC)))
-#define is_human(ptr) ((((ptr)->mflags2 & M2_HUMAN) != 0L) \
-                     || ((ptr) == g.youmonst.data &&       \
-                         !Upolyd && Race_if(PM_HUMAN)))
+#define is_elf(ptr) (((ptr)->mflags2 & M2_ELF) != 0L)
+#define is_dwarf(ptr) (((ptr)->mflags2 & M2_DWARF) != 0L)
+#define is_gnome(ptr) (((ptr)->mflags2 & M2_GNOME) != 0L)
+#define is_orc(ptr) (((ptr)->mflags2 & M2_ORC) != 0L)
+#define is_human(ptr) (((ptr)->mflags2 & M2_HUMAN) != 0L)
 #define your_race(ptr) (((ptr)->mflags2 & g.urace.selfmask) != 0L)
 #define is_bat(ptr)                                         \
     ((ptr) == &mons[PM_BAT] || (ptr) == &mons[PM_GIANT_BAT] \

--- a/src/shk.c
+++ b/src/shk.c
@@ -2761,12 +2761,12 @@ append_honorific(char *buf)
     Strcat(buf, honored[rn2(SIZE(honored) - 1) + u.uevent.udemigod]);
     if (is_vampire(g.youmonst.data))
         Strcat(buf, (flags.female) ? " dark lady" : " dark lord");
-    else if (is_elf(g.youmonst.data))
+    else if (maybe_polyd(is_elf(g.youmonst.data), Race_if(PM_ELF)))
         Strcat(buf, (flags.female) ? " hiril" : " hir");
     else
         Strcat(buf, !is_human(g.youmonst.data) ? " creature"
-                                             : (flags.female) ? " lady"
-                                                              : " sir");
+                      : (flags.female) ? " lady"
+                        : " sir");
 }
 
 void


### PR DESCRIPTION
Reverts 690e072, which changed the various is_foo macros from this:

```c
#define is_elf(ptr) ((((ptr)->mflags2 & M2_ELF) != 0L)
```

to this:

```c
#define is_elf(ptr) ((((ptr)->mflags2 & M2_ELF) != 0L)     \
                     || ((ptr) == g.youmonst.data &&       \
                         !Upolyd && Race_if(PM_ELF)))
```

This is a problem because g.youmonst.data is not unique to the hero:
the '(ptr) == g.youmonst.data' test will also be true of all player
monsters of the same role.  For this reason, any of those player
monsters will be treated as sharing the hero's race, producing strange
results.  For example, if the player is an elven ranger, any ranger
player monster generated will be considered 'elven' too (so will get a
to-hit bonus when attacking orcs, etc) -- but only while the hero is
unpolymorphed.

There are already other ways of checking the hero's race in addition to
her current polyform, most notably the maybe_polyd() macro.  maybe_polyd
or something similar is already used in nearly all the cases where the
hero's race is being evaluated, meaning Race_if gets used instead when
the hero is in her natural form.  So I think the check of the hero's
race in is_foo had very little effect except for the unintended
side-effects on player monsters.

In reviewing all the uses of is_{elf,dwarf,gnome,orc,human}, I noticed
only one case that relied on the hero-race-checking behavior.  That has
been changed in this commit to use maybe_polyd (there's another 'raw'
is_human(g.youmonst.data) a few lines down, but it doesn't need
maybe_polyd since it already distinguishes between 'hero in nonhuman
polyform' vs 'nonpolyd or human polyform').  same_race(mondata.c) is
another case where &g.youmonst.data can be passed to is_foo, but
everywhere that calls it for the hero also calls your_race() or
same_race(&mons[Race_switch]) to handle the racial case.
