### PR TITLE
Fix parsing of Unicode symsets

### DIFF
--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1155,7 +1155,7 @@ purge_custom_entries(enum graphics_sets which_set)
 {
     struct symset_customization *gdc = &g.sym_customizations[which_set];
     struct customization_detail *details = gdc->details, *next;
-    if (details) {
+    while (details) {
         next = details->next;
         if (gdc->custtype == custom_ureps) {
             if (details->content.urep.u.utf8str)

--- a/src/utf8map.c
+++ b/src/utf8map.c
@@ -65,7 +65,7 @@ to_custom_symset_entry_callback(int glyph, struct find_struct *findwhat)
                   (findwhat->color != 0L) ? findwhat->color : 0L);
 #endif
         add_custom_urep_entry(known_handling[H_UTF8], glyph,
-                              uval, utf8str, findwhat->color, UNICODESET);
+                              uval, utf8str, findwhat->color, g.symset_which_set);
     }
 }
 


### PR DESCRIPTION
At present, if the symbols file has two or more Unicode symsets, selecting any of them will import all settings from all Unicode symsets. This change makes Unicode symsets behave like other kinds: only the selected symset is imported.

It doesn't seem to work with the Rogue level. I guess that's a change for another day.

A use-after-free caused by shuffling gem appearances is also fixed.