### PR TITLE
Charge hero for making off with shop-owned boulder

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2481,6 +2481,7 @@ extern void shopper_financial_report(void);
 extern int inhishop(struct monst *);
 extern struct monst *shop_keeper(char);
 extern boolean tended_shop(struct mkroom *);
+struct bill_x *onbill(struct obj *, struct monst *, boolean);
 extern boolean is_unpaid(struct obj *);
 extern void delete_contents(struct obj *);
 extern void obfree(struct obj *, struct obj *);

--- a/src/do.c
+++ b/src/do.c
@@ -134,7 +134,7 @@ boulder_hits_pool(
 
         /* boulder is now gone */
         if (pushing)
-            delobj(otmp);
+            useupf(otmp, otmp->quan);
         else
             obfree(otmp, (struct obj *) 0);
         return TRUE;

--- a/src/shk.c
+++ b/src/shk.c
@@ -29,7 +29,6 @@ static const char the_contents_of[] = "the contents of ";
 static void append_honorific(char *);
 static long addupbill(struct monst *);
 static void pacify_shk(struct monst *, boolean);
-static struct bill_x *onbill(struct obj *, struct monst *, boolean);
 static struct monst *next_shkp(struct monst *, boolean);
 static long shop_debt(struct eshk *);
 static char *shk_owns(char *, struct obj *);
@@ -868,8 +867,8 @@ tended_shop(struct mkroom* sroom)
     return !mtmp ? FALSE : (boolean) inhishop(mtmp);
 }
 
-static struct bill_x *
-onbill(struct obj* obj, struct monst* shkp, boolean silent)
+struct bill_x *
+onbill(struct obj *obj, struct monst *shkp, boolean silent)
 {
     if (shkp) {
         register struct bill_x *bp = ESHK(shkp)->bill_p;


### PR DESCRIPTION
Pushing a shop-owned boulder out of the shop wouldn't charge the hero
anything.  If the hero pushes a shop-owned boulder out of the shop,
charge for it (and remove it from the bill if the hero then pushes it
back in).  Also tried to handle a couple other uncharged boulder "theft"
scenarios: pushing a boulder into lava or water, pushing it into a
trapdoor/hole, and pushing it into a level teleporter (various other
traps already charge for the boulder -- it was pretty inconsistent).

I externified onbill() for this, since relying on otmp->unpaid by itself
impossibles if you push a boulder through a gap in a wall between two
adjoining shops.
