### PR TITLE
Fix: 'A'+'P' regression when dropping by type

### DIFF
--- a/src/do.c
+++ b/src/do.c
@@ -924,6 +924,7 @@ menu_drop(int retry)
             } else if (pick_list[i].item.a_int == 'P') {
                 justpicked_quan = max(0, pick_list[i].count);
                 drop_justpicked = TRUE;
+                drop_everything = FALSE;
                 add_valid_menu_class(pick_list[i].item.a_int);
             } else {
                 add_valid_menu_class(pick_list[i].item.a_int);


### PR DESCRIPTION
Selecting both 'P' (the just-picked-up items category) and 'A' (the
'auto-select relevant items' flag) when dropping items by type with 'D'
was automatically dropping every item in inventory instead of only items
that were marked as just having been picked up.  Basically, it was
causing 'A' to act like it did before b65c93c amended its functionality.

This commit is more-or-less identical to 991e739, both in terms of the
problem and the fix, except that it applies to dropping items instead of
looting.