### PR TITLE
Old software compatibility

### DIFF
--- a/include/tradstdc.h
+++ b/include/tradstdc.h
@@ -401,6 +401,9 @@ typedef genericptr genericptr_t; /* (void *) or (char *) */
 #if (__GNUC__ >= 2) && !defined(USE_OLDARGS)
 #define PRINTF_F(f, v) __attribute__((format(printf, f, v)))
 #endif
+#if (__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1)
+#define PRINTF_F_PTR(f, v) PRINTF_F(f, v)
+#endif
 #if __GNUC__ >= 3
 #define UNUSED __attribute__((unused))
 #define NORETURN __attribute__((noreturn))
@@ -418,6 +421,9 @@ typedef genericptr genericptr_t; /* (void *) or (char *) */
 
 #ifndef PRINTF_F
 #define PRINTF_F(f, v)
+#endif
+#ifndef PRINTF_F_PTR
+#define PRINTF_F_PTR(f, v)
 #endif
 #ifndef UNUSED
 #define UNUSED

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -761,7 +761,7 @@ static const char dknowns[] = { WAND_CLASS,   RING_CLASS, POTION_CLASS,
 void
 clear_dknown(struct obj *obj)
 {
-    obj->dknown = index(dknowns, obj->oclass) ? 0 : 1;
+    obj->dknown = strchr(dknowns, obj->oclass) ? 0 : 1;
     if ((obj->otyp >= ELVEN_SHIELD && obj->otyp <= ORCISH_SHIELD)
         || obj->otyp == SHIELD_OF_REFLECTION
         || objects[obj->otyp].oc_merge)

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -761,7 +761,7 @@ static const char dknowns[] = { WAND_CLASS,   RING_CLASS, POTION_CLASS,
 void
 clear_dknown(struct obj *obj)
 {
-    obj->dknown = strchr(dknowns, obj->oclass) ? 0 : 1;
+    obj->dknown = index(dknowns, obj->oclass) ? 0 : 1;
     if ((obj->otyp >= ELVEN_SHIELD && obj->otyp <= ORCISH_SHIELD)
         || obj->otyp == SHIELD_OF_REFLECTION
         || objects[obj->otyp].oc_merge)
@@ -2107,7 +2107,7 @@ place_object(struct obj *otmp, coordxy x, coordxy y)
     register struct obj *otmp2;
 
     if (!isok(x, y)) { /* validate location */
-        void (*func)(const char *, ...) PRINTF_F(1, 2);
+        void (*func)(const char *, ...) PRINTF_F_PTR(1, 2);
 
         func = (x < 0 || y < 0 || x > COLNO - 1 || y > ROWNO - 1) ? panic
                : impossible;

--- a/src/vault.c
+++ b/src/vault.c
@@ -413,7 +413,7 @@ invault(void)
            otherwise the hero wouldn't be able to push one to follow the
            guard out of the vault because that guard would be in its way */
         if ((otmp = sobj_at(BOULDER, guard->mx, guard->my)) != 0) {
-            void (*func)(const char *, ...) PRINTF_F(1, 2);
+            void (*func)(const char *, ...) PRINTF_F_PTR(1, 2);
             const char *bname = simpleonames(otmp);
             int bcnt = 0;
 

--- a/win/X11/NetHack.ad
+++ b/win/X11/NetHack.ad
@@ -321,7 +321,7 @@ NetHack*map*orange:         orange
 NetHack*map*bright_green:   green
 NetHack*map*yellow:         yellow
 NetHack*map*bright_blue:    Royal blue
-NetHack*map*bright_magenta: Fuchsia
+NetHack*map*bright_magenta: magenta
 NetHack*map*bright_cyan:    cyan
 NetHack*map*white:          white
 !

--- a/win/X11/winmenu.c
+++ b/win/X11/winmenu.c
@@ -12,6 +12,7 @@
 #define PRESERVE_NO_SYSV /* X11 include files may define SYSV */
 #endif
 
+#include <X11/Xlib.h>
 #include <X11/Xresource.h>
 #include <X11/Intrinsic.h>
 #include <X11/StringDefs.h>


### PR DESCRIPTION
* Don't use __attribute__((printf(...))) with function pointers unless GCC is at least 3.1. Older GCCs understand it with functions only.
* Older X servers don't understand "Fuchsia", causing impossibles. Use "magenta", which is the same as "Fuchsia" in the current Xorg.

This pushes back the minimum GCC version to 3.0. NetHack compiled with these changes works with XFree86 4.2.0 and possibly earlier versions as well.