### PR TITLE
Rust gauntlets when washing hands even if Glib and fix #dipping hands from menu

### DIFF
--- a/src/fountain.c
+++ b/src/fountain.c
@@ -551,18 +551,20 @@ wash_hands(void)
 {
     const char *hands = makeplural(body_part(HAND));
     int res = ER_NOTHING;
+    boolean was_glib = !!Glib;
 
     You("wash your %s%s in the %s.", uarmg ? "gloved " : "", hands,
         hliquid("water"));
     if (Glib) {
         make_glib(0);
         Your("%s are no longer slippery.", fingers_or_gloves(TRUE));
-        /* not what ER_GREASED is for, but the checks in dipfountain just
-           compare the result to ER_DESTROYED and ER_NOTHING, so it works */
-        res = ER_GREASED;
-    } else if (uarmg) {
-        res = water_damage(uarmg, (const char *) 0, TRUE);
     }
+    if (uarmg)
+        res = water_damage(uarmg, (const char *) 0, TRUE);
+    /* not what ER_GREASED is for, but the checks in dipfountain just
+       compare the result to ER_DESTROYED and ER_NOTHING, so it works */
+    if (was_glib && res == ER_NOTHING)
+        res = ER_GREASED;
     return res;
 }
 

--- a/src/invent.c
+++ b/src/invent.c
@@ -30,7 +30,7 @@ static int ckunpaid(struct obj *);
 static char *safeq_xprname(struct obj *);
 static char *safeq_shortxprname(struct obj *);
 static char display_pickinv(const char *, const char *, const char *,
-                            boolean, long *);
+                            boolean, boolean, long *);
 static char display_used_invlets(char);
 static boolean this_type_only(struct obj *);
 static void dounpaid(int, int, int);
@@ -1896,26 +1896,31 @@ getobj(
             long ctmp = 0;
             char menuquery[QBUFSZ];
 
+            if (ilet == '?' && !*lets && *altlets)
+                allowed_choices = altlets;
+
             menuquery[0] = qbuf[0] = '\0';
             if (iflags.force_invmenu)
                 Sprintf(menuquery, "What do you want to %s?", word);
-            if (!strcmp(word, "grease"))
-                Sprintf(qbuf, "your %s", fingers_or_gloves(FALSE));
-            else if (!strcmp(word, "write with"))
-                Sprintf(qbuf, "your %s", body_part(FINGERTIP));
-            else if (!strcmp(word, "wield"))
-                Sprintf(qbuf, "your %s %s%s", uarmg ? "gloved" : "bare",
-                        makeplural(body_part(HAND)),
-                        !uwep ? " (wielded)" : "");
-            else if (!strcmp(word, "ready"))
-                Sprintf(qbuf, "empty quiver%s",
-                        !uquiver ? " (nothing readied)" : "");
-
-            if (ilet == '?' && !*lets && *altlets)
-                allowed_choices = altlets;
+            if (!allowed_choices || *allowed_choices == '-' || *buf == '-') {
+                if (!strcmp(word, "grease")) {
+                    Sprintf(qbuf, "your %s", fingers_or_gloves(FALSE));
+                } else if (!strcmp(word, "write with")) {
+                    Sprintf(qbuf, "your %s", body_part(FINGERTIP));
+                } else if (!strcmp(word, "wield")) {
+                    Sprintf(qbuf, "your %s %s%s", uarmg ? "gloved" : "bare",
+                            makeplural(body_part(HAND)),
+                            !uwep ? " (wielded)" : "");
+                } else if (!strcmp(word, "ready")) {
+                    Sprintf(qbuf, "empty quiver%s",
+                            !uquiver ? " (nothing readied)" : "");
+                } else {
+                    Sprintf(qbuf, "your %s", makeplural(body_part(HAND)));
+                }
+            }
             ilet = display_pickinv(allowed_choices, *qbuf ? qbuf : (char *) 0,
-                                   menuquery,
-                                   TRUE, allowcnt ? &ctmp : (long *) 0);
+                                   menuquery, allownone, TRUE,
+                                   allowcnt ? &ctmp : (long *) 0);
             if (!ilet) {
                 if (oneloop)
                     return (struct obj *) 0;
@@ -3494,6 +3499,7 @@ display_pickinv(
     const char *lets,        /* non-compacted list of invlet values */
     const char *xtra_choice, /* non-object "bare hands" or "fingers" */
     const char *query,       /* optional; prompt string for menu */
+    boolean allowxtra,       /* hands are allowed (maybe alternate) choice */
     boolean want_reply,      /* True: select an item, False: just display */
     long *out_cnt) /* optional; count player entered when selecting an item */
 {
@@ -3516,7 +3522,8 @@ display_pickinv(
     boolean wizid = (wizard && iflags.override_ID), gotsomething = FALSE;
     int clr = NO_COLOR, menu_behavior = MENU_BEHAVE_STANDARD;
     boolean show_gold = TRUE, inuse_only = FALSE, skipped_gold = FALSE,
-            doing_perm_invent = FALSE, save_flags_sortpack = flags.sortpack;
+            doing_perm_invent = FALSE, save_flags_sortpack = flags.sortpack,
+            usextra = (xtra_choice && allowxtra);
 
     if (lets && !*lets)
         lets = 0; /* simplify tests: (lets) instead of (lets && *lets) */
@@ -3526,7 +3533,7 @@ display_pickinv(
         win = 0; /* passed to dump_putstr() which ignores it... */
     } else
 #endif
-    if (lets || xtra_choice || wizid || want_reply
+    if (lets || usextra || wizid || want_reply
 #ifdef TTY_PERM_INVENT
         /*|| !gi.in_sync_perminvent*/
 #endif
@@ -3569,7 +3576,7 @@ display_pickinv(
        for !lets (full invent or inuse_only) and for override_ID (wizard
        mode identify), skip message_menu handling of single item even if
        item count was 1 */
-    if (xtra_choice || (n == 1 && (!lets || wizid)))
+    if (usextra || (n == 1 && (!lets || wizid)))
         ++n;
 
     if (n == 0) {
@@ -3586,9 +3593,10 @@ display_pickinv(
            we actually use a fake message-line menu in order to allow
            the user to perform selection at the --More-- prompt for tty */
         ret = '\0';
-        if (xtra_choice) {
+        if (usextra) {
             /* xtra_choice is "bare hands" (wield), "fingertip" (Engrave),
-               "nothing" (ready Quiver), or "fingers" (apply grease) */
+               "nothing" (prepare Quiver), "fingers" (apply grease), or
+               "hands" (default) */
             ret = message_menu(HANDS_SYM, PICK_ONE,
                                xprname((struct obj *) 0, xtra_choice,
                                        HANDS_SYM, TRUE, 0L, 0L)); /* '-' */
@@ -3684,7 +3692,7 @@ display_pickinv(
                      ATR_NONE, clr, prompt, MENU_ITEMFLAGS_SKIPINVERT);
             gotsomething = TRUE;
         }
-   } else if (xtra_choice) {
+   } else if (usextra) {
         /* wizard override ID and xtra_choice are mutually exclusive */
         if (flags.sortpack)
             add_menu_heading(win, "Miscellaneous");
@@ -3781,7 +3789,8 @@ display_pickinv(
        includes everything; won't work via keyboard if current menu
        uses '*' as group accelerator for gems but might work via mouse */
     if (iflags.force_invmenu && lets && want_reply
-        && (int) strlen(lets) < inv_cnt(TRUE)) {
+        && ((allowxtra && !usextra)
+            || (int) strlen(lets) < inv_cnt(TRUE))) {
         any = cg.zeroany;
         add_menu_heading(win, "Special");
         any.a_char = '*';
@@ -3873,7 +3882,7 @@ display_inventory(const char *lets, boolean want_reply)
         return '\0';
     }
     return display_pickinv(lets, (char *) 0, (char *) 0,
-                           want_reply, (long *) 0);
+                           FALSE, want_reply, (long *) 0);
 }
 
 /*


### PR DESCRIPTION
Make it so that washing your gloved hands in a fountain, pool, or sink
can still rust your gauntlets even if it successfully removes the grease
from your fingers.  There wasn't much logic behind the two effects being
mutually exclusive, since the oily fingers of the Glib effect don't
normally protect against water damage like the item being 'greased'
does, and this introduces a possible tradeoff that could make whether or
not to clear Glib by washing your hands a more interesting tactical
decision.

Also make #dipping hands (and other possible future 'hands'-accepting
actions) work with OPTIONS=force_invmenu or selecting '?'/'*' from the
getobj prompt.
