### PR TITLE
Make "cookie-only" rumors explicit in rumors file

### DIFF
--- a/dat/rumors.fal
+++ b/dat/rumors.fal
@@ -22,7 +22,7 @@ A visit to the Zoo is very educational; you meet interesting animals.
 A wand of deaf is a more dangerous weapon than a wand of sheep.
 A wand of vibration might bring the whole cave crashing about your ears.
 A winner never quits.  A quitter never wins.
-A wish?  Okay, make me a fortune cookie!
+[cookie] A wish?  Okay, make me a fortune cookie!
 Afraid of mimics?  Try to wear a ring of true seeing.
 All monsters are created evil, but some are more evil than others.
 Always attack a floating eye from behind!
@@ -76,7 +76,7 @@ For any remedy there is a misery.
 Giant bats turn into giant vampires.
 Good day for overcoming obstacles.  Try a steeplechase.
 Half Moon tonight.  (At least it's better than no Moon at all.)
-Help!  I'm being held prisoner in a fortune cookie factory!
+[cookie] Help!  I'm being held prisoner in a fortune cookie factory!
 Housecats have nine lives, kittens only one.
 How long can you tread water?
 Hungry?  There is an abundance of food on the next level.
@@ -126,7 +126,7 @@ Never teach your pet rust monster to fetch.
 Never trust a random generator in magic fields.
 Never use a wand of death.
 No level contains two shops.  The maze is no level.  So...
-No part of this fortune may be reproduced, stored in a retrieval system, ...
+[cookie] No part of this fortune may be reproduced, stored in a retrieval system, ...
 Not all rumors are as misleading as this one.
 Nymphs and nurses like beautiful rings.
 Nymphs are blondes.  Are you a gentleman?
@@ -155,7 +155,7 @@ Shopkeepers sometimes die from old age.
 Some mazes (especially small ones) have no solutions, says man 6 maze.
 Some questions the Sphynx asks just *don't* have any answers.
 Sometimes "mu" is the answer.
-Sorry, no fortune this time.  Better luck next cookie!
+[cookie] Sorry, no fortune this time.  Better luck next cookie!
 Spare your scrolls of make-edible until it's really necessary!
 Sticks and stones may break your bones but manes will never hurt you.
 Stormbringer doesn't steal souls.  People steal souls.
@@ -188,12 +188,12 @@ They say that a desperate shopper might pay any price in a shop.
 They say that a diamond dog is everybody's best friend.
 They say that a dwarf lord can carry a pick-axe because his armor is light.
 They say that a floating eye can defeat Medusa.
-They say that a fortune only has 1 line and you can't read between it.
-They say that a fortune only has 1 line, but you can read between it.
+[cookie] They say that a fortune only has 1 line and you can't read between it.
+[cookie] They say that a fortune only has 1 line, but you can read between it.
 They say that a fountain looks nothing like a regularly erupting geyser.
 They say that a gold doubloon is worth more than its weight in gold.
 They say that a grid bug won't pay a shopkeeper for zapping you in a shop.
-They say that a gypsy could tell your fortune for a price.
+[cookie] They say that a gypsy could tell your fortune for a price.
 They say that a hacker named Alice once level teleported by using a mirror.
 They say that a hacker named David once slew a giant with a sling and a rock.
 They say that a hacker named Dorothy once rode a fog cloud to Oz.
@@ -248,7 +248,7 @@ They say that everyone knows why Medusa stands alone in the dark.
 They say that everyone wanted rec.games.hack to undergo a name change.
 They say that finding a winning strategy is a deliberate move on your part.
 They say that finding worthless glass is worth something.
-They say that fortune cookies are food for thought.
+[cookie] They say that fortune cookies are food for thought.
 They say that gold is only wasted on a pet dragon.
 They say that good things come to those that wait.
 They say that greased objects will slip out of monsters' hands.
@@ -350,8 +350,8 @@ They say that you should never introduce a rope golem to a succubus.
 They say that you should never sleep near invisible ring wraiths.
 They say that you should never try to leave the dungeon with a bag of gems.
 They say that you should remove your armor before sitting on a throne.
-This fortune cookie is copy protected.
-This fortune cookie is the property of Fortune Cookies, Inc.
+[cookie] This fortune cookie is copy protected.
+[cookie] This fortune cookie is the property of Fortune Cookies, Inc.
 This release contains 10% recycled material.
 Time stands still as the succubus changes her calendar to January 1, 2000.
 Tired?  Try a scroll of charging on yourself.
@@ -366,30 +366,30 @@ Waltz, dumb nymph, for quick jigs vex.
 Want a hint?  Zap a wand of make invisible on your weapon!
 Want to ascend in a hurry?  Apply at Gizmonic Institute.
 Wanted: shopkeepers.  Send a scroll of mail to Mage of Yendor/Level 35/Dungeon.
-Warning:  fortune reading can be hazardous to your health.
+[cookie] Warning:  fortune reading can be hazardous to your health.
 We have new ways of detecting treachery...
 Wet towels make great weapons!
-What a pity, you cannot read it!
+[cookie] What a pity, you cannot read it!
 Whatever can go wrong, will go wrong.
 When a piercer drops in on you, you will be tempted to hit the ceiling!
 When in a maze follow the right wall and you will never get lost.
 When you have a key, you don't have to wait for the guard.
-Why are you wasting time reading fortunes?
+[cookie] Why are you wasting time reading fortunes?
 Wish for a master key and open the Magic Memory Vault!
 Wizard expects every monster to do its duty.
 Wow!  You could've had a potion of fruit juice!
 Yet Another Silly Message (YASM).
-You are destined to be misled by a fortune.
+[cookie] You are destined to be misled by a fortune.
 You can get a genuine Amulet of Yendor by doing the following:  --More--
 You can make holy water by boiling the hell out of it.
 You can protect yourself from black dragons by doing the following:  --More--
 You can't get by the snake.
-You choke on the fortune cookie.  --More--
+[cookie] You choke on the fortune cookie.  --More--
 You feel like someone is pulling your leg.
 You have to outwit the Sphynx or pay her.
-You hear the fortune cookie's hissing!
+[cookie] You hear the fortune cookie's hissing!
 You may get rich selling letters, but beware of being blackmailed!
 You offend Shai-Hulud by sheathing your crysknife without having drawn blood.
-You swallowed the fortune!
+[cookie] You swallowed the fortune!
 You want to regain strength?  Two levels ahead is a guesthouse!
 You will encounter a tall, dark, and gruesome creature...

--- a/src/rumors.c
+++ b/src/rumors.c
@@ -121,6 +121,8 @@ getrumor(
     dlb *rumors;
     long beginning, ending;
     char line[BUFSZ];
+    static const char *cookie_marker = "[cookie] ";
+    const int marklen = strlen(cookie_marker);
 
     rumor_buf[0] = '\0';
     if (gt.true_rumor_size < 0L) /* a previous try failed to open RUMORFILE */
@@ -163,9 +165,8 @@ getrumor(
             Strcpy(rumor_buf,
                    get_rnd_line(rumors, line, (unsigned) sizeof line, rn2,
                                 beginning, ending, MD_PAD_RUMORS));
-        } while (count++ < 50 && (exclude_cookie
-                                  && (strstri(rumor_buf, "fortune")
-                                      || strstri(rumor_buf, "pity"))));
+        } while (count++ < 50 && exclude_cookie
+                 && !strncmp(rumor_buf, cookie_marker, marklen));
         (void) dlb_fclose(rumors);
         if (count >= 50)
             impossible("Can't find non-cookie rumor?");
@@ -174,6 +175,16 @@ getrumor(
     } else {
         couldnt_open_file(RUMORFILE);
         gt.true_rumor_size = -1; /* don't try to open it again */
+    }
+    if (!exclude_cookie
+        && !strncmp(rumor_buf, cookie_marker, marklen)) {
+        /* remove cookie_marker from the string */
+        char *src = rumor_buf + marklen;
+        char *dst = rumor_buf;
+        for (; *src != '\0'; ++src, ++dst) {
+            *dst = *src;
+        }
+        *dst = '\0'; /* terminator wasn't copied */
     }
     return rumor_buf;
 }


### PR DESCRIPTION
The prior behavior was an ugly kludge that treated rumors as only-eligible-to-appear-from-fortune-cookies if they contained the string "fortune" or "pity". This commit gets rid of that system and introduces a system where each rumor can be specified as such by prefixing it with "[cookie]".

In order to avoid changing existing behavior, I have applied the [cookie] prefix to all the rumors which were affected under the old rules. However, several rumors seem like they were misclassified under the old rules, and I am in favor of changing them as follows:

Should be made cookie-only (they only really make sense in context of eating a fortune cookie):
- "Ouch. I hate when that happens."
- "PLEASE ignore previous rumor."
- "Suddenly, the dungeon will collapse..."
- "Unfortunately, this message was left intentionally blank."

Should be made non-cookie-only (they make sense if they appear as engravings or artifact whispers):
- "They say that a gypsy could tell your fortune for a price."
- "They say that fortune cookies are food for thought."