### PR TITLE
Fix memory errors in qt_tilewidth and qt_tileheight

### DIFF
--- a/win/Qt/qt_main.cpp
+++ b/win/Qt/qt_main.cpp
@@ -877,17 +877,14 @@ NetHackQtMainWindow::NetHackQtMainWindow(NetHackQtKeyBuffer& ks) :
     int w=screensize.width()-10; // XXX arbitrary extra space for frame
     int h=screensize.height()-50;
 
-    int maxwn;
-    int maxhn;
-    if (qt_tilewidth != NULL) {
-	maxwn = atoi(qt_tilewidth) * COLNO + 10;
-    } else {
-	maxwn = 1400;
-    }
-    if (qt_tileheight != NULL) {
-	maxhn = atoi(qt_tileheight) * ROWNO * 6/4;
-    } else {
-	maxhn = 1024;
+    int maxwn = 1400;
+    int maxhn = 1024;
+    if (qt_settings != NULL) {
+        auto glyphs = &qt_settings->glyphs();
+        if (glyphs != NULL) {
+            maxwn = glyphs->width() * COLNO + 10;
+            maxhn = glyphs->height() * ROWNO * 6/4;
+        }
     }
 
     // Be exactly the size we want to be - full map...
@@ -1239,6 +1236,9 @@ void NetHackQtMainWindow::layout()
         splittersizes[2] = w / 2 - (d * 1 / 4); // status
         splittersizes[1] = d;                   // invusage
         splittersizes[0] = w / 2 - (d * 3 / 4); // messages
+        printf("w = %d d = %d splittersizes = %d %d %d\n",
+                w, d,
+                splittersizes[0], splittersizes[1], splittersizes[2]);
         hsplitter->setSizes(splittersizes);
     }
 }

--- a/win/Qt/qt_set.cpp
+++ b/win/Qt/qt_set.cpp
@@ -118,11 +118,13 @@ NetHackQtSettings::NetHackQtSettings() :
     // Tile/font sizes read from .nethackrc
     if (qt_tilewidth != NULL) {
 	tilewidth.setValue(atoi(qt_tilewidth));
-	delete[] qt_tilewidth;
+	free(qt_tilewidth);
+        qt_tilewidth = NULL;
     }
     if (qt_tileheight != NULL) {
 	tileheight.setValue(atoi(qt_tileheight));
-	delete[] qt_tileheight;
+	free(qt_tileheight);
+        qt_tileheight = NULL;
     }
     if (qt_fontsize != NULL) {
 	switch (tolower(qt_fontsize[0])) {
@@ -132,7 +134,8 @@ NetHackQtSettings::NetHackQtSettings() :
 	  case 's': default_fontsize = 3; break;
 	  case 't': default_fontsize = 4; break;
 	}
-	delete[] qt_fontsize;
+	free(qt_fontsize);
+        qt_fontsize = NULL;
     }
 
     theglyphs=new NetHackQtGlyphs();


### PR DESCRIPTION
* qt_tilewidth and qt_tileheight are allocated with alloc() and need to be freed with free().
* Don't use them after they're freed. Instead, retrieve the size from the glyphs object.