### PR TITLE
Sit to trigger squeaky board even if flying

### DIFF
--- a/src/trap.c
+++ b/src/trap.c
@@ -1270,7 +1270,8 @@ trapeffect_sqky_board(
         se_squeak_A, se_squeak_B_flat, se_squeak_B,
     };
     boolean forcetrap = ((trflags & FORCETRAP) != 0
-                         || (trflags & FAILEDUNTRAP) != 0);
+                         || (trflags & FAILEDUNTRAP) != 0
+                         || (Flying && (trflags & VIASITTING) != 0));
 
     if (mtmp == &gy.youmonst) {
         if ((Levitation || Flying) && !forcetrap) {


### PR DESCRIPTION
If the hero sits on the floor while flying over a squeaky board, then either they're trying to squeak it on purpose or they haven't noticed it. Either way, sitting should trigger it instead of producing "You notice a loose board below you."