### PR TITLE
add a statushilite option for critically low HP

### DIFF
--- a/include/botl.h
+++ b/include/botl.h
@@ -210,7 +210,7 @@ extern int cond_idx[CONDITION_COUNT];
 #define BL_TH_CONDITION 103      /* threshold is bitmask of conditions */
 #define BL_TH_TEXTMATCH 104      /* threshold text value to match against */
 #define BL_TH_ALWAYS_HILITE 105  /* highlight regardless of value */
-
+#define BL_TH_CRITICALHP 106     /* highlight critically low HP */
 
 #define HL_ATTCLR_DIM     CLR_MAX + 0
 #define HL_ATTCLR_BLINK   CLR_MAX + 1


### PR DESCRIPTION
This allows players to specify a highlight for critically low HP in the config file, for example:

OPTIONS=hilite_status:hitpoints/criticalhp/purple&inverse

This will cause the hitpoints field to be highlighted when HP is low enough to be considered a major trouble.  The new "criticalhp" setting only applies to the hitpoints field.

Since the critical HP threshold changes with level (and most of the fractions are not integer percents) it was impossible to set highlights to match the critical HP threshold using percentage settings.

---

One of the common questions from new players is "I prayed when I had low HP; why didn't my god heal me?", and the answer to that is usually "Your HP wasn't low enough", and then the natural follow-up question is "How low is low enough?".  This pull request allows players to set an option to highlight the HP field when HP is low enough to be considered a major trouble.  This will save players who already know about the critical HP threshold from having to calculate it (having to look up the relevant HP fraction for their experience level, and then doing some arithmetic) every time they are considering praying to heal.