### PR TITLE
Fix: default lregion exclusion area occupied real space on the map

### DIFF
--- a/doc/lua.adoc
+++ b/doc/lua.adoc
@@ -896,7 +896,7 @@ Example:
 Example:
 
  des.teleport_region({ region = { x1,y1, x2,y2} });
- des.teleport_region({ region = { x1,y1, x2,y2}, region_islev = 1, exclude = { x1,y1, x2,y2}, exclude_islen = 1, dir = "up" });
+ des.teleport_region({ region = { x1,y1, x2,y2}, region_islev = 1, exclude = { x1,y1, x2,y2}, exclude_islev = 1, dir = "up" });
 
 
 === terrain

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -5887,7 +5887,8 @@ levregion_add(lev_region* lregion)
 /* get params from topmost lua hash:
    - region = {x1,y1,x2,y2}
    - exclude = {x1,y1,x2,y2} (optional)
-   - region_islev=true, exclude_idlev=true (optional) */
+   - region_islev=true, exclude_islev=true (optional)
+   - negative x and y are invalid */
 static void
 l_get_lregion(lua_State *L, lev_region *tmplregion)
 {
@@ -5899,7 +5900,7 @@ l_get_lregion(lua_State *L, lev_region *tmplregion)
     tmplregion->inarea.x2 = x2;
     tmplregion->inarea.y2 = y2;
 
-    x1 = y1 = x2 = y2 = 0;
+    x1 = y1 = x2 = y2 = -1;
     get_table_region(L, "exclude", &x1, &y1, &x2, &y2, TRUE);
     tmplregion->delarea.x1 = x1;
     tmplregion->delarea.y1 = y1;
@@ -5908,6 +5909,13 @@ l_get_lregion(lua_State *L, lev_region *tmplregion)
 
     tmplregion->in_islev = get_table_boolean_opt(L, "region_islev", 0);
     tmplregion->del_islev = get_table_boolean_opt(L, "exclude_islev", 0);
+
+    /* if x1 is still negative, exclude wasn't specified, so we should treat it
+     * as if there is no exclude region at all. Force exclude_islev to true so
+     * the -1,-1,-1,-1 region is safely off the map and won't interfere with
+     * branch or portal placement. */
+    if (x1 < 0)
+        tmplregion->del_islev = TRUE;
 }
 
 /* teleport_region({ region = { x1,y1, x2,y2} }); */


### PR DESCRIPTION
The intuitive behavior of des.levregion or des.teleport_region when "exclude" is left unspecified is that there is no exclusion area. However, this wasn't actually the case: since l_get_lregion defaulted the exclusion area to (0,0,0,0) and exclude_islev to 0, this meant that the 0,0 space on the map would always be excluded from regions. In cases where a region was specified with its inclusion area constrained to the 0,0 space of the map, this would create a "Couldn't place lregion" impossible message.

This fixes that issue by defaulting the exclusion area to (-1,-1,-1,-1), and if the exclusion area is left unspecified, forces exclude_islev=1. This means that the exclusion zone will be outside the walkable space of the level where it can't cause any problems.

If a level designer puts negative coordinates in their inclusion or exclusion parameters, this might not work correctly, but negative region coordinates aren't currently used anywhere and probably shouldn't be supported anyway.