### PR TITLE
Initialize scrollbar 'framecolor' before use

### DIFF
--- a/win/curses/curswins.c
+++ b/win/curses/curswins.c
@@ -725,18 +725,22 @@ curses_draw_map(int sx, int sy, int ex, int ey)
 #ifdef MAP_SCROLLBARS
     hsb_back.ch = '-';
     hsb_back.color = SCROLLBAR_BACK_COLOR;
+    hsb_back.framecolor = NO_COLOR;
     hsb_back.attr = A_NORMAL;
     hsb_back.unicode_representation = NULL;
     hsb_bar.ch = '*';
     hsb_bar.color = SCROLLBAR_COLOR;
+    hsb_bar.framecolor = NO_COLOR;
     hsb_bar.attr = A_NORMAL;
     hsb_bar.unicode_representation = NULL;
     vsb_back.ch = '|';
     vsb_back.color = SCROLLBAR_BACK_COLOR;
+    vsb_back.framecolor = NO_COLOR;
     vsb_back.attr = A_NORMAL;
     vsb_back.unicode_representation = NULL;
     vsb_bar.ch = '*';
     vsb_bar.color = SCROLLBAR_COLOR;
+    vsb_bar.framecolor = NO_COLOR;
     vsb_bar.attr = A_NORMAL;
     vsb_bar.unicode_representation = NULL;
 


### PR DESCRIPTION
Caused an asan crash because the value is used to index an array.
