### PR TITLE
Flipping coins.

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -4336,14 +4336,16 @@ flip_coin(struct obj *obj)
         if (otmp->quan > 1L) {
             otmp = splitobj(otmp, 1L);
         }
-        if (carried(otmp))
-            dropx(otmp);
-        else
-            stackobj(otmp);
+        dropx(otmp);
         return ECMD_TIME;
     }
-    pline_The("%s comes up %s.", xname(obj), 
-                                rn2(2) ? "heads" : "tails");
+    if (Hallucination) {
+        pline(rn2(100) ? "Wow, a double header!"
+                       : "The coin miraculously lands on its edge!");
+    } else {
+        pline_The("%s comes up %s.", xname(obj), 
+                                    rn2(2) ? "heads" : "tails");
+    }
     return ECMD_TIME;
 }
 

--- a/src/apply.c
+++ b/src/apply.c
@@ -4333,14 +4333,14 @@ flip_coin(struct obj *obj)
     }
 
     if (lose_coin) {
-        if (otmp->quan > 1L) {
+        if (otmp->quan > 1L)
             otmp = splitobj(otmp, 1L);
-        }
         dropx(otmp);
         return ECMD_TIME;
     }
     if (Hallucination) {
         pline(rn2(100) ? "Wow, a double header!"
+                        /* edge case */
                        : "The coin miraculously lands on its edge!");
     } else {
         pline_The("%s comes up %s.", xname(obj), 

--- a/src/apply.c
+++ b/src/apply.c
@@ -3964,8 +3964,13 @@ apply_ok(struct obj *obj)
     /* all tools, all wands (breaking), all spellbooks (flipping through -
        including blank/novel/Book of the Dead) */
     if (obj->oclass == TOOL_CLASS || obj->oclass == WAND_CLASS
-        || obj->oclass == SPBOOK_CLASS || obj->oclass == COIN_CLASS)
+        || obj->oclass == SPBOOK_CLASS)
         return GETOBJ_SUGGEST;
+
+    /* applying coins to flip them is a minor easter egg, so do not suggest
+       coin application to the player */
+    if (obj->oclass == COIN_CLASS)
+        return GETOBJ_DOWNPLAY;
 
     /* certain weapons */
     if (obj->oclass == WEAPON_CLASS
@@ -4322,7 +4327,7 @@ flip_coin(struct obj *obj)
     struct obj *otmp = obj;
     boolean lose_coin = FALSE;
 
-    You("flip %s.", an(xname(obj)));
+    You("flip %s.", an(cxname_singular(obj)));
     if (Underwater) {
         pline_The("%s floats away.", xname(obj));
         lose_coin = TRUE;
@@ -4343,8 +4348,7 @@ flip_coin(struct obj *obj)
                         /* edge case */
                        : "The coin miraculously lands on its edge!");
     } else {
-        pline_The("%s comes up %s.", xname(obj), 
-                                    rn2(2) ? "heads" : "tails");
+        pline("It comes up %s.", rn2(2) ? "heads" : "tails");
     }
     return ECMD_TIME;
 }

--- a/src/invent.c
+++ b/src/invent.c
@@ -2935,7 +2935,9 @@ itemactions(struct obj *otmp)
     }
 
     /* a: apply */
-    if (otmp->otyp == CREAM_PIE)
+    if (otmp->oclass == COIN_CLASS)
+        ia_addmenu(win, IA_APPLY_OBJ, 'a', "Flip a coin");
+    else if (otmp->otyp == CREAM_PIE)
         ia_addmenu(win, IA_APPLY_OBJ, 'a', "Hit yourself with this cream pie");
     else if (otmp->otyp == BULLWHIP)
         ia_addmenu(win, IA_APPLY_OBJ, 'a', "Lash out with this whip");


### PR DESCRIPTION
Applying one or more gold pieces now flips one of them, which will cause it to come up heads or tails. This is NetHack, so there are special cases for flipping a coin underwater or while fumbling or greasy.

I've tried to future-proof this commit so that the code will not need to be modified if other items are eventually added to the coin class.

If memory serves, there was a patch for this on the bilious patch database, but I was unable to locate it or who the original author was. If someone is able to find the original patch, please let me know. In any case, the code is entirely original.