### PR TITLE
Don't anger target via mon vs mon zap/breath

### DIFF
--- a/src/zap.c
+++ b/src/zap.c
@@ -4482,7 +4482,7 @@ dobuzz(
                         if (mon_could_move && !mon->mcanmove) /* ZT_SLEEP */
                             slept_monst(mon);
                         if (abstype != ZT_SLEEP)
-                            wakeup(mon, TRUE);
+                            wakeup(mon, !gc.context.mon_moving);
                     }
                 }
                 range -= 2;


### PR DESCRIPTION
dobuzz() was modified in 677b32c2a7 to anger the target, but beams
handled by dobuzz() don't necessarily originate from the hero.  Monsters
can zap wands that hit other monsters, dragons can use their breath
attacks, etc.  Those things were causing the targets to become angry at
the hero.
