### PR TITLE
Add option to exclude dropped items from autopick, and to autopick stolen items

### DIFF
--- a/dat/opthelp
+++ b/dat/opthelp
@@ -17,7 +17,7 @@ cmdassist      give help for errors on direction & other commands  [True]
 color          use different colors for objects on screen  [True for micros]
 confirm        ask before hitting tame or peaceful monsters        [True]
 dark_room      show floor not in sight in different color          [True]
-dropped_nopick exclude dropped objects from autopickup            [False]
+dropped_nopick exclude dropped objects from autopickup             [True]
 eight_bit_tty  send 8-bit characters straight to terminal         [False]
 extmenu        tty, curses: use menu for # (extended commands)    [False]
                X11: menu has all commands (T) or traditional subset (F)

--- a/dat/opthelp
+++ b/dat/opthelp
@@ -50,6 +50,7 @@ null           allow nulls to be sent to your terminal             [True]
                try turning this option off (forcing NetHack to use its own
                delay code) if moving objects seem to teleport across rooms
 perm_invent    keep inventory in a permanent window               [False]
+pickup_stolen  override pickup_types for stolen objects            [True]
 pickup_thrown  override pickup_types for thrown objects            [True]
 pushweapon     when wielding a new weapon, put your previously    [False]
                wielded weapon into the secondary weapon slot

--- a/dat/opthelp
+++ b/dat/opthelp
@@ -50,6 +50,7 @@ null           allow nulls to be sent to your terminal             [True]
                delay code) if moving objects seem to teleport across rooms
 perm_invent    keep inventory in a permanent window               [False]
 pickup_thrown  override pickup_types for thrown objects            [True]
+pickup_dropped evaluate pickup_types for dropped objects           [True]
 pushweapon     when wielding a new weapon, put your previously    [False]
                wielded weapon into the secondary weapon slot
 quick_farsight usually skip the chance to browse the map when     [False]

--- a/dat/opthelp
+++ b/dat/opthelp
@@ -17,6 +17,7 @@ cmdassist      give help for errors on direction & other commands  [True]
 color          use different colors for objects on screen  [True for micros]
 confirm        ask before hitting tame or peaceful monsters        [True]
 dark_room      show floor not in sight in different color          [True]
+dropped_nopick exclude dropped objects from autopickup            [False]
 eight_bit_tty  send 8-bit characters straight to terminal         [False]
 extmenu        tty, curses: use menu for # (extended commands)    [False]
                X11: menu has all commands (T) or traditional subset (F)
@@ -50,7 +51,6 @@ null           allow nulls to be sent to your terminal             [True]
                delay code) if moving objects seem to teleport across rooms
 perm_invent    keep inventory in a permanent window               [False]
 pickup_thrown  override pickup_types for thrown objects            [True]
-pickup_dropped evaluate pickup_types for dropped objects           [True]
 pushweapon     when wielding a new weapon, put your previously    [False]
                wielded weapon into the secondary weapon slot
 quick_farsight usually skip the chance to browse the map when     [False]

--- a/doc/Guidebook.mn
+++ b/doc/Guidebook.mn
@@ -3868,6 +3868,13 @@ Show out-of-sight areas of lit rooms (default on).  Persistent.
 .lp "deaf    "
 Start the character permanently deaf (default false).
 Persistent.
+.lp dropped_nopick
+If this option is on, items you dropped will not be automatically
+picked up, even if
+.op autopickup
+is also on and they are in
+.op pickup_types
+or match a positive autopickup exception (defualt off).  Persistent.
 .lp disclose
 Controls what information the program reveals when the game ends.
 Value is a space separated list of prompting/category pairs
@@ -4386,17 +4393,6 @@ When you pick up an item that would exceed this encumbrance
 level (Unencumbered, Burdened, streSsed, straiNed, overTaxed,
 or overLoaded), you will be asked if you want to continue.
 (Default \(oqS\(cq).
-Persistent.
-.lp pickup_dropped
-If this option is on, items you dropped will be treated like normal items for
-.op autopickup
-purposes.   If it is disabled, items you dropped will not be automatically
-picked up, even if
-.op autopickup
-is on and they are in
-.op pickup_types
-or match a positive autopickup exception.
-Default is on.
 Persistent.
 .lp pickup_thrown
 If this option is on and

--- a/doc/Guidebook.mn
+++ b/doc/Guidebook.mn
@@ -4387,6 +4387,17 @@ level (Unencumbered, Burdened, streSsed, straiNed, overTaxed,
 or overLoaded), you will be asked if you want to continue.
 (Default \(oqS\(cq).
 Persistent.
+.lp pickup_dropped
+If this option is on, items you dropped will be treated like normal items for
+.op autopickup
+purposes.   If it is disabled, items you dropped will not be automatically
+picked up, even if
+.op autopickup
+is on and they are in
+.op pickup_types
+or match a positive autopickup exception.
+Default is on.
+Persistent.
 .lp pickup_thrown
 If this option is on and
 .op autopickup

--- a/doc/Guidebook.mn
+++ b/doc/Guidebook.mn
@@ -4394,6 +4394,15 @@ level (Unencumbered, Burdened, streSsed, straiNed, overTaxed,
 or overLoaded), you will be asked if you want to continue.
 (Default \(oqS\(cq).
 Persistent.
+.lp pickup_stolen
+If this option is on and
+.op autopickup
+is also on, try to pick up things that a monster stole from you, even if they
+aren't in
+.op pickup_types
+or match an autopickup exception.
+Default is on.
+Persistent.
 .lp pickup_thrown
 If this option is on and
 .op autopickup

--- a/doc/Guidebook.mn
+++ b/doc/Guidebook.mn
@@ -3874,7 +3874,7 @@ picked up, even if
 .op autopickup
 is also on and they are in
 .op pickup_types
-or match a positive autopickup exception (defualt off).  Persistent.
+or match a positive autopickup exception (defualt on).  Persistent.
 .lp disclose
 Controls what information the program reveals when the game ends.
 Value is a space separated list of prompting/category pairs

--- a/doc/Guidebook.tex
+++ b/doc/Guidebook.tex
@@ -4815,6 +4815,14 @@ level (Unencumbered, Burdened, streSsed, straiNed, overTaxed,
 or overLoaded), you will be asked if you want to continue.
 (Default `S').  Persistent.
 %.lp
+\item[\ib{pickup\verb+_+stolen}]
+If this option is on and ``{\it autopickup\/}'' is also on, try to pick up
+things that a monster stole from you, even if they aren't in
+``{\it pickup\verb+_+types\/}'' or
+match an autopickup exception.
+Default is on.
+Persistent.
+%.lp
 \item[\ib{pickup\verb+_+thrown}]
 If this option is on and ``{\it autopickup\/}'' is also on, try to pick up
 things that you threw, even if they aren't in

--- a/doc/Guidebook.tex
+++ b/doc/Guidebook.tex
@@ -4228,7 +4228,7 @@ Start the character permanently deaf (default false).  Persistent.
 If this option is on, items you dropped will not be automatically picked up,
 even if ``{\it autopickup\/}'' is also on and they are in
 ``{\it pickup\verb+_+types\/}'' or match a positive autopickup exception
-(default off).  Persistent.
+(default on).  Persistent.
 %.lp
 \item[\ib{disclose}]
 Controls what information the program reveals when the game ends.

--- a/doc/Guidebook.tex
+++ b/doc/Guidebook.tex
@@ -4809,6 +4809,15 @@ level (Unencumbered, Burdened, streSsed, straiNed, overTaxed,
 or overLoaded), you will be asked if you want to continue.
 (Default `S').  Persistent.
 %.lp
+\item[\ib{pickup\verb+_+dropped}]
+If this option is on, items you dropped will be treated like normal items for
+``{\it autopickup\/}'' purposes.  If it disabled, items you dropped will not be
+automatically picked up, even if ``{\it autopickup\/}'' is on and they are in
+``{\it pickup\verb+_+types\/}'' or
+match an autopickup exception.
+Default is on.
+Persistent.
+%.lp
 \item[\ib{pickup\verb+_+thrown}]
 If this option is on and ``{\it autopickup\/}'' is also on, try to pick up
 things that you threw, even if they aren't in

--- a/doc/Guidebook.tex
+++ b/doc/Guidebook.tex
@@ -4224,6 +4224,12 @@ Show out-of-sight areas of lit rooms (default on).  Persistent.
 \item[\ib{deaf}]
 Start the character permanently deaf (default false).  Persistent.
 %.lp
+\item[\ib{dropped\verb+_+nopick}]
+If this option is on, items you dropped will not be automatically picked up,
+even if ``{\it autopickup\/}'' is also on and they are in
+``{\it pickup\verb+_+types\/}'' or match a positive autopickup exception
+(default off).  Persistent.
+%.lp
 \item[\ib{disclose}]
 Controls what information the program reveals when the game ends.
 Value is a space separated list of prompting/category pairs
@@ -4808,15 +4814,6 @@ When you pick up an item that would exceed this encumbrance
 level (Unencumbered, Burdened, streSsed, straiNed, overTaxed,
 or overLoaded), you will be asked if you want to continue.
 (Default `S').  Persistent.
-%.lp
-\item[\ib{pickup\verb+_+dropped}]
-If this option is on, items you dropped will be treated like normal items for
-``{\it autopickup\/}'' purposes.  If it disabled, items you dropped will not be
-automatically picked up, even if ``{\it autopickup\/}'' is on and they are in
-``{\it pickup\verb+_+types\/}'' or
-match an autopickup exception.
-Default is on.
-Persistent.
 %.lp
 \item[\ib{pickup\verb+_+thrown}]
 If this option is on and ``{\it autopickup\/}'' is also on, try to pick up

--- a/include/flag.h
+++ b/include/flag.h
@@ -45,9 +45,9 @@ struct flag {
     boolean mention_decor;   /* give feedback for unobscured furniture */
     boolean mention_walls;   /* give feedback when bumping walls */
     boolean nap;             /* `timed_delay' option for display effects */
+    boolean nopick_dropped;  /* items you dropped may be autopicked */
     boolean null;            /* OK to send nulls to the terminal */
     boolean pickup;          /* whether you pickup or move and look */
-    boolean pickup_dropped;  /* items you dropped may be autopicked */
     boolean pickup_thrown;   /* auto-pickup items you threw */
     boolean pushweapon; /* When wielding, push old weapon into second slot */
     boolean quick_farsight;  /* True disables map browsing during random

--- a/include/flag.h
+++ b/include/flag.h
@@ -48,6 +48,7 @@ struct flag {
     boolean nopick_dropped;  /* items you dropped may be autopicked */
     boolean null;            /* OK to send nulls to the terminal */
     boolean pickup;          /* whether you pickup or move and look */
+    boolean pickup_stolen;   /* auto-pickup items stolen by a monster */
     boolean pickup_thrown;   /* auto-pickup items you threw */
     boolean pushweapon; /* When wielding, push old weapon into second slot */
     boolean quick_farsight;  /* True disables map browsing during random

--- a/include/flag.h
+++ b/include/flag.h
@@ -47,6 +47,7 @@ struct flag {
     boolean nap;             /* `timed_delay' option for display effects */
     boolean null;            /* OK to send nulls to the terminal */
     boolean pickup;          /* whether you pickup or move and look */
+    boolean pickup_dropped;  /* items you dropped may be autopicked */
     boolean pickup_thrown;   /* auto-pickup items you threw */
     boolean pushweapon; /* When wielding, push old weapon into second slot */
     boolean quick_farsight;  /* True disables map browsing during random

--- a/include/obj.h
+++ b/include/obj.h
@@ -124,10 +124,9 @@ struct obj {
 #define on_ice recharged    /* corpse on ice */
     Bitfield(lamplit, 1);   /* a light-source -- can be lit */
     Bitfield(globby, 1);    /* combines with like types on adjacent squares */
-    Bitfield(greased, 1);    /* covered with grease */
-    Bitfield(nomerge, 1);    /* set temporarily to prevent merging */
-    Bitfield(was_thrown, 1); /* thrown by hero since last picked up */
-    Bitfield(was_dropped, 1); /* dropped deliberately by the hero */
+    Bitfield(greased, 1);   /* covered with grease */
+    Bitfield(nomerge, 1);   /* set temporarily to prevent merging */
+    Bitfield(how_lost, 2);  /* stolen by mon or thrown, dropped by hero */
 
     Bitfield(in_use, 1); /* for magic items before useup items */
     Bitfield(bypass, 1); /* mark this as an object to be skipped by bhito() */
@@ -458,6 +457,12 @@ struct obj {
 #define POTHIT_HERO_THROW  1 /* thrown by hero */
 #define POTHIT_MONST_THROW 2 /* thrown by a monster */
 #define POTHIT_OTHER_THROW 3 /* propelled by some other means [scatter()] */
+
+/* tracking how an item left your inventory */
+#define LOST_NONE    0 /* still in inventory, or method not covered below */
+#define LOST_THROWN  1 /* thrown or fired by the hero */
+#define LOST_DROPPED 2 /* dropped or tipped out of a container by the hero */
+#define LOST_STOLEN  3 /* stolen from hero's inventory by a monster */
 
 /*
  *  Notes for adding new oextra structures:

--- a/include/obj.h
+++ b/include/obj.h
@@ -127,6 +127,7 @@ struct obj {
     Bitfield(greased, 1);    /* covered with grease */
     Bitfield(nomerge, 1);    /* set temporarily to prevent merging */
     Bitfield(was_thrown, 1); /* thrown by hero since last picked up */
+    Bitfield(was_dropped, 1); /* dropped deliberately by the hero */
 
     Bitfield(in_use, 1); /* for magic items before useup items */
     Bitfield(bypass, 1); /* mark this as an object to be skipped by bhito() */
@@ -144,9 +145,9 @@ struct obj {
     Bitfield(eknown, 1); /* effect known for wands zapped or rings worn when
                           * not seen yet after being picked up while blind
                           * [maybe for remaining stack of used potion too] */
-    /* 0 free bits */
+    /* 7 free bits */
 #else
-    /* 2 free bits */
+    /* 1 free bit */
 #endif
 
     int corpsenm;         /* type of corpse is mons[corpsenm] */

--- a/include/optlist.h
+++ b/include/optlist.h
@@ -531,6 +531,9 @@ static int optfn_##a(int, int, boolean, char *, char *);
     NHOPTC(pickup_burden, Advanced, 20, opt_in, set_in_game,
                 No, Yes, No, Yes, NoAlias,
                 "maximum burden picked up before prompt")
+    NHOPTB(pickup_dropped, Behavior, 0, opt_out, set_in_game,
+           On, Yes, No, No, NoAlias, &flags.pickup_dropped, Term_False,
+           "consider dropped items for autopickup")
     NHOPTB(pickup_thrown, Behavior, 0, opt_out, set_in_game,
            On, Yes, No, No, NoAlias, &flags.pickup_thrown, Term_False,
            "autopickup thrown items")

--- a/include/optlist.h
+++ b/include/optlist.h
@@ -534,6 +534,9 @@ static int optfn_##a(int, int, boolean, char *, char *);
     NHOPTC(pickup_burden, Advanced, 20, opt_in, set_in_game,
                 No, Yes, No, Yes, NoAlias,
                 "maximum burden picked up before prompt")
+    NHOPTB(pickup_stolen, Behavior, 0, opt_out, set_in_game,
+           On, Yes, No, No, NoAlias, &flags.pickup_stolen, Term_False,
+           "autopickup thrown items")
     NHOPTB(pickup_thrown, Behavior, 0, opt_out, set_in_game,
            On, Yes, No, No, NoAlias, &flags.pickup_thrown, Term_False,
            "autopickup thrown items")

--- a/include/optlist.h
+++ b/include/optlist.h
@@ -261,8 +261,8 @@ static int optfn_##a(int, int, boolean, char *, char *);
     NHOPTC(dogname, Advanced, PL_PSIZ, opt_in, set_gameview,
                 No, Yes, No, No, NoAlias,
                 "name of your starting pet if it is a little dog")
-    NHOPTB(dropped_nopick, Behavior, 0, opt_in, set_in_game,
-           Off, Yes, No, No, NoAlias, &flags.nopick_dropped, Term_False,
+    NHOPTB(dropped_nopick, Behavior, 0, opt_out, set_in_game,
+           On, Yes, No, No, NoAlias, &flags.nopick_dropped, Term_False,
            "don't autopickup dropped items")
     NHOPTC(dungeon, Advanced, MAXDCHARS + 1,opt_in, set_in_config,
                 No, Yes, No, No, NoAlias,

--- a/include/optlist.h
+++ b/include/optlist.h
@@ -261,6 +261,9 @@ static int optfn_##a(int, int, boolean, char *, char *);
     NHOPTC(dogname, Advanced, PL_PSIZ, opt_in, set_gameview,
                 No, Yes, No, No, NoAlias,
                 "name of your starting pet if it is a little dog")
+    NHOPTB(dropped_nopick, Behavior, 0, opt_in, set_in_game,
+           Off, Yes, No, No, NoAlias, &flags.nopick_dropped, Term_False,
+           "don't autopickup dropped items")
     NHOPTC(dungeon, Advanced, MAXDCHARS + 1,opt_in, set_in_config,
                 No, Yes, No, No, NoAlias,
                 "list of symbols to use in drawing the dungeon map")
@@ -531,9 +534,6 @@ static int optfn_##a(int, int, boolean, char *, char *);
     NHOPTC(pickup_burden, Advanced, 20, opt_in, set_in_game,
                 No, Yes, No, Yes, NoAlias,
                 "maximum burden picked up before prompt")
-    NHOPTB(pickup_dropped, Behavior, 0, opt_out, set_in_game,
-           On, Yes, No, No, NoAlias, &flags.pickup_dropped, Term_False,
-           "consider dropped items for autopickup")
     NHOPTB(pickup_thrown, Behavior, 0, opt_out, set_in_game,
            On, Yes, No, No, NoAlias, &flags.pickup_thrown, Term_False,
            "autopickup thrown items")

--- a/src/bones.c
+++ b/src/bones.c
@@ -108,6 +108,7 @@ resetobjs(struct obj *ochain, boolean restore)
             otmp->invlet = 0;
             otmp->no_charge = 0;
             otmp->was_thrown = 0;
+            otmp->was_dropped = 0;
 
             /* strip user-supplied names */
             /* Statue and some corpse names are left intact,

--- a/src/bones.c
+++ b/src/bones.c
@@ -107,8 +107,7 @@ resetobjs(struct obj *ochain, boolean restore)
             otmp->cknown = 0;
             otmp->invlet = 0;
             otmp->no_charge = 0;
-            otmp->was_thrown = 0;
-            otmp->was_dropped = 0;
+            otmp->how_lost = LOST_NONE;
 
             /* strip user-supplied names */
             /* Statue and some corpse names are left intact,

--- a/src/do.c
+++ b/src/do.c
@@ -758,7 +758,7 @@ drop(struct obj *obj)
         if (!IS_ALTAR(levl[u.ux][u.uy].typ) && flags.verbose)
             You("drop %s.", doname(obj));
     }
-    obj->was_dropped = 1;
+    obj->how_lost = LOST_DROPPED;
     dropx(obj);
     return ECMD_TIME;
 }

--- a/src/do.c
+++ b/src/do.c
@@ -758,6 +758,7 @@ drop(struct obj *obj)
         if (!IS_ALTAR(levl[u.ux][u.uy].typ) && flags.verbose)
             You("drop %s.", doname(obj));
     }
+    obj->was_dropped = 1;
     dropx(obj);
     return ECMD_TIME;
 }

--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -1504,7 +1504,7 @@ throwit(struct obj *obj,
     }
 
     gt.thrownobj = obj;
-    gt.thrownobj->was_thrown = 1;
+    gt.thrownobj->how_lost = LOST_THROWN;
     iflags.returning_missile = AutoReturn(obj, wep_mask) ? (genericptr_t) obj
                                                          : (genericptr_t) 0;
     /* NOTE:  No early returns after this point or returning_missile
@@ -1719,7 +1719,7 @@ throwit(struct obj *obj,
                 if (tethered_weapon)
                     tmp_at(DISP_END, 0);
                 /* when this location is stepped on, the weapon will be
-                   auto-picked up due to 'obj->was_thrown' of 1;
+                   auto-picked up due to 'obj->how_lost' of LOST_THROWN;
                    addinv() prevents thrown Mjollnir from being placed
                    into the quiver slot, but an aklys will end up there if
                    that slot is empty at the time; since hero will need to

--- a/src/invent.c
+++ b/src/invent.c
@@ -942,7 +942,7 @@ merged(struct obj **potmp, struct obj **pobj)
            items, where this would be too spammy as such items get
            unidentified by monsters very frequently). */
         if (discovered && otmp->where == OBJ_INVENT &&
-            !obj->was_thrown && !otmp->was_thrown) {
+            obj->how_lost != LOST_THROWN && otmp->how_lost != LOST_THROWN) {
             pline("You learn more about your items by comparing them.");
         }
 
@@ -1049,8 +1049,8 @@ addinv_core0(struct obj *obj, struct obj *other_obj,
     obj->no_charge = 0; /* should not be set in hero's invent */
     if (Has_contents(obj))
         picked_container(obj); /* clear no_charge */
-    obj_was_thrown = obj->was_thrown;
-    obj->was_thrown = obj->was_dropped = 0; /* not meaningful for invent */
+    obj_was_thrown = (obj->how_lost == LOST_THROWN);
+    obj->how_lost = LOST_NONE;
 
     if (gl.loot_reset_justpicked) {
         gl.loot_reset_justpicked = FALSE;
@@ -4820,8 +4820,7 @@ mergable(
     if (obj->unpaid != otmp->unpaid || obj->spe != otmp->spe
         || obj->no_charge != otmp->no_charge || obj->obroken != otmp->obroken
         || obj->otrapped != otmp->otrapped || obj->lamplit != otmp->lamplit
-        || obj->was_thrown != otmp->was_thrown
-        || obj->was_dropped != otmp->was_dropped)
+        || obj->how_lost != otmp->how_lost)
         return FALSE;
 
     if (obj->oclass == FOOD_CLASS

--- a/src/invent.c
+++ b/src/invent.c
@@ -1050,7 +1050,7 @@ addinv_core0(struct obj *obj, struct obj *other_obj,
     if (Has_contents(obj))
         picked_container(obj); /* clear no_charge */
     obj_was_thrown = obj->was_thrown;
-    obj->was_thrown = 0;       /* not meaningful for invent */
+    obj->was_thrown = obj->was_dropped = 0; /* not meaningful for invent */
 
     if (gl.loot_reset_justpicked) {
         gl.loot_reset_justpicked = FALSE;

--- a/src/invent.c
+++ b/src/invent.c
@@ -4819,7 +4819,9 @@ mergable(
 
     if (obj->unpaid != otmp->unpaid || obj->spe != otmp->spe
         || obj->no_charge != otmp->no_charge || obj->obroken != otmp->obroken
-        || obj->otrapped != otmp->otrapped || obj->lamplit != otmp->lamplit)
+        || obj->otrapped != otmp->otrapped || obj->lamplit != otmp->lamplit
+        || obj->was_thrown != otmp->was_thrown
+        || obj->was_dropped != otmp->was_dropped)
         return FALSE;
 
     if (obj->oclass == FOOD_CLASS

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -2863,9 +2863,10 @@ objlist_sanity(struct obj *objlist, int wheretype, const char *mesg)
     for (obj = objlist; obj; obj = obj->nobj) {
         if (obj->where != wheretype)
             insane_object(obj, ofmt0, mesg, (struct monst *) 0);
-        if (obj->was_thrown && obj->was_dropped) {
-            insane_object(obj, "%s obj is both thrown and dropped! %s %s: %s",
-                          mesg, obj->ocarry);
+        if (obj->where == OBJ_INVENT && obj->how_lost != LOST_NONE) {
+            char lostbuf[40];
+            Sprintf(lostbuf, "how_lost=%d obj in inventory!", obj->how_lost);
+            insane_object(obj, ofmt0, lostbuf, (struct monst *) 0);
         }
         if (Has_contents(obj)) {
             if (wheretype == OBJ_ONBILL)

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -2863,6 +2863,10 @@ objlist_sanity(struct obj *objlist, int wheretype, const char *mesg)
     for (obj = objlist; obj; obj = obj->nobj) {
         if (obj->where != wheretype)
             insane_object(obj, ofmt0, mesg, (struct monst *) 0);
+        if (obj->was_thrown && obj->was_dropped) {
+            insane_object(obj, "%s obj is both thrown and dropped! %s %s: %s",
+                          mesg, obj->ocarry);
+        }
         if (Has_contents(obj)) {
             if (wheretype == OBJ_ONBILL)
                 /* containers on shop bill should always be empty */

--- a/src/nhlobj.c
+++ b/src/nhlobj.c
@@ -312,7 +312,7 @@ l_obj_to_table(lua_State *L)
     nhl_add_table_entry_int(L, "globby", obj->globby);
     nhl_add_table_entry_int(L, "greased", obj->greased);
     nhl_add_table_entry_int(L, "nomerge", obj->nomerge);
-    nhl_add_table_entry_int(L, "was_thrown", obj->was_thrown);
+    nhl_add_table_entry_int(L, "how_lost", obj->how_lost);
     nhl_add_table_entry_int(L, "in_use", obj->in_use);
     nhl_add_table_entry_int(L, "bypass", obj->bypass);
     nhl_add_table_entry_int(L, "cknown", obj->cknown);

--- a/src/options.c
+++ b/src/options.c
@@ -8591,7 +8591,8 @@ doset_simple_menu(void)
             /* pickup_types is separated from autopickup due to the
                spelling of their names; emphasize what it means */
             if (allopt[i].idx == opt_pickup_types
-                || allopt[i].idx == opt_pickup_thrown)
+                || allopt[i].idx == opt_pickup_thrown
+                || allopt[i].idx == opt_pickup_dropped)
                 Strcat(buf, "  (for autopickup)");
             add_menu(tmpwin, &nul_glyphinfo, &any, 0, 0,
                      ATR_NONE, NO_COLOR, buf, MENU_ITEMFLAGS_NONE);

--- a/src/options.c
+++ b/src/options.c
@@ -8592,7 +8592,7 @@ doset_simple_menu(void)
                spelling of their names; emphasize what it means */
             if (allopt[i].idx == opt_pickup_types
                 || allopt[i].idx == opt_pickup_thrown
-                || allopt[i].idx == opt_pickup_dropped)
+                || allopt[i].idx == opt_dropped_nopick)
                 Strcat(buf, "  (for autopickup)");
             add_menu(tmpwin, &nul_glyphinfo, &any, 0, 0,
                      ATR_NONE, NO_COLOR, buf, MENU_ITEMFLAGS_NONE);

--- a/src/options.c
+++ b/src/options.c
@@ -8592,6 +8592,7 @@ doset_simple_menu(void)
                spelling of their names; emphasize what it means */
             if (allopt[i].idx == opt_pickup_types
                 || allopt[i].idx == opt_pickup_thrown
+                || allopt[i].idx == opt_pickup_stolen
                 || allopt[i].idx == opt_dropped_nopick)
                 Strcat(buf, "  (for autopickup)");
             add_menu(tmpwin, &nul_glyphinfo, &any, 0, 0,

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -904,10 +904,12 @@ autopick_testobj(struct obj *otmp, boolean calc_costly)
     if (costly && !otmp->no_charge)
         return FALSE;
 
-    /* pickup_thrown/nopick_dropped override pickup_types and exceptions */
-    if (flags.pickup_thrown && otmp->was_thrown)
+    /* pickup_thrown/pickup_stolen/nopick_dropped override pickup_types and
+       exceptions */
+    if ((flags.pickup_thrown && otmp->how_lost == LOST_THROWN)
+        || (flags.pickup_stolen && otmp->how_lost == LOST_STOLEN))
         return TRUE;
-    if (flags.nopick_dropped && otmp->was_dropped)
+    if (flags.nopick_dropped && otmp->how_lost == LOST_DROPPED)
         return FALSE;
 
     /* check for pickup_types */
@@ -3667,7 +3669,7 @@ tipcontainer(struct obj *box) /* or bag */
                     (void) add_to_container(targetbox, otmp);
                 }
             } else if (highdrop) {
-                otmp->was_dropped = 1;
+                otmp->how_lost = LOST_DROPPED;
                 /* might break or fall down stairs; handles altars itself */
                 hitfloor(otmp, TRUE);
             } else {
@@ -3680,7 +3682,7 @@ tipcontainer(struct obj *box) /* or bag */
                     pline("%s%c", doname(otmp), nobj ? ',' : '.');
                     iflags.last_msg = PLNMSG_OBJNAM_ONLY;
                 }
-                otmp->was_dropped = 1;
+                otmp->how_lost = LOST_DROPPED;
                 dropy(otmp);
                 if (iflags.last_msg != PLNMSG_OBJNAM_ONLY)
                     terse = FALSE; /* terse formatting has been interrupted */

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -904,10 +904,10 @@ autopick_testobj(struct obj *otmp, boolean calc_costly)
     if (costly && !otmp->no_charge)
         return FALSE;
 
-    /* pickup_thrown/!pickup_dropped override pickup_types and exceptions */
+    /* pickup_thrown/nopick_dropped override pickup_types and exceptions */
     if (flags.pickup_thrown && otmp->was_thrown)
         return TRUE;
-    if (!flags.pickup_dropped && otmp->was_dropped)
+    if (flags.nopick_dropped && otmp->was_dropped)
         return FALSE;
 
     /* check for pickup_types */

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -904,6 +904,12 @@ autopick_testobj(struct obj *otmp, boolean calc_costly)
     if (costly && !otmp->no_charge)
         return FALSE;
 
+    /* pickup_thrown/!pickup_dropped override pickup_types and exceptions */
+    if (flags.pickup_thrown && otmp->was_thrown)
+        return TRUE;
+    if (!flags.pickup_dropped && otmp->was_dropped)
+        return FALSE;
+
     /* check for pickup_types */
     pickit = (!*otypes || strchr(otypes, otmp->oclass));
 
@@ -912,9 +918,6 @@ autopick_testobj(struct obj *otmp, boolean calc_costly)
     if (ape)
         pickit = ape->grab;
 
-    /* pickup_thrown overrides pickup_types and exceptions */
-    if (!pickit)
-        pickit = (flags.pickup_thrown && otmp->was_thrown);
     return pickit;
 }
 
@@ -3664,6 +3667,7 @@ tipcontainer(struct obj *box) /* or bag */
                     (void) add_to_container(targetbox, otmp);
                 }
             } else if (highdrop) {
+                otmp->was_dropped = 1;
                 /* might break or fall down stairs; handles altars itself */
                 hitfloor(otmp, TRUE);
             } else {
@@ -3676,6 +3680,7 @@ tipcontainer(struct obj *box) /* or bag */
                     pline("%s%c", doname(otmp), nobj ? ',' : '.');
                     iflags.last_msg = PLNMSG_OBJNAM_ONLY;
                 }
+                otmp->was_dropped = 1;
                 dropy(otmp);
                 if (iflags.last_msg != PLNMSG_OBJNAM_ONLY)
                     terse = FALSE; /* terse formatting has been interrupted */

--- a/src/steal.c
+++ b/src/steal.c
@@ -527,6 +527,7 @@ steal(struct monst* mtmp, char* objnambuf)
     (void) encumber_msg();
     could_petrify = (otmp->otyp == CORPSE
                      && touch_petrifies(&mons[otmp->corpsenm]));
+    otmp->how_lost = LOST_STOLEN;
     (void) mpickobj(mtmp, otmp); /* may free otmp */
     if (could_petrify && !(mtmp->misc_worn_check & W_ARMG)) {
         minstapetrify(mtmp, TRUE);


### PR DESCRIPTION
This is based on a feature in UnNetHack (and I think some other variants
as well).  If the hero intentionally drops an item with 'pickup_dropped'
disabled, don't autopick it back up when walking over that square again.

Typically when the player drops an item, it's because she doesn't want
it in her inventory any more, and this option stops autopickup from
defeating that goal (especially useful for tasks like stash management
without a container).  Players have come up with workarounds to this
problem like toggling autopickup when approaching their stash pile or
adding name-based autopickup exceptions to allow them to exclude
individual items from autopickup, but this behavior should reduce the
need for those things.

I think 'pickup_dropped' is a little unfortunate because it suggests
equivalence to 'pickup_thrown' (i.e. any dropped items will be
automatically picked up regardless of autopickup exceptions).  Calling
it something like 'nopick_dropped' might be better, but as far as I can
tell options cannot start with the word 'no' because it's interpreted as
a negation of the rest of the option name.
