### PR TITLE
remove unnecessary condition on save_mtraits()

### DIFF
--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -2052,8 +2052,7 @@ save_mtraits(struct obj *obj, struct monst *mtmp)
 
         *mtmp2 = *mtmp;
         mtmp2->mextra = (struct mextra *) 0;
-        if (mtmp->data)
-            mtmp2->mnum = monsndx(mtmp->data);
+        mtmp2->mnum = monsndx(mtmp->data);
         /* invalidate pointers */
         /* m_id is needed to know if this is a revived quest leader */
         /* but m_id must be cleared when loading bones */


### PR DESCRIPTION
`mtmp->data` here is always non-null, otherwise it leads segv at earlier code.