### PR TITLE
Fix: use-after-free in dog_eat()

### DIFF
--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -312,7 +312,6 @@ dog_eat(struct monst *mtmp,
         if (dogfood(mtmp, obj) == DOGFOOD && obj->invlet)
             edog->apport += (int) (200L / ((long) edog->dropdist + gm.moves
                                            - edog->droptime));
-        m_consume_obj(mtmp, obj);
         if (obj->unpaid) {
             /* edible item owned by shop has been thrown or kicked
                by hero and caught by tame or food-tameable monst */
@@ -321,6 +320,7 @@ dog_eat(struct monst *mtmp,
                   currency(oprice));
             /* m_consume_obj->delobj->obfree will handle actual shop billing update */
         }
+        m_consume_obj(mtmp, obj);
     }
 
     return (DEADMONSTER(mtmp)) ? 2 : 1;


### PR DESCRIPTION
I think moving the m_consume_obj call (which will free the eaten item)
further down should fix this without causing any really wacky message
sequencing issues, but if maintaining the exact order is important
obj->unpaid and its price could be cached before the free instead.
