### PR TITLE
Improve processing of Unicode glyph IDs

### DIFF
--- a/include/sym.h
+++ b/include/sym.h
@@ -157,6 +157,7 @@ struct symset_customization {
     int count;
     int custtype;
     struct customization_detail *details;
+    struct customization_detail *details_end;
 };
 #endif /* ENHANCED_SYMBOLS */
 

--- a/include/system.h
+++ b/include/system.h
@@ -148,17 +148,12 @@ extern void perror(const char *);
 #ifdef POSIX_TYPES
 extern void qsort(genericptr_t, size_t, size_t,
              int (*)(const genericptr, const genericptr));
-extern genericptr_t bsearch(const genericptr, const genericptr, size_t, size_t,
-             int (*)(const genericptr, const genericptr));
 #else
 #if defined(BSD) || defined(ULTRIX)
 extern int qsort();
-extern genericptr_t bsearch();
 #else
 #if !defined(LATTICE) && !defined(AZTEC_50)
 extern void qsort(genericptr_t, size_t, size_t,
-             int (*)(const genericptr, const genericptr));
-extern genericptr_t bsearch(const genericptr, const genericptr, size_t, size_t,
              int (*)(const genericptr, const genericptr));
 #endif
 #endif

--- a/include/system.h
+++ b/include/system.h
@@ -148,12 +148,17 @@ extern void perror(const char *);
 #ifdef POSIX_TYPES
 extern void qsort(genericptr_t, size_t, size_t,
              int (*)(const genericptr, const genericptr));
+extern genericptr_t bsearch(const genericptr, const genericptr, size_t, size_t,
+             int (*)(const genericptr, const genericptr));
 #else
 #if defined(BSD) || defined(ULTRIX)
 extern int qsort();
+extern genericptr_t bsearch();
 #else
 #if !defined(LATTICE) && !defined(AZTEC_50)
 extern void qsort(genericptr_t, size_t, size_t,
+             int (*)(const genericptr, const genericptr));
+extern genericptr_t bsearch(const genericptr, const genericptr, size_t, size_t,
              int (*)(const genericptr, const genericptr));
 #endif
 #endif

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -835,6 +835,10 @@ match_sym(char *buf)
     const char *p = strchr(buf, ':'), *q = strchr(buf, '=');
     const struct symparse *sp = loadsyms;
 
+    /* G_ lines will never match here */
+    if ((buf[0] == 'G' || buf[0] == 'g') && buf[1] == '_')
+        return (struct symparse *) 0;
+
     if (!p || (q && q < p))
         p = q;
     if (p) {

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1031,7 +1031,19 @@ do_symset(boolean rogueflag)
 
     if (gs.symset[which_set].name) {
         /* non-default symbols */
-        if (read_sym_file(which_set)) {
+        int ok;
+#ifdef ENHANCED_SYMBOLS
+        if (!glyphid_cache_status()) {
+            fill_glyphid_cache();
+        }
+#endif
+        ok = read_sym_file(which_set);
+#ifdef ENHANCED_SYMBOLS
+        if (glyphid_cache_status()) {
+            free_glyphid_cache();
+        }
+#endif
+        if (ok) {
             ready_to_switch = TRUE;
         } else {
             clear_symsetentry(which_set, TRUE);

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1200,6 +1200,7 @@ purge_custom_entries(enum graphics_sets which_set)
         details = next;
     }
     gdc->details = 0;
+    gdc->details_end = 0;
     if (gdc->customization_name) {
         free((genericptr_t) gdc->customization_name);
         gdc->customization_name = 0;

--- a/src/utf8map.c
+++ b/src/utf8map.c
@@ -393,10 +393,8 @@ add_glyph_to_cache(int glyphnum, const char *id)
     size_t hash2 = (size_t)
             (((hash >> glyphid_cache_lsize) & (glyphid_cache_size - 1)) | 1);
     size_t i = hash1;
-    unsigned count = 0;
 
     do {
-        ++count;
         if (glyphid_cache[i].id == NULL) {
             /* Empty bucket found */
             glyphid_cache[i].id = dupstr(id);
@@ -418,10 +416,8 @@ find_glyph_in_cache(const char *id)
     size_t hash2 = (size_t)
             (((hash >> glyphid_cache_lsize) & (glyphid_cache_size - 1)) | 1);
     size_t i = hash1;
-    unsigned count = 0;
 
     do {
-        ++count;
         if (glyphid_cache[i].id == NULL) {
             /* Empty bucket found */
             return -1;

--- a/src/utf8map.c
+++ b/src/utf8map.c
@@ -509,16 +509,15 @@ add_custom_urep_entry(
 {
     static uint32_t closecolor = 0;
     static int clridx = 0;
-    int retval = 0;
     struct symset_customization *gdc = &gs.sym_customizations[which_set];
-    struct customization_detail *details, *prev = 0, *newdetails = 0,
-                                          *lastdetail = 0;
+    struct customization_detail *details, *newdetails = 0;
 
 
     if (!gdc->details) {
         gdc->customization_name = dupstr(customization_name);
         gdc->custtype = custom_ureps;
         gdc->details = 0;
+        gdc->details_end = 0;
     }
     details = find_matching_symset_customization(customization_name,
                                                  custom_symbols, which_set);
@@ -537,7 +536,6 @@ add_custom_urep_entry(
                 details->content.urep.u.utf32ch = utf32ch;
                 return 1;
             }
-            prev = details;
             details = details->next;
         }
     }
@@ -554,23 +552,14 @@ add_custom_urep_entry(
         newdetails->content.urep.u.u256coloridx = 0;
     newdetails->content.urep.u.utf32ch = utf32ch;
     newdetails->next = (struct customization_detail *) 0;
-    if (!details && prev) {
-        prev->next = newdetails;
-        retval = 1;
-    } else if (!gdc->details) {
+    if (gdc->details == NULL) {
         gdc->details = newdetails;
-        retval = 1;
     } else {
-        lastdetail = gdc->details;
-        while (lastdetail) {
-            prev = lastdetail;
-            lastdetail = lastdetail->next;
-        }
-        prev->next = newdetails;
-        retval = 1;
+        gdc->details_end->next = newdetails;
     }
+    gdc->details_end = newdetails;
     gdc->count++;
-    return retval;
+    return 1;
 }
 
 static int

--- a/src/utf8map.c
+++ b/src/utf8map.c
@@ -659,7 +659,9 @@ parse_id(const char *id, struct find_struct *findwhat)
                     } else if (glyph_is_female_pet(glyph)) {
                         buf2 = "pet_female_";
                     }
-                    Snprintf(buf[1], sizeof buf[1], "%s%s", buf2, buf3);
+                    Strcpy(buf[0], "G_");
+                    Strcat(buf[0], buf2);
+                    Strcat(buf[0], buf3);
                 } else if (glyph_is_body(glyph)) {
                     /* buf2 will hold the distinguishing prefix */
                     /* buf3 will hold the base name */
@@ -670,7 +672,9 @@ parse_id(const char *id, struct find_struct *findwhat)
                     } else {
                         buf2 = "body_";
                     }
-                    Snprintf(buf[1], sizeof buf[1], "%s%s", buf2, buf3);
+                    Strcpy(buf[0], "G_");
+                    Strcat(buf[0], buf2);
+                    Strcat(buf[0], buf3);
                 } else if (glyph_is_statue(glyph)) {
                     /* buf2 will hold the distinguishing prefix */
                     /* buf3 will hold the base name */
@@ -685,7 +689,9 @@ parse_id(const char *id, struct find_struct *findwhat)
                     } else if (glyph_is_male_statue(glyph)) {
                         buf2 = "statue_of_male_";
                     }
-                    Snprintf(buf[1], sizeof buf[1], "%s%s", buf2, buf3);
+                    Strcpy(buf[0], "G_");
+                    Strcat(buf[0], buf2);
+                    Strcat(buf[0], buf3);
                 } else if (glyph_is_object(glyph)) {
                     i = glyph_to_obj(glyph);
                     /* buf2 will hold the distinguishing prefix */
@@ -717,11 +723,11 @@ parse_id(const char *id, struct find_struct *findwhat)
                                      : (i == SLIME_MOLD)
                                      ? "slime mold"
                                      : obj_descr[i].oc_name;
-                        Snprintf(buf[1], sizeof buf[1], "%s%s%s",
-                                 glyph_is_normal_piletop_obj(glyph)
-                                     ? "piletop_"
-                                     : "",
-                                 buf2, buf3);
+                        Strcpy(buf[0], "G_");
+                        if (glyph_is_normal_piletop_obj(glyph))
+                            Strcat(buf[0], "piletop_");
+                        Strcat(buf[0], buf2);
+                        Strcat(buf[0], buf3);
                     }
                 } else if (glyph_is_cmap(glyph) || glyph_is_cmap_zap(glyph)
                            || glyph_is_swallow(glyph)
@@ -798,8 +804,10 @@ parse_id(const char *id, struct find_struct *findwhat)
                         cmap = glyph_to_swallow(glyph);
                         mnum = j / ((S_sw_br - S_sw_tl) + 1);
                         i = cmap - S_sw_tl;
-                        Snprintf(buf[3], sizeof buf[3], "%s %s %s", "swallow",
-                                 monsdump[mnum].nm, swallow_texts[cmap]);
+                        Strcpy(buf[3], "swallow ");
+                        Strcat(buf[3], monsdump[mnum].nm);
+                        Strcat(buf[3], " ");
+                        Strcat(buf[3], swallow_texts[cmap]);
                         buf3 = buf[3];
                         skip_base = TRUE;
                     } else if (glyph_is_explosion(glyph)) {
@@ -828,26 +836,27 @@ parse_id(const char *id, struct find_struct *findwhat)
                     }
                     if (!skip_base) {
                         if (cmap >= 0 && cmap < MAXPCHARS) {
-                            Snprintf(buf[3], sizeof buf[3], "%s",
-                                     loadsyms[cmap + cmap_offset].name + 2);
-                            buf3 = buf[3];
+                            buf3 = loadsyms[cmap + cmap_offset].name + 2;
                         }
                     }
-                    Snprintf(buf[1], sizeof buf[1], "%s%s%s", buf2, buf3,
-                             buf4);
+                    Strcpy(buf[0], "G_");
+                    Strcat(buf[0], buf2);
+                    Strcat(buf[0], buf3);
+                    Strcat(buf[0], buf4);
                 } else if (glyph_is_invisible(glyph)) {
-                    Snprintf(buf[1], sizeof buf[1], "invisible");
+                    Strcpy(buf[0], "G_invisible");
                 } else if (glyph_is_nothing(glyph)) {
-                    Snprintf(buf[1], sizeof buf[1], "nothing");
+                    Strcpy(buf[0], "G_nothing");
                 } else if (glyph_is_unexplored(glyph)) {
-                    Snprintf(buf[1], sizeof buf[1], "unexplored");
+                    Strcpy(buf[0], "G_unexplored");
                 } else if (glyph_is_warning(glyph)) {
                     j = glyph - GLYPH_WARNING_OFF;
-                    Snprintf(buf[1], sizeof buf[1], "%s%d", "warning", j);
+                    Snprintf(buf[0], sizeof buf[0], "G_%s%d", "warning", j);
                 }
+                if (memchr(buf[0], '\0', sizeof buf[0]) == NULL)
+                    panic("parse_id: buf[0] overflowed\n");
                 if (!skip_this_one) {
-                    Snprintf(buf[0], sizeof buf[0], "G_%s",
-                             fix_glyphname(buf[1]));
+                    fix_glyphname(buf[0]+2);
                     if (dump_ids) {
                         Fprintf(fp, "(%04d) %s\n", glyph, buf[0]);
                     } else if (filling_cache) {

--- a/src/utf8map.c
+++ b/src/utf8map.c
@@ -581,7 +581,7 @@ parse_id(const char *id, struct find_struct *findwhat)
         pm_count = 0, oc_count = 0, cmap_count = 0;
     boolean skip_base = FALSE, skip_this_one, dump_ids = FALSE,
             filling_cache = FALSE, is_S = FALSE, is_G = FALSE;
-    char buf[5][QBUFSZ];
+    char buf[4][QBUFSZ];
 
     if (findwhat->findtype == find_nothing && findwhat->restype) {
         if (findwhat->restype == res_dump_glyphids) {
@@ -647,129 +647,123 @@ parse_id(const char *id, struct find_struct *findwhat)
             for (glyph = 0; glyph < MAX_GLYPH; ++glyph) {
                 skip_base = FALSE;
                 skip_this_one = FALSE;
-                buf[0][0] = buf[1][0] = buf[2][0] = buf[3][0] = buf[4][0] =
-                    '\0';
+                buf[0][0] = buf[1][0] = buf[2][0] = buf[3][0] = '\0';
                 if (glyph_is_monster(glyph)) {
-                    /* buf[2] will hold the distinguishing prefix */
-                    /* buf[3] will hold the base name */
-                    buf[2][0] = '\0';
-                    Snprintf(buf[3], sizeof buf[3], "%s",
-                             monsdump[glyph_to_mon(glyph)].nm);
+                    /* buf2 will hold the distinguishing prefix */
+                    /* buf3 will hold the base name */
+                    const char *buf2 = "";
+                    const char *buf3 = monsdump[glyph_to_mon(glyph)].nm;
                     if (glyph_is_normal_male_monster(glyph)) {
-                        Snprintf(buf[2], sizeof buf[2], "male_");
+                        buf2 = "male_";
                     } else if (glyph_is_normal_female_monster(glyph)) {
-                        Snprintf(buf[2], sizeof buf[2], "female_");
+                        buf2 = "female_";
                     } else if (glyph_is_ridden_male_monster(glyph)) {
-                        Snprintf(buf[2], sizeof buf[2], "ridden_male_");
+                        buf2 = "ridden_male_";
                     } else if (glyph_is_ridden_female_monster(glyph)) {
-                        Snprintf(buf[2], sizeof buf[2], "ridden_female_");
+                        buf2 = "ridden_female_";
                     } else if (glyph_is_detected_male_monster(glyph)) {
-                        Snprintf(buf[2], sizeof buf[2], "detected_male_");
+                        buf2 = "detected_male_";
                     } else if (glyph_is_detected_female_monster(glyph)) {
-                        Snprintf(buf[2], sizeof buf[2], "detected_female_");
+                        buf2 = "detected_female_";
                     } else if (glyph_is_male_pet(glyph)) {
-                        Snprintf(buf[2], sizeof buf[2], "pet_male_");
+                        buf2 = "pet_male_";
                     } else if (glyph_is_female_pet(glyph)) {
-                        Snprintf(buf[2], sizeof buf[2], "pet_female_");
+                        buf2 = "pet_female_";
                     }
-                    Snprintf(buf[1], sizeof buf[1], "%s%s", buf[2], buf[3]);
+                    Snprintf(buf[1], sizeof buf[1], "%s%s", buf2, buf3);
                 } else if (glyph_is_body(glyph)) {
-                    /* buf[2] will hold the distinguishing prefix */
-                    /* buf[3] will hold the base name */
-                    buf[2][0] = '\0';
-                    Snprintf(buf[3], sizeof buf[3], "%s",
-                             monsdump[glyph_to_body_corpsenm(glyph)].nm);
+                    /* buf2 will hold the distinguishing prefix */
+                    /* buf3 will hold the base name */
+                    const char *buf2 = "";
+                    const char *buf3 = monsdump[glyph_to_body_corpsenm(glyph)].nm;
                     if (glyph_is_body_piletop(glyph)) {
-                        Snprintf(buf[2], sizeof buf[2], "piletop_body_");
+                        buf2 = "piletop_body_";
                     } else {
-                        Snprintf(buf[2], sizeof buf[2], "body_");
+                        buf2 = "body_";
                     }
-                    Snprintf(buf[1], sizeof buf[1], "%s%s", buf[2], buf[3]);
+                    Snprintf(buf[1], sizeof buf[1], "%s%s", buf2, buf3);
                 } else if (glyph_is_statue(glyph)) {
-                    /* buf[2] will hold the distinguishing prefix */
-                    /* buf[3] will hold the base name */
-                    buf[2][0] = '\0';
-                    Snprintf(buf[3], sizeof buf[3], "%s",
-                             monsdump[glyph_to_statue_corpsenm(glyph)].nm);
+                    /* buf2 will hold the distinguishing prefix */
+                    /* buf3 will hold the base name */
+                    const char *buf2 = "";
+                    const char *buf3 = monsdump[glyph_to_statue_corpsenm(glyph)].nm;
                     if (glyph_is_fem_statue_piletop(glyph)) {
-                        Snprintf(buf[2], sizeof buf[2],
-                                 "piletop_statue_of_female_");
+                        buf2 = "piletop_statue_of_female_";
                     } else if (glyph_is_fem_statue(glyph)) {
-                        Snprintf(buf[2], sizeof buf[2], "statue_of_female_");
+                        buf2 = "statue_of_female_";
                     } else if (glyph_is_male_statue_piletop(glyph)) {
-                        Snprintf(buf[2], sizeof buf[2],
-                                 "piletop_statue_of_male_");
+                        buf2 = "piletop_statue_of_male_";
                     } else if (glyph_is_male_statue(glyph)) {
-                        Snprintf(buf[2], sizeof buf[2], "statue_of_male_");
+                        buf2 = "statue_of_male_";
                     }
-                    Snprintf(buf[1], sizeof buf[1], "%s%s", buf[2], buf[3]);
+                    Snprintf(buf[1], sizeof buf[1], "%s%s", buf2, buf3);
                 } else if (glyph_is_object(glyph)) {
                     i = glyph_to_obj(glyph);
-                    /* buf[2] will hold the distinguishing prefix */
-                    /* buf[3] will hold the base name */
-                    buf[2][0] = '\0';
+                    /* buf2 will hold the distinguishing prefix */
+                    /* buf3 will hold the base name */
+                    const char *buf2 = "";
+                    const char *buf3 = "";
                     if (((i > SCR_STINKING_CLOUD) && (i < SCR_MAIL))
                         || ((i > WAN_LIGHTNING) && (i < GOLD_PIECE)))
                         skip_this_one = TRUE;
                     if (!skip_this_one) {
                         if ((i >= WAN_LIGHT) && (i <= WAN_LIGHTNING))
-                            Snprintf(buf[2], sizeof buf[2], "wand of ");
+                            buf2 = "wand of ";
                         else if ((i >= SPE_DIG) && (i < SPE_BLANK_PAPER))
-                            Snprintf(buf[2], sizeof buf[2], "spellbook of ");
+                            buf2 = "spellbook of ";
                         else if ((i >= SCR_ENCHANT_ARMOR)
                                  && (i <= SCR_STINKING_CLOUD))
-                            Snprintf(buf[2], sizeof buf[2], "scroll of ");
+                            buf2 = "scroll of ";
                         else if ((i >= POT_GAIN_ABILITY) && (i <= POT_WATER))
-                            Snprintf(buf[2], sizeof buf[2], "%s",
-                                     (i == POT_WATER) ? "flask of n"
-                                                      : "potion of ");
+                            buf2 = (i == POT_WATER) ? "flask of n"
+                                                    : "potion of ";
                         else if ((i >= RIN_ADORNMENT)
                                  && (i <= RIN_PROTECTION_FROM_SHAPE_CHAN))
-                            Snprintf(buf[2], sizeof buf[2], "ring of ");
+                            buf2 = "ring of ";
                         else if (i == LAND_MINE)
-                            Snprintf(buf[2], sizeof buf[2], "unset ");
-                        Snprintf(buf[3], sizeof buf[3], "%s",
-                                 (i == SCR_BLANK_PAPER) ? "blank scroll"
+                            buf2 = "unset ";
+                        buf3 = (i == SCR_BLANK_PAPER) ? "blank scroll"
                                  : (i == SPE_BLANK_PAPER)
                                      ? "blank spellbook"
                                      : (i == SLIME_MOLD)
                                      ? "slime mold"
-                                     : obj_descr[i].oc_name);
+                                     : obj_descr[i].oc_name;
                         Snprintf(buf[1], sizeof buf[1], "%s%s%s",
                                  glyph_is_normal_piletop_obj(glyph)
                                      ? "piletop_"
                                      : "",
-                                 buf[2], buf[3]);
+                                 buf2, buf3);
                     }
                 } else if (glyph_is_cmap(glyph) || glyph_is_cmap_zap(glyph)
                            || glyph_is_swallow(glyph)
                            || glyph_is_explosion(glyph)) {
                     int cmap = -1;
 
-                    buf[2][0] =
-                        '\0'; /* buf[2] will hold the distinguishing prefix */
-                    buf[3][0] = '\0'; /* buf[3] will hold the base name */
-                    buf[4][0] =
-                        '\0'; /* buf[4] will hold the distinguishing suffix */
+                    /* buf2 will hold the distinguishing prefix */
+                    /* buf3 will hold the base name */
+                    /* buf4 will hold the distinguishing suffix */
+                    const char *buf2 = "";
+                    const char *buf3 = "";
+                    const char *buf4 = "";
                     if (glyph == GLYPH_CMAP_OFF) {
                         cmap = S_stone;
-                        Strcpy(buf[3], "stone substrate");
+                        buf3 = "stone substrate";
                         skip_base = TRUE;
                     } else if (glyph_is_cmap_gehennom(glyph)) {
                         cmap = (glyph - GLYPH_CMAP_GEH_OFF) + S_vwall;
-                        Snprintf(buf[4], sizeof buf[4], "%s", "_gehennom");
+                        buf4 = "_gehennom";
                     } else if (glyph_is_cmap_knox(glyph)) {
                         cmap = (glyph - GLYPH_CMAP_KNOX_OFF) + S_vwall;
-                        Snprintf(buf[4], sizeof buf[4], "%s", "_knox");
+                        buf4 = "_knox";
                     } else if (glyph_is_cmap_main(glyph)) {
                         cmap = (glyph - GLYPH_CMAP_MAIN_OFF) + S_vwall;
-                        Snprintf(buf[4], sizeof buf[4], "%s", "_main");
+                        buf4 = "_main";
                     } else if (glyph_is_cmap_mines(glyph)) {
                         cmap = (glyph - GLYPH_CMAP_MINES_OFF) + S_vwall;
-                        Snprintf(buf[4], sizeof buf[4], "%s", "_mines");
+                        buf4 = "_mines";
                     } else if (glyph_is_cmap_sokoban(glyph)) {
                         cmap = (glyph - GLYPH_CMAP_SOKO_OFF) + S_vwall;
-                        Snprintf(buf[4], sizeof buf[4], "%s", "_sokoban");
+                        buf4 = "_sokoban";
                     } else if (glyph_is_cmap_a(glyph)) {
                         cmap = (glyph - GLYPH_CMAP_A_OFF) + S_ndoor;
                     } else if (glyph_is_cmap_altar(glyph)) {
@@ -782,8 +776,9 @@ parse_id(const char *id, struct find_struct *findwhat)
                         if (j != altar_other) {
                             Snprintf(buf[2], sizeof buf[2], "%s_",
                                      altar_text[j]);
+                            buf2 = buf[2];
                         } else {
-                            Strcpy(buf[3], "altar other");
+                            buf3 = "altar other";
                             skip_base = TRUE;
                         }
                     } else if (glyph_is_cmap_b(glyph)) {
@@ -799,7 +794,8 @@ parse_id(const char *id, struct find_struct *findwhat)
                                  loadsyms[cmap + cmap_offset].name + 2);
                         Snprintf(buf[3], sizeof buf[3], "%s zap %s",
                                  zap_texts[j / 4], fix_glyphname(buf[2]));
-                        buf[2][0] = '\0';
+                        buf3 = buf[3];
+                        buf2 = "";
                         skip_base = TRUE;
                     } else if (glyph_is_cmap_c(glyph)) {
                         cmap = (glyph - GLYPH_CMAP_C_OFF) + S_digbeam;
@@ -815,6 +811,7 @@ parse_id(const char *id, struct find_struct *findwhat)
                         i = cmap - S_sw_tl;
                         Snprintf(buf[3], sizeof buf[3], "%s %s %s", "swallow",
                                  monsdump[mnum].nm, swallow_texts[cmap]);
+                        buf3 = buf[3];
                         skip_base = TRUE;
                     } else if (glyph_is_explosion(glyph)) {
                         int expl;
@@ -834,24 +831,27 @@ parse_id(const char *id, struct find_struct *findwhat)
                         i = cmap - S_expl_tl;
                         Snprintf(buf[2], sizeof buf[2], "%s ",
                                  expl_type_texts[expl]);
+                        buf2 = buf[2];
                         Snprintf(buf[3], sizeof buf[3], "%s%s", "expl_",
                                  expl_texts[i]);
+                        buf3 = buf[3];
                         skip_base = TRUE;
                     }
                     if (!skip_base) {
                         if (cmap >= 0 && cmap < MAXPCHARS) {
                             Snprintf(buf[3], sizeof buf[3], "%s",
                                      loadsyms[cmap + cmap_offset].name + 2);
+                            buf3 = buf[3];
                         }
                     }
-                    Snprintf(buf[1], sizeof buf[1], "%s%s%s", buf[2], buf[3],
-                             buf[4]);
+                    Snprintf(buf[1], sizeof buf[1], "%s%s%s", buf2, buf3,
+                             buf4);
                 } else if (glyph_is_invisible(glyph)) {
-                    Snprintf(buf[1], sizeof buf[1], "%s", "invisible");
+                    Snprintf(buf[1], sizeof buf[1], "invisible");
                 } else if (glyph_is_nothing(glyph)) {
-                    Snprintf(buf[1], sizeof buf[1], "%s", "nothing");
+                    Snprintf(buf[1], sizeof buf[1], "nothing");
                 } else if (glyph_is_unexplored(glyph)) {
-                    Snprintf(buf[1], sizeof buf[1], "%s", "unexplored");
+                    Snprintf(buf[1], sizeof buf[1], "unexplored");
                 } else if (glyph_is_warning(glyph)) {
                     j = glyph - GLYPH_WARNING_OFF;
                     Snprintf(buf[1], sizeof buf[1], "%s%d", "warning", j);

--- a/sys/unix/unixmain.c
+++ b/sys/unix/unixmain.c
@@ -114,12 +114,12 @@ main(int argc, char *argv[])
     if (!dir)
         dir = nh_getenv("HACKDIR");
 #endif /* CHDIR */
-    /* handle -dalthackdir, -s <score stuff>, --version, --showpaths */
-    early_options(&argc, &argv, &dir);
 #ifdef ENHANCED_SYMBOLS
     if (argcheck(argc, argv, ARG_DUMPGLYPHIDS) == 2)
         exit(EXIT_SUCCESS);
 #endif
+    /* handle -dalthackdir, -s <score stuff>, --version, --showpaths */
+    early_options(&argc, &argv, &dir);
 #ifdef CHDIR
     /*
      * Change directories before we initialize the window system so


### PR DESCRIPTION
I am building up to a mapping of every glyph that can be generated to a code point in the Private Use Area at U+E000-U+F9FF. Such a mapping amounts to a tile set that can be displayed in the TTY or the Curses port. This mapping has, at present, 5719 glyphs. Without changes to the code, such a large mapping becomes impractical for the DOS port running under DOSBox, and for other configurations on slow platforms.

These changes speed the processing of Unicode glyphs, and make the described mapping practical.

I am not including the mapping itself in the pull request, because the list of glyphs may change.

* Load the glyph ID cache when switching symbol sets
* Reimplement the glyph ID cache as a hash table
* Maintain a tail pointer for the linked list of glyphs, to avoid quadratic   time complexity when building that list
* Bypass match_sym for symbols beginning with G_
* Use strcpy in preference to snprintf to construct glyph IDs

Another change fixes handling of -dumpglyphids on Unix.