### PR TITLE
Avoid calling Curses after it is shut down

### DIFF
--- a/win/curses/cursmain.c
+++ b/win/curses/cursmain.c
@@ -841,9 +841,11 @@ wait_synch()    -- Wait until all pending output is complete (*flush*() for
 void
 curses_wait_synch(void)
 {
-    if (curses_got_output())
-        (void) curses_more();
-    curses_mark_synch();
+    if (iflags.window_inited) {
+        if (curses_got_output())
+            (void) curses_more();
+        curses_mark_synch();
+    }
     /* [do we need 'if (counting) curses_count_window((char *)0);' here?] */
 }
 


### PR DESCRIPTION
curses_wait_synch may call Curses functions after Curses is shut down. For the DOSVGA Curses, this causes a crash on exit. The crash is harmless, as the save file is already complete, but it is still worrying to the user. This patch adds a check for Curses being active.