### PR TITLE
sp_lvl: fortify selection_getbounds

### DIFF
--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -4547,8 +4547,12 @@ selection_clone(struct selectionvar *sel)
 void
 selection_getbounds(struct selectionvar *sel, NhRect *b)
 {
-    if (!sel || !b)
+    nhassert(b);
+
+    if (!sel) {
+        memset(b, 0, sizeof(NhRect));
         return;
+    }
 
     selection_recalc_bounds(sel);
 


### PR DESCRIPTION
All callsites for selection_getbounds use NhRect from stack. If selection is not set, remember to set all rect values (to zero) as the callsites do not check for selection before iterating thru NhRect.

This prevents random values from stack ending up being used in temporary NhRects.