### PR TITLE
doc: add note that USE_XPM can be defined otherwise

### DIFF
--- a/win/X11/NetHack.ad
+++ b/win/X11/NetHack.ad
@@ -30,7 +30,8 @@ NetHack*text*borderWidth:  0
 ! tile_file names a file containing full-color tiles for the map.
 ! If you use a 100dpi (or greater) monitor you may wish to double the
 ! tile size so you can see the figures.  If NetHack was compiled to
-! use XPM (USE_XPM in config.h), the tile_file is a standard XPM file.
+! use XPM (USE_XPM in config.h or via the Makefile),
+! the tile_file is a standard XPM file.
 ! Otherwise, it is a custom format.  double_tile_size only applies to
 ! the custom format - to enlarge an XPM file, use processing tools
 ! such as XV or preferably PBMplus.


### PR DESCRIPTION
 * Add an additional hint to win/X11/NetHack.ad that `USE_XPM` can be defined outsite of `config.h` as it is the case with `hints/linux-x11`-