### PR TITLE
Don't refer to type-named hat as "helmet" (etc...)

### DIFF
--- a/src/objnam.c
+++ b/src/objnam.c
@@ -635,15 +635,15 @@ xname_flags(
             Strcat(buf, actualn);
         } else if (un) {
             if (is_boots(obj))
-                Strcat(buf, "boots");
+                Strcat(buf, boots_simple_name(obj));
             else if (is_gloves(obj))
-                Strcat(buf, "gloves");
+                Strcat(buf, gloves_simple_name(obj));
             else if (is_cloak(obj))
-                Strcpy(buf, "cloak");
+                Strcpy(buf, cloak_simple_name(obj));
             else if (is_helmet(obj))
-                Strcpy(buf, "helmet");
+                Strcpy(buf, helm_simple_name(obj));
             else if (is_shield(obj))
-                Strcpy(buf, "shield");
+                Strcpy(buf, shield_simple_name(obj));
             else
                 Strcpy(buf, "armor");
             Strcat(buf, " called ");


### PR DESCRIPTION
When a non-metallic hat like a cornuthaum or dunce cap was type-named
"foo", xname would call it a "helmet called foo".  Calling a soft hat a
"helmet" like that sounded a bit off to me, especially since many other
parts of the game already distinguish between "hats" and "helms" when
describing headgear -- do the same in xname_flags for type-named hats.

The use of helm_simple_name() means hard helmets are described as
"helms" instead of "helmets".  I'm not sure if that is a big problem.
An inline ternary with "hat"/"helmet" could be used instead, but I
figured doing it this way would keep the verbiage consistent if the
"hat" vs "helm" rules in helm_simple_name() were ever updated, and the
additional needless change was probably worth it for that.  Others may
disagree...
