### PR TITLE
Allow wish for "high altar" in wizard mode

### DIFF
--- a/src/objnam.c
+++ b/src/objnam.c
@@ -3329,18 +3329,22 @@ wizterrainwish(struct _readobjnam_data *d)
         aligntyp al;
 
         lev->typ = ALTAR;
-        if (!strncmpi(bp, "chaotic ", 8))
-            al = A_CHAOTIC;
-        else if (!strncmpi(bp, "neutral ", 8))
-            al = A_NEUTRAL;
-        else if (!strncmpi(bp, "lawful ", 7))
-            al = A_LAWFUL;
-        else if (!strncmpi(bp, "unaligned ", 10))
-            al = A_NONE;
-        else /* -1 - A_CHAOTIC, 0 - A_NEUTRAL, 1 - A_LAWFUL */
+        if (!strncmpi(bp, "chaotic ", 8)) {
+            al = A_CHAOTIC, bp += 8;
+        } else if (!strncmpi(bp, "neutral ", 8)) {
+            al = A_NEUTRAL, bp += 8;
+        } else if (!strncmpi(bp, "lawful ", 7)) {
+            al = A_LAWFUL, bp += 7;
+        } else if (!strncmpi(bp, "unaligned ", 10)) {
+            al = A_NONE, bp += 10;
+        } else { /* -1 - A_CHAOTIC, 0 - A_NEUTRAL, 1 - A_LAWFUL */
             al = !rn2(6) ? A_NONE : (rn2((int) A_LAWFUL + 2) - 1);
+        }
         lev->altarmask = Align2amask(al); /* overlays 'flags' */
-        pline("%s altar.", An(align_str(al)));
+        if (!strncmpi(bp, "high ", 5))
+            lev->altarmask |= AM_SANCTUM;
+        pline("%s %saltar.", An(align_str(al)),
+              (lev->altarmask & AM_SANCTUM) != 0 ? "high " : "");
         madeterrain = TRUE;
     } else if (!BSTRCMPI(bp, p - 5, "grave")
                || !BSTRCMPI(bp, p - 9, "headstone")) {


### PR DESCRIPTION
This would make it more convenient to test of things that treat or
affect normal altars and high altars differently, e.g. altar coloration,
something that can destroy a normal altar but not a high altar, etc: the
developer can wish for a "high altar" or "lawful high altar" and so on
to interact with one without levelporting to the Sanctum or Astral and
dealing with the monsters there.

The syntax is pretty rigid ("high lawful altar" doesn't work) -- I do
have another commit locally that is much more flexible in that regard
but since this is strictly a debug command and that adds more complexity
to the code I figured it's probably better to keep it simple.
