### PR TITLE
Adjust statue traps to be biased toward more difficult monsters.

### DIFF
--- a/src/trap.c
+++ b/src/trap.c
@@ -356,7 +356,7 @@ mk_trap_statue(coordxy x, coordxy y)
     int trycount = 10;
 
     do { /* avoid ultimately hostile co-aligned unicorn */
-        mptr = &mons[rndmonnum()];
+        mptr = &mons[rndmonnum_adj(5, 10)];
     } while (--trycount > 0 && is_unicorn(mptr)
              && sgn(u.ualign.type) == sgn(mptr->maligntyp));
     statue = mkcorpstat(STATUE, (struct monst *) 0, mptr, x, y,


### PR DESCRIPTION
This is originally from the YANI archive as well, but dovetails nicely with the recent change to bias figurines toward more difficult monsters. The purpose of this change is to make statue traps somewhat dangerous, as they currently suffer from a problem similar to the one that figurines used to.

I experimented with biasing all statues toward more difficult monsters, but I ultimately decided against it. From a flavor perspective, it feels odd to see a statue of something that does not normally appear on the level, and it could also potentially unbalance the game in favor of players that can cast stone-to-flesh. Additionally, if only statue traps are more difficult, the savvy player can pick out statue traps before triggering them.