### PR TITLE
Enable statue traps with specific statues of monsters

### DIFF
--- a/doc/lua.adoc
+++ b/doc/lua.adoc
@@ -807,7 +807,7 @@ The table parameter accepts the following:
 | lit         | boolean  | Is the object lit?
 | eroded      | int      | Object erosion
 | locked      | boolean  | Is the object locked?
-| trapped     | boolean  | Is the object trapped?
+| trapped     | boolean  | Is the object trapped? (If the object is a statue, a statue trap will be created underneath it.)
 | recharged   | boolean  | Is the object recharged?
 | greased     | boolean  | Is the object greased?
 | broken      | boolean  | Is the object broken?

--- a/include/extern.h
+++ b/include/extern.h
@@ -2885,6 +2885,7 @@ extern coord *gettrack(coordxy, coordxy);
 
 extern boolean burnarmor(struct monst *);
 extern int erode_obj(struct obj *, const char *, int, int);
+extern void mk_trap_statue(coordxy, coordxy);
 extern boolean grease_protect(struct obj *, const char *, struct monst *);
 extern struct trap *maketrap(coordxy, coordxy, int);
 extern d_level *clamp_hole_destination(d_level *);

--- a/src/mklev.c
+++ b/src/mklev.c
@@ -1664,6 +1664,8 @@ mktrap(
        should prevent cases where that might not happen) but be paranoid */
     kind = t ? t->ttyp : NO_TRAP;
 
+    if (kind == STATUE_TRAP)
+        mk_trap_statue(m.x, m.y);
     if (kind == WEB && !(mktrapflags & MKTRAP_NOSPIDERONWEB))
         (void) makemon(&mons[PM_GIANT_SPIDER], m.x, m.y, NO_MM_FLAGS);
     if (t && (mktrapflags & MKTRAP_SEEN))

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -3250,6 +3250,8 @@ wizterrainwish(struct _readobjnam_data *d)
         if (is_hole(trap) && !Can_fall_thru(&u.uz))
             trap = ROCKTRAP;
         if ((t = maketrap(x, y, trap)) != 0) {
+            if (t->ttyp == STATUE_TRAP)
+                mk_trap_statue(x, y);
             trap = t->ttyp;
             tname = trapname(trap, TRUE);
             pline("%s%s.", An(tname),

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -2266,8 +2266,18 @@ create_object(object *o, struct mkroom *croom)
         otmp->olocked = 0; /* obj generation may set */
     }
     if (o->trapped == 0 || o->trapped == 1) {
-        if (otmp->otyp == STATUE && o->trapped)
+        if (otmp->otyp == STATUE && o->trapped) {
+            /* if x and y were specified randomly, there may already be a trap
+             * on this space; because of the coordinate packing system it's
+             * difficult to tell whether x and y here are supposed to be random
+             * or not, or to compute within lspo_object ahead of time what x and
+             * y will be and if there will be a trap there, so just get rid of
+             * the preexisting trap */
+            struct trap *trap = t_at(x, y);
+            if (trap)
+                deltrap(trap);
             maketrap(x, y, STATUE_TRAP);
+        }
         else
             otmp->otrapped = o->trapped;
     }

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -2265,8 +2265,12 @@ create_object(object *o, struct mkroom *croom)
         otmp->obroken = 1;
         otmp->olocked = 0; /* obj generation may set */
     }
-    if (o->trapped == 0 || o->trapped == 1)
-        otmp->otrapped = o->trapped;
+    if (o->trapped == 0 || o->trapped == 1) {
+        if (otmp->otyp == STATUE && o->trapped)
+            maketrap(x, y, STATUE_TRAP);
+        else
+            otmp->otrapped = o->trapped;
+    }
     otmp->greased = o->greased ? 1 : 0;
 
     if (o->quan > 0 && objects[otmp->otyp].oc_merge) {
@@ -2933,6 +2937,8 @@ fill_empty_maze(void)
                 while (is_pit(trytrap) || is_hole(trytrap))
                     trytrap = rndtrap();
             (void) maketrap(mm.x, mm.y, trytrap);
+            if (trytrap == STATUE_TRAP)
+                mk_trap_statue(mm.x, mm.y);
         }
     }
 }

--- a/src/trap.c
+++ b/src/trap.c
@@ -7,7 +7,6 @@
 
 extern const char *const destroy_strings[][3]; /* from zap.c */
 
-static void mk_trap_statue(coordxy, coordxy);
 static int dng_bottom(d_level *lev);
 static void hole_destination(d_level *);
 static boolean keep_saddle_with_steedcorpse(unsigned, struct obj *,
@@ -368,7 +367,7 @@ grease_protect(
 }
 
 /* create a "living" statue at x,y */
-static void
+void
 mk_trap_statue(coordxy x, coordxy y)
 {
     struct monst *mtmp;
@@ -486,9 +485,6 @@ maketrap(coordxy x, coordxy y, int typ)
     switch (typ) {
     case SQKY_BOARD:
         ttmp->tnote = choose_trapnote(ttmp);
-        break;
-    case STATUE_TRAP: /* create a "living" statue */
-        mk_trap_statue(x, y);
         break;
     case ROLLING_BOULDER_TRAP: /* boulder will roll towards trigger */
         (void) mkroll_launch(ttmp, x, y, BOULDER, 1L);


### PR DESCRIPTION
Previously, attempting to specify a statue trap would have it unconditionally create a statue of a random monster in maketrap() on top of the trap, which is no good if one wants a certain type of monster to be the statue trap. (A poor workaround would be to add another statue of the desired monster on the same space since statue traps animate the topmost statue, but since this would create a pile of statues, it would be readily apparent.)

This commit lets the level designer create a statue trap by specifying the "trapped" field on a statue created with des.object. Instead of setting otrapped on the statue, it will create a statue trap on the floor underneath it.

A des.trap('statue') will still always create a statue of a random monster. I originally implemented an extra flag to pass into des.trap that would disable this behavior, but then figured that a statueless statue trap still needs a des.object('statue') statement to make the statue, which could just be specified as trapped in the first place. So it wouldn't really add anything.

Internally, this moves the statue creation out of maketrap(), so that a trapped statue can call maketrap(STATUE_TRAP) without side effects. This means that responsibility for making a statue now falls to the caller of maketrap, which is only relevant in 3 places (generic mktrap(), wizard mode trap wishing, and adding random traps to a maze).