### PR TITLE
remove unnecessary condition on optfn_pickup_types()

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -3230,8 +3230,6 @@ optfn_pickup_types(
         return optn_ok;
     }
     if (req == get_val || req == get_cnf_val) {
-        if (!opts)
-            return optn_err;
         oc_to_str(flags.pickup_types, ocl);
         Sprintf(opts, "%s", ocl[0] ? ocl : "all");
         return optn_ok;


### PR DESCRIPTION
`opts` here is always non-null, otherwise it leads segv at earlier code.