### PR TITLE
remove unnecessary condition on use_offensive()

### DIFF
--- a/src/muse.c
+++ b/src/muse.c
@@ -1673,7 +1673,7 @@ use_offensive(struct monst *mtmp)
     /* offensive potions are not drunk, they're thrown */
     if (otmp->oclass != POTION_CLASS && (i = precheck(mtmp, otmp)) != 0)
         return i;
-    oseen = otmp && canseemon(mtmp);
+    oseen = canseemon(mtmp);
 
     switch (gm.m.has_offense) {
     case MUSE_WAN_DEATH:


### PR DESCRIPTION
`otmp` here is always non-null, otherwise it leads segv at earlier code.