### PR TITLE
Some shopkeeper chatting tweaks

### DIFF
--- a/src/shk.c
+++ b/src/shk.c
@@ -4468,7 +4468,7 @@ shop_object(register coordxy x, register coordxy y)
             break;
     /* note: otmp might have ->no_charge set, but that's ok */
     return (otmp && costly_spot(x, y)
-            && NOTANGRY(shkp) && !helpless(shkp))
+            && NOTANGRY(shkp) && !muteshk(shkp))
                ? otmp
                : (struct obj *) 0;
 }

--- a/src/shk.c
+++ b/src/shk.c
@@ -4514,15 +4514,15 @@ price_quote(register struct obj* first_obj)
     } else if (cnt == 1) {
         if (!cost) {
             /* "<doname(obj)>, no charge" */
-            pline("%s!", upstart(buf)); /* buf still contains the string */
+            verbalize("%s!", upstart(buf)); /* buf contains the string */
         } else {
             /* print cost in slightly different format, so can't reuse buf;
                cost and contentsonly are already set up */
             Sprintf(buf, "%s%s", contentsonly ? the_contents_of : "",
                     doname(first_obj));
-            pline("%s, price %ld %s%s%s", upstart(buf), cost, currency(cost),
-                  (first_obj->quan > 1L) ? " each" : "",
-                  contentsonly ? "." : shk_embellish(first_obj, cost));
+            verbalize("%s, price %ld %s%s%s", upstart(buf), cost,
+                      currency(cost), (first_obj->quan > 1L) ? " each" : "",
+                      contentsonly ? "." : shk_embellish(first_obj, cost));
         }
     }
     destroy_nhwindow(tmpwin);


### PR DESCRIPTION
A mute shopkeeper shouldn't be able to verbally tell you the prices of
objects.  For normal chatting, on the other hand, shk_chat can handle a
mute shopkeeper (by changing from speech to "indications" -- hand signs,
body language, etc), so allow execution to reach that even if the
shopkeeper is mute (in a silent polyform).

Also more generally allow a shopkeeper to continue chatting with normal
shopkeeper responses if polymorphed into another creature, since they
apparently retain their minds (are able to tell you prices, can
transact, etc).

This is mostly inspired by the fact shk_chat has extensive handling for
mute shopkeepers, but it was unreachable as far as I can tell.  It is
also funny to think of a newt or something wriggling around to indicate
it's been making a lot of money lately.

Also, use verbalize() for verbal price checks.