### PR TITLE
Remove the manual 50% vertical swap of doors in Baalzebub level

### DIFF
--- a/dat/baalz.lua
+++ b/dat/baalz.lua
@@ -33,12 +33,6 @@ des.non_diggable(selection.area(00,00,47,12))
 des.mazewalk(00,06,"west")
 des.stair("down", 44,06)
 des.door("locked",00,06)
-if percent(50) then
-   des.terrain(34,08,'-')
-   des.terrain(34,04,'S')
-   des.terrain(29,05,'|')
-   des.terrain(29,07,'S')
-end
 -- The fellow in residence
 des.monster("Baalzebub",35,06)
 -- Some random weapons and armor.


### PR DESCRIPTION
This was added before level flipping, and its purpose effectively was to randomize the interior secret door layout (and thus the entire level, because the rest is vertically symmetric) by manually flipping it. Now that the entire level can be flipped and produce this same effect, this is no longer necessary.