### PR TITLE
Don't leak ID of magic tools in charging prompt

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -698,7 +698,13 @@ charge_ok(struct obj* obj)
                 && !objects[MAGIC_LAMP].oc_name_known)) {
             return GETOBJ_SUGGEST;
         }
-        return objects[obj->otyp].oc_charged ? GETOBJ_SUGGEST : GETOBJ_EXCLUDE;
+        /* suggest chargeable tools only if discovered, to prevent leaking
+           info (e.g. revealing if an unidentified 'flute' is magic or not) */
+        if (objects[obj->otyp].oc_charged) {
+            return (obj->dknown && objects[obj->otyp].oc_name_known)
+                     ? GETOBJ_SUGGEST : GETOBJ_DOWNPLAY;
+        }
+        return GETOBJ_EXCLUDE;
     }
     /* why are weapons/armor considered charged anyway?
      * make them selectable even so for "feeling of loss" message */


### PR DESCRIPTION
The getobj prompt for charging was presenting any chargeable tool in the
hero's inventory as a suggested charging target, even tools which were
unidentified and undistinguishable from their mundane counterparts
(e.g. bag of tricks, magic harp, horn of plenty...).  This leaked
information about the identity of these items and made it possible to
determine whether a generic 'harp' was magic or not.

When suggesting chargeable tools, include only those which are actually
known to be chargeable (unidentified or unseen chargeable tools can
still be selected, they just won't be suggested targets).  Basically the
same as what's done for a potion of oil in the apply prompt.
