### PR TITLE
Fix: wrong glyphs for clouds and water on Planes

### DIFF
--- a/src/mkmaze.c
+++ b/src/mkmaze.c
@@ -1465,9 +1465,9 @@ static void mv_bubble(struct bubble *, coordxy, coordxy, boolean);
 void
 movebubbles(void)
 {
-    static const struct rm water_pos = { cmap_a_to_glyph(S_water), WATER, 0, 0,
-                                         0, 0, 0, 0, 0, 0 };
-    static const struct rm air_pos = { cmap_a_to_glyph(S_cloud), AIR, 0, 0, 0,
+    static const struct rm water_pos = { cmap_b_to_glyph(S_water), WATER, 0,
+                                         0, 0, 0, 0, 0, 0, 0 };
+    static const struct rm air_pos = { cmap_b_to_glyph(S_cloud), AIR, 0, 0, 0,
                                        1, 0, 0, 0, 0 };
     static boolean up = FALSE;
     struct bubble *b;


### PR DESCRIPTION
ff727e9 introduced an issue where unseen water and cloud on the
respective planes were shown with open and closed drawbridge glyphs
instead of the appropriate glyphs.  This is because they fall into cmap
section B, but the translation from symbols/cmap index to glyphs was
being done as though they were in cmap section A (ff727e9 manually used
that particular cmap section macro instead of the general cmap_to_glyph
to work around some compiler warning).
