### PR TITLE
Add WANT_SOURCE_INSTALL to linux.370 hints file

### DIFF
--- a/sys/unix/hints/linux.370
+++ b/sys/unix/hints/linux.370
@@ -295,10 +295,25 @@ override GAME=
 MOREALL += ( cd src ; $(MAKE) pregame ; $(MAKE) $(TARGETPFX)libnh.a )
 endif  # WANT_LIBNH
 
+ifdef WANT_SOURCE_INSTALL
+PREFIX=$(abspath $(NHSROOT))
+#SHELLDIR=
+HACKDIR=$(PREFIX)/playground
+GAMEPERM = 0700
+VARFILEPERM = 0600
+VARDIRPERM = 0700
+CFLAGS+=-DSYSCF -DSYSCF_FILE=\"$(HACKDIR)/sysconf\" -DSECURE
+MOREALL=$(MAKE) install
+else #!WANT_SOURCE_INTSALL
 #PREFIX=/usr
 PREFIX=$(wildcard ~)/nh/install
 HACKDIR=$(PREFIX)/games/lib/nethackdir
 SHELLDIR = $(PREFIX)/games
+VARDIRPERM = 0755
+VARFILEPERM = 0600
+GAMEPERM = 0755
+endif #?WANT_SOURCE_INSTALL
+
 INSTDIR=$(HACKDIR)
 VARDIR = $(HACKDIR)
 
@@ -347,10 +362,6 @@ LFLAGS+=-rdynamic
 CHOWN=true
 CHGRP=true
 
-VARDIRPERM = 0755
-VARFILEPERM = 0600
-GAMEPERM = 0755
-#
 # manpages directory
 MANDIR=/usr/share/man/man6
 #


### PR DESCRIPTION
WANT_SOURCE_INSTALL=1 can be specified when compiling to build NetHack
within the repo/source tree, rather than in the normal system install
location.  I find it useful for development on OSX, but it wasn't
present in any other hints files, so I've been using a custom hints file
on Linux for a while that adds the same option.  The code is based on
the macOS.370 hints file.
