### PR TITLE
Use idPressed signal for Qt 6

### DIFF
--- a/win/Qt/qt_main.cpp
+++ b/win/Qt/qt_main.cpp
@@ -829,8 +829,13 @@ NetHackQtMainWindow::NetHackQtMainWindow(NetHackQtKeyBuffer& ks) :
     // order changed: was Again, Get, Kick, Throw, Fire, Drop, Eat, Rest
     //                now Again, PickUp, Drop, Kick, Throw, Fire, Eat, Rest
     QSignalMapper* sm = new QSignalMapper(this);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    connect(sm, SIGNAL(mappedString(const QString&)),
+            this, SLOT(doKeys(const QString&)));
+#else
     connect(sm, SIGNAL(mapped(const QString&)),
             this, SLOT(doKeys(const QString&)));
+#endif
     AddToolButton(toolbar, sm, "Again", do_repeat, QPixmap(again_xpm));
     // this used to be called "Get" which is confusing to experienced players
     AddToolButton(toolbar, sm, "Pick up", dopickup, QPixmap(pickup_xpm));

--- a/win/Qt/qt_svsel.cpp
+++ b/win/Qt/qt_svsel.cpp
@@ -99,7 +99,11 @@ QLayout: Attempting to add QLayout "" to QDialog "", which already has a layout
     QGroupBox *box = new QGroupBox("Saved Characters", this);
     QVBoxLayout *bgl = new QVBoxLayout();
     QButtonGroup *bg = new QButtonGroup();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    connect(bg, SIGNAL(idPressed(int)), this, SLOT(done(int)));
+#else
     connect(bg, SIGNAL(buttonPressed(int)), this, SLOT(done(int)));
+#endif
     for (int i = 0; saved[i]; ++i) {
         QPushButton *b = new QPushButton(saved[i]);
         bgl->addWidget(b);

--- a/win/Qt/qt_xcmd.cpp
+++ b/win/Qt/qt_xcmd.cpp
@@ -335,7 +335,11 @@ NetHackQtExtCmdRequestor::NetHackQtExtCmdRequestor(QWidget *parent) :
         }
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    connect(group, SIGNAL(idPressed(int)), this, SLOT(Button(int)));
+#else
     connect(group, SIGNAL(buttonPressed(int)), this, SLOT(Button(int)));
+#endif
 
     bl->activate();
     xl->activate();


### PR DESCRIPTION
Qt 5.15 introduced the idPressed(int) signal and deprecated buttonPressed(int). buttonPressed(int) disappeared in Qt 6, with the result that dialog buttons don't work. This change uses idPressed(int) where it is available.