### PR TITLE
Follow up on disturbing buried zombies

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -993,7 +993,8 @@ extern boolean test_move(coordxy, coordxy, coordxy, coordxy, int);
 extern int wiz_debug_cmd_traveldisplay(void);
 #endif
 extern boolean u_rooted(void);
-extern void check_buried_zombies(coordxy, coordxy);
+extern void impact_disturbs_zombies(struct obj *, boolean);
+extern void disturb_buried_zombies(coordxy, coordxy);
 extern boolean u_maybe_impaired(void);
 extern const char *u_locomotion(const char *);
 extern void handle_tip(int);

--- a/src/do.c
+++ b/src/do.c
@@ -305,7 +305,6 @@ flooreffects(struct obj *obj, coordxy x, coordxy y, const char *verb)
                && cansee(x,y)) {
         doaltarobj(obj);
     }
-    check_buried_zombies(x, y);
 
     gb.bhitpos = save_bhitpos;
     return res;
@@ -779,6 +778,7 @@ dropz(struct obj *obj, boolean with_impact)
         place_object(obj, u.ux, u.uy);
         if (with_impact)
             container_impact_dmg(obj, u.ux, u.uy);
+        impact_disturbs_zombies(obj, with_impact);
         if (obj == uball)
             drop_ball(u.ux, u.uy);
         else if (gl.level.flags.has_shop)

--- a/src/dokick.c
+++ b/src/dokick.c
@@ -627,6 +627,7 @@ really_kick_object(coordxy x, coordxy y)
         }
         if (!flooreffects(gk.kickedobj, u.ux, u.uy, "fall")) {
             place_object(gk.kickedobj, u.ux, u.uy);
+            impact_disturbs_zombies(gk.kickedobj, TRUE);
             stackobj(gk.kickedobj);
             newsym(u.ux, u.uy);
         }
@@ -770,6 +771,7 @@ really_kick_object(coordxy x, coordxy y)
             donate_gold(gtg, shkp, FALSE);
     }
     place_object(gk.kickedobj, gb.bhitpos.x, gb.bhitpos.y);
+    impact_disturbs_zombies(gk.kickedobj, TRUE);
     stackobj(gk.kickedobj);
     newsym(gk.kickedobj->ox, gk.kickedobj->oy);
     return 1;

--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -1778,9 +1778,11 @@ throwit(struct obj *obj,
         /* container contents might break;
            do so before turning ownership of gt.thrownobj over to shk
            (container_impact_dmg handles item already owned by shop) */
-        if (!IS_SOFT(levl[gb.bhitpos.x][gb.bhitpos.y].typ))
+        if (!IS_SOFT(levl[gb.bhitpos.x][gb.bhitpos.y].typ)) {
             /* <x,y> is spot where you initiated throw, not gb.bhitpos */
             container_impact_dmg(obj, u.ux, u.uy);
+            impact_disturbs_zombies(obj, TRUE);
+        }
         /* charge for items thrown out of shop;
            shk takes possession for items thrown into one */
         if ((*u.ushops || obj->unpaid) && obj != uball)

--- a/src/mon.c
+++ b/src/mon.c
@@ -4033,6 +4033,7 @@ wake_nearto(coordxy x, coordxy y, int distance)
             }
         }
     }
+    disturb_buried_zombies(x, y);
 }
 
 /* NOTE: we must check for mimicry before calling this routine */


### PR DESCRIPTION
Change 852f8e4 by requiring a minimum impact before a buried zombie
nearby will be disturbed: light, but still excluding things like
scrolls, if it's a violent impact (dropped while levitating, thrown, or
kicked), and fairly heavy if the hero is just placing the item on the
ground normally.

Moving the call out of flooreffects meant it no longer applied to
pushing boulders around, so have moverock disturb nearby zombies.  I
additionally had wake_nearby do the same thing.

Finally, I renamed check_buried_zombies (which doesn't really reflect
what it does) to disturb_buried_zombies.
