### PR TITLE
Enable hero to wash hands in fountains and pools (and sinks!)

### DIFF
--- a/include/decl.h
+++ b/include/decl.h
@@ -29,6 +29,7 @@ extern NEARDATA const struct c_color_names c_color_names;
 /* common_strings */
 extern const struct c_common_strings c_common_strings;
 #define nothing_happens c_common_strings.c_nothing_happens
+#define nothing_seems_to_happen c_common_strings.c_nothing_seems_to_happen
 #define thats_enough_tries c_common_strings.c_thats_enough_tries
 #define silly_thing_to c_common_strings.c_silly_thing_to
 #define shudder_for_moment c_common_strings.c_shudder_for_moment

--- a/include/extern.h
+++ b/include/extern.h
@@ -970,6 +970,7 @@ extern void dogushforth(int);
 extern void dryup(coordxy, coordxy, boolean);
 extern void drinkfountain(void);
 extern void dipfountain(struct obj *);
+extern int wash_hands(void);
 extern void breaksink(coordxy, coordxy);
 extern void drinksink(void);
 

--- a/include/extern.h
+++ b/include/extern.h
@@ -470,6 +470,7 @@ extern int dodrop(void);
 extern boolean boulder_hits_pool(struct obj *, coordxy, coordxy, boolean);
 extern boolean flooreffects(struct obj *, coordxy, coordxy, const char *);
 extern void doaltarobj(struct obj *);
+extern void polymorph_sink(void);
 extern void trycall(struct obj *);
 extern boolean canletgo(struct obj *, const char *);
 extern void dropx(struct obj *);
@@ -973,6 +974,7 @@ extern void dipfountain(struct obj *);
 extern int wash_hands(void);
 extern void breaksink(coordxy, coordxy);
 extern void drinksink(void);
+extern void dipsink(struct obj *);
 
 /* ### hack.c ### */
 

--- a/include/extern.h
+++ b/include/extern.h
@@ -975,6 +975,7 @@ extern int wash_hands(void);
 extern void breaksink(coordxy, coordxy);
 extern void drinksink(void);
 extern void dipsink(struct obj *);
+extern void sink_backs_up(coordxy, coordxy);
 
 /* ### hack.c ### */
 

--- a/include/hack.h
+++ b/include/hack.h
@@ -270,11 +270,11 @@ struct c_color_names {
 };
 
 struct c_common_strings {
-    const char *const c_nothing_happens, *const c_thats_enough_tries,
-        *const c_silly_thing_to, *const c_shudder_for_moment,
-        *const c_something, *const c_Something, *const c_You_can_move_again,
-        *const c_Never_mind, *c_vision_clears, *const c_the_your[2],
-        *const c_fakename[2];
+    const char *const c_nothing_happens, *const c_nothing_seems_to_happen,
+        *const c_thats_enough_tries, *const c_silly_thing_to,
+        *const c_shudder_for_moment, *const c_something, *const c_Something,
+        *const c_You_can_move_again, *const c_Never_mind, *c_vision_clears,
+        *const c_the_your[2], *const c_fakename[2];
 };
 
 struct container {

--- a/include/hack.h
+++ b/include/hack.h
@@ -273,8 +273,8 @@ struct c_common_strings {
     const char *const c_nothing_happens, *const c_nothing_seems_to_happen,
         *const c_thats_enough_tries, *const c_silly_thing_to,
         *const c_shudder_for_moment, *const c_something, *const c_Something,
-        *const c_You_can_move_again, *const c_Never_mind, *c_vision_clears,
-        *const c_the_your[2], *const c_fakename[2];
+        *const c_You_can_move_again, *const c_Never_mind,
+        *const c_vision_clears, *const c_the_your[2], *const c_fakename[2];
 };
 
 struct container {

--- a/src/apply.c
+++ b/src/apply.c
@@ -49,7 +49,6 @@ static boolean get_valid_polearm_position(coordxy, coordxy);
 static boolean find_poleable_mon(coord *, int, int);
 
 static const char
-    Nothing_seems_to_happen[] = "Nothing seems to happen.",
     no_elbow_room[] = "don't have enough elbow-room to maneuver.";
 
 static int
@@ -1010,7 +1009,7 @@ use_mirror(struct obj *obj)
         if (!Blind)
             pline_The("%s fogs up and doesn't reflect!", mirror);
         else
-            pline("%s", Nothing_seems_to_happen);
+            pline("%s", nothing_seems_to_happen);
         return ECMD_TIME;
     }
     if (!u.dx && !u.dy && !u.dz) {
@@ -1629,7 +1628,7 @@ use_lamp(struct obj *obj)
             if (!Blind)
                 Your("lantern is out of power.");
             else
-                pline("%s", Nothing_seems_to_happen);
+                pline("%s", nothing_seems_to_happen);
         } else {
             pline("This %s has no oil.", xname(obj));
         }
@@ -1644,7 +1643,7 @@ use_lamp(struct obj *obj)
             pline("%s for a moment, then %s.", Tobjnam(obj, "flicker"),
                   otense(obj, "die"));
         } else {
-            pline("%s", Nothing_seems_to_happen);
+            pline("%s", nothing_seems_to_happen);
         }
     } else {
         if (lamp) { /* lamp or lantern */
@@ -2232,7 +2231,7 @@ use_unicorn_horn(struct obj **optr)
             break;
         case 6:
             if (Deaf) /* make_deaf() won't give feedback when already deaf */
-                pline("%s", Nothing_seems_to_happen);
+                pline("%s", nothing_seems_to_happen);
             make_deaf((HDeaf & TIMEOUT) + lcount, TRUE);
             break;
         }
@@ -2320,7 +2319,7 @@ use_unicorn_horn(struct obj **optr)
     if (did_prop)
         gc.context.botl = TRUE;
     else
-        pline("%s", Nothing_seems_to_happen);
+        pline("%s", nothing_seems_to_happen);
 
 #undef PROP_COUNT
 #undef prop_trouble
@@ -3519,7 +3518,7 @@ use_royal_jelly(struct obj **optr)
         if (eobj->timed || eobj->corpsenm != oldcorpsenm)
             pline("The %s %s feebly.", xname(eobj), otense(eobj, "quiver"));
         else
-            pline("%s", Nothing_seems_to_happen);
+            pline("%s", nothing_seems_to_happen);
         kill_egg(eobj);
         goto useup_jelly;
     }
@@ -3538,7 +3537,7 @@ use_royal_jelly(struct obj **optr)
         || eobj->corpsenm != oldcorpsenm)
         pline("The %s %s briefly.", xname(eobj), otense(eobj, "quiver"));
     else
-        pline("%s", Nothing_seems_to_happen);
+        pline("%s", nothing_seems_to_happen);
 
  useup_jelly:
     /* not useup() because we've already done freeinv() */

--- a/src/decl.c
+++ b/src/decl.c
@@ -38,6 +38,7 @@ const char *c_obj_colors[] = {
 
 const struct c_common_strings c_common_strings =
     { "Nothing happens.",
+      "Nothing seems to happen.",
       "That's enough tries!",
       "That is a silly thing to %s.",
       "shudder for a moment.",

--- a/src/do.c
+++ b/src/do.c
@@ -7,7 +7,6 @@
 
 #include "hack.h"
 
-static void polymorph_sink(void);
 static boolean teleport_sink(void);
 static void dosinkring(struct obj *);
 static int drop(struct obj *);
@@ -352,7 +351,7 @@ trycall(struct obj *obj)
 
 /* Transforms the sink at the player's position into
    a fountain, throne, altar or grave. */
-static void
+void
 polymorph_sink(void)
 {
     uchar sym = S_sink;

--- a/src/dokick.c
+++ b/src/dokick.c
@@ -958,7 +958,6 @@ dokick(void)
     int glyph, oldglyph = -1;
     register struct monst *mtmp;
     boolean no_kick = FALSE;
-    char buf[BUFSZ];
 
     if (nolimbs(gy.youmonst.data) || slithy(gy.youmonst.data)) {
         You("have no legs to kick with.");
@@ -1419,25 +1418,7 @@ dokick(void)
                 exercise(A_DEX, TRUE);
                 return ECMD_TIME;
             } else if (!rn2(3)) {
-                if (Blind && Deaf)
-                    Sprintf(buf, " %s", body_part(FACE));
-                else
-                    buf[0] = '\0';
-                pline("%s%s%s.", !Deaf ? "Flupp! " : "",
-                      !Blind
-                          ? "Muddy waste pops up from the drain"
-                          : !Deaf
-                              ? "You hear a sloshing sound"  /* Deaf-aware */
-                              : "Something splashes you in the", buf);
-                if (!(gm.maploc->looted & S_LRING)) { /* once per sink */
-                    if (!Blind)
-                        You_see("a ring shining in its midst.");
-                    (void) mkobj_at(RING_CLASS, x, y, TRUE);
-                    newsym(x, y);
-                    exercise(A_DEX, TRUE);
-                    exercise(A_WIS, TRUE); /* a discovery! */
-                    gm.maploc->looted |= S_LRING;
-                }
+                sink_backs_up(x, y);
                 return ECMD_TIME;
             }
             kick_ouch(x, y, "");

--- a/src/fountain.c
+++ b/src/fountain.c
@@ -694,4 +694,47 @@ drinksink(void)
     }
 }
 
+void
+dipsink(struct obj *obj)
+{
+    boolean try_call = FALSE;
+
+    if (obj == &cg.zeroobj || obj == uarmg) {
+        (void) wash_hands();
+        return;
+    } else if (obj->oclass != POTION_CLASS) {
+        You("hold %s under the tap.", the(xname(obj)));
+        if (water_damage(obj, (const char *) 0, TRUE) == ER_NOTHING)
+            pline("Nothing seems to happen.");
+        return;
+    }
+
+    /* at this point the object must be a potion */
+    You("pour %s%s down the drain.", (obj->quan > 1L ? "one of " : ""),
+        the(xname(obj)));
+    switch (obj->otyp) {
+    case POT_POLYMORPH:
+        polymorph_sink();
+        try_call = TRUE;
+        break;
+    case POT_OIL:
+        if (!Blind) {
+            pline("It leaves an oily film on the basin.");
+            try_call = TRUE;
+        }
+        break;
+    default:
+        /* hero can feel the vapor on her skin, so no need to check Blind or
+           breathless for this message */
+        pline("A wisp of vapor rises up...");
+        /* NB: potionbreathe calls trycall or makeknown as appropriate */
+        if (!breathless(gy.youmonst.data) || haseyes(gy.youmonst.data))
+            potionbreathe(obj);
+        break;
+    }
+    if (try_call && obj->dknown)
+        trycall(obj);
+    useup(obj);
+}
+
 /*fountain.c*/

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -2422,7 +2422,7 @@ bagotricks(
                 update_inventory(); /* for perm_invent */
             }
         } else if (!tipping) {
-            pline1(!moncount ? nothing_happens : "Nothing seems to happen.");
+            pline1(!moncount ? nothing_happens : nothing_seems_to_happen);
         }
     }
     return moncount;

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -3865,7 +3865,7 @@ tipcontainer_checks(
 
         if (box->spe < old_spe) {
             if (bag && !totseen)
-                pline("Nothing seems to happen.");
+                pline1(nothing_seems_to_happen);
             /* check_unpaid wants to see a non-zero charge count */
             box->spe = old_spe;
             check_unpaid_usage(box, TRUE);

--- a/src/potion.c
+++ b/src/potion.c
@@ -2180,8 +2180,10 @@ mixtype(struct obj *o1, struct obj *o2)
 static int
 dip_ok(struct obj *obj)
 {
-    /* dipping hands and gold isn't currently implemented */
-    if (!obj || obj->oclass == COIN_CLASS)
+    if (!obj)
+        return GETOBJ_DOWNPLAY;
+    /* dipping gold isn't currently implemented */
+    if (obj->oclass == COIN_CLASS)
         return GETOBJ_EXCLUDE;
 
     if (inaccessible_equipment(obj, (const char *) 0, FALSE))
@@ -2221,14 +2223,16 @@ dodip(void)
     uchar here;
     char qbuf[QBUFSZ], obuf[QBUFSZ];
     const char *shortestname; /* last resort obj name for prompt */
+    boolean is_hands;
 
     if (!(obj = getobj("dip", dip_ok, GETOBJ_PROMPT)))
         return ECMD_CANCEL;
     if (inaccessible_equipment(obj, "dip", FALSE))
         return ECMD_OK;
 
-    shortestname = (is_plural(obj) || pair_of(obj)) ? "them" : "it";
-
+    is_hands = (obj == &cg.zeroobj);
+    shortestname = (is_hands || is_plural(obj) || pair_of(obj)) ? "them"
+                                                                : "it";
     drink_ok_extra = 0;
     /* preceding #dip with 'm' skips the possibility of dipping into
        fountains and pools plus the prompting which those entail */
@@ -2242,10 +2246,16 @@ dodip(void)
          * supplied type name.
          * getobj: "What do you want to dip <the object> into? [xyz or ?*] "
          */
-        Strcpy(obuf, short_oname(obj, doname, thesimpleoname,
-                             /* 128 - (24 + 54 + 1) leaves 49 for <object> */
-                                 QBUFSZ - sizeof "What do you want to dip \
+        if (is_hands) {
+            Snprintf(obuf, sizeof(obuf), "your %s",
+                     makeplural(body_part(HAND)));
+        } else {
+            Strcpy(obuf, short_oname(obj, doname, thesimpleoname,
+                                     /* 128 - (24 + 54 + 1) leaves 49 for
+                                        <object> */
+                                     QBUFSZ - sizeof "What do you want to dip\
  into? [abdeghjkmnpqstvwyzBCEFHIKLNOQRTUWXZ#-# or ?*] "));
+        }
 
         here = levl[u.ux][u.uy].typ;
         /* Is there a fountain to dip into here? */
@@ -2256,7 +2266,8 @@ dodip(void)
                      flags.verbose ? obuf : shortestname);
             /* "Dip <the object> into the fountain?" */
             if (y_n(qbuf) == 'y') {
-                obj->pickup_prev = 0;
+                if (!is_hands)
+                    obj->pickup_prev = 0;
                 dipfountain(obj);
                 return ECMD_TIME;
             }
@@ -2273,6 +2284,10 @@ dodip(void)
                 } else if (u.usteed && !is_swimmer(u.usteed->data)
                            && P_SKILL(P_RIDING) < P_BASIC) {
                     rider_cant_reach(); /* not skilled enough to reach */
+                } else if (is_hands || obj == uarmg) {
+                    if (!is_hands)
+                        obj->pickup_prev = 0;
+                    (void) wash_hands();
                 } else {
                     obj->pickup_prev = 0;
                     if (obj->otyp == POT_ACID)
@@ -2339,6 +2354,11 @@ potion_dip(struct obj *obj, struct obj *potion)
 
     if (potion == obj && potion->quan == 1L) {
         pline("That is a potion bottle, not a Klein bottle!");
+        return ECMD_OK;
+    }
+    if (obj == &cg.zeroobj) {
+        You("can't fit your %s into the mouth of the bottle!",
+            body_part(HAND));
         return ECMD_OK;
     }
 

--- a/src/potion.c
+++ b/src/potion.c
@@ -2408,7 +2408,7 @@ potion_dip(struct obj *obj, struct obj *potion)
                 prinv((char *) 0, obj, 0L);
                 return ECMD_TIME;
             } else {
-                pline("Nothing seems to happen.");
+                pline1(nothing_seems_to_happen);
                 goto poof;
             }
         }

--- a/src/potion.c
+++ b/src/potion.c
@@ -2272,6 +2272,16 @@ dodip(void)
                 return ECMD_TIME;
             }
             ++drink_ok_extra;
+        } else if (IS_SINK(here)) {
+            Snprintf(qbuf, sizeof(qbuf), "%s%s into the sink?", Dip_,
+                     flags.verbose ? obuf : shortestname);
+            if (y_n(qbuf) == 'y') {
+                if (!is_hands)
+                    obj->pickup_prev = 0;
+                dipsink(obj);
+                return ECMD_TIME;
+            }
+            ++drink_ok_extra;
         } else if (is_pool(u.ux, u.uy)) {
             const char *pooltype = waterbody_name(u.ux, u.uy);
 


### PR DESCRIPTION
Dipping hands (with '-') or currently-worn gloves in a fountain or pool
will cause the hero to wash her hands, washing away any oil and clearing
the Glib intrinsic timeout.  This does mean bare hands can be used to
fish for fountain effects, without having to pick up a stray arrow and
carry it around as a dipping item, but having your hands be the only
thing that does not activate those effects felt weird.  If that would be
too unbalancing this could be scrapped.

With further commits this now also adds a system for #dipping items into
a sink, which can aid in potion identification (much like dropping a
ring into the sink can).  This is based on code from xNetHack written by
@copperwater, with additions and amendments.  It also means you can wash
your hands in a sink.
