### PR TITLE
Fix: underwater vision update frequency

### DIFF
--- a/src/allmain.c
+++ b/src/allmain.c
@@ -329,16 +329,11 @@ moveloop_core(void)
 /* XXX This should be recoded to use something like regions - a list of
  * things that are active and need to be handled that is dynamically
  * maintained and not a list of special cases. */
-                /* underwater and waterlevel vision are done here */
+                /* vision will be updated as bubbles move */
                 if (Is_waterlevel(&u.uz) || Is_airlevel(&u.uz))
                     movebubbles();
                 else if (Is_firelevel(&u.uz))
                     fumaroles();
-                else if (Underwater)
-                    under_water(0);
-                /* vision while buried done here */
-                else if (u.uburied)
-                    under_ground(0);
 
                 /* when immobile, count is in turns */
                 if (gm.multi < 0) {
@@ -390,6 +385,12 @@ moveloop_core(void)
         /* when/if hero escapes from lava, he can't just stay there */
         else if (!u.umoved)
             (void) pooleffects(FALSE);
+
+        /* vision while buried or underwater is updated here */
+        if (Underwater)
+            under_water(0);
+        else if (u.uburied)
+            under_ground(0);
 
     } /* actual time passed */
 

--- a/src/apply.c
+++ b/src/apply.c
@@ -1592,7 +1592,7 @@ use_lamp(struct obj *obj)
         return;
     }
     if (Underwater) {
-        pline(!Is_candle(obj) ? "This is not a diving lamp"
+        pline(!Is_candle(obj) ? "This is not a diving lamp."
                               : "Sorry, fire and water don't mix.");
         return;
     }


### PR DESCRIPTION
Underwater vision was updated only once per turn, so if the hero had
more than one move per turn it could cause some spots to be left behind
on the map.  For example, after moving around underwater while very fast
for a while:

            }
          }}}
          }}}}
       }  }}@}
      }    }}}

Not only does the radius of vision appear to "smear" temporarily, but if
the hero moves fast enough, isolated spots can be left entirely behind
(since the normal underwater vision update only clears nearby spots, not
the entire map).  Both these effects are visible in the example above.

The fix in this commit is to update the frequency of underwater vision
updates to "once-per-time-taken" rather than "once-per-turn", so that it
updates with every move.  I'm not sure if it needs to happen more
frequently than that (i.e. in the "once-per-input" section) but I might
be overlooking something.

Also add missing punctuation to the message for applying a lamp
underwater.
