### PR TITLE
Ice and fumbling-related tweaks

### DIFF
--- a/src/hack.c
+++ b/src/hack.c
@@ -2142,12 +2142,13 @@ static void
 slippery_ice_fumbling(void)
 {
     boolean on_ice = !Levitation && is_ice(u.ux, u.uy);
+    struct monst *iceskater = u.usteed ? u.usteed : &gy.youmonst;
 
     if (on_ice) {
         if ((uarmf && objdescr_is(uarmf, "snow boots"))
-            || resists_cold(&gy.youmonst) || Flying
-            || is_floater(gy.youmonst.data) || is_clinger(gy.youmonst.data)
-            || is_whirly(gy.youmonst.data)) {
+            || resists_cold(iceskater) || Flying
+            || is_floater(iceskater->data) || is_clinger(iceskater->data)
+            || is_whirly(iceskater->data)) {
             on_ice = FALSE;
         } else if (!rn2(Cold_resistance ? 3 : 2)) {
             HFumbling |= FROMOUTSIDE;

--- a/src/music.c
+++ b/src/music.c
@@ -415,9 +415,9 @@ do_earthquake(int force)
                         selftouch("Falling, you");
                     } else if (u.utrap && u.utraptype == TT_PIT) {
                         boolean keepfooting =
-                                ((Fumbling && !rn2(5))
-                                 || (!rnl(Role_if(PM_ARCHEOLOGIST) ? 3 : 9))
-                                 || ((ACURR(A_DEX) > 7) && rn2(5)));
+                                (!(Fumbling && rn2(5))
+                                 && (!(rnl(Role_if(PM_ARCHEOLOGIST) ? 3 : 9))
+                                     || ((ACURR(A_DEX) > 7) && rn2(5))));
 
                         You("are jostled around violently!");
                         set_utrap(rn1(6, 2), TT_PIT);

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -1175,14 +1175,23 @@ slip_or_trip(void)
                     an(mons[otmp->corpsenm].pmnames[NEUTRAL]));
             instapetrify(gk.killer.name);
         }
-    } else if (rn2(3) && is_ice(u.ux, u.uy)) {
+    } else if ((HFumbling & FROMOUTSIDE) || (is_ice(u.ux, u.uy) && !rn2(3))) {
+        /* is fumbling from ice alone? */
+        boolean ice_only = !(EFumbling || (HFumbling & ~FROMOUTSIDE));
+
         pline("%s %s%s on the ice.",
-              u.usteed ? upstart(x_monnam(u.usteed,
-                                      (has_mgivenname(u.usteed)) ? ARTICLE_NONE
-                                                                 : ARTICLE_THE,
-                                      (char *) 0, SUPPRESS_SADDLE, FALSE))
+              u.usteed ? upstart(x_monnam(u.usteed, ARTICLE_THE, (char *) 0,
+                                          SUPPRESS_SADDLE, FALSE))
                        : "You",
               rn2(2) ? "slip" : "slide", on_foot ? "" : "s");
+        /* fumbling outside of ice while mounted always causes the hero to
+           fall from the saddle, so to avoid a counterintuitive effect where
+           ice makes riding _less_ hazardous, unconditionally dismount if
+           fumbling is from a non-ice source */
+        if (!on_foot && (!ice_only || !rn2(3))) {
+            You("lose your balance.");
+            dismount_steed(DISMOUNT_FELL);
+        }
     } else {
         if (on_foot) {
             switch (rn2(4)) {


### PR DESCRIPTION
This came out of an IRC discussion about how ice uses fumbling internally, and it can cause some unexpected effects.

- Fix: fumbling vs losing footing in earthquake
- Refine ice fumbling effects vs mounted hero
- Check whether steed will slip on ice if mounted
