### PR TITLE
Saving a bones file should not free memory; the function really_done …

### DIFF
--- a/src/bones.c
+++ b/src/bones.c
@@ -575,7 +575,7 @@ savebones(int how, time_t when, struct obj *corpse)
     }
     c = (char) (strlen(bonesid) + 1);
 
-    nhfp->mode = WRITING | FREEING;
+    nhfp->mode = WRITING;
     store_version(nhfp);
     store_savefileinfo(nhfp);
     if (nhfp->structlevel) {


### PR DESCRIPTION
…will be using that information after the call to savebones, resulting in a heap-use-after-free error (and possibly later in a double-free in nh_terminate if things get that far).