### PR TITLE
Don't drop aklys on the floor due to slippery fingers

### DIFF
--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -2421,7 +2421,7 @@ glibr(void)
             dropx(otmp);
     }
     otmp = uwep;
-    if (otmp && !welded(otmp)) {
+    if (otmp && otmp->otyp != AKLYS && !welded(otmp)) {
         long savequan = otmp->quan;
 
         /* nice wording if both weapons are the same type */


### PR DESCRIPTION
Aklyses uniquely have a tether attached to one's wrist, which would stay secure even when one's fingers are slippery. Therefore, it doesn't make for the weapon to be dropped completely, tether and all, when Glib.

However, the game doesn't have a way to model a weapon that's on the floor at your feet but still attached to your arm. (Technically the uball and uchain code does do this sort of thing already, but it can't be used here - what if you have an aklys slipping out of your grasp and are punished at the same time?) So the next best thing is to give aklyses immunity to slipping from one's hand.