### PR TITLE
Copyedit PYEC encyclopedia entry

### DIFF
--- a/dat/data.base
+++ b/dat/data.base
@@ -4225,12 +4225,11 @@ pit fiend
 	domains.
 platinum yendorian express card
 	This is an ancient artifact made of an unknown material.  It
-	is rectangular in shape, very thin, and inscribed with
-	unreadable ancient runes.  When carried, it grants the one
-	who carries it ESP, and reduces all spell induced damage done to
-	the carrier by half.  It also protects from magic missile
-	attacks.  Finally, its power is such that when invoked, it
-	can charge other objects.
+	is rectangular in shape, very thin, and inscribed with archaic
+	runes of power.  When carried, it grants the bearer ESP, reduces
+	incoming damage from spells by half, and protects from magic
+	missile attacks.  Additionally, its power is such that when
+	invoked, it can charge other objects.
 # playing style, rather vague topic but these quotes are too apt to pass up
 player
 play* style


### PR DESCRIPTION
I initially went in here to change the description of "unreadable" text
on the card, since it has been possible to read it in-game since commit
870b124 in 2015.  Then I also ended up making some edits to stylistic
issues I noticed, primarily varying vocabulary to eliminate the
repetition/reuse of words in phrases like "an /ancient/ artifact...
inscribed with /ancient/ runes" and "when /carried/, it grants the one
who /carries/ it ESP, and reduces all spell damage done to the
/carrier/".  The result is a little bit tighter and I think reads
somehwat better.
