### PR TITLE
Call hallu high priest "grand poohbah", not "high"

### DIFF
--- a/src/priest.c
+++ b/src/priest.c
@@ -347,7 +347,7 @@ priestname(
             ; /* polymorphed priest; use ``what'' as is */
         } else {
             if (high_priest)
-                Strcat(pname, "high ");
+                Strcat(pname, Hallucination ? "grand " : "high ");
             if (Hallucination)
                 what = "poohbah";
             else if (mon->female)


### PR DESCRIPTION
"Grand poohbah" is a common term while "high poohbah" is not, and it
seems appropriate for hallucinogen-distorted high priests.  (It seems to
most commonly be spelled "grand poobah" but I left that alone; "poohbah"
seems like a decent compromise between that and the spelling of the
character's name in the Mikado).
