### PR TITLE
Rework erinyes into avenging Furies

### DIFF
--- a/dat/data.base
+++ b/dat/data.base
@@ -1730,8 +1730,18 @@ A.S*
 		[ Wikipedia, the free encyclopedia ]
 erinys
 erinyes
-	These female-seeming devils named after the Furies of mythology
-	attack hand to hand and poison their unwary victims as well.
+	Holy and pure, from Zeus Khthonios born
+	and Persephone, whom lovely locks adorn:
+	Whose piercing sight, with vision unconfin'd,
+	surveys the deeds of all the impious kind:
+	On Fate attendant, punishing the race
+	(with wrath severe) of deeds unjust and base.
+	Dark-colour'd queens, whose glittering eyes are bright
+	with dreadful, radiant, life-destroying, light:
+	Eternal rulers, terrible and strong,
+	to whom revenge, and tortures dire belong.
+		[ LXIX. To the Furies, The Orphic Hymns,
+		  translated by Thomas Taylor ]
 ettin
 	The two-headed giant, or ettin, is a vicious and unpredictable
 	hunter that stalks by night and eats any meat it can catch.

--- a/dat/rumors.tru
+++ b/dat/rumors.tru
@@ -332,6 +332,7 @@ They say that you should pray for divine inspiration.
 They say that you should religiously give your gold away.
 They say that you will never get healthy by eating geckos.
 They say that zapping yourself with a wand of undead turning is stupid.
+They say the Furies are more furious if you've been sinning.
 They say the Wizard's castle is booby-trapped!
 They say the gods get angry if you kill your dog.
 They say the gods get angry if you pray too much.

--- a/include/align.h
+++ b/include/align.h
@@ -60,4 +60,11 @@ typedef struct align { /* alignment & record */
 #define Msa2amask(x) (((x) == 3) ? 4 : (x))
 #define MSA_NONE    0  /* unaligned or multiple alignments */
 
+/* alignment change reasons for uchangealign(attrib.c) */
+enum uchangealign_reasons {
+    A_CG_CONVERT  = 0, /* permanently converted */
+    A_CG_HELM_ON  = 1, /* donned helm of opposite alignment */
+    A_CG_HELM_OFF = 2, /* doffed helm of opposite alignment */
+};
+
 #endif /* ALIGN_H */

--- a/include/align.h
+++ b/include/align.h
@@ -10,6 +10,7 @@ typedef schar aligntyp; /* basic alignment type */
 typedef struct align { /* alignment & record */
     aligntyp type;
     int record;
+    unsigned abuse;
 } align;
 
 /* bounds for "record" -- respect initial alignments of 10 */

--- a/include/extern.h
+++ b/include/extern.h
@@ -1341,6 +1341,7 @@ extern int mbirth_limit(int);
 extern void mkmonmoney(struct monst *, long);
 extern int bagotricks(struct obj *, boolean, int *);
 extern boolean propagate(int, boolean, boolean);
+extern void summon_furies(int);
 
 /* ### mcastu.c ### */
 

--- a/include/extern.h
+++ b/include/extern.h
@@ -1663,6 +1663,7 @@ extern void copy_mextra(struct monst *, struct monst *);
 extern void dealloc_mextra(struct monst *);
 extern boolean usmellmon(struct permonst *);
 extern void mimic_hit_msg(struct monst *, short);
+extern void adj_erinys(unsigned);
 
 /* ### mondata.c ### */
 

--- a/include/monsters.h
+++ b/include/monsters.h
@@ -2489,12 +2489,14 @@
        and spelled this way */
     MON("erinys", S_DEMON, LVL(7, 12, 2, 30, 10),
         (G_HELL | G_NOCORPSE | G_SGROUP | 2),
+        /* erinys attacks (among other things) are variable depending on your
+           alignment abuse, can be increased from here by adj_erinys(mon.c) */
         A(ATTK(AT_WEAP, AD_DRST, 2, 4), NO_ATTK, NO_ATTK, NO_ATTK, NO_ATTK,
           NO_ATTK),
         SIZ(WT_HUMAN, 400, MS_SILENT, MZ_HUMAN), MR_FIRE | MR_POISON, 0,
         M1_HUMANOID | M1_POIS,
-        M2_NOPOLY | M2_DEMON | M2_STALK | M2_HOSTILE | M2_STRONG | M2_NASTY
-            | M2_FEMALE | M2_COLLECT,
+        M2_NOPOLY | M2_DEMON | M2_STALK | M2_STRONG | M2_NASTY | M2_FEMALE
+            | M2_COLLECT,
         M3_INFRAVISIBLE | M3_INFRAVISION, 10, CLR_RED, ERINYS),
     MON("barbed devil", S_DEMON, LVL(8, 12, 0, 35, 8),
         (G_HELL | G_NOCORPSE | G_SGROUP | 2),

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1222,7 +1222,7 @@ adjalign(int n)
 /* change hero's alignment type, possibly losing use of artifacts */
 void
 uchangealign(int newalign,
-             int reason) /* 0==conversion, 1==helm-of-OA on, 2==helm-of-OA off */
+             int reason) /* A_CG_CONVERT, A_CG_HELM_ON, or A_CG_HELM_OFF */
 {
     aligntyp oldalign = u.ualign.type;
 
@@ -1230,7 +1230,7 @@ uchangealign(int newalign,
     /* You/Your/pline message with call flush_screen(), triggering bot(),
        so the actual data change needs to come before the message */
     gc.context.botl = TRUE; /* status line needs updating */
-    if (reason == 0) {
+    if (reason == A_CG_CONVERT) {
         /* conversion via altar */
         livelog_printf(LL_ALIGNMENT, "permanently converted to %s",
                        aligns[1 - newalign].adj);
@@ -1243,7 +1243,7 @@ uchangealign(int newalign,
     } else {
         /* putting on or taking off a helm of opposite alignment */
         u.ualign.type = (aligntyp) newalign;
-        if (reason == 1) {
+        if (reason == A_CG_HELM_ON) {
             adjalign(-7); /* for abuse -- record will be cleared shortly */
             Your("mind oscillates %s.", Hallucination ? "wildly" : "briefly");
             make_confused(rn1(2, 3), FALSE);
@@ -1252,7 +1252,7 @@ uchangealign(int newalign,
             /* don't livelog taking it back off */
             livelog_printf(LL_ALIGNMENT, "used a helm to turn %s",
                            aligns[1 - newalign].adj);
-        } else if (reason == 2) {
+        } else if (reason == A_CG_HELM_OFF) {
             Your("mind is %s.", Hallucination
                                     ? "much of a muchness"
                                     : "back in sync with your body");

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1242,18 +1242,19 @@ uchangealign(int newalign,
             (u.ualign.type != oldalign) ? "sudden " : "");
     } else {
         /* putting on or taking off a helm of opposite alignment */
+        u.ualign.type = (aligntyp) newalign;
         if (reason == 1) {
+            Your("mind oscillates %s.", Hallucination ? "wildly" : "briefly");
+            make_confused(rn1(2, 3), FALSE);
+            summon_furies(Is_astralevel(&u.uz) ? 0 : 1);
             /* don't livelog taking it back off */
             livelog_printf(LL_ALIGNMENT, "used a helm to turn %s",
                            aligns[1 - newalign].adj);
-        }
-        u.ualign.type = (aligntyp) newalign;
-        if (reason == 1)
-            Your("mind oscillates %s.", Hallucination ? "wildly" : "briefly");
-        else if (reason == 2)
+        } else if (reason == 2) {
             Your("mind is %s.", Hallucination
                                     ? "much of a muchness"
                                     : "back in sync with your body");
+        }
     }
     if (u.ualign.type != oldalign) {
         u.ualign.record = 0; /* slate is wiped clean */

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1204,8 +1204,14 @@ adjalign(int n)
     int newalign = u.ualign.record + n;
 
     if (n < 0) {
+        unsigned newabuse = u.ualign.abuse - n;
+
         if (newalign < u.ualign.record)
             u.ualign.record = newalign;
+        if (newabuse > u.ualign.abuse) {
+            u.ualign.abuse = newabuse;
+            adj_erinys(newabuse);
+        }
     } else if (newalign > u.ualign.record) {
         u.ualign.record = newalign;
         if (u.ualign.record > ALIGNLIM)

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1244,9 +1244,11 @@ uchangealign(int newalign,
         /* putting on or taking off a helm of opposite alignment */
         u.ualign.type = (aligntyp) newalign;
         if (reason == 1) {
+            adjalign(-7); /* for abuse -- record will be cleared shortly */
             Your("mind oscillates %s.", Hallucination ? "wildly" : "briefly");
             make_confused(rn1(2, 3), FALSE);
-            summon_furies(Is_astralevel(&u.uz) ? 0 : 1);
+            if (Is_astralevel(&u.uz) || ((unsigned) rn2(50) < u.ualign.abuse))
+                summon_furies(Is_astralevel(&u.uz) ? 0 : 1);
             /* don't livelog taking it back off */
             livelog_printf(LL_ALIGNMENT, "used a helm to turn %s",
                            aligns[1 - newalign].adj);

--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -437,7 +437,7 @@ Helmet_on(void)
         uchangealign((u.ualign.type != A_NEUTRAL)
                          ? -u.ualign.type
                          : (uarmh->o_id % 2) ? A_CHAOTIC : A_LAWFUL,
-                     1);
+                     A_CG_HELM_ON);
         /* makeknown(HELM_OF_OPPOSITE_ALIGNMENT); -- below, after Tobjnam() */
     /*FALLTHRU*/
     case DUNCE_CAP:
@@ -518,7 +518,7 @@ Helmet_off(void)
         /* changing alignment can toggle off active artifact
            properties, including levitation; uarmh could get
            dropped or destroyed here */
-        uchangealign(u.ualignbase[A_CURRENT], 2);
+        uchangealign(u.ualignbase[A_CURRENT], A_CG_HELM_OFF);
         break;
     default:
         impossible(unknown_type, c_helmet, uarmh->otyp);

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -2434,4 +2434,15 @@ bagotricks(
     return moncount;
 }
 
+/* create some or all remaining erinyes around the player */
+void
+summon_furies(int limit) /* number to create, or 0 to create until extinct */
+{
+    int i = 0;
+    while (mk_gen_ok(PM_ERINYS, G_GONE, 0U) && (i < limit || !limit)) {
+        makemon(&mons[PM_ERINYS], u.ux, u.uy, MM_ADJACENTOK | MM_NOWAIT);
+        i++;
+    }
+}
+
 /*makemon.c*/

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -2111,6 +2111,8 @@ peace_minded(register struct permonst *ptr)
         return TRUE;
     if (ptr->msound == MS_NEMESIS)
         return FALSE;
+    if (ptr == &mons[PM_ERINYS])
+        return !u.ualign.abuse;
 
     if (race_peaceful(ptr))
         return TRUE;

--- a/src/mon.c
+++ b/src/mon.c
@@ -5444,4 +5444,53 @@ check_gear_next_turn(struct monst *mon)
 {
     mon->misc_worn_check |= I_SPECIAL;
 }
+
+/* make erinyes more dangerous based on your alignment abuse */
+void
+adj_erinys(unsigned abuse)
+{
+    struct permonst *pm = &mons[PM_ERINYS];
+
+    if (abuse > 5L) {
+        pm->mflags1 |= M1_SEE_INVIS;
+    }
+    if (abuse > 10L) {
+        pm->mflags1 |= M1_AMPHIBIOUS;
+    }
+    if (abuse > 15L) {
+        pm->mflags1 |= M1_FLY;
+    }
+    if (abuse > 20L) {
+        /* more powerful attack */
+        pm->mattk[0].damn = 3;
+    }
+    if (abuse > 25L) {
+        pm->mflags1 |= M1_REGEN;
+    }
+    if (abuse > 30L) {
+        pm->mflags1 |= M1_TPORT_CNTRL;
+    }
+    if (abuse > 35L) {
+        /* second attack */
+        pm->mattk[1].aatyp = AT_WEAP;
+        pm->mattk[1].adtyp = AD_DRST;
+        pm->mattk[1].damn = 3;
+        pm->mattk[1].damd = 4;
+    }
+    if (abuse > 40L) {
+        pm->mflags1 |= M1_TPORT;
+    }
+    if (abuse > 50L) {
+        /* third (spellcasting) attack */
+        pm->mattk[2].aatyp = AT_MAGC;
+        pm->mattk[2].adtyp = AD_SPEL;
+        pm->mattk[2].damn = 3;
+        pm->mattk[2].damd = 4;
+    }
+
+    /* also adjust level and difficulty */
+    pm->mlevel = min(7 + u.ualign.abuse, 50);
+    pm->difficulty = min(10 + (u.ualign.abuse / 3), 25);
+}
+
 /*mon.c*/

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -639,6 +639,10 @@ dochug(register struct monst* mtmp)
         return 0;
     }
 
+    /* Erinyes will inform surrounding monsters of your crimes */
+    if (mdat == &mons[PM_ERINYS] && !mtmp->mpeaceful && m_canseeu(mtmp))
+        aggravate();
+
     /* Shriekers and Medusa have irregular abilities which must be
        checked every turn. These abilities do not cost a turn when
        used. */

--- a/src/pray.c
+++ b/src/pray.c
@@ -1810,6 +1810,9 @@ dosacrifice(void)
     if (!on_altar() || u.uswallow) {
         You("are not standing on an altar.");
         return ECMD_OK;
+    } else if (Confusion || Stunned || Hallucination) {
+        You("are too impaired to perform the rite.");
+        return ECMD_OK;
     }
     highaltar = (levl[u.ux][u.uy].altarmask & AM_SANCTUM);
 

--- a/src/pray.c
+++ b/src/pray.c
@@ -1612,7 +1612,7 @@ offer_different_alignment_altar(
             consume_offering(otmp);
             pline("%s accepts your allegiance.", a_gname());
 
-            uchangealign(altaralign, 0);
+            uchangealign(altaralign, A_CG_CONVERT);
             /* Beware, Conversion is costly */
             change_luck(-3);
             u.ublesscnt += 300;

--- a/src/restore.c
+++ b/src/restore.c
@@ -690,6 +690,7 @@ restgamestate(NHFILE *nhfp)
     /* must come after all mons & objs are restored */
     relink_timers(FALSE);
     relink_light_sources(FALSE);
+    adj_erinys(u.ualign.abuse);
     /* inventory display is now viable */
     iflags.perm_invent = defer_perm_invent;
     return TRUE;

--- a/src/teleport.c
+++ b/src/teleport.c
@@ -2150,8 +2150,8 @@ u_teleport_mon(struct monst* mtmp, boolean give_feedback)
             You("are no longer inside %s!", mon_nam(mtmp));
         unstuck(mtmp);
         (void) rloc(mtmp, RLOC_MSG);
-    } else if (is_rider(mtmp->data) && rn2(13)
-               && enexto(&cc, u.ux, u.uy, mtmp->data))
+    } else if ((is_rider(mtmp->data) || control_teleport(mtmp->data))
+               && rn2(13) && enexto(&cc, u.ux, u.uy, mtmp->data))
         rloc_to(mtmp, cc.x, cc.y);
     else
         (void) rloc(mtmp, RLOC_MSG);


### PR DESCRIPTION
Based on conversations on IRC with paxed, bhaak, K2, and Umbire.  This is an idea based on the role of the erinyes in Greek myth: punishers of oathbreakers, hosts who harm their guests, murderers, and others who have violated important ancient social mores or customs.  This is reflected in NetHack by the erinyes becoming more dangerous as you abuse your alignment -- something like killing a peaceful monster does seem consistent to me with things that bring down the Furies in mythology.  The alignment abuse metric that determines the difficulty of the erinyes is tracked separately from alignment record, and only counts negative adjustments to alignment: 'adjalign(-5); adjalign(10); adjalign(-5);' would leave you with an alignment record of 0, but alignment abuse value of 10.

If extinction allows, one or more erinyes are also (edit: potentially, based on a roll against abuse value) summoned when you don a helm of opposite alignment (since you're breaking your oath to your god, so it especially incites them).  The helm of opposite alignment also causes brief confusion, and #offering is made impossible while confused, in order to make this a potential challenge on Astral rather than something which can easily be blown past by #offering the amulet on the next turn.

This could use more testing and conversation about possible changes or extensions (or alternatives), but I think it's at a point now where I am comfortable submitting the patch in its current state and starting some discussion around it.
