### PR TITLE
Corpsenm fixes

### DIFF
--- a/src/dog.c
+++ b/src/dog.c
@@ -931,14 +931,15 @@ dogfood(struct monst *mon, struct obj *obj)
         fx = (obj->otyp == CORPSE || obj->otyp == TIN || obj->otyp == EGG)
                 ? obj->corpsenm
                 : NUMMONS; /* valid mons[mndx] to pacify static analyzer */
-        fptr = &mons[fx];
+
+        fptr = fx >= LOW_PM ? &mons[fx] : NULL;
 
         if (obj->otyp == CORPSE && is_rider(fptr))
             return TABU;
         if ((obj->otyp == CORPSE || obj->otyp == EGG)
             /* Medusa's corpse doesn't pass the touch_petrifies() test
                but does cause petrification if eaten */
-            && (touch_petrifies(fptr) || obj->corpsenm == PM_MEDUSA)
+            && ((fptr && touch_petrifies(fptr)) || obj->corpsenm == PM_MEDUSA)
             && !resists_ston(mon))
             return POISON;
         if (obj->otyp == LUMP_OF_ROYAL_JELLY

--- a/src/eat.c
+++ b/src/eat.c
@@ -57,7 +57,8 @@ static int tin_ok(struct obj *);
    they can be sacrificed regardless of age which implies that they never
    become rotten */
 #define nonrotting_corpse(mnum) \
-    ((mnum) == PM_LIZARD || (mnum) == PM_LICHEN || is_rider(&mons[mnum]) \
+    ((mnum) == PM_LIZARD || (mnum) == PM_LICHEN \
+     || ((mnum) >= LOW_PM && is_rider(&mons[mnum])) \
      || (mnum) == PM_ACID_BLOB)
 
 /* non-rotting non-corpses; unlike lizard corpses, these items will behave

--- a/src/mon.c
+++ b/src/mon.c
@@ -11,6 +11,7 @@ static void sanity_check_single_mon(struct monst *, boolean, const char *);
 static struct obj *make_corpse(struct monst *, unsigned);
 static int minliquid_core(struct monst *);
 static void m_calcdistress(struct monst *);
+static boolean mstoning(const struct obj *obj);
 static boolean monlineu(struct monst *, int, int);
 static long mm_2way_aggression(struct monst *, struct monst *);
 static long mm_aggression(struct monst *, struct monst *);
@@ -1156,9 +1157,19 @@ meatbox(struct monst *mon, struct obj *otmp)
     }
 }
 
-#define mstoning(obj)                                       \
-    (ofood(obj) && (touch_petrifies(&mons[(obj)->corpsenm]) \
-                    || (obj)->corpsenm == PM_MEDUSA))
+static boolean
+mstoning(const struct obj *obj)
+{
+    const int nm = obj->corpsenm;
+
+    if (nm < LOW_PM)
+        return FALSE;
+
+    if (nm == PM_MEDUSA)
+        return TRUE;
+
+    return ofood(obj) && touch_petrifies(&mons[nm]);
+}
 
 /* monster consumes an object.
 
@@ -1417,8 +1428,6 @@ meatobj(struct monst* mtmp) /* for gelatinous cubes */
     }
     return (count > 0 || ecount > 0) ? 1 : 0;
 }
-
-#undef mstoning
 
 /* Monster eats a corpse off the ground.
  * Return value is 0 = nothing eaten, 1 = ate a corpse, 2 = died */

--- a/src/muse.c
+++ b/src/muse.c
@@ -2624,7 +2624,7 @@ searches_for_item(struct monst *mon, struct obj *obj)
             return (boolean) (mcould_eat_tin(mon)
                               && (!resists_ston(mon)
                                   && cures_stoning(mon, obj, TRUE)));
-        if (typ == EGG)
+        if (typ == EGG && obj->corpsenm >= LOW_PM)
             return (boolean) touch_petrifies(&mons[obj->corpsenm]);
         break;
     default:

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -1156,7 +1156,8 @@ hmon_hitmon_misc_obj(
                 change_luck(-5);
         }
 
-        if (touch_petrifies(&mons[obj->corpsenm])) {
+        if (obj->corpsenm >= LOW_PM
+            && touch_petrifies(&mons[obj->corpsenm])) {
             /*learn_egg_type(obj->corpsenm);*/
             pline("Splat!  You hit %s with %s %s egg%s!",
                   mon_nam(mon),

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -469,17 +469,24 @@ static struct obj *oselect(struct monst *, int);
     } while (0)
 
 static struct obj *
-oselect(struct monst *mtmp, int x)
+oselect(struct monst *mtmp, int type)
 {
     struct obj *otmp;
 
     for (otmp = mtmp->minvent; otmp; otmp = otmp->nobj) {
-        if (otmp->otyp == x
-            /* never select non-cockatrice corpses */
-            && !((x == CORPSE || x == EGG)
-                 && !touch_petrifies(&mons[otmp->corpsenm]))
-            && (!otmp->oartifact || touch_artifact(otmp, mtmp)))
-            return otmp;
+        if (otmp->otyp != type)
+            continue;
+
+        /* never select non-cockatrice corpses */
+        if ((type == CORPSE || type == EGG)
+            && (otmp->corpsenm == NON_PM
+                || !touch_petrifies(&mons[otmp->corpsenm])))
+            continue;
+
+        if (!can_touch_safely(mtmp, otmp))
+            continue;
+
+        return otmp;
     }
     return (struct obj *) 0;
 }


### PR DESCRIPTION
This pull requests fixes handful of callsites where corpsenm was used
into the permanent monster array. As corpsenm for TINs and EGGs can be -1
 (reported by ubsan), we need to adjust with >= LOW_PM check as adviced
by the obj.h:

    /* note: sometimes eggs and tins have special corpsenm values that
       shouldn't be used as an index into mons[]                       */

Please consider all or cherrypicking one-by-one basis.
