### PR TITLE
Fix memory leak in sp_lvl:lspo_region

### DIFF
--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -6191,6 +6191,8 @@ lspo_region(lua_State *L)
             selection_do_grow(sel, W_ANY);
         selection_iterate(sel, sel_set_lit, (genericptr_t) &rlit);
 
+        selection_free(sel, TRUE);
+
         /* TODO: skip the rest of this function? */
         return 0;
     } else {


### PR DESCRIPTION
We have cloned a selection, free it in order
to avoid memory leak.