### PR TITLE
Fix: clipping on horizontal window resize

### DIFF
--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -452,7 +452,7 @@ new_status_window(void)
 
 #ifdef CLIPPING
     if (u.ux) {
-        if (LI < 1 + ROWNO + iflags.wc2_statuslines) {
+        if (CO < COLNO || LI < 1 + ROWNO + iflags.wc2_statuslines) {
             setclipped();
             tty_cliparound(u.ux, u.uy);
         } else {


### PR DESCRIPTION
Clipping mode was not activated when a comfortably-sized game window was
resized horizontally to become too narrow to display the entire map,
causing various display errors and bugs if the window was resized like
that.  I think the horizontal resize check was removed by mistake in
d1dade164ef220a011bf89fa445a8b0012bf38df.
