### PR TITLE
Guidebook: formatting for '#repeat' heading

### DIFF
--- a/doc/Guidebook.tex
+++ b/doc/Guidebook.tex
@@ -1604,7 +1604,7 @@ and also `{\tt \^{}L}' if {\it number\verb+_+pad\/} is on.
 \item[\tb{\#remove}]
 Remove an accessory (ring, amulet, etc). Default key is `{\tt R}'.
 %.lp
-\item[{\bb{\#repeat}}]
+\item[{\tb{\#repeat}}]
 Repeat the previous command.
 Default key is~`{\tt \^{}A}'.
 %.lp


### PR DESCRIPTION
Minuscule change.  #repeat was not monospaced like the other extended
commands.
