### PR TITLE
Allow des.object "trapped" field to be a boolean

### DIFF
--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -2266,7 +2266,7 @@ create_object(object* o, struct mkroom* croom)
         otmp->olocked = 0; /* obj generation may set */
     }
     if (o->trapped == 0 || o->trapped == 1)
-        otmp->otrapped = o->trapped;
+        otmp->otrapped = (boolean) o->trapped;
     if (o->greased)
         otmp->greased = 1;
     else {
@@ -3581,7 +3581,7 @@ lspo_object(lua_State *L)
         tmpobj.lit = get_table_boolean_opt(L, "lit", 0);
         tmpobj.eroded = get_table_int_opt(L, "eroded", 0);
         tmpobj.locked = get_table_boolean_opt(L, "locked", -1);
-        tmpobj.trapped = get_table_int_opt(L, "trapped", -1);
+        tmpobj.trapped = get_table_boolean_opt(L, "trapped", -1);
         tmpobj.recharged = get_table_int_opt(L, "recharged", 0);
         tmpobj.greased = get_table_boolean_opt(L, "greased", 0);
         tmpobj.broken = get_table_boolean_opt(L, "broken", 0);


### PR DESCRIPTION
I thought there were more object fields that currently only accept ints but ought to accept booleans, but when I checked I found that most of them do already, and the ones that take ints are the ones that the number carries meaning (spe, recharged, etc).

Except for trapped. In struct obj, otrapped is a 1-bit flag, so there's no good reason for the level parser to treat it as a type error if someone intuitively makes a des.object call with trapped=true or trapped=false. Change it to an optional boolean argument, like the other boolean flags (locked, greased, etc).

Note that get_table_boolean_opt still accepts ints, so existing uses of trapped=0 or trapped=1 won't be affected.