### PR TITLE
Don't grant tame djinni from lamps/potions if player is petless.

### DIFF
--- a/src/potion.c
+++ b/src/potion.c
@@ -2778,9 +2778,14 @@ djinni_from_bottle(struct obj *obj)
         mongrantswish(&mtmp);
         break;
     case 1:
-        verbalize("Thank you for freeing me!");
-        (void) tamedog(mtmp, (struct obj *) 0);
-        break;
+        /* if the player is trying to play petless, make it safe
+           for them to rub lamps */
+        if (u.uconduct.pets) {
+            verbalize("Thank you for freeing me!");
+            (void) tamedog(mtmp, (struct obj *) 0);
+            break;
+        }
+        /* FALLTHRU */
     case 2:
         verbalize("You freed me!");
         mtmp->mpeaceful = TRUE;


### PR DESCRIPTION
From xNetHack git commit 9ee7a0e:

'This is similar to the Astral angel not appearing if the player is petless. Strictly speaking, players attempting to play petless could control this simply by not rubbing any lamps or quaffing any smoky potions, but that has a rather large impact on the game just for maintaining a conduct.

It doesn't change the overall probability of a hostile or wish-granting djinni; a petless player will simply get the neutral "You freed me!" djinni twice as often.

This could technically deny a djinn pet from players who actually wanted one, but since such players would have to have the pet option turned off and acquire no other pets along the way to making the djinn come out, it's probably an extreme edge case.'