### PR TITLE
Allow quest leader to catch and return unique item

### DIFF
--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -1920,8 +1920,8 @@ tmiss(struct obj *obj, struct monst *mon, boolean maybe_wakeup)
     return;
 }
 
-#define quest_arti_hits_leader(obj, mon)      \
-    (obj->oartifact && is_quest_artifact(obj) \
+#define special_obj_hits_leader(obj, mon)      \
+    ((is_quest_artifact(obj) || objects[obj->otyp].oc_unique) \
      && mon->m_id == gq.quest_status.leader_m_id)
 
 /*
@@ -2024,7 +2024,7 @@ thitmonst(
     /* don't make game unwinnable if naive player throws artifact
        at leader... (kicked artifact is ok too; HMON_APPLIED could
        occur if quest artifact polearm or grapnel ever gets added) */
-    if (hmode != HMON_APPLIED && quest_arti_hits_leader(obj, mon)) {
+    if (hmode != HMON_APPLIED && special_obj_hits_leader(obj, mon)) {
         /* AIS: changes to wakeup() means that it's now less inappropriate
            here than it used to be, but manual version works just as well */
         mon->msleeping = 0;


### PR DESCRIPTION
It's been possible for a while to throw your quest artifact to your
quest leader, completing the quest (he will then throw the object back
to you).  The quest leader will also react to being brought the Amulet
of Yendor (i.e. having it in inventory when you approach or #chat), but
tossing it over like the quest artifact was treated as a hostile act and
would cause the quest leader and guardians to become hostile and attack
the hero.

Make throwing the Amulet of Yendor at the quest leader work like
throwing the quest artifact, and treat the invocation items similarly
just in case people try throwing those (maybe because they are lost,
unsure what to do, and have already seen their quest leader catch and
react to the quest artifact -- regardless of the reason, throwing over
the Book of the Dead is almost certainly not intended to be an attack).
Doing so for invocation items will ID them but not do much more than
that.  The Amulet of Yendor triggers the existing quest pager message.
