### PR TITLE
Tweak maybe_unhide_at() a bit more

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -4128,16 +4128,21 @@ void
 maybe_unhide_at(coordxy x, coordxy y)
 {
     struct monst *mtmp;
-    boolean undetected = FALSE;
+    boolean undetected = FALSE, trapped = FALSE;
 
-    if ((mtmp = m_at(x, y)) == 0 && u_at(x, y)) {
+    if ((mtmp = m_at(x, y)) != (struct monst *) 0) {
+        undetected = mtmp->mundetected;
+        trapped = mtmp->mtrapped;
+    } else if (u_at(x, y)) {
         mtmp = &gy.youmonst;
         undetected = u.uundetected;
-    } else if (mtmp) {
-        undetected = mtmp->mundetected;
+        trapped = u.utrap;
+    } else {
+        return;
     }
-    if (mtmp && undetected
-        && ((hides_under(mtmp->data) && (!OBJ_AT(x, y) || mtmp->mtrapped))
+
+    if (undetected
+        && ((hides_under(mtmp->data) && (!OBJ_AT(x, y) || trapped))
             || (mtmp->data->mlet == S_EEL && !is_pool(x, y))))
         (void) hideunder(mtmp);
 }


### PR DESCRIPTION
A monster may be unhidden if it's caught in a trap, but maybe_unhide_at
was checking mtmp->mtrapped across the board, which wouldn't work for
the hero.  Use u.utrap instead under those circumstances.  Also refactor
a bit so it shouldn't need the repeated guards against mtmp being null.
