### PR TITLE
A couple fountain things

### DIFF
--- a/src/fountain.c
+++ b/src/fountain.c
@@ -429,12 +429,8 @@ dipfountain(register struct obj *obj)
     } else {
         er = water_damage(obj, NULL, TRUE);
 
-        if (obj->otyp == POT_ACID
-            && er != ER_DESTROYED) { /* Acid and water don't mix */
-            useup(obj);
-            return;
-        } else if (er != ER_NOTHING && !rn2(2)) { /* no further effect */
-            return;
+        if (er == ER_DESTROYED || (er != ER_NOTHING && !rn2(2))) {
+            return; /* no further effect */
         }
     }
 

--- a/src/trap.c
+++ b/src/trap.c
@@ -4146,10 +4146,13 @@ water_damage(
         wet_a_towel(obj, -rnd(7 - obj->spe), TRUE);
         return ER_NOTHING;
     } else if (obj->greased) {
-        if (!rn2(2))
+        if (!rn2(2)) {
             obj->greased = 0;
-        if (carried(obj))
-            update_inventory();
+            if (carried(obj)) {
+                pline_The("grease on %s washes off.", yname(obj));
+                update_inventory();
+            }
+        }
         return ER_GREASED;
     } else if (Is_container(obj)
                && (!Waterproof_container(obj) || (obj->cursed && !rn2(3)))) {


### PR DESCRIPTION
Some minor fountain things.  Or grease things, I guess, depending on how 
you look at it. Fix a use-after-free when dipping a potion of acid into 
a fountain, and print a message when water damage removes grease from an 
object in your inventory.

- Tell player when water damage removes grease
- Fix: use-after-free when fountain dipping
