### PR TITLE
Avoid casting time_t to int

### DIFF
--- a/src/hacklib.c
+++ b/src/hacklib.c
@@ -1157,7 +1157,7 @@ time_from_yyyymmddhhmmss(char *buf)
             t.tm_sec = atoi(s);
             timeresult = mktime(&t);
         }
-        if ((int) timeresult == -1)
+        if (timeresult == (time_t) -1)
             debugpline1("time_from_yyyymmddhhmmss(%s) would have returned -1",
                         buf ? buf : "");
         else


### PR DESCRIPTION
As time_t may not fit int, cast -1 to time_t instead.