### PR TITLE
Fix: message when pet moves from water to eat

### DIFF
--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -260,7 +260,7 @@ dog_eat(struct monst *mtmp,
         obj = splitobj(obj, 1L);
     if (obj->unpaid)
         iflags.suppress_price++;
-    if (is_pool(x, y) && !Underwater) {
+    if (is_pool(mtmp->mx, mtmp->my) && !Underwater) {
         /* Don't print obj */
         /* TODO: Reveal presence of sea monster (especially sharks) */
     } else {


### PR DESCRIPTION
The <x,y> params of dog_eat are the pet's starting position that turn,
not necessarily the position of the object being eaten.  If the pet is
doing a combined move-and-eat action, <x,y> will be its original spot,
but it will have already moved to <mtmp->mx,mtmp->my>, where the food
object also is.

The attempt to check whether the eating was happening out-of-sight
underwater (to suppress the message in that case) was checking the pet's
starting location, not its new location/the location of the food object.
So if a pet moved from water to land to eat something, the chowing-down
message would be improperly suppressed (and presumably the message for a
pet moving from land to water to eat would be improperly left
_un_suppressed, though I didn't actually try to reproduce that).
