### PR TITLE
Fix: using a selection in a lit des.region modified it

### DIFF
--- a/doc/lua.adoc
+++ b/doc/lua.adoc
@@ -804,6 +804,11 @@ Example:
 
 Create a room region, which can be irregular; use the boundary <<_map_characters,map character>> to restrict the floodfilled area.
 
+If using the first form with a selection and "lit", the lit area will extend
+outward 1 space from the selection to attempt to accomodate adjacent walls,
+regardless of whether they are actually walls or not. If using "unlit", this
+will not happen.
+
 Example:
 
  des.region(selection, lit);

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -6045,12 +6045,12 @@ lspo_region(lua_State *L)
     } else if (argc == 2) {
         /* region(selection, "lit"); */
         static const char *const lits[] = { "unlit", "lit", NULL };
-        struct selectionvar *sel = l_selection_check(L, 1);
+        struct selectionvar *orig = l_selection_check(L, 1),
+                            *sel = selection_clone(orig);
 
         rlit = luaL_checkoption(L, 2, "lit", lits);
 
         /*
-    TODO: adjust region size for wall, but only if lit
     TODO: lit=random
         */
         if (rlit)


### PR DESCRIPTION
The intuitive behavior when passing a selection to des.region, e.g.

    local foo = selection.area(07,02,10,24)
    des.region(foo, "lit")

is that foo will remain unmodified for further use. However, this wasn't the case whenever making a lit region from it, because in order to light walls adjacent to the lit area, the selection was having a grow transformation applied as well. (This also seems like a problem - it grows the selection even if what is being lit is not surrounded by walls. I added a note in lua.adoc about this behavior.)

This fixes the selection mutation by cloning the passed-in selection and growing the clone which leaves the original one unaffected.

This should not affect any special levels currently because the only instance of des.region being used with a selection appears to be in bigrm-2, which specifies *unlit* areas, which did not get grown.

I started writing a patch to change the behavior of selection_do_grow when it's being used for lit areas extending to walls to only apply to terrain types which are not `SPACE_POS`, but decided not to until I know whether it's truly unintended behavior.