### PR TITLE
Avoid "It turns into [Name]" on vamp engulf

### DIFF
--- a/src/mhitm.c
+++ b/src/mhitm.c
@@ -784,8 +784,13 @@ gulpmm(
                using that would be excessively verbose */
             pline("%s expels %s.", Monnam(magr),
                   canspotmon(mdef) ? "it" : something);
-            if (canspotmon(mdef))
-                pline("It turns into %s.", a_monnam(mdef));
+            if (canspotmon(mdef)) {
+                pline("It turns into %s.",
+                      x_monnam(mdef, ARTICLE_A, (char *) 0,
+                               (SUPPRESS_NAME | SUPPRESS_IT
+                                | SUPPRESS_INVISIBLE), FALSE));
+                
+            }
         }
         return MM_HIT; /* bypass mdamagem() */
     }

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -4548,10 +4548,17 @@ gulpum(struct monst *mdef, struct attack *mattk)
             && newcham(mdef, &mons[mdef->cham], NO_NC_FLAGS)) {
             You("%s it, then %s it.", u_digest ? "swallow" : "engulf",
                 expel_verb);
-            if (canspotmon(mdef))
-                pline("It turns into %s.", a_monnam(mdef));
-            else
+            if (canspotmon(mdef)) {
+                /* Avoiding a_monnam here: if the target is named, it gives us
+                   a sequence like "You bite Dracula.  You swallow it, then
+                   regurgitate it.  It turns into Dracula." */
+                pline("It turns into %s.",
+                      x_monnam(mdef, ARTICLE_A, (char *) 0,
+                               (SUPPRESS_NAME | SUPPRESS_IT
+                                | SUPPRESS_INVISIBLE), FALSE));
+            } else {
                 map_invisible(mdef->mx, mdef->my);
+            }
             return MM_HIT;
         }
 


### PR DESCRIPTION
Apply a similar fix as a791b4b and f441696 ended up settling on for
normal vampire transformation to the vampire transformation that happens
when their shapeshifted form is engulfed.
