### PR TITLE
potion of sickness hit effect

### DIFF
--- a/src/potion.c
+++ b/src/potion.c
@@ -1743,14 +1743,11 @@ potionhit(struct monst *mon, struct obj *obj, int how)
                 break;
             }
  do_illness:
-            if ((mon->mhpmax > 3) && !resist(mon, POTION_CLASS, 0, NOTELL))
-                mon->mhpmax /= 2;
-            if ((mon->mhp > 2) && !resist(mon, POTION_CLASS, 0, NOTELL))
+            if (mon->mhp > 2) {
                 mon->mhp /= 2;
-            if (mon->mhp > mon->mhpmax)
-                mon->mhp = mon->mhpmax;
-            if (canseemon(mon))
-                pline("%s looks rather ill.", Monnam(mon));
+                if (canseemon(mon))
+                    pline("%s looks rather ill.", Monnam(mon));
+            }
             break;
         case POT_CONFUSION:
         case POT_BOOZE:


### PR DESCRIPTION
The potion of sickness would previously always print the message "\<mon\> looks rather ill." when hitting a non-poison-resistant monster, even if all effects were resisted due to monster magic resistance.

To make the potion more useful against high-MR monsters, this change removes the dependence on monster MR, but also removes the halving of maximum HP to prevent it from being overpowered.  Hitting with a potion of sickness now reliably halves only the current HP of non-poison-resistant targets.

The effect of poisoned projectiles, which can be created from a potion of sickness, is not resisted by monster MR, so it does not make much sense for the potion effect to be subject to monster MR.  There is also code to make Pestilence suffer the sickness effect when hit by a potion of healing, but due to monster MR, it had no practical effect other than printing a misleading message.