### PR TITLE
'mdistu' macro and dry rattle message

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -47,15 +47,14 @@
           /* OR 2b. hero is using a telepathy inducing */  \
           /*        object and in range                */  \
           || (Unblind_telepat                              \
-              && (distu(mon->mx, mon->my) <= (BOLT_LIM * BOLT_LIM)))))
+              && (mdistu(mon) <= (BOLT_LIM * BOLT_LIM)))))
 
 /* organized to perform cheaper tests first;
    is_pool() vs is_pool_or_lava(): hero who is underwater can see adjacent
    lava, but presumeably any monster there is on top so not sensed */
 #define _sensemon(mon) \
-    (   (!u.uswallow || (mon) == u.ustuck)                                 \
-     && (!Underwater || (distu((mon)->mx, (mon)->my) <= 2                  \
-                         && is_pool((mon)->mx, (mon)->my)))                \
+    (   (!u.uswallow || (mon) == u.ustuck)                                   \
+     && (!Underwater || (mdistu(mon) <= 2 && is_pool((mon)->mx, (mon)->my))) \
      && (Detect_monsters || tp_sensemon(mon) || MATCH_WARN_OF_MON(mon))   )
 
 /*
@@ -63,7 +62,7 @@
  * vicinity, and a glyph representing the warning level is displayed.
  */
 #define _mon_warning(mon) \
-    (Warning && !(mon)->mpeaceful && (distu((mon)->mx, (mon)->my) < 100) \
+    (Warning && !(mon)->mpeaceful && (mdistu(mon) < 100)     \
      && (((int) ((mon)->m_lev / 4)) >= g.context.warnlevel))
 
 /*
@@ -149,7 +148,7 @@
      && ((cansee((mon)->mx, (mon)->my)                                  \
           && (See_invisible || Detect_monsters))                        \
          || (!Blind && (HTelepat & ~INTRINSIC)                          \
-             && distu((mon)->mx, (mon)->my) <= (BOLT_LIM * BOLT_LIM))))
+             && mdistu(mon) <= (BOLT_LIM * BOLT_LIM))))
 
 /*
  * is_safemon(mon)

--- a/include/hack.h
+++ b/include/hack.h
@@ -715,6 +715,8 @@ enum optset_restrictions {
 
 #define makeknown(x) discover_object((x), TRUE, TRUE)
 #define distu(xx, yy) dist2((int)(xx), (int)(yy), (int) u.ux, (int) u.uy)
+#define mdistu(mon) \
+    dist2((int) (mon)->mx, (int) (mon)->my, (int) u.ux, (int) u.uy)
 #define onlineu(xx, yy) online2((int)(xx), (int)(yy), (int) u.ux, (int) u.uy)
 
 #define rn1(x, y) (rn2(x) + (y))

--- a/src/apply.c
+++ b/src/apply.c
@@ -3288,8 +3288,7 @@ use_pole(struct obj *obj, boolean autohit)
     cc.y = u.uy;
     if (!find_poleable_mon(&cc, min_range, max_range) && hitm
         && !DEADMONSTER(hitm) && sensemon(hitm)
-        && distu(hitm->mx, hitm->my) <= max_range
-        && distu(hitm->mx, hitm->my) >= min_range) {
+        && mdistu(hitm) <= max_range && mdistu(hitm) >= min_range) {
         cc.x = hitm->mx;
         cc.y = hitm->my;
     }

--- a/src/do.c
+++ b/src/do.c
@@ -2035,7 +2035,7 @@ revive_corpse(struct obj *corpse)
                     pline("%s claws itself out of the ground!",
                           canspotmon(mtmp) ? Amonnam(mtmp) : Something);
                     newsym(mtmp->mx, mtmp->my);
-                } else if (distu(mtmp->mx, mtmp->my) < 5*5)
+                } else if (mdistu(mtmp) < 5*5)
                     You_hear("scratching noises.");
                 break;
             }

--- a/src/mhitm.c
+++ b/src/mhitm.c
@@ -26,7 +26,7 @@ static int passivemm(struct monst *, struct monst *, boolean, int,
 static void
 noises(register struct monst *magr, register struct attack *mattk)
 {
-    boolean farq = (distu(magr->mx, magr->my) > 15);
+    boolean farq = (mdistu(magr) > 15);
 
     if (!Deaf && (farq != g.far_noise || g.moves - g.noisetime > 10)) {
         g.far_noise = farq;

--- a/src/mhitu.c
+++ b/src/mhitu.c
@@ -404,7 +404,7 @@ mattacku(register struct monst *mtmp)
      *     excessively verbose miss feedback when monster can do multiple
      *     attacks and would miss the same wrong spot each time.)
      */
-    boolean ranged = (distu(mtmp->mx, mtmp->my) > 3),
+    boolean ranged = (mdistu(mtmp) > 3),
             range2 = !monnear(mtmp, mtmp->mux, mtmp->muy),
             foundyou = u_at(mtmp->mux, mtmp->muy),
             youseeit = canseemon(mtmp),
@@ -1606,7 +1606,7 @@ gazemu(struct monst *mtmp, struct attack *mattk)
         break;
     case AD_BLND:
         if (canseemon(mtmp) && !resists_blnd(&g.youmonst)
-            && distu(mtmp->mx, mtmp->my) <= BOLT_LIM * BOLT_LIM) {
+            && mdistu(mtmp) <= BOLT_LIM * BOLT_LIM) {
             if (cancelled) {
                 react = rn1(2, 2); /* "puzzled" || "dazzled" */
                 already = (mtmp->mcansee == 0);

--- a/src/mon.c
+++ b/src/mon.c
@@ -1053,7 +1053,7 @@ movemon_singlemon(struct monst *mtmp)
          *  have died if it returns 1.
          */
         if (cansee(mtmp->mx, mtmp->my)
-            && (distu(mtmp->mx, mtmp->my) <= BOLT_LIM * BOLT_LIM)
+            && (mdistu(mtmp) <= BOLT_LIM * BOLT_LIM)
             && fightm(mtmp))
             return FALSE; /* mon might have died */
     }
@@ -2988,7 +2988,7 @@ set_ustuck(struct monst *mtmp)
     if (iflags.sanity_check || iflags.debug_fuzzer) {
         if (mtmp && !next2u(mtmp->mx, mtmp->my))
             impossible("Sticking to %s at distu %d?",
-                       mon_nam(mtmp), distu(mtmp->mx, mtmp->my));
+                       mon_nam(mtmp), mdistu(mtmp));
     }
 
     g.context.botl = 1;
@@ -4212,7 +4212,7 @@ decide_to_shapeshift(struct monst *mon, int shiftflags)
             } else if (mon->data == &mons[PM_FOG_CLOUD]
                        && mon->mhp == mon->mhpmax && !rn2(4)
                        && (!canseemon(mon)
-                           || distu(mon->mx, mon->my) > BOLT_LIM * BOLT_LIM)) {
+                           || mdistu(mon) > BOLT_LIM * BOLT_LIM)) {
                 /* if a fog cloud, maybe change to wolf or vampire bat;
                    those are more likely to take damage--at least when
                    tame--and then switch back to vampire; they'll also
@@ -4234,7 +4234,7 @@ decide_to_shapeshift(struct monst *mon, int shiftflags)
         } else {
             if (mon->mhp >= 9 * mon->mhpmax / 10 && !rn2(6)
                 && (!canseemon(mon)
-                    || distu(mon->mx, mon->my) > BOLT_LIM * BOLT_LIM))
+                    || mdistu(mon) > BOLT_LIM * BOLT_LIM))
                 dochng = TRUE; /* 'ptr' stays Null */
         }
     }

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -33,8 +33,7 @@ mb_trapped(struct monst *mtmp, boolean canseeit)
             pline("KABOOM!!  You see a door explode.");
         else if (!Deaf)
             You_hear("a %s explosion.",
-                     (distu(mtmp->mx, mtmp->my) > 7 * 7) ? "distant"
-                                                         : "nearby");
+                     (mdistu(mtmp) > 7 * 7) ? "distant" : "nearby");
     }
     wake_nearto(mtmp->mx, mtmp->my, 7 * 7);
     mtmp->mstun = 1;
@@ -153,7 +152,7 @@ dochugw(
         /* monster is hostile and can attack (or hallu distorts knowledge) */
         && (Hallucination || (!mtmp->mpeaceful && !noattacks(mtmp->data)))
         /* it's close enough to be a threat */
-        && distu(mtmp->mx, mtmp->my) <= (BOLT_LIM + 1) * (BOLT_LIM + 1)
+        && mdistu(mtmp) <= (BOLT_LIM + 1) * (BOLT_LIM + 1)
         /* and either couldn't see it before, or it was too far away */
         && (!already_saw_mon || !couldsee(x, y)
             || distu(x, y) > (BOLT_LIM + 1) * (BOLT_LIM + 1))
@@ -257,7 +256,7 @@ disturb(register struct monst *mtmp)
      *  Aggravate or mon is (dog or human) or
      *      (1/7 and mon is not mimicing furniture or object)
      */
-    if (couldsee(mtmp->mx, mtmp->my) && distu(mtmp->mx, mtmp->my) <= 100
+    if (couldsee(mtmp->mx, mtmp->my) && mdistu(mtmp) <= 100
         && (!Stealth || (mtmp->data == &mons[PM_ETTIN] && rn2(10)))
         && (!(mtmp->data->mlet == S_NYMPH
               || mtmp->data == &mons[PM_JABBERWOCK]
@@ -477,7 +476,7 @@ mind_blast(register struct monst* mtmp)
 
     if (canseemon(mtmp))
         pline("%s concentrates.", Monnam(mtmp));
-    if (distu(mtmp->mx, mtmp->my) > BOLT_LIM * BOLT_LIM) {
+    if (mdistu(mtmp) > BOLT_LIM * BOLT_LIM) {
         You("sense a faint wave of psychic energy.");
         return;
     }

--- a/src/mthrowu.c
+++ b/src/mthrowu.c
@@ -826,9 +826,14 @@ spitmm(struct monst* mtmp, struct attack* mattk, struct monst* mtarg)
     struct obj *otmp;
 
     if (mtmp->mcan) {
-        if (!Deaf)
-            pline("A dry rattle comes from %s throat.",
-                  s_suffix(mon_nam(mtmp)));
+        if (!Deaf && distu(mtmp->mx, mtmp->my) < BOLT_LIM * BOLT_LIM) {
+            if (canspotmon(mtmp)) {
+                pline("A dry rattle comes from %s throat.",
+                      s_suffix(mon_nam(mtmp)));
+            } else {
+                You_hear("a dry rattle nearby.");
+            }
+        }
         return MM_MISS;
     }
     if (m_lined_up(mtarg, mtmp)) {

--- a/src/mthrowu.c
+++ b/src/mthrowu.c
@@ -826,7 +826,7 @@ spitmm(struct monst* mtmp, struct attack* mattk, struct monst* mtarg)
     struct obj *otmp;
 
     if (mtmp->mcan) {
-        if (!Deaf && distu(mtmp->mx, mtmp->my) < BOLT_LIM * BOLT_LIM) {
+        if (!Deaf && mdistu(mtmp) < BOLT_LIM * BOLT_LIM) {
             if (canspotmon(mtmp)) {
                 pline("A dry rattle comes from %s throat.",
                       s_suffix(mon_nam(mtmp)));

--- a/src/muse.c
+++ b/src/muse.c
@@ -133,7 +133,7 @@ precheck(struct monst* mon, struct obj* obj)
                            ? (BOLT_LIM + 1) : (BOLT_LIM - 3);
 
             You_hear("a zap and an explosion %s.",
-                     (distu(mon->mx, mon->my) <= range * range)
+                     (mdistu(mon) <= range * range)
                         ? "nearby" : "in the distance");
         }
         m_useup(mon, obj);
@@ -164,7 +164,7 @@ mzapwand(
         int range = couldsee(mtmp->mx, mtmp->my) /* 9 or 5 */
                        ? (BOLT_LIM + 1) : (BOLT_LIM - 3);
 
-        You_hear("a %s zap.", (distu(mtmp->mx, mtmp->my) <= range * range)
+        You_hear("a %s zap.", (mdistu(mtmp) <= range * range)
                                  ? "nearby" : "distant");
         unknow_object(otmp); /* hero loses info when unseen obj is used */
     } else if (self) {
@@ -192,8 +192,8 @@ mplayhorn(
                        ? (BOLT_LIM + 1) : (BOLT_LIM - 3);
 
         You_hear("a horn being played %s.",
-                 (distu(mtmp->mx, mtmp->my) <= range * range)
-                 ? "nearby" : "in the distance");
+                 (mdistu(mtmp) <= range * range)
+                    ? "nearby" : "in the distance");
         unknow_object(otmp); /* hero loses info when unseen obj is used */
     } else if (self) {
         otmp->dknown = 1;
@@ -2063,7 +2063,7 @@ mloot_container(
         takeout_count = 4;
         break;
     }
-    howfar = distu(mon->mx, mon->my);
+    howfar = mdistu(mon);
     nearby = (howfar <= 7 * 7);
     contnr_nam[0] = mpronounbuf[0] = '\0';
     if (vismon) {

--- a/src/music.c
+++ b/src/music.c
@@ -50,7 +50,7 @@ awaken_monsters(int distance)
     for (mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
         if (DEADMONSTER(mtmp))
             continue;
-        if ((distm = distu(mtmp->mx, mtmp->my)) < distance) {
+        if ((distm = mdistu(mtmp)) < distance) {
             mtmp->msleeping = 0;
             mtmp->mcanmove = 1;
             mtmp->mfrozen = 0;
@@ -79,7 +79,7 @@ put_monsters_to_sleep(int distance)
     for (mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
         if (DEADMONSTER(mtmp))
             continue;
-        if (distu(mtmp->mx, mtmp->my) < distance
+        if (mdistu(mtmp) < distance
             && sleep_monst(mtmp, d(10, 10), TOOL_CLASS)) {
             mtmp->msleeping = 1; /* 10d10 turns + wake_nearby to rouse */
             slept_monst(mtmp);
@@ -101,7 +101,7 @@ charm_snakes(int distance)
         if (DEADMONSTER(mtmp))
             continue;
         if (mtmp->data->mlet == S_SNAKE && mtmp->mcanmove
-            && distu(mtmp->mx, mtmp->my) < distance) {
+            && mdistu(mtmp) < distance) {
             was_peaceful = mtmp->mpeaceful;
             mtmp->mpeaceful = 1;
             mtmp->mavenge = 0;
@@ -134,7 +134,7 @@ calm_nymphs(int distance)
         if (DEADMONSTER(mtmp))
             continue;
         if (mtmp->data->mlet == S_NYMPH && mtmp->mcanmove
-            && distu(mtmp->mx, mtmp->my) < distance) {
+            && mdistu(mtmp) < distance) {
             mtmp->msleeping = 0;
             mtmp->mpeaceful = 1;
             mtmp->mavenge = 0;
@@ -170,7 +170,7 @@ awaken_soldiers(struct monst* bugler  /* monster that played instrument */)
                 Norep("%s the rattle of battle gear being readied.",
                       "You hear");  /* Deaf-aware */
         } else if ((distm = ((bugler == &g.youmonst)
-                                 ? distu(mtmp->mx, mtmp->my)
+                                 ? mdistu(mtmp)
                                  : dist2(bugler->mx, bugler->my, mtmp->mx,
                                          mtmp->my))) < distance) {
             mtmp->msleeping = 0;
@@ -204,7 +204,7 @@ charm_monsters(int distance)
         if (DEADMONSTER(mtmp))
             continue;
 
-        if (distu(mtmp->mx, mtmp->my) <= distance) {
+        if (mdistu(mtmp) <= distance) {
             /* a shopkeeper can't be tamed but tamedog() pacifies an angry
                one; do that even if mtmp resists in order to behave the same
                as a non-cursed scroll of taming or spell of charm monster */

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -2188,8 +2188,8 @@ reverse_loot(void)
                 if (coffers->spe == 2)
                     break; /* a throne room chest */
                 if (!otmp
-                    || distu(coffers->ox, coffers->oy)
-                           < distu(otmp->ox, otmp->oy))
+                    || (distu(coffers->ox, coffers->oy)
+                        < distu(otmp->ox, otmp->oy)))
                     otmp = coffers; /* remember closest ordinary chest */
             }
         if (!coffers)

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -1782,7 +1782,7 @@ domindblast(void)
         nmon = mtmp->nmon;
         if (DEADMONSTER(mtmp))
             continue;
-        if (distu(mtmp->mx, mtmp->my) > BOLT_LIM * BOLT_LIM)
+        if (mdistu(mtmp) > BOLT_LIM * BOLT_LIM)
             continue;
         if (mtmp->mpeaceful)
             continue;

--- a/src/pray.c
+++ b/src/pray.c
@@ -2192,7 +2192,7 @@ doturn(void)
            #turn operating through walls, not to require that the hero be
            able to see the target location */
         if (!couldsee(mtmp->mx, mtmp->my)
-            || distu(mtmp->mx, mtmp->my) > range)
+            || mdistu(mtmp) > range)
             continue;
 
         if (!mtmp->mpeaceful

--- a/src/shk.c
+++ b/src/shk.c
@@ -3650,8 +3650,7 @@ shk_fixes_damage(struct monst *shkp)
     if (!dam)
         return;
 
-    shk_closeby = (distu(shkp->mx, shkp->my)
-                   <= (BOLT_LIM / 2) * (BOLT_LIM / 2));
+    shk_closeby = (mdistu(shkp) <= (BOLT_LIM / 2) * (BOLT_LIM / 2));
 
     if (canseemon(shkp))
         pline("%s whispers %s.", Shknam(shkp),
@@ -4221,7 +4220,7 @@ pay_for_damage(const char* dmgstr, boolean cant_mollify)
             }
             if (!inhishop(tmp_shk))
                 continue;
-            shk_distance = distu(tmp_shk->mx, tmp_shk->my);
+            shk_distance = mdistu(tmp_shk);
             if (shk_distance > nearest_shk)
                 continue;
             if ((shk_distance == nearest_shk) && picks) {

--- a/src/spell.c
+++ b/src/spell.c
@@ -302,7 +302,7 @@ deadbook(struct obj* book2)
                 && cansee(mtmp->mx, mtmp->my)) {
                 mtmp->mpeaceful = TRUE;
                 if (sgn(mtmp->data->maligntyp) == sgn(u.ualign.type)
-                    && distu(mtmp->mx, mtmp->my) < 4)
+                    && mdistu(mtmp) < 4)
                     if (mtmp->mtame) {
                         if (mtmp->mtame < 20)
                             mtmp->mtame++;

--- a/src/trap.c
+++ b/src/trap.c
@@ -1264,8 +1264,8 @@ trapeffect_sqky_board(
                 ? (BOLT_LIM + 1) : (BOLT_LIM - 3);
 
             You_hear("%s squeak %s.", trapnote(trap, FALSE),
-                     (distu(mtmp->mx, mtmp->my) <= range * range)
-                     ? "nearby" : "in the distance");
+                     (mdistu(mtmp) <= range * range)
+                        ? "nearby" : "in the distance");
         }
         /* wake up nearby monsters */
         wake_nearto(mtmp->mx, mtmp->my, 40);
@@ -2456,8 +2456,8 @@ trapeffect_vibrating_square(
                 /* notice something (hearing uses a larger threshold
                    for 'nearby') */
                 You_see("the ground vibrate %s.",
-                        (distu(mtmp->mx, mtmp->my) <= 2 * 2)
-                        ? "nearby" : "in the distance");
+                        (mdistu(mtmp) <= 2 * 2)
+                           ? "nearby" : "in the distance");
             }
         }
     }
@@ -2860,7 +2860,7 @@ launch_obj(
                 You_hear("someone bowling.");
             } else {
                 You_hear("rumbling %s.", (distu(x1, y1) <= 4 * 4) ? "nearby"
-                                         : "in the distance");
+                                           : "in the distance");
             }
 
         }

--- a/src/vision.c
+++ b/src/vision.c
@@ -2133,7 +2133,7 @@ howmonseen(struct monst *mon)
     if (tp_sensemon(mon))
         how_seen |= MONSEEN_TELEPAT;
     /* xray */
-    if (useemon && xraydist > 0 && distu(mon->mx, mon->my) <= xraydist)
+    if (useemon && xraydist > 0 && mdistu(mon) <= xraydist)
         how_seen |= MONSEEN_XRAYVIS;
     /* extended detection */
     if (Detect_monsters)

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -863,9 +863,7 @@ mon_wield_item(struct monst *mon)
             /* 3.6.3: artifact might be getting wielded by invisible monst */
             else if (cansee(mon->mx, mon->my))
                 pline("Light begins shining %s.",
-                      (distu(mon->mx, mon->my) <= 5 * 5)
-                          ? "nearby"
-                          : "in the distance");
+                      (mdistu(mon) <= 5 * 5) ? "nearby" : "in the distance");
         }
         obj->owornmask = W_WEP;
         return 1;


### PR DESCRIPTION
Tries to avoid the message "a dry rattle comes from its throat" when you 
can't see a canceled spitting monster, and adds 'mdistu' as shorthand 
for getting the distance between the hero and a monster.

Those may seem unrelated; the reason they're on one branch is because I 
tried to use 'mdistu' in the "dry rattle" commit only to realize it 
didn't exist. I really thought something like that was in use already, 
but the evidence seems to suggest I imagined it.

- Fix: "a dry rattle comes from its throat"
- Add 'mdistu' macro
