### PR TITLE
Release obufs used by sortloot

### DIFF
--- a/src/invent.c
+++ b/src/invent.c
@@ -320,7 +320,7 @@ sortloot_cmp(const genericptr vptr1, const genericptr vptr2)
                          *sli2 = (struct sortloot_item *) vptr2;
     struct obj *obj1 = sli1->obj,
                *obj2 = sli2->obj;
-    char *nam1, *nam2;
+    char *nam1, *nam2, *tmpstr;
     int val1, val2, namcmp;
 
     /* order by object class unless we're doing by-invlet without sortpack */
@@ -382,11 +382,17 @@ sortloot_cmp(const genericptr vptr1, const genericptr vptr2)
      * comparisons it gets subjected to.
      */
     nam1 = sli1->str;
-    if (!nam1)
-        nam1 = sli1->str = dupstr(loot_xname(obj1));
+    if (!nam1) {
+        tmpstr = loot_xname(obj1);
+        nam1 = sli1->str = dupstr(tmpstr);
+        maybereleaseobuf(tmpstr);
+    }
     nam2 = sli2->str;
-    if (!nam2)
-        nam2 = sli2->str = dupstr(loot_xname(obj2));
+    if (!nam2) {
+        tmpstr = loot_xname(obj2);
+        nam2 = sli2->str = dupstr(tmpstr);
+        maybereleaseobuf(tmpstr);
+    }
     if ((namcmp = strcmpi(nam1, nam2)) != 0)
         return namcmp;
 


### PR DESCRIPTION
Some further application of e43ec0c logic, which was intended to fix odd
messages produced by obufs clobbered by inventory updates (like "the
ogre lord yanks Cleaver from your corpses!").  That issue was still
lurking around because sortloot(), via sortloot_cmp(), was continuing to
call for obufs via loot_xname() without releasing them immediately.  It
was going through the entire inventory doing that, much like
display_pickinv() was prior to Pat's fix in e43ec0ce, so could cause
the contents of obufs to still be clobbered by perm_invent updates.
This changes sortloot_cmp() to releases the obufs it calls for as soon
as possible so that won't happen any more.
