### PR TITLE
remove GCC_WARN (again)

### DIFF
--- a/include/wincurs.h
+++ b/include/wincurs.h
@@ -58,10 +58,8 @@ typedef enum orient_type
     UNDEFINED
 } orient;
 
-#ifdef GCC_WARN
 int wprintw(WINDOW *, const char *, ...) PRINTF_F(2, 3);
 int mvwprintw(WINDOW *, int, int, const char *, ...) PRINTF_F(4, 5);
-#endif
 
 /* cursmain.c */
 

--- a/sys/unix/Makefile.src
+++ b/sys/unix/Makefile.src
@@ -91,7 +91,7 @@ SYSOBJ = $(TARGETPFX)ioctl.o $(TARGETPFX)unixmain.o $(TARGETPFX)unixtty.o \
 #
 #
 # if you're debugging and want gcc to check as much as possible, use:
-# CC = gcc -W -Wimplicit -Wreturn-type -Wunused -Wformat -Wswitch -Wshadow -Wcast-qual -Wwrite-strings -DGCC_WARN
+# CC = gcc -W -Wimplicit -Wreturn-type -Wunused -Wformat -Wswitch -Wshadow -Wcast-qual -Wwrite-strings
 
 # flags may have to be changed as required
 # flags for 286 Xenix:

--- a/sys/unix/hints/include/compiler.370
+++ b/sys/unix/hints/include/compiler.370
@@ -133,10 +133,6 @@ CCXXFLAGS+=-Wno-deprecated-declarations
 endif  # WANT_WIN_QT
 endif  # clang-specific ends here
 
-# enable some optional code in various NetHack source files
-CFLAGS+=-DGCC_WARN
-CCXXFLAGS+=-DGCC_WARN
-
 ifdef MAKEFILE_SRC
 ifdef WANT_WIN_QT
 # when switching from Qt5 to Qt6 or vice versa, any old .moc files will be

--- a/sys/unix/hints/include/cross-pre.370
+++ b/sys/unix/hints/include/cross-pre.370
@@ -159,8 +159,7 @@ MSDOS_TARGET_CFLAGS = -c -O -I../include -I../sys/msdos -I../win/share \
         -Wall -Wextra -Wno-missing-field-initializers -Wreturn-type -Wunused \
         -Wformat -Wswitch -Wshadow -Wwrite-strings \
 	-Wimplicit -Wimplicit-function-declaration -Wimplicit-int \
-	-Wmissing-parameter-type -Wold-style-definition -Wstrict-prototypes \
-	-DGCC_WARN
+	-Wmissing-parameter-type -Wold-style-definition -Wstrict-prototypes
 PDCINCL += -I$(PDCPORT)
 PDC_TARGET_CFLAGS = $(MSDOS_TARGET_CFLAGS) -Wno-unused-parameter \
 			-Wno-missing-prototypes
@@ -285,7 +284,6 @@ WASM_CFLAGS += -Wshadow
 WASM_CFLAGS += $(WINCFLAGS)   #WINCFLAGS set from multiw-2.370
 WASM_CFLAGS += -DSYSCF -DSYSCF_FILE=\"/sysconf\" -DSECURE
 WASM_CFLAGS += -g -I../include -DNOTPARMDECL
-WASM_CFLAGS += -DGCC_WARN
 # NetHack sources control
 WASM_CFLAGS += -DDLB
 WASM_CFLAGS += -DHACKDIR=\"$(HACKDIR)\"


### PR DESCRIPTION
Now, the only usage of GCC_WARN is for the guard of PRINTF_F in wincurs.h.
This guard can be removed safely, as PRINTF_F is already used unconditionally in extern.h.