### PR TITLE
Wand of speed gives player temporary speed and potion gives intrinsic

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2234,6 +2234,7 @@ extern void mongrantswish(struct monst **);
 extern void djinni_from_bottle(struct obj *);
 extern struct monst *split_mon(struct monst *, struct monst *);
 extern const char *bottlename(void);
+extern void speed_up(long);
 
 /* ### pray.c ### */
 

--- a/src/potion.c
+++ b/src/potion.c
@@ -1035,14 +1035,13 @@ peffect_speed(struct obj *otmp)
         return;
     }
 
-    if (!Very_fast) { /* wwf@doe.carleton.ca */
-        You("are suddenly moving %sfaster.", Fast ? "" : "much ");
-    } else {
-        Your("%s get new energy.", makeplural(body_part(LEG)));
-        gp.potion_unkn++;
+    speed_up(rn1(10, 100 + 60 * bcsign(otmp)));
+
+    /* non-cursed potion grants intrinsic speed */
+    if (is_speed && !otmp->cursed && !(HFast & INTRINSIC)) {
+        Your("quickness feels very natural.");
+        HFast |= FROMOUTSIDE;
     }
-    exercise(A_DEX, TRUE);
-    incr_itimeout(&HFast, rn1(10, 100 + 60 * bcsign(otmp)));
 }
 
 static void
@@ -2783,6 +2782,19 @@ split_mon(
         }
     }
     return mtmp2;
+}
+
+/* Character becomes very fast temporarily. */
+void
+speed_up(long duration)
+{
+   if (!Very_fast)
+       You("are suddenly moving %sfaster.", Fast ? "" : "much ");
+   else
+       Your("%s get new energy.", makeplural(body_part(LEG)));
+
+   exercise(A_DEX, TRUE);
+   incr_itimeout(&HFast, duration);
 }
 
 /*potion.c*/

--- a/src/zap.c
+++ b/src/zap.c
@@ -2657,15 +2657,9 @@ zapyourself(struct obj *obj, boolean ordinary)
     }
 
     case WAN_SPEED_MONSTER:
-        if (!(HFast & INTRINSIC)) {
-            learn_it = TRUE;
-            if (!Fast)
-                You("speed up.");
-            else
-                Your("quickness feels more natural.");
-            exercise(A_DEX, TRUE);
-        }
-        HFast |= FROMOUTSIDE;
+        /* no longer gives intrinsic, but gives very fast speed instead */
+        speed_up(rn1(25, 50));
+        learn_it = TRUE;
         break;
 
     case WAN_SLEEP:


### PR DESCRIPTION
paxed said to submit a PR for this, so here it is. This is a port of https://github.com/copperwater/xNetHack/commit/33a63aa.

This aims to fix the issue in which there are way more wands of speed monster in the game than the player has any use for. Usually, one is enough for the whole game (unless a player has a lot of pets they want to speed up) but since they're an item monsters can generate with, it's typical to see eight to twelve of them, useless for anything besides polypiling into other wands since they just grant an intrinsic that's usually obtained early in the game.

By making the wand effect (on the player) temporary very fast speed, it becomes desirable to keep the wand around again. By adding a lightweight source of very fast speed, it also helps diversify character builds away from always relying on speed boots. And importantly, it becomes an item the player can use situationally early in the game to enhance their odds in a fight or run away from danger.

Meanwhile, the speed-intrinsic-granting has been moved to the potion, and the potion is still superior to the wand in the duration of very fast speed it grants (100 + d10 turns for an uncursed potion or 160 + d10 turns for a blessed one, versus 50 + d25 turns for the wand).

Since monsters don't have a concept of very fast speed, this doesn't change the wand or potion effects on them. They will still gain permanent intrinsic speed by either method.