### PR TITLE
Update Guidebook #showgold info

### DIFF
--- a/doc/Guidebook.mn
+++ b/doc/Guidebook.mn
@@ -1560,9 +1560,9 @@ configuration file.
 Use the shell command \(oq\f(CRexit\fP\(cq to return to the game.
 Default key is \(oq!\(cq.
 .lp "#showgold"
-Report the gold in your inventory and if you are inside a shop,
-report any credit or debt you have in that shop.
-Does not report on any gold inside containers you're carrying.
+Report the gold in your inventory, including gold you know about in
+containers you're carrying.  If you are inside a shop, report any credit
+or debt you have in that shop.
 Default key is \(oq$\(cq.
 .lp #showspells
 List and reorder known spells.
@@ -2112,9 +2112,8 @@ where it was obtained; other shopkeepers won't honor it.
 find a \(lqcredit card\(rq in the dungeon, don't bother trying to use it in
 shops; shopkeepers will not accept it.)
 .pg
-The \(oq$\(cq command, which reports the amount of gold you are carrying
-(in inventory, not inside bags or boxes), will also show current shop
-debt or credit, if any.
+The \(oq$\(cq command, which reports the amount of gold you are carrying,
+will also show current shop debt or credit, if any.
 The \(lqIu\(rq command lists unpaid items
 (those which still belong to the shop) if you are carrying any.
 The \(lqIx\(rq command shows an inventory-like display of any unpaid

--- a/doc/Guidebook.tex
+++ b/doc/Guidebook.tex
@@ -1130,7 +1130,7 @@ via the ``{\tt \#twoweapon}'' extended command.\\
 %.lp ""
 (In versions prior to 3.6 this keystroke ran the command to switch from normal
 play to ``explore mode'', also known as ``discovery mode'', which has now
-been moved to ``{\tt \#exploremode}'' and M-X.)
+been moved to ``{\tt \#exploremode}'' and {\tt M-X}.)
 %.lp
 \item[\tb{\^{}X}]
 Display basic information about your character.\\
@@ -1679,9 +1679,9 @@ Use the shell command `{\tt exit}' to return to the game.
 Default key is `{\tt !}'.
 %.lp
 \item[\tb{\#showgold}]
-Report the gold in your inventory and if you are inside a shop,
-report any credit or debt you have in that shop.
-Does not report on any gold inside containers you're carrying.
+Report the gold in your inventory, including gold you know about in
+containers you're carrying.  If you are inside a shop, report any credit
+or debt you have in that shop.
 Default key is `{\tt \$}'.
 %.lp
 \item[\tb{\#showspells}]
@@ -2311,12 +2311,12 @@ find a ``credit card'' in the dungeon, don't bother trying to use it in
 shops; shopkeepers will not accept it.)
 
 %.pg
-The {\tt \$} command, which reports the amount of gold you are carrying
-(in inventory, not inside bags or boxes), will also show current shop
-debt or credit, if any.  The {\tt Iu} command lists unpaid items
-(those which still belong to the shop) if you are carrying any.
-The {\tt Ix} command shows an inventory-like display of any unpaid
-items which have been used up, along with other shop fees, if any.
+The {\tt \$} command, which reports the amount of gold you are carrying,
+will also show current shop debt or credit, if any.
+The {\tt Iu} command lists unpaid items (those which still belong to the
+shop) if you are carrying any.
+The {\tt Ix} command shows an inventory-like display of any unpaid items
+which have been used up, along with other shop fees, if any.
 
 %.hn 3
 \subsubsection*{Shop idiosyncrasies}


### PR DESCRIPTION
The #showgold command now does mention known contained gold in your
inventory, so the various lines in the Guidebook which explicitly state
that it doesn't needed to be updated.  Wish I had noticed this in time
to put it into the previous Guidebook patch I submitted, but what can
you do.
