### PR TITLE
Qt: remove window size debug print statement

### DIFF
--- a/win/Qt/qt_main.cpp
+++ b/win/Qt/qt_main.cpp
@@ -1236,9 +1236,6 @@ void NetHackQtMainWindow::layout()
         splittersizes[2] = w / 2 - (d * 1 / 4); // status
         splittersizes[1] = d;                   // invusage
         splittersizes[0] = w / 2 - (d * 3 / 4); // messages
-        printf("w = %d d = %d splittersizes = %d %d %d\n",
-                w, d,
-                splittersizes[0], splittersizes[1], splittersizes[2]);
         hsplitter->setSizes(splittersizes);
     }
 }


### PR DESCRIPTION
A printf call was introduced in 20fb008012 that caused the terminal
window to be filled with repeated debugging messages as the window
containing the Qt windowport was resized.  I removed it because I
assumed it was meant to be temporary and was left in the commit by
mistake, considering it isn't mentioned in the commit message; if it was
meant to be permanent it'd probably be good to block it out with #ifdef
DEBUG or something at least, because it produces a real deluge of
terminal output if the player spends any time resizing the window by
hand.
