### PR TITLE
Make paralysis intefere with seduction attempts

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2657,6 +2657,7 @@ extern int num_spells(void);
 extern long somegold(long);
 extern void stealgold(struct monst *);
 extern void thiefdead(void);
+extern boolean unresponsive(void);
 extern void remove_worn_item(struct obj *, boolean);
 extern int steal(struct monst *, char *);
 extern int mpickobj(struct monst *, struct obj *);

--- a/src/mhitu.c
+++ b/src/mhitu.c
@@ -1797,7 +1797,7 @@ doseduce(struct monst *mon)
               mhe(mon), mon->mcan ? "severe " : "");
         return 0;
     }
-    if (unconscious()) {
+    if (unresponsive()) {
         pline("%s seems dismayed at your lack of response.", Monnam(mon));
         return 0;
     }

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -1764,7 +1764,7 @@ steal_it(struct monst *mdef, struct attack *mattk)
 
     /* look for worn body armor */
     ustealo = (struct obj *) 0;
-    if (could_seduce(&gy.youmonst, mdef, mattk)) {
+    if (could_seduce(&gy.youmonst, mdef, mattk) && mdef->mcanmove) {
         /* find armor, and move it to end of inventory in the process */
         minvent_ptr = &mdef->minvent;
         while ((otmp = *minvent_ptr) != 0)


### PR DESCRIPTION
tinklebear on IRC noticed that a hero paralyzed by a floating eye was
still "charmed" and capable of "removing her armor" as part of a nymph's
theft attack.  The same thing was true of foocubus seduction: a
paralyzed hero was still able to respond to the questions about whether
particular pieces of armor should be removed (and also do whatever else
may be involved in a successful attack...).

I think paralysis should prevent both those things.  Nymph theft will
still work, unless she needs the hero's active cooperation in removing a
bulky piece of armor.  Foocubus attacks will be prevented entirely by
paralysis, making it interfere like unconsciousness already does.

Apply a similar constraint to hero vs monster seduction, as well.
