### PR TITLE
avoid potential out-of-bounds access on choose_classes_menu()

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -9748,6 +9748,7 @@ choose_classes_menu(const char *prompt,
             break;
         default:
             impossible("choose_classes_menu: invalid category %d", category);
+            buf[0] = '\0';
         }
         if (way && *class_select) { /* Selections there already */
             if (strchr(class_select, *class_list)) {


### PR DESCRIPTION
If `category` is neither 0 nor 1, `buf` is not initialized.