### PR TITLE
delete ancient commented out codes on wall_angle()

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -3426,22 +3426,6 @@ wall_angle(struct rm *lev)
             }
             break;
         case WM_T_BL:
-#if 0  /* older method, fixed */
-            if (only(seenv, SV4 | SV5)) {
-                col = T_tlcorn;
-            } else if ((seenv & (SV0 | SV1 | SV2))
-                       && only(seenv, SV0 | SV1 | SV2 | SV6 | SV7)) {
-                col = T_hwall;
-            } else if ((seenv & SV3)
-                       || ((seenv & (SV0 | SV1 | SV2))
-                           && (seenv & (SV4 | SV5)))) {
-                col = T_tdwall;
-            } else {
-                if (seenv != SV6)
-                    t_warn(lev);
-                col = T_stone;
-            }
-#endif /* 0 */
             if (only(seenv, SV4 | SV5))
                 col = T_tlcorn;
             else if ((seenv & (SV0 | SV1 | SV2 | SV7))
@@ -3453,22 +3437,6 @@ wall_angle(struct rm *lev)
                 col = T_tdwall;
             break;
         case WM_T_BR:
-#if 0  /* older method, fixed */
-            if (only(seenv, SV5 | SV6)) {
-                col = T_trcorn;
-            } else if ((seenv & (SV0 | SV1 | SV2))
-                       && only(seenv, SV0 | SV1 | SV2 | SV3 | SV4)) {
-                col = T_hwall;
-            } else if ((seenv & SV7)
-                       || ((seenv & (SV0 | SV1 | SV2))
-                           && (seenv & (SV5 | SV6)))) {
-                col = T_tdwall;
-            } else {
-                if (seenv != SV4)
-                    t_warn(lev);
-                col = T_stone;
-            }
-#endif /* 0 */
             if (only(seenv, SV5 | SV6))
                 col = T_trcorn;
             else if ((seenv & (SV0 | SV1 | SV2 | SV3))


### PR DESCRIPTION
These codes have been commented out since 3.4.3, at least.