### PR TITLE
Give a message when a monster is zapped with make invisible

### DIFF
--- a/src/zap.c
+++ b/src/zap.c
@@ -307,9 +307,11 @@ bhitm(struct monst *mtmp, struct obj *otmp)
         if (disguised_mimic)
             seemimic(mtmp);
         reveal_invis = !u_teleport_mon(mtmp, TRUE);
+        learn_it = canspotmon(mtmp);
         break;
     case WAN_MAKE_INVISIBLE: {
         int oldinvis = mtmp->minvis;
+        boolean couldsee = canseemon(mtmp);
         char nambuf[BUFSZ];
 
         if (disguised_mimic)
@@ -321,6 +323,12 @@ bhitm(struct monst *mtmp, struct obj *otmp)
             pline("%s turns transparent!", nambuf);
             reveal_invis = TRUE;
             learn_it = TRUE;
+        }
+        else if (couldsee && !canseemon(mtmp)) {
+            /* keep the immediate effects of make invisible and teleportation
+             * ambiguous by using the same message that's used if we teleported
+             * mtmp (and it ended up somewhere you can't see) */
+            pline("%s vanishes!", nambuf);
         }
         break;
     }


### PR DESCRIPTION
Every other case I'm aware of where a visible monster that the hero can see turns invisible has some associated message, but not when zapping it with the wand of make invisible and lacking see invisible. This adds a message "[monster] vanishes!" in this case, which is the same as the most common message one gets for zapping a monster with teleportation, by design to keep the wand's identity ambiguous.

Technically, prior to this commit, there was a leak of information if one zapped a wand that made a monster disappear: the identity of the want could be determined immediately by the presence or absence of a vanishing message. Practically, though, it was easy to check if there was a new invisible monster in the same spot or not.

Also, zapping teleportation at a monster and having it land somewhere visible to the hero now has attention explicitly drawn to it with a message (in prior versions it didn't, so it could potentially be a different monster appearing by some other means), so I additionally made the wand of teleportation automatically identify itself when the hero sees the monster appear as a result of their zap.