### PR TITLE
remove the code for embedding SCCS ID

### DIFF
--- a/util/makedefs.c
+++ b/util/makedefs.c
@@ -42,10 +42,6 @@
 #define rewind(fp) fseek((fp), 0L, SEEK_SET) /* guarantee a return value */
 #endif
 
-#if defined(UNIX) && !defined(LINT) && !defined(GCC_WARN)
-static const char SCCS_Id[] UNUSED = "@(#)makedefs.c\t3.7\t2020/01/18";
-#endif
-
 /* names of files to be generated */
 #define DATE_FILE "date.h"
 #define MONST_FILE "pm.h"


### PR DESCRIPTION
This code is for UNIXy build, but current UNIXy builds define GCC_WARN, so this is never used.

(After all, embedding SCCS ID itself is out of date.)