### PR TITLE
Fix: hurtling into wall of water

### DIFF
--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -924,8 +924,7 @@ hurtle_step(genericptr_t arg, coordxy x, coordxy y)
     check_special_room(FALSE);
 
     if (is_pool(x, y) && !u.uinwater) {
-        if ((Is_waterlevel(&u.uz) && is_waterwall(x,y))
-            || !(Levitation || Flying || Wwalking)) {
+        if (is_waterwall(x, y) || !(Levitation || Flying || Wwalking)) {
             /* couldn't move while hurtling; allow movement now so that
                drown() will give a chance to crawl out of pool and survive */
             gm.multi = 0;

--- a/src/invent.c
+++ b/src/invent.c
@@ -4225,6 +4225,8 @@ dfeature_at(coordxy x, coordxy y, char *buf)
         cmap = S_lava; /* "molten lava" */
     else if (is_ice(x, y))
         dfeature = ice_descr(x, y, altbuf), cmap = -1; /* "ice" */
+    else if (IS_WATERWALL(ltyp))
+        dfeature = "wall of water";
     else if (is_pool(x, y))
         dfeature = "pool of water";
     else if (IS_SINK(ltyp))

--- a/src/trap.c
+++ b/src/trap.c
@@ -4587,6 +4587,7 @@ water_damage_chain(
 {
     struct obj *otmp;
     coordxy x, y;
+    coord save_bhitpos;
 
     if (!obj)
         return;
@@ -4595,7 +4596,10 @@ water_damage_chain(
        acid nor unseen have exploded during this water damage sequence */
     ga.acid_ctx.dkn_boom = ga.acid_ctx.unk_boom = 0;
     ga.acid_ctx.ctx_valid = TRUE;
-
+    /* we don't want to permanently overwrite bhitpos below, since we can get
+       here from scenarios where it was in use up the call stack (e.g. thrown
+       item hurtling the levitating hero into a wall of water) */
+    save_bhitpos = gb.bhitpos;
     /* erode_obj() relies on bhitpos if target objects aren't carried by
        the hero or a monster, to check visibility controlling feedback */
     if (get_obj_location(obj, &x, &y, CONTAINED_TOO))
@@ -4606,9 +4610,10 @@ water_damage_chain(
         water_damage(obj, (char *) 0, FALSE);
     }
 
-    /* reset acid context */
+    /* reset acid context and bhitpos */
     ga.acid_ctx.dkn_boom = ga.acid_ctx.unk_boom = 0;
     ga.acid_ctx.ctx_valid = FALSE;
+    gb.bhitpos = save_bhitpos;
 }
 
 /*


### PR DESCRIPTION
A hero hurtled into a wall of water while levitating, flying, or wearing
water-walking boots wouldn't be stopped by it unless it was on the Plane
of Water.  Make it stop hurtling heroes immediately no matter the
location.

I also noticed that once I was hurtled safely into the wall of water, it
was described as a "pool" when I examined it with ':'.  Fix that, too,
even though I think it shouldn't really be encountered in-game.
