### PR TITLE
Use "delphi" as "oracle" levelport alias

### DIFF
--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -2017,6 +2017,9 @@ lev_by_name(const char *nam)
                 nam = " to Vlad's tower"; /* branch to... */
             else
                 nam = "valley";
+        } else if (!strcmpi(nam, "delphi")) {
+            /* Oracle says "welcome to Delphi" so recognize that name too */ 
+            nam = "oracle";
         }
 
         if ((slev = find_level(nam)) != 0)


### PR DESCRIPTION
Permit levelport by name to "delphi".  That is what the Oracle calls the
level (or at least her room) in-game, so it seems like a natural guess
for the name of the level.
