### PR TITLE
fix MENUCOLOR non-attribute overriding

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -7728,13 +7728,19 @@ boolean
 get_menu_coloring(const char *str, int *color, int *attr)
 {
     struct menucoloring *tmpmc;
+    boolean first_match = TRUE;
 
     if (iflags.use_menu_color)
         for (tmpmc = gm.menu_colorings; tmpmc; tmpmc = tmpmc->next)
             if (regex_match(str, tmpmc->match)) {
-                *color = tmpmc->color;
+                if (first_match) {
+                    *color = tmpmc->color;
+                    first_match = FALSE;
+                }
                 *attr = tmpmc->attr;
-                return TRUE;
+                if (*attr != ATR_NONE) {
+                    return TRUE;
+                }
             }
     return FALSE;
 }


### PR DESCRIPTION
One may make their wearing and wielding items underlined.
`MENUCOLOR="(being worn|wielded)"=gray&underline`

But the latter matching rules only setting a color will change
the line's attribute none. It forces players to manually copy
their rules and add underlined versions.
`MENUCOLOR="(robe)"=bright magenta`
`MENUCOLOR="(robe).*worn"=bright magenta&underline`

So if the matching rule's attr is ATR_NONE, we keep searching
back previous rules to find the first matching rule which provides
an attribute.

This may slightly influence the performance due to more regex_match.
But makes the config more concise if one has many MENUCOLORs.