### PR TITLE
remove the code to silence lint

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -39,18 +39,6 @@ extern void panic(const char *, ...);
 long *
 alloc(unsigned int lth)
 {
-#ifdef LINT
-    /*
-     * a ridiculous definition, suppressing
-     *  "possible pointer alignment problem" for (long *) malloc()
-     * from lint
-     */
-    long dummy = ftell(stderr);
-
-    if (lth)
-        dummy = 0; /* make sure arg is used */
-    return &dummy;
-#else
     register genericptr_t ptr;
 
     ptr = malloc(lth);
@@ -59,18 +47,12 @@ alloc(unsigned int lth)
         panic("Memory allocation failure; cannot get %u bytes", lth);
 #endif
     return (long *) ptr;
-#endif
 }
 
 /* realloc() call that might get substituted by nhrealloc(p,n,file,line) */
 long *
 re_alloc(long *oldptr, unsigned int newlth)
 {
-    /*
-     * If LINT support ever gets resurrected,
-     * we'll probably need some hackery here.
-     */
-
     long *newptr = (long *) realloc((genericptr_t) oldptr, (size_t) newlth);
 #ifndef MONITOR_HEAP
     /* "extend to":  assume it won't ever fail if asked to shrink */

--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -312,12 +312,8 @@ dog_eat(struct monst *mtmp,
     /* It's a reward if it's DOGFOOD and the player dropped/threw it.
        We know the player had it if invlet is set. -dlc */
     if (dogfood(mtmp, obj) == DOGFOOD && obj->invlet)
-#ifdef LINT
-        edog->apport = 0;
-#else
         edog->apport += (int) (200L / ((long) edog->dropdist + g.moves
                                        - edog->droptime));
-#endif
     if (mtmp->data == &mons[PM_RUST_MONSTER] && obj->oerodeproof) {
         /* The object's rustproofing is gone now */
         if (obj->unpaid)

--- a/src/end.c
+++ b/src/end.c
@@ -365,9 +365,7 @@ done2(void)
             done_stopprint++;
     }
 #endif
-#ifndef LINT
     done(QUIT);
-#endif
     return ECMD_OK;
 }
 

--- a/src/hack.c
+++ b/src/hack.c
@@ -410,13 +410,8 @@ moverock(void)
             }
 
             {
-#ifdef LINT /* static long lastmovetime; */
-                long lastmovetime;
-                lastmovetime = 0;
-#else
                 /* note: reset to zero after save/restore cycle */
                 static NEARDATA long lastmovetime;
-#endif
  dopush:
                 what = the(xname(otmp));
                 if (!u.usteed) {

--- a/src/hacklib.c
+++ b/src/hacklib.c
@@ -79,12 +79,6 @@
         void            nh_snprintf     (const char *, int, char *, size_t,
                                          const char *, ...)
 =*/
-#ifdef LINT
-#define Static /* pacify lint */
-#else
-#define Static static
-#endif
-
 static boolean pmatch_internal(const char *, const char *, boolean,
                                const char *);
 
@@ -371,7 +365,7 @@ strcasecpy(char *dst, const char *src)
 char *
 s_suffix(const char *s)
 {
-    Static char buf[BUFSZ];
+    static char buf[BUFSZ];
 
     Strcpy(buf, s);
     if (!strcmpi(buf, "it")) /* it -> its */
@@ -495,7 +489,7 @@ tabexpand(
 char *
 visctrl(char c)
 {
-    Static char visctrl_bufs[VISCTRL_NBUF][5];
+    static char visctrl_bufs[VISCTRL_NBUF][5];
     static int nbuf = 0;
     register int i = 0;
     char *ccc = visctrl_bufs[nbuf];
@@ -638,7 +632,7 @@ DISABLE_WARNING_FORMAT_NONLITERAL  /* one compiler complains about
 char *
 sitoa(int n)
 {
-    Static char buf[13];
+    static char buf[13];
 
     Sprintf(buf, (n < 0) ? "%d" : "+%d", n);
     return buf;
@@ -1015,7 +1009,7 @@ getyear(void)
 char *
 yymmdd(time_t date)
 {
-    Static char datestr[10];
+    static char datestr[10];
     struct tm *lt;
 
     if (date == 0)

--- a/src/invent.c
+++ b/src/invent.c
@@ -2561,11 +2561,7 @@ xprname(struct obj *obj,
         long cost,       /* cost (for inventory of unpaid or expended items) */
         long quan)       /* if non-0, print this quantity, not obj->quan */
 {
-#ifdef LINT /* handle static char li[BUFSZ]; */
-    char li[BUFSZ];
-#else
     static char li[BUFSZ];
-#endif
     boolean use_invlet = (flags.invlet_constant
                           && let != CONTAINED_SYM && let != HANDS_SYM);
     long savequan = 0;

--- a/src/mhitm.c
+++ b/src/mhitm.c
@@ -112,9 +112,6 @@ fightm(register struct monst *mtmp)
 {
     register struct monst *mon, *nmon;
     int result, has_u_swallowed;
-#ifdef LINT
-    nmon = 0;
-#endif
     /* perhaps the monster will resist Conflict */
     if (resist_conflict(mtmp))
         return 0;

--- a/src/mklev.c
+++ b/src/mklev.c
@@ -49,13 +49,6 @@ static void mk_knox_portal(coordxy, coordxy);
 static int QSORTCALLBACK
 mkroom_cmp(const genericptr vx, const genericptr vy)
 {
-#ifdef LINT
-    /* lint complains about possible pointer alignment problems, but we know
-       that vx and vy are always properly aligned. Hence, the following
-       bogus definition:
-    */
-    return (vx == vy) ? 0 : -1;
-#else
     register const struct mkroom *x, *y;
 
     x = (const struct mkroom *) vx;
@@ -63,7 +56,6 @@ mkroom_cmp(const genericptr vx, const genericptr vy)
     if (x->lx < y->lx)
         return -1;
     return (x->lx > y->lx);
-#endif /* LINT */
 }
 
 /* Return TRUE if a door placed at (x, y) which otherwise passes okdoor()

--- a/src/mon.c
+++ b/src/mon.c
@@ -4660,9 +4660,7 @@ newcham(
     /* set level and hit points */
     newmonhp(mtmp, monsndx(mdat));
     /* new hp: same fraction of max as before */
-#ifndef LINT
     mtmp->mhp = (int) (((long) hpn * (long) mtmp->mhp) / (long) hpd);
-#endif
     /* sanity check (potential overflow) */
     if (mtmp->mhp < 0 || mtmp->mhp > mtmp->mhpmax)
         mtmp->mhp = mtmp->mhpmax;

--- a/src/rnd.c
+++ b/src/rnd.c
@@ -73,17 +73,12 @@ rn2_on_display_rng(register int x)
 #else   /* USE_ISAAC64 */
 
 /* "Rand()"s definition is determined by [OS]conf.h */
-#if defined(LINT) && defined(UNIX) /* rand() is long... */
-extern int rand(void);
-#define RND(x) (rand() % x)
-#else /* LINT */
 #if defined(UNIX) || defined(RANDOM)
 #define RND(x) ((int) (Rand() % (long) (x)))
 #else
 /* Good luck: the bottom order bits are cyclic. */
 #define RND(x) ((int) ((Rand() >> 3) % (x)))
 #endif
-#endif /* LINT */
 int
 rn2_on_display_rng(register int x)
 {
@@ -216,13 +211,8 @@ rne(register int x)
 int
 rnz(int i)
 {
-#ifdef LINT
-    int x = i;
-    int tmp = 1000;
-#else
     register long x = (long) i;
     register long tmp = 1000L;
-#endif
 
     tmp += rn2(1000);
     tmp *= rne(4);

--- a/src/steal.c
+++ b/src/steal.c
@@ -25,11 +25,7 @@ equipname(register struct obj* otmp)
 long
 somegold(long lmoney)
 {
-#ifdef LINT /* long conv. ok */
-    int igold = 0;
-#else
     int igold = (lmoney >= (long) LARGEST_INT) ? LARGEST_INT : (int) lmoney;
-#endif
 
     if (igold < 50)
         ; /* all gold */

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -4366,11 +4366,7 @@ end_engulf(void)
 static int
 gulpum(struct monst *mdef, struct attack *mattk)
 {
-#ifdef LINT /* static char msgbuf[BUFSZ]; */
-    char msgbuf[BUFSZ];
-#else
     static char msgbuf[BUFSZ]; /* for g.nomovemsg */
-#endif
     register int tmp;
     register int dam = d((int) mattk->damn, (int) mattk->damd);
     boolean fatal_gulp, u_digest = digests(g.youmonst.data);

--- a/sys/share/unixtty.c
+++ b/sys/share/unixtty.c
@@ -136,9 +136,7 @@ int has_colors(void);
 
 #if defined(TTY_GRAPHICS) && ((!defined(SYSV) && !defined(HPUX)) \
                               || defined(UNIXPC) || defined(SVR4))
-#ifndef LINT
 extern /* it is defined in libtermlib (libtermcap) */
-#endif
     short ospeed; /* terminal baudrate; set by gettty */
 #else
 short ospeed = 0; /* gets around "not defined" error message */


### PR DESCRIPTION
Warning facilities on recent compilers are incredibly improved, so the code to silence "good-old" lint is much less sense.