### PR TITLE
x_monnam: use 'the' with adjective + given name

### DIFF
--- a/src/do_name.c
+++ b/src/do_name.c
@@ -2022,8 +2022,8 @@ x_monnam(
         name_at_start = (boolean) type_is_pname(mdat);
     }
 
-    if (name_at_start && (article == ARTICLE_YOUR || !has_adjectives)) {
-        if (mdat == &mons[PM_WIZARD_OF_YENDOR])
+    if (name_at_start) {
+        if (has_adjectives || mdat == &mons[PM_WIZARD_OF_YENDOR])
             article = ARTICLE_THE;
         else
             article = ARTICLE_NONE;


### PR DESCRIPTION
Most x_monnam articles retained the given article for an adjective +
name phrase, and y_monnam/ARTICLE_YOUR would drop the article even if
there were adjectives before the name.  Some of the resulting messages
and phrases like "Invisible Fido appears" (for ARTICLE_YOUR) or
"interior of an invisible Worm Boy" (for ARTICLE_AN) sound wrong to me;
normally if I am using an adjective with a given name, I will include
use a definite article ("the invisible Sally").  If there's a given name
combined with adjectives, use "the" (and continue to drop the article if
there's a given name on its own).

I have done some testing with this and the results sound more
idiomatic/natural to me, but hard to say for sure there wouldn't be any
strange results given the myriad different circumstances in which
monster names are used.
