### PR TITLE
Explore mode authorization fixes

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2117,6 +2117,7 @@ extern int dohistory(void);
 extern void chdirx(char *, boolean);
 #endif /* CHDIR */
 extern boolean authorize_wizard_mode(void);
+extern boolean authorize_explore_mode(void);
 #endif
 #if defined(WIN32)
 extern int getlock(void);
@@ -3093,6 +3094,7 @@ extern void port_help(void);
 #endif
 extern void sethanguphandler(void(*)(int));
 extern boolean authorize_wizard_mode(void);
+extern boolean authorize_explore_mode(void);
 extern void append_slash(char *);
 extern boolean check_user_string(const char *);
 extern char *get_login_name(void);
@@ -3257,6 +3259,7 @@ extern void chdirx(const char *, boolean);
 #endif /* CHDIR */
 extern void sethanguphandler(void(*)(int));
 extern boolean authorize_wizard_mode(void);
+extern boolean authorize_explore_mode(void);
 
 /* ### vmsmisc.c ### */
 

--- a/include/flag.h
+++ b/include/flag.h
@@ -404,6 +404,8 @@ struct instance_flags {
                                     chosen_windowport[], but do not switch to
                                     it in the midst of options processing */
     genericptr_t returning_missile; /* 'struct obj *'; Mjollnir or aklys */
+    boolean wiz_error_flag;     /* flag for tracking failed wizmode auth */
+    boolean explore_error_flag; /* ditto for explore mode */
     boolean obsolete;  /* obsolete options can point at this, it isn't used */
 };
 

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -979,10 +979,7 @@ enter_explore_mode(void)
     } else {
         const char *oldmode = !wizard ? "normal game" : "debug mode";
 
-#ifdef SYSCF
-#if defined(UNIX)
-        if (!sysopt.explorers || !sysopt.explorers[0]
-            || !check_user_string(sysopt.explorers)) {
+        if (!authorize_explore_mode()) {
             if (!wizard) {
                 You("cannot access explore mode.");
                 return ECMD_OK;
@@ -992,8 +989,6 @@ enter_explore_mode(void)
                 /* keep going */
             }
         }
-#endif
-#endif
         pline("Beware!  From explore mode there will be no return to %s,",
               oldmode);
         if (paranoid_query(ParanoidQuit,

--- a/src/options.c
+++ b/src/options.c
@@ -10208,11 +10208,14 @@ set_playmode(void)
             gp.plnamelen = (int) strlen(strcpy(gp.plname, "wizard"));
         else
             wizard = FALSE; /* not allowed or not available */
-        /* force explore mode if we didn't make it into wizard mode */
+        /* try explore mode if we didn't make it into wizard mode */
         discover = !wizard;
         iflags.deferred_X = FALSE;
     }
-    /* don't need to do anything special for explore mode or normal play */
+    if (discover && !authorize_explore_mode()) {
+        discover = iflags.deferred_X = FALSE;
+    }
+    /* don't need to do anything special for normal play */
 }
 
 static void

--- a/src/options.c
+++ b/src/options.c
@@ -10209,8 +10209,10 @@ set_playmode(void)
         else
             wizard = FALSE; /* not allowed or not available */
         /* try explore mode if we didn't make it into wizard mode */
+        /* if requesting wizard mode when restoring a normal game, this will
+           set iflags.deferred_X and prompt to activate explore mode after the
+           save file has already been deleted */
         discover = !wizard;
-        iflags.deferred_X = FALSE;
     }
     if (discover && !authorize_explore_mode()) {
         discover = iflags.deferred_X = FALSE;

--- a/src/options.c
+++ b/src/options.c
@@ -10213,6 +10213,7 @@ set_playmode(void)
            set iflags.deferred_X and prompt to activate explore mode after the
            save file has already been deleted */
         discover = !wizard;
+        iflags.deferred_X = FALSE;
     }
     if (discover && !authorize_explore_mode()) {
         discover = iflags.deferred_X = FALSE;

--- a/src/restore.c
+++ b/src/restore.c
@@ -512,7 +512,7 @@ restgamestate(NHFILE *nhfp)
     struct obj *bc_obj;
     char timebuf[15];
     unsigned long uid = 0;
-    boolean defer_perm_invent;
+    boolean defer_perm_invent, restoring_special;
 
     if (nhfp->structlevel)
         Mread(nhfp->fd, &uid, sizeof uid);
@@ -557,10 +557,11 @@ restgamestate(NHFILE *nhfp)
        in the discover case, we don't want to set that for a normal
        game until after the save file has been removed */
     iflags.deferred_X = (newgameflags.explore && !discover);
+    restoring_special = (wizard || discover);
     if (newgameflags.debug) {
         /* authorized by startup code; wizard mode exists and is allowed */
         wizard = TRUE, discover = iflags.deferred_X = FALSE;
-    } else if (wizard || discover) {
+    } else if (restoring_special) {
         /* specified by save file; check authorization now. */
         set_playmode();
     }
@@ -571,6 +572,13 @@ restgamestate(NHFILE *nhfp)
     if (nhfp->structlevel)
         Mread(nhfp->fd, &u, sizeof u);
     gy.youmonst.cham = u.mcham;
+
+    if (restoring_special && iflags.explore_error_flag) {
+        /* savefile has wizard or explore mode, but player is no longer
+           authorized to access either; can't downgrade mode any further, so
+           fail restoration. */
+        u.uhp = 0; 
+    }
 
     if (nhfp->structlevel)
         Mread(nhfp->fd, timebuf, 14);

--- a/src/restore.c
+++ b/src/restore.c
@@ -560,8 +560,8 @@ restgamestate(NHFILE *nhfp)
     if (newgameflags.debug) {
         /* authorized by startup code; wizard mode exists and is allowed */
         wizard = TRUE, discover = iflags.deferred_X = FALSE;
-    } else if (wizard) {
-        /* specified by save file; check authorization now */
+    } else if (wizard || discover) {
+        /* specified by save file; check authorization now. */
         set_playmode();
     }
     role_init(); /* Reset the initial role, race, gender, and alignment */

--- a/sys/libnh/libnhmain.c
+++ b/sys/libnh/libnhmain.c
@@ -633,14 +633,12 @@ wd_message(void)
         } else {
             You("cannot access debug (wizard) mode.");
         }
-        wizard = 0; /* (paranoia) */
-        if (!explore_error_flag) {
+        wizard = FALSE; /* (paranoia) */
+        if (!explore_error_flag)
             pline("Entering explore/discovery mode instead.");
-            discover = 1;
-        }
     } else if (explore_error_flag) {
         You("cannot access explore mode."); /* same as enter_explore_mode */
-        discover = 0; /* (more paranoia) */
+        discover = iflags.deferred_X = FALSE; /* (more paranoia) */
     } else if (discover)
         You("are in non-scoring explore/discovery mode.");
 }

--- a/sys/libnh/libnhmain.c
+++ b/sys/libnh/libnhmain.c
@@ -50,7 +50,7 @@ extern void init_linux_cons(void);
 #endif
 
 static void wd_message(void);
-static boolean wiz_error_flag = FALSE;
+static boolean wiz_error_flag = FALSE, explore_error_flag = FALSE;
 static struct passwd *get_unix_pw(void);
 
 #ifdef __EMSCRIPTEN__
@@ -605,6 +605,22 @@ authorize_wizard_mode(void)
     return FALSE;
 }
 
+/* similar to above, validate explore mode access */
+boolean
+authorize_explore_mode(void)
+{
+#ifdef SYSCF
+    if (sysopt.explorers && sysopt.explorers[0]) {
+        if (check_user_string(sysopt.explorers))
+            return TRUE;
+    }
+    explore_error_flag = TRUE; /* not being allowed into explore mode */
+    return FALSE;
+#else
+    return TRUE; /* if sysconf disabled, no restrictions on explore mode */
+#endif
+}
+
 static void
 wd_message(void)
 {
@@ -614,9 +630,17 @@ wd_message(void)
             pline("Only user%s %s may access debug (wizard) mode.",
                   strchr(sysopt.wizards, ' ') ? "s" : "", tmp);
             free(tmp);
-        } else
+        } else {
+            You("cannot access debug (wizard) mode.");
+        }
+        wizard = 0; /* (paranoia) */
+        if (!explore_error_flag) {
             pline("Entering explore/discovery mode instead.");
-        wizard = 0, discover = 1; /* (paranoia) */
+            discover = 1;
+        }
+    } else if (explore_error_flag) {
+        You("cannot access explore mode."); /* same as enter_explore_mode */
+        discover = 0; /* (more paranoia) */
     } else if (discover)
         You("are in non-scoring explore/discovery mode.");
 }

--- a/sys/libnh/libnhmain.c
+++ b/sys/libnh/libnhmain.c
@@ -50,7 +50,6 @@ extern void init_linux_cons(void);
 #endif
 
 static void wd_message(void);
-static boolean wiz_error_flag = FALSE, explore_error_flag = FALSE;
 static struct passwd *get_unix_pw(void);
 
 #ifdef __EMSCRIPTEN__
@@ -601,7 +600,7 @@ authorize_wizard_mode(void)
         if (check_user_string(sysopt.wizards))
             return TRUE;
     }
-    wiz_error_flag = TRUE; /* not being allowed into wizard mode */
+    iflags.wiz_error_flag = TRUE; /* not being allowed into wizard mode */
     return FALSE;
 }
 
@@ -614,7 +613,7 @@ authorize_explore_mode(void)
         if (check_user_string(sysopt.explorers))
             return TRUE;
     }
-    explore_error_flag = TRUE; /* not being allowed into explore mode */
+    iflags.explore_error_flag = TRUE; /* not allowed into explore mode */
     return FALSE;
 #else
     return TRUE; /* if sysconf disabled, no restrictions on explore mode */
@@ -624,7 +623,7 @@ authorize_explore_mode(void)
 static void
 wd_message(void)
 {
-    if (wiz_error_flag) {
+    if (iflags.wiz_error_flag) {
         if (sysopt.wizards && sysopt.wizards[0]) {
             char *tmp = build_english_list(sysopt.wizards);
             pline("Only user%s %s may access debug (wizard) mode.",
@@ -634,9 +633,9 @@ wd_message(void)
             You("cannot access debug (wizard) mode.");
         }
         wizard = FALSE; /* (paranoia) */
-        if (!explore_error_flag)
+        if (!iflags.explore_error_flag)
             pline("Entering explore/discovery mode instead.");
-    } else if (explore_error_flag) {
+    } else if (iflags.explore_error_flag) {
         You("cannot access explore mode."); /* same as enter_explore_mode */
         discover = iflags.deferred_X = FALSE; /* (more paranoia) */
     } else if (discover)

--- a/sys/libnh/libnhmain.c
+++ b/sys/libnh/libnhmain.c
@@ -597,9 +597,7 @@ port_help(void)
 boolean
 authorize_wizard_mode(void)
 {
-    struct passwd *pw = get_unix_pw();
-
-    if (pw && sysopt.wizards && sysopt.wizards[0]) {
+    if (sysopt.wizards && sysopt.wizards[0]) {
         if (check_user_string(sysopt.wizards))
             return TRUE;
     }

--- a/sys/share/pcmain.c
+++ b/sys/share/pcmain.c
@@ -720,6 +720,13 @@ authorize_wizard_mode(void)
     return FALSE;
 }
 
+/* similar to above, validate explore mode access */
+boolean
+authorize_explore_mode(void)
+{
+    return TRUE; /* no restrictions on explore mode */
+}
+
 #ifdef EXEPATH
 #ifdef __DJGPP__
 #define PATH_SEPARATOR '/'

--- a/sys/unix/unixmain.c
+++ b/sys/unix/unixmain.c
@@ -947,9 +947,7 @@ port_help(void)
 boolean
 authorize_wizard_mode(void)
 {
-    struct passwd *pw = get_unix_pw();
-
-    if (pw && sysopt.wizards && sysopt.wizards[0]) {
+    if (sysopt.wizards && sysopt.wizards[0]) {
         if (check_user_string(sysopt.wizards))
             return TRUE;
     }

--- a/sys/unix/unixmain.c
+++ b/sys/unix/unixmain.c
@@ -53,7 +53,6 @@ extern void init_linux_cons(void);
 #endif
 
 static void wd_message(void);
-static boolean wiz_error_flag = FALSE, explore_error_flag = FALSE;
 static struct passwd *get_unix_pw(void);
 
 int
@@ -951,7 +950,7 @@ authorize_wizard_mode(void)
         if (check_user_string(sysopt.wizards))
             return TRUE;
     }
-    wiz_error_flag = TRUE; /* not being allowed into wizard mode */
+    iflags.wiz_error_flag = TRUE; /* not being allowed into wizard mode */
     return FALSE;
 }
 
@@ -964,7 +963,7 @@ authorize_explore_mode(void)
         if (check_user_string(sysopt.explorers))
             return TRUE;
     }
-    explore_error_flag = TRUE; /* not being allowed into explore mode */
+    iflags.explore_error_flag = TRUE; /* not allowed into explore mode */
     return FALSE;
 #else
     return TRUE; /* if sysconf disabled, no restrictions on explore mode */
@@ -974,7 +973,7 @@ authorize_explore_mode(void)
 static void
 wd_message(void)
 {
-    if (wiz_error_flag) {
+    if (iflags.wiz_error_flag) {
         if (sysopt.wizards && sysopt.wizards[0]) {
             char *tmp = build_english_list(sysopt.wizards);
             pline("Only user%s %s may access debug (wizard) mode.",
@@ -984,9 +983,9 @@ wd_message(void)
             You("cannot access debug (wizard) mode.");
         }
         wizard = FALSE; /* (paranoia) */
-        if (!explore_error_flag)
+        if (!iflags.explore_error_flag)
             pline("Entering explore/discovery mode instead.");
-    } else if (explore_error_flag) {
+    } else if (iflags.explore_error_flag) {
         You("cannot access explore mode."); /* same as enter_explore_mode */
         discover = iflags.deferred_X = FALSE; /* (more paranoia) */
     } else if (discover)

--- a/sys/unix/unixmain.c
+++ b/sys/unix/unixmain.c
@@ -983,14 +983,12 @@ wd_message(void)
         } else {
             You("cannot access debug (wizard) mode.");
         }
-        wizard = 0; /* (paranoia) */
-        if (!explore_error_flag) {
+        wizard = FALSE; /* (paranoia) */
+        if (!explore_error_flag)
             pline("Entering explore/discovery mode instead.");
-            discover = 1;
-        }
     } else if (explore_error_flag) {
         You("cannot access explore mode."); /* same as enter_explore_mode */
-        discover = 0; /* (more paranoia) */
+        discover = iflags.deferred_X = FALSE; /* (more paranoia) */
     } else if (discover)
         You("are in non-scoring explore/discovery mode.");
 }

--- a/sys/vms/vmsmain.c
+++ b/sys/vms/vmsmain.c
@@ -484,6 +484,13 @@ authorize_wizard_mode(void)
     return FALSE;
 }
 
+/* similar to above, validate explore mode access */
+boolean
+authorize_explore_mode(void)
+{
+    return TRUE; /* no restrictions on explore mode */
+}
+
 static void
 wd_message(void)
 {

--- a/sys/windows/windmain.c
+++ b/sys/windows/windmain.c
@@ -1021,6 +1021,13 @@ authorize_wizard_mode(void)
     return FALSE;
 }
 
+/* similar to above, validate explore mode access */
+boolean
+authorize_explore_mode(void)
+{
+    return TRUE; /* no restrictions on explore mode */
+}
+
 #define PATH_SEPARATOR '\\'
 
 #if defined(WIN32) && !defined(WIN32CON)


### PR DESCRIPTION
With SYSCF defined, EXPLORERS was being checked for explore mode authorization
when using #exploremode or resuming a previous normal game (if explore mode was
requested via command line or options), but if launching a new game with
OPTIONS=playmode:explore or -X, EXPLORERS was not evaluated or used.  Check it
before entering explore mode under all circumstances.

There was also an issue with the way failed wizard mode authorization would
push the game into explore mode when resuming a previous normal game, which
interfered with iflags.deferred_X and caused problems.

- Remove pw check in authorize_wizard_mode
- Apply sysconf EXPLORERS restriction on startup
- Fix: shunt to explore mode after wizmode auth fail
