### PR TITLE
Provide escape item in water-surrounded vaults

### DIFF
--- a/dat/themerms.lua
+++ b/dat/themerms.lua
@@ -628,10 +628,25 @@ xx|.....|xx
 }----}
 }}}}}}]], contents = function(m) des.region({ region={3,3,3,3}, type="themed", irregular=true, filled=0, joined=false });
      local nasty_undead = { "giant zombie", "ettin zombie", "vampire lord" };
-     des.object("chest", 2, 2);
-     des.object("chest", 3, 2);
-     des.object("chest", 2, 3);
-     des.object("chest", 3, 3);
+     local chest_spots = { { 2, 2 }, { 3, 2 }, { 2, 3 }, { 3, 3 } };
+
+     shuffle(chest_spots)
+     -- Guarantee an escape item inside one of the chests, to prevent the hero
+     -- falling in from above and becoming permanently stuck
+     -- [cf. generate_way_out_method(sp_lev.c)].
+     -- "pick-axe", "dwarvish mattock" could be included in the list of escape
+     -- items but don't normally generate in containers.
+     local escape_items = {
+        "scroll of teleportation", "ring of teleportation",
+        "wand of teleportation", "wand of digging"
+     };
+     local box = des.object({ id = "chest", coord = chest_spots[1] })
+     box:addcontent(obj.new(escape_items[math.random(#escape_items)]));
+
+     for i = 2, #chest_spots do
+         des.object({ id = "chest", coord = chest_spots[i] });
+     end
+
      shuffle(nasty_undead);
      des.monster(nasty_undead[1], 2, 2);
 end });

--- a/src/nhlobj.c
+++ b/src/nhlobj.c
@@ -106,7 +106,7 @@ l_obj_getcontents(lua_State *L)
 
 /* Puts object inside another object. */
 /* local box = obj.new("large chest");
-   box.addcontent(obj.new("rock"));
+   box:addcontent(obj.new("rock"));
 */
 static int
 l_obj_add_to_container(lua_State *L)


### PR DESCRIPTION
Water vaults are one of the few places that can/will generate completely
sealed off in a normal level.  Other such spots are designed to provide
a guaranteed means of escape (vault guard, scrolls of teleportation in
niches, etc) -- water vaults were an exception that didn't do this, so a
hero who fell into one from above could have ended up in a position
where she had no choice but to wait to starve to death or #quit. Provide
an escape item in one of the vault's chests to give a hero more options
in that position.

Also fix a minor mistake (I'm pretty sure, though I'm not a Lua expert
enough to be certain) in an nhlib.c comment describing how to use
obj.addcontent() -- when called as box.addcontent(contents) as the
comment suggested it produces an error, but works OK when called as
box:addcontent(contents) or obj.addcontent(box, contents).