### PR TITLE
Make loadstone useful

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1516,6 +1516,7 @@ extern int add_to_minv(struct monst *, struct obj *);
 extern struct obj *add_to_container(struct obj *, struct obj *);
 extern void add_to_migration(struct obj *);
 extern void add_to_buried(struct obj *);
+extern void container_weight(struct obj *);
 extern void dealloc_obj(struct obj *);
 extern void obj_ice_effects(coordxy, coordxy, boolean);
 extern long peek_at_iced_corpse_age(struct obj *);

--- a/src/do.c
+++ b/src/do.c
@@ -858,6 +858,17 @@ obj_no_longer_held(struct obj *obj)
             obj->oerodeproof = 0;
         }
         break;
+    case LOADSTONE:
+        if (obj->blessed) {
+            unbless(obj);
+        } else {
+            curse(obj);
+        }
+        /* loadstone may change weight */
+        if (obj->where == OBJ_CONTAINED) {
+            container_weight(obj->ocontainer);
+        }
+        break;
     }
 }
 

--- a/src/invent.c
+++ b/src/invent.c
@@ -1188,9 +1188,7 @@ freeinv_core(struct obj *obj)
         set_artifact_intrinsic(obj, 0, W_ART);
     }
 
-    if (obj->otyp == LOADSTONE) {
-        curse(obj);
-    } else if (confers_luck(obj)) {
+    if (confers_luck(obj)) {
         set_moreluck();
         gc.context.botl = 1;
     } else if (obj->otyp == FIGURINE && obj->timed) {

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -13,7 +13,6 @@ static void mksobj_init(struct obj *, boolean);
 static int item_on_ice(struct obj *);
 static void shrinking_glob_gone(struct obj *);
 static void obj_timer_checks(struct obj *, coordxy, coordxy, int);
-static void container_weight(struct obj *);
 static struct obj *save_mtraits(struct obj *, struct monst *);
 static void objlist_sanity(struct obj *, int, const char *);
 static void shop_obj_sanity(struct obj *, const char *);
@@ -2592,7 +2591,7 @@ add_to_buried(struct obj *obj)
 }
 
 /* Recalculate the weight of this container and all of _its_ containers. */
-static void
+void
 container_weight(struct obj *container)
 {
     container->owt = weight(container);

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -1680,7 +1680,7 @@ bless(struct obj *otmp)
     otmp->blessed = 1;
     if (carried(otmp) && confers_luck(otmp))
         set_moreluck();
-    else if (otmp->otyp == BAG_OF_HOLDING)
+    else if (otmp->otyp == BAG_OF_HOLDING || otmp->otyp == LOADSTONE)
         otmp->owt = weight(otmp);
     else if (otmp->otyp == FIGURINE && otmp->timed)
         (void) stop_timer(FIG_TRANSFORM, obj_to_any(otmp));
@@ -1699,7 +1699,7 @@ unbless(struct obj *otmp)
     otmp->blessed = 0;
     if (carried(otmp) && confers_luck(otmp))
         set_moreluck();
-    else if (otmp->otyp == BAG_OF_HOLDING)
+    else if (otmp->otyp == BAG_OF_HOLDING || otmp->otyp == LOADSTONE)
         otmp->owt = weight(otmp);
     if (otmp->lamplit)
         maybe_adjust_light(otmp, old_light);
@@ -1728,7 +1728,7 @@ curse(struct obj *otmp)
     /* some cursed items need immediate updating */
     if (carried(otmp) && confers_luck(otmp)) {
         set_moreluck();
-    } else if (otmp->otyp == BAG_OF_HOLDING) {
+    } else if (otmp->otyp == BAG_OF_HOLDING || otmp->otyp == LOADSTONE) {
         otmp->owt = weight(otmp);
     } else if (otmp->otyp == FIGURINE) {
         if (otmp->corpsenm != NON_PM && !dead_species(otmp->corpsenm, TRUE)
@@ -1754,7 +1754,7 @@ uncurse(struct obj *otmp)
     otmp->cursed = 0;
     if (carried(otmp) && confers_luck(otmp))
         set_moreluck();
-    else if (otmp->otyp == BAG_OF_HOLDING)
+    else if (otmp->otyp == BAG_OF_HOLDING || otmp->otyp == LOADSTONE)
         otmp->owt = weight(otmp);
     else if (otmp->otyp == FIGURINE && otmp->timed)
         (void) stop_timer(FIG_TRANSFORM, obj_to_any(otmp));
@@ -1881,6 +1881,9 @@ weight(struct obj *obj)
         return (int) obj->owt; /* kludge for "very" heavy iron ball */
     } else if (obj->otyp == CANDELABRUM_OF_INVOCATION && obj->spe) {
         return wt + obj->spe * (int) objects[TALLOW_CANDLE].oc_weight;
+    }
+    if (obj->otyp == LOADSTONE && obj->blessed) {
+        wt /= 5;
     }
     return (wt ? wt * (int) obj->quan : ((int) obj->quan + 1) >> 1);
 }


### PR DESCRIPTION
#906 had loadstones give steadfastness (preventing knockback), but loadstones are still too heavy to be practically useful.

This pull request contains 3 commits, so parts of it may be picked if you don't like all of them:
1. Reduce the weight of blessed loadstones to 100 units, 1/5 of their normal weight.  They are magically heavy items, so it makes sense for a blessing to change how the magic acts.
2. Allow putting a loadstone in a bag without it autocursing, if it does not leave your inventory.  This allows players to put a loadstone away to protect from the curse items spell when they don't need steadfastness.  The loadstone autocurse condition is changed to be the same as crysknife reversion condition, so dropping a bag containing a loadstone will degrade the loadstone's beatitude.
3. Prevent loadstones (and bags containing them) from being put in bags of holding, so that they will still be a decent load to the hero when not being used for steadfastness.  Loadstones will not explode bags of holding since we don't need more bag-exploding things; they will just refuse to be put in.  This can be explained by loadstones being smart enough to not want to go in a bag of holding (because they would rather be a load to the hero), just like they are smart enough to not want to leave the main inventory when they are cursed.  As a side effect, attempting to put a sack containing a loadstone and a wand of cancellation into a bag of holding will not explode the bag of holding, because the loadstone will prevent it before the explosion.

Loadstones are still an early-game trap for players without a means of uncursing them.  Players who accidentally pick up a loadstone and then dump it as soon as they uncurse it should not notice any difference.  But this pull request does give players a reason to carry a loadstone if they are able to bless it.  A blessed loadstone is also heavier than Giantslayer, has the risk of causing encumbrance if it gets cursed, and can't be put in a bag of holding to reduce weight, so it doesn't make Giantslayer useless either.
