### PR TITLE
Print current level annotation when restoring

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -749,7 +749,7 @@ extern schar lev_by_name(const char *);
 extern boolean known_branch_stairs(stairway *);
 extern char *stairs_description(stairway *, char *, boolean);
 extern schar print_dungeon(boolean, schar *, xint16 *);
-extern char *get_annotation(d_level *);
+extern void print_level_annotation(void);
 extern int donamelevel(void);
 extern void free_exclusions(void);
 extern void save_exclusions(NHFILE *);

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -832,6 +832,8 @@ welcome(boolean new_game) /* false => restoring an old game */
         /* if restoring in Gehennom, give same hot/smoky message as when
            first entering it */
         hellish_smoke_mesg();
+        /* remind player of the level annotation, like in goto_level() */
+        print_level_annotation();
     }
 }
 

--- a/src/do.c
+++ b/src/do.c
@@ -1419,7 +1419,6 @@ goto_level(
             new = FALSE; /* made a new level? */
     struct monst *mtmp;
     char whynot[BUFSZ];
-    char *annotation;
     int dist = depth(newlevel) - depth(&u.uz);
     boolean do_fall_dmg = FALSE;
     schar prev_temperature = gl.level.flags.temperature;
@@ -1881,9 +1880,7 @@ goto_level(
     save_currentstate();
 #endif
 
-    if ((annotation = get_annotation(&u.uz)) != 0)
-        You("remember this level as %s.", annotation);
-
+    print_level_annotation();
     /* give room entrance message, if any */
     check_special_room(FALSE);
     /* deliver objects traveling with player */

--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -56,6 +56,7 @@ static void tport_menu(winid, char *, struct lchoice *, d_level *, boolean);
 static const char *br_string(int);
 static char chr_u_on_lvl(d_level *);
 static void print_branch(winid, int, int, int, boolean, struct lchoice *);
+static char *get_annotation(d_level *);
 static void query_annotation(d_level *);
 static mapseen *load_mapseen(NHFILE *);
 static void save_mapseen(NHFILE *, mapseen *);
@@ -2603,7 +2604,7 @@ recbranch_mapseen(d_level *source, d_level *dest)
     }
 }
 
-char *
+static char *
 get_annotation(d_level *lev)
 {
     mapseen *mptr;
@@ -2611,6 +2612,16 @@ get_annotation(d_level *lev)
     if ((mptr = find_mapseen(lev)))
         return mptr->custom;
     return NULL;
+}
+
+/* print the annotation for the current level, if it exists */
+void
+print_level_annotation(void)
+{
+    const char *annotation;
+
+    if ((annotation = get_annotation(&u.uz)) != 0)
+        You("remember this level as %s.", annotation);
 }
 
 /* ask user to annotate level lev.


### PR DESCRIPTION
Sometimes I annotate a level with a note like "watch out, chameleon
below", which is useful to remind myself of some danger or thing to
remember when returning to the level -- but if saving and restoring on
the level itself there's no reminder of that annotation.  If you restore
on a level with an annotation, print it as part of the "welcome back"
message.
