### PR TITLE
Keep track of movement points between saves

### DIFF
--- a/src/allmain.c
+++ b/src/allmain.c
@@ -68,6 +68,7 @@ moveloop_preamble(boolean resuming)
            clairvoyance (wizard with cornuthaum perhaps?); without this,
            first "random" occurrence would always kick in on turn 1 */
         gc.context.seer_turn = (long) rnd(30);
+        gy.youmonst.movement = NORMAL_SPEED; /* give hero some movement points */
     }
     gc.context.botlx = TRUE; /* for STATUS_HILITES */
     if (resuming) { /* restoring old game */
@@ -83,7 +84,6 @@ moveloop_preamble(boolean resuming)
     initrack();
 
     u.uz0.dlevel = u.uz.dlevel;
-    gy.youmonst.movement = NORMAL_SPEED; /* give hero some movement points */
     gc.context.move = 0;
 
     gp.program_state.in_moveloop = 1;

--- a/src/restore.c
+++ b/src/restore.c
@@ -573,6 +573,7 @@ restgamestate(
     if (nhfp->structlevel)
         Mread(nhfp->fd, &u, sizeof u);
     gy.youmonst.cham = u.mcham;
+    Mread(nhfp->fd, &(gy.youmonst.movement), 2);
 
     if (nhfp->structlevel)
         Mread(nhfp->fd, timebuf, 14);

--- a/src/save.c
+++ b/src/save.c
@@ -290,6 +290,7 @@ savegamestate(NHFILE *nhfp)
                                       urealtime.start_timing);
     if (nhfp->structlevel) {
         bwrite(nhfp->fd, (genericptr_t) &u, sizeof u);
+        bwrite(nhfp->fd, (genericptr_t) &(gy.youmonst.movement), 2);
         bwrite(nhfp->fd, yyyymmddhhmmss(ubirthday), 14);
         bwrite(nhfp->fd, (genericptr_t) &urealtime.realtime,
                sizeof urealtime.realtime);


### PR DESCRIPTION
Currently, whenever a saved game is loaded, a character is granted a flat 12 movement points, which they immediately use to move. This means that any movement points they had when saving are wasted, meaning saving has an in-game disadvantage---a small one, but possibly noticeable if you care about turncount or you save in a dangerous situation to think about your options. For instance, if you are burdened and not fast, moving after saving always takes two turns. If you are unburdened and fast, moving after saving always takes one turn. 

This commit keeps track of your movement points between saves in the least elegant way possible, and definitely breaks saves. But it works!