### PR TITLE
Fix: undoing monsters' permablindness by accident

### DIFF
--- a/include/monst.h
+++ b/include/monst.h
@@ -248,6 +248,8 @@ struct monst {
 #define engulfing_u(mon) (u.uswallow && (u.ustuck == (mon)))
 #define helpless(mon) ((mon)->msleeping || !(mon)->mcanmove)
 
+#define mon_perma_blind(mon) (!mon->mcansee && !mon->mblinded)
+
 #define mon_offmap(mon) (((mon)->mstate & (MON_DETACH|MON_MIGRATING|MON_LIMBO|MON_OFFMAP)) != 0)
 
 /* Get the maximum difficulty monsters that can currently be generated,

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -226,6 +226,10 @@ can_blnd(
     if (!haseyes(mdef->data))
         return FALSE;
 
+    /* if monster has been permanently blinded, the deed is already done */
+    if (!is_you && mon_perma_blind(mdef))
+        return FALSE;
+
     /* /corvus oculum corvi non eruit/
        a saying expressed in Latin rather than a zoological observation:
        "a crow will not pluck out the eye of another crow"

--- a/src/potion.c
+++ b/src/potion.c
@@ -1786,7 +1786,7 @@ potionhit(struct monst *mon, struct obj *obj, int how)
             mon_adjust_speed(mon, 1, obj);
             break;
         case POT_BLINDNESS:
-            if (haseyes(mon->data)) {
+            if (haseyes(mon->data) && !mon_perma_blind(mon)) {
                 int btmp = 64 + rn2(32)
                             + rn2(32) * !resist(mon, POTION_CLASS, 0, NOTELL);
 


### PR DESCRIPTION
Monsters can become permanently blind (in very narrow circumstances -- I
think limited only to a very short-range camera flash), in which case
they have both mon->mblinded and mon->mcansee set to 0.  Such
permanently blinded monsters can counterintuitively regain their sight
by being blinded a second time from a different source: for example, by
being hit with a cream pie.  That second blinding will increase
mon->mblinded (which functions as a blindness timeout) by some amount,
and when it runs out the monster will regain its sight.  Try to make
sure that doesn't happen by skipping any blinding attacks if the monster
has already been permanently blinded.
