### PR TITLE
Some displacer beast swapping tweaks

### DIFF
--- a/src/hack.c
+++ b/src/hack.c
@@ -1906,7 +1906,7 @@ domove_fight_empty(coordxy x, coordxy y)
     /* specifying 'F' with no monster wastes a turn */
     if (g.context.forcefight
         /* remembered an 'I' && didn't use a move command */
-        || (glyph_is_invisible(glyph) && !g.context.nopick)) {
+        || (glyph_is_invisible(glyph) && !m_at(x, y) && !g.context.nopick)) {
         struct obj *boulder = 0;
         boolean explo = (Upolyd && attacktype(g.youmonst.data, AT_EXPL)),
                 solid = (off_edge || (!accessible(x, y)
@@ -2444,6 +2444,9 @@ domove_core(void)
     }
 
     if (displaceu && mtmp) {
+        boolean noticed_it = (canspotmon(mtmp) || glyph_is_invisible(glyph)
+                              || glyph_is_warning(glyph));
+
         remove_monster(u.ux, u.uy);
         place_monster(mtmp, u.ux0, u.uy0);
         newsym(u.ux, u.uy);
@@ -2451,7 +2454,10 @@ domove_core(void)
         /* monst still knows where hero is */
         mtmp->mux = u.ux, mtmp->muy = u.uy;
 
-        pline("%s swaps places with you...", Monnam(mtmp));
+        pline("%s swaps places with you...",
+              !noticed_it ? Something : Monnam(mtmp));
+        if (!canspotmon(mtmp))
+            map_invisible(u.ux0, u.uy0);
         /* monster chose to swap places; hero doesn't get any credit
            or blame if something bad happens to it */
         g.context.mon_moving = 1;


### PR DESCRIPTION
When fighting an unseen displacer beast mapped as an 'I' glyph on the
map, its typical ability to swap places with you was disabled and
replaced by it being treated like "thin air".  This was because
execution reaches domove_fight_empty when the target swaps places with
you.  Other than the displacement passive, this function is typically
only reached if there's no monster on the target square, so it prints
the "thin air" message and wastes a turn if you'd "expect" to attack
something (either because the player used an 'F' prefix, or because
there is an 'I' mapped on the destination square being moved into).

Hitting "thin air" seems like OK behavior for force-fighting a displacer
beast, since you are explicitly not trying to move into its spot (though
you could probably make an argument that the displacement should happen
even then, since it's the displacer beast initiating it), but the mon
being mapped as an 'I' doesn't seem like a good reason to disallow the
actual displacement from happening.

Don't treat an 'I' as "thin air" in domove_fight_empty if there's
actually a monster there, since it means there's a displacer beast
trying to swap places with you.

A couple other related changes: put an 'I' down on the map when an
unseen displacer beast swaps places with you, and use 'something' in the
'it swaps places with you' message when you didn't even realize there
was a monster there to begin with, so there's no context for the 'it' (I
used Some_Monnam at first, but the 'something' felt a little weird when
you were intentionally attacking an 'I' or warning glyph; this limits
the usage of 'something' further than Some_Monnam does).
