### PR TITLE
Tweak encumbrance messages

### DIFF
--- a/src/pickup.c
+++ b/src/pickup.c
@@ -62,7 +62,8 @@ static void tipcontainer(struct obj *);
 #define Icebox (gc.current_container->otyp == ICE_BOX)
 
 static const char
-        moderateloadmsg[] = "You have a little trouble lifting",
+        slightloadmsg[] = "You have a little trouble lifting",
+        moderateloadmsg[] = "You have trouble lifting",
         nearloadmsg[] = "You have much trouble lifting",
         overloadmsg[] = "You have extreme difficulty lifting";
 
@@ -1672,11 +1673,10 @@ lift_object(
                 long savequan = obj->quan;
 
                 obj->quan = *cnt_p;
-                Strcpy(qbuf, (next_encumbr > HVY_ENCUMBER)
-                                 ? overloadmsg
-                                 : (next_encumbr > MOD_ENCUMBER)
-                                       ? nearloadmsg
-                                       : moderateloadmsg);
+                Strcpy(qbuf, (next_encumbr >= EXT_ENCUMBER) ? overloadmsg
+                                 : (next_encumbr >= HVY_ENCUMBER) ? nearloadmsg
+                                 : (next_encumbr >= MOD_ENCUMBER) ? moderateloadmsg
+                                 : slightloadmsg);
                 if (container)
                     (void) strsubst(qbuf, "lifting", "removing");
                 Strcat(qbuf, " ");

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1715,7 +1715,7 @@ pickup_object(
     boolean telekinesis) /* not picking it up directly by hand */
 {
     int res, nearload;
-    const char* prefix;
+    const char *prefix;
 
     if (obj->quan < count) {
         impossible("pickup_object: count %ld > quan %ld?", count, obj->quan);

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1715,6 +1715,7 @@ pickup_object(
     boolean telekinesis) /* not picking it up directly by hand */
 {
     int res, nearload;
+    const char* prefix;
 
     if (obj->quan < count) {
         impossible("pickup_object: count %ld > quan %ld?", count, obj->quan);
@@ -1784,8 +1785,12 @@ pickup_object(
     if (uwep && uwep == obj)
         gm.mrg_to_wielded = TRUE;
     nearload = near_capacity();
-    prinv(nearload == SLT_ENCUMBER ? moderateloadmsg : (char *) 0, obj,
-          count);
+    prefix = (nearload >= EXT_ENCUMBER) ? overloadmsg
+        : (nearload >= HVY_ENCUMBER) ? nearloadmsg
+        : (nearload >= MOD_ENCUMBER) ? moderateloadmsg
+        : (nearload >= SLT_ENCUMBER) ? slightloadmsg
+        : (char *) 0;
+    prinv(prefix, obj, count);
     gm.mrg_to_wielded = FALSE;
     return 1;
 }


### PR DESCRIPTION
This branch proposes a minor change to the messages related to encumbrance in `lift_object` and `pickup_object`:

- In the `pickup_burden` prompt, keep the message _'You have a little trouble lifting...'_ for becoming burdened, but change it to _'You have trouble lifting...'_ for becoming stressed. This better informs the player how badly encumbered you are when it's set to `unencumbered`, since those two encumberance levels are the only ones that shared a message. Furthermore, the speed reduction and other effects of being stressed are more than what I could call 'a little trouble'.
- Use the prefix _'You have trouble lifting/removing...'_ etc. for picking up each object at any encumbrance level. I'm not sure why this was used only when burdened but not worse, and would consider either showing this at any encumbrance level or never. I chose to show it because it informs the player which objects crossed encumbrance thresholds without using `pickup_burden`.