### PR TITLE
Add correct Cyclops pluralization

### DIFF
--- a/src/objnam.c
+++ b/src/objnam.c
@@ -2362,6 +2362,7 @@ static const struct sing_plur one_off[] = {
       "children" },      /* (for wise guys who give their food funny names) */
     { "cubus", "cubi" }, /* in-/suc-cubus */
     { "culus", "culi" }, /* homunculus */
+    { "Cyclops", "Cyclopes" },
     { "djinni", "djinn" },
     { "erinys", "erinyes" },
     { "foot", "feet" },


### PR DESCRIPTION
The correct plural of "Cyclops" is "Cyclopes", not "Cyclopses".  I don't
know if anyone would actually use that as a fruitname, but it wouldn't
hurt to add it -- especially since a Cyclops does appear in the game.
