### PR TITLE
Add a funny message for smelling yourself

### DIFF
--- a/src/cmd.c
+++ b/src/cmd.c
@@ -1936,7 +1936,7 @@ wiz_smell(void)
                 mptr = gy.youmonst.data;
                 is_you = TRUE;
             }
-        } else if ((mtmp = m_at(cc.x, cc.y)) && canspotmon(mtmp)) {
+        } else if ((mtmp = m_at(cc.x, cc.y)) != (struct monst *) 0) {
             mptr = mtmp->data;
         } else {
             mptr = (struct permonst *) 0;
@@ -1949,7 +1949,7 @@ wiz_smell(void)
                 pline("%s to give off no smell.",
                       is_you ? "You seem" : "That monster seems");
         } else {
-            You("see no monster there.");
+            pline("That is not a monster.");
         }
     } while (TRUE);
     return ECMD_OK;


### PR DESCRIPTION
I know this is inane, especially for a little-used debug-mode-only
command, but I can't get it out of my head...

The use of the actual monster data instead of the glyph as a proxy ought
to make it somewhat more consistent as well (e.g. hallucination and
'showrace' won't affect the results), though I think that'd hardly be
worth it were it not for the incredibly funny message.
