### PR TITLE
Fix autodescribe after reading a cursed scroll of gold detection

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -924,7 +924,7 @@ static void
 display_trap_map(struct trap *ttmp, int cursed_src)
 {
     struct monst *mon;
-    int door, glyph, ter_typ = TER_DETECT | TER_TRP;
+    int door, glyph, ter_typ = TER_DETECT | ( cursed_src ? TER_OBJ : TER_TRP );
     coord cc;
 
     cls();
@@ -963,7 +963,7 @@ display_trap_map(struct trap *ttmp, int cursed_src)
     }
     You_feel("%s.", cursed_src ? "very greedy" : "entrapped");
 
-    browse_map(ter_typ, "trap of interest");
+    browse_map(ter_typ, cursed_src ? "gold" : "trap of interest");
 
     map_redisplay();
 }


### PR DESCRIPTION
Autodescribe was not updating during browse_map() when the cursor was moved over a gold glyph that was actually a trap, causing the trap to be described as the previous square that the cursor was on (probably "unexplored area") instead of as gold pieces.  This was especially noticeable when using OPTIONS=whatis_coord:m, because the coordinate was not updating when moving the cursor over the trap.