### PR TITLE
Limit graves to produce only one corpse/undead mon

### DIFF
--- a/include/rm.h
+++ b/include/rm.h
@@ -331,7 +331,7 @@ struct rm {
 /* horizonal applies to walls, doors (including sdoor); also to iron bars
    even though they don't have separate symbols for horizontal and vertical */
 #define blessedftn horizontal /* a fountain that grants attribs */
-#define disturbed  horizontal /* a grave that has been disturbed */
+#define disturbed  horizontal /* a grave without a corpse in it */
 
 struct damage {
     struct damage *next;

--- a/src/dig.c
+++ b/src/dig.c
@@ -926,6 +926,12 @@ dig_up_grave(coord *cc)
         You("have violated the sanctity of this grave!");
     }
 
+    if (levl[dig_x][dig_y].disturbed) {
+        /* grave already produced a corpse: either corpse was generated on the
+           surface to begin with (bones), or hero disturbed the grave */
+        goto empty_grave;
+    }
+
     switch (rn2(5)) {
     case 0:
     case 1:
@@ -946,8 +952,10 @@ dig_up_grave(coord *cc)
         (void) makemon(mkclass(S_MUMMY, 0), dig_x, dig_y, MM_NOMSG);
         break;
     default:
-        /* No corpse */
-        pline_The("grave seems unused.  Strange....");
+ empty_grave:
+        pline_The("grave seems to be empty.");
+        if (!levl[dig_x][dig_y].disturbed)
+            pline("Strange....");
         break;
     }
     levl[dig_x][dig_y].typ = ROOM, levl[dig_x][dig_y].flags = 0;

--- a/src/dig.c
+++ b/src/dig.c
@@ -901,6 +901,7 @@ static void
 dig_up_grave(coord *cc)
 {
     struct obj *otmp;
+    struct permonst *undeadtyp;
     coordxy dig_x, dig_y;
 
     if (!cc) {
@@ -940,16 +941,22 @@ dig_up_grave(coord *cc)
             otmp->age -= (TAINT_AGE + 1); /* this is an *OLD* corpse */
         break;
     case 2:
+        undeadtyp = mkclass(S_ZOMBIE, 0);
+        if (!undeadtyp)
+            goto empty_grave;
         if (!Blind)
             pline(Hallucination ? "Dude!  The living dead!"
                                 : "The grave's owner is very upset!");
-        (void) makemon(mkclass(S_ZOMBIE, 0), dig_x, dig_y, MM_NOMSG);
+        (void) makemon(undeadtyp, dig_x, dig_y, MM_NOMSG);
         break;
     case 3:
+        undeadtyp = mkclass(S_MUMMY, 0);
+        if (!undeadtyp)
+            goto empty_grave;
         if (!Blind)
             pline(Hallucination ? "I want my mummy!"
                                 : "You've disturbed a tomb!");
-        (void) makemon(mkclass(S_MUMMY, 0), dig_x, dig_y, MM_NOMSG);
+        (void) makemon(undeadtyp, dig_x, dig_y, MM_NOMSG);
         break;
     default:
  empty_grave:

--- a/src/end.c
+++ b/src/end.c
@@ -1433,6 +1433,10 @@ really_done(int how)
         Sprintf(pbuf, "%s, ", gp.plname);
         formatkiller(eos(pbuf), sizeof pbuf - Strlen(pbuf), how, TRUE);
         make_grave(u.ux, u.uy, pbuf);
+        /* if grave creation succeeded, mark it as empty ('disturbed') so it
+           won't produce a zombie, etc, when dug up: corpse is aboveground. */
+        if (IS_GRAVE(levl[u.ux][u.uy].typ))
+            levl[u.ux][u.uy].disturbed = 1;
     }
     pbuf[0] = '\0'; /* clear grave text; also lint suppression */
 

--- a/src/engrave.c
+++ b/src/engrave.c
@@ -614,11 +614,16 @@ doengrave(void)
                 surface(u.ux, u.uy));
             return ECMD_OK;
         } else if (!levl[u.ux][u.uy].disturbed) {
-            You("disturb the undead!");
+            struct permonst *undeadtyp;
             levl[u.ux][u.uy].disturbed = 1;
-            (void) makemon(&mons[PM_GHOUL], u.ux, u.uy, NO_MM_FLAGS);
-            exercise(A_WIS, FALSE);
-            return ECMD_TIME;
+            /* list of possible monsters is consistent with dig_up_grave() */
+            undeadtyp = mkclass((rn2(2) ? S_ZOMBIE : S_MUMMY), 0);
+            if (undeadtyp) {
+                You("disturb the undead!");
+                makemon(undeadtyp, u.ux, u.uy, NO_MM_FLAGS);
+                exercise(A_WIS, FALSE);
+                return ECMD_TIME;
+            }
         }
     }
 


### PR DESCRIPTION
Graves could produce multiple undead and/or corpses.  For example, as a
sort of worst-case-scenario, for a grave in a bones level: the grave was
generated with the former hero's corpse on top of it.  Then a new hero
engraves on the headstone with a wand of digging and wakes an undead
creature from the grave.  Then the hero digs up the grave with a pick
and finds another corpse or undead monster inside.  That's three corpses
or undead creatures associated with a single grave.

Use the existing 'disturbed' field (actually alias for 'horizontal') to
track whether the grave ought to be empty (i.e. whether it has already
produced a corpse somehow), and check its value before creating more
corpses or undead from a particular grave.
