### PR TITLE
Doppelgangers mimic top ten list members.

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2866,6 +2866,7 @@ extern void topten(int, time_t);
 extern void prscore(int, char **);
 extern struct toptenentry *get_rnd_toptenentry(void);
 extern struct obj *tt_oname(struct obj *);
+extern int tt_doppel(struct monst *);
 
 /* ### track.c ### */
 

--- a/src/mon.c
+++ b/src/mon.c
@@ -4471,7 +4471,7 @@ select_newcham_form(struct monst* mon)
         if (!rn2(7)) {
             mndx = pick_nasty(mons[PM_JABBERWOCK].difficulty - 1);
         } else if (rn2(3)) { /* role monsters */
-            mndx = rn1(PM_WIZARD - PM_ARCHEOLOGIST + 1, PM_ARCHEOLOGIST);
+            mndx = tt_doppel(mon);
         } else if (!rn2(3)) { /* quest guardians */
             mndx = rn1(PM_APPRENTICE - PM_STUDENT + 1, PM_STUDENT);
             /* avoid own role's guardian */

--- a/src/topten.c
+++ b/src/topten.c
@@ -1428,6 +1428,29 @@ tt_oname(struct obj *otmp)
     return otmp;
 }
 
+/* Randomly select a topten entry to mimic */
+int
+tt_doppel(struct monst *mon) {
+    struct toptenentry *tt = get_rnd_toptenentry();
+    int ret;
+
+    if (!tt)
+        ret = rn1(PM_WIZARD - PM_ARCHEOLOGIST + 1, PM_ARCHEOLOGIST);
+    else {
+        if (tt->plgend[0] == 'F')
+            mon->female = 1;
+        else if (tt->plgend[0] == 'M')
+            mon->female = 0;
+        ret = classmon(tt->plrole);
+        /* Only take on a name if the player can see
+           the doppelganger, otherwise we end up with 
+           named monsters spoiling the fun - Kes */
+        if (canseemon(mon))
+            christen_monst(mon, tt->name);
+    }
+    return ret;
+}
+
 #ifdef NO_SCAN_BRACK
 /* Lattice scanf isn't up to reading the scorefile.  What */
 /* follows deals with that; I admit it's ugly. (KL) */


### PR DESCRIPTION
I saw this idea in the YANI archive, and I thought it was a fairly interesting feature. Doppelgangers in D&D are known for committing identity theft, but in NetHack they are almost indistinguishable from other shapeshifters, at least for the average player. This commit makes them a bit more interesting, I think.

The canseemon check exists because otherwise the player might run into a random monster named after a top ten list character, and be slightly confused. While it might have been a bit cleaner to rechristen the monster after every shapechange, that would present its own set of issues. 

If the game cannot find a top ten list member, the doppelganger simply changes into a random player monster, as they do currently.

(cherry picked from commit 2ba9c96f1df2093669c20d869730b2a4a1bdc3ea)