### PR TITLE
Fix: map refresh in #terrain

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -366,6 +366,7 @@ extern void warnreveal(void);
 extern int dosearch0(int);
 extern int dosearch(void);
 extern void sokoban_detect(void);
+extern void reveal_terrain_docrt(int, int);
 #ifdef DUMPLOG
 extern void dump_map(void);
 #endif

--- a/include/extern.h
+++ b/include/extern.h
@@ -366,11 +366,11 @@ extern void warnreveal(void);
 extern int dosearch0(int);
 extern int dosearch(void);
 extern void sokoban_detect(void);
-extern void reveal_terrain_docrt(int, int);
+extern void reveal_terrain_docrt(int);
 #ifdef DUMPLOG
 extern void dump_map(void);
 #endif
-extern void reveal_terrain(int, int);
+extern void reveal_terrain(int);
 extern int wiz_mgender(void);
 
 /* ### dig.c ### */

--- a/include/flag.h
+++ b/include/flag.h
@@ -219,6 +219,7 @@ struct instance_flags {
 #define TER_OBJ    0x04
 #define TER_MON    0x08
 #define TER_DETECT 0x10    /* detect_foo magic rather than #terrain */
+#define TER_FULL   0x20
     int getdir_click;      /* as input to getdir(): non-zero, accept simulated
                             * click that's not adjacent to or on hero;
                             * as output from getdir(): simulated button used

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -2238,16 +2238,16 @@ doterrain(void)
 
     switch (which) {
     case 1: /* known map */
-        reveal_terrain(0, TER_MAP);
+        reveal_terrain(TER_MAP);
         break;
     case 2: /* known map with known traps */
-        reveal_terrain(0, TER_MAP | TER_TRP);
+        reveal_terrain(TER_MAP | TER_TRP);
         break;
     case 3: /* known map with known traps and objects */
-        reveal_terrain(0, TER_MAP | TER_TRP | TER_OBJ);
+        reveal_terrain(TER_MAP | TER_TRP | TER_OBJ);
         break;
     case 4: /* full map */
-        reveal_terrain(1, TER_MAP);
+        reveal_terrain(TER_MAP | TER_FULL);
         break;
     case 5: /* map internals */
         wiz_map_levltyp();

--- a/src/detect.c
+++ b/src/detect.c
@@ -2092,6 +2092,23 @@ reveal_terrain_getglyph(coordxy x, coordxy y, int full, unsigned swallowed,
     return glyph;
 }
 
+void
+reveal_terrain_docrt(int full, int which_subset)
+{
+    coordxy x, y;
+    int glyph, default_glyph;
+
+    default_glyph = cmap_to_glyph(gl.level.flags.arboreal ? S_tree
+                                                          : S_stone);
+    for (x = 1; x < COLNO; x++) {
+        for (y = 0; y < ROWNO; y++) {
+            glyph = reveal_terrain_getglyph(x,y, full, iflags.save_uswallow,
+                                            default_glyph, which_subset);
+            show_glyph(x, y, glyph);
+        }
+    }
+}
+
 #ifdef DUMPLOG
 void
 dump_map(void)
@@ -2160,26 +2177,16 @@ reveal_terrain(
     if ((Hallucination || Stunned || Confusion) && !full) {
         You("are too disoriented for this.");
     } else {
-        coordxy x, y;
-        int glyph, default_glyph;
         char buf[BUFSZ];
         /* there is a TER_MAP bit too; we always show map regardless of it */
-        boolean keep_traps = (which_subset & TER_TRP) !=0,
+        boolean keep_traps = (which_subset & TER_TRP) != 0,
                 keep_objs = (which_subset & TER_OBJ) != 0,
                 keep_mons = (which_subset & TER_MON) != 0; /* not used */
-        unsigned swallowed = u.uswallow; /* before unconstrain_map() */
 
         if (unconstrain_map())
             docrt();
-        default_glyph = cmap_to_glyph(gl.level.flags.arboreal ? S_tree
-                                                             : S_stone);
 
-        for (x = 1; x < COLNO; x++)
-            for (y = 0; y < ROWNO; y++) {
-                glyph = reveal_terrain_getglyph(x,y, full, swallowed,
-                                                default_glyph, which_subset);
-                show_glyph(x, y, glyph);
-            }
+        reveal_terrain_docrt(full, which_subset);
 
         /* hero's location is not highlighted, but getpos() starts with
            cursor there, and after moving it anywhere '@' moves it back */

--- a/src/display.c
+++ b/src/display.c
@@ -1647,7 +1647,7 @@ docrt(void)
     see_monsters();
 
     if (iflags.terrainmode)
-        reveal_terrain_docrt(FALSE, iflags.terrainmode);
+        reveal_terrain_docrt(iflags.terrainmode);
 
  post_map:
 

--- a/src/display.c
+++ b/src/display.c
@@ -1646,6 +1646,9 @@ docrt(void)
     /* overlay with monsters */
     see_monsters();
 
+    if (iflags.terrainmode)
+        reveal_terrain_docrt(FALSE, iflags.terrainmode);
+
  post_map:
 
     /* perm_invent */
@@ -2071,10 +2074,13 @@ flush_screen(int cursor_on_u)
         register gbuf_entry *gptr = &gg.gbuf[y][x = gg.gbuf_start[y]];
 
         for (; x <= gg.gbuf_stop[y]; gptr++, x++) {
-            get_bkglyph_and_framecolor(x, y, &bkglyph, &bkglyphinfo.framecolor);
+            get_bkglyph_and_framecolor(x, y, &bkglyph,
+                                       &bkglyphinfo.framecolor);
             if (gptr->gnew
-                || (gw.wsettings.map_frame_color != NO_COLOR && bkglyphinfo.framecolor != NO_COLOR)) {
-                map_glyphinfo(x, y, bkglyph, 0, &bkglyphinfo); /* won't touch framecolor */
+                || (gw.wsettings.map_frame_color != NO_COLOR
+                    && bkglyphinfo.framecolor != NO_COLOR)) {
+                /* map_glyphinfo won't touch framecolor */
+                map_glyphinfo(x, y, bkglyph, 0, &bkglyphinfo);
                 print_glyph(WIN_MAP, x, y,
                             Glyphinfo_at(x, y, gptr->glyph), &bkglyphinfo);
                 gptr->gnew = 0;


### PR DESCRIPTION
When the map was refreshed in #terrain mode (from ^R or because of
SIGWINCH, etc), it wouldn't honor the #terrain constraints.  Use
iflags.terrainmode to continue to apply the terrainmode restrictions
when docrt() is called, so that resizing or refreshing the map in
#terrain mode will not lose the #terrain view.
