### PR TITLE
Make pets unwilling to eat all polymorphing corpses

### DIFF
--- a/include/obj.h
+++ b/include/obj.h
@@ -303,7 +303,7 @@ struct obj {
 #define ofood(o) ((o)->otyp == CORPSE || (o)->otyp == EGG || (o)->otyp == TIN)
     /* note: sometimes eggs and tins have special corpsenm values that
        shouldn't be used as an index into mons[]                       */
-#define polyfodder(obj) \
+#define polyfood(obj) \
     (ofood(obj) && (obj)->corpsenm >= LOW_PM                            \
      && (pm_to_cham((obj)->corpsenm) != NON_PM                          \
                     || dmgtype(&mons[(obj)->corpsenm], AD_POLY)))

--- a/src/do.c
+++ b/src/do.c
@@ -849,7 +849,7 @@ engulfer_digests_food(struct obj *obj)
 
         if (obj->otyp == CORPSE) {
             could_petrify = touch_petrifies(&mons[obj->corpsenm]);
-            could_poly = polyfodder(obj);
+            could_poly = polyfood(obj);
             could_grow = (obj->corpsenm == PM_WRAITH);
             could_heal = (obj->corpsenm == PM_NURSE);
         } else if (obj->otyp == GLOB_OF_GREEN_SLIME) {

--- a/src/dog.c
+++ b/src/dog.c
@@ -990,7 +990,7 @@ dogfood(struct monst *mon, struct obj *obj)
                 return POISON;
             /* avoid polymorph unless starving or abused (in which case the
                pet will consider it for a chance to become more powerful) */
-            else if (is_shapeshifter(fptr) && mon->mtame > 1 && !starving)
+            else if (polyfood(obj) && mon->mtame > 1 && !starving)
                 return MANFOOD;
             else if (vegan(fptr))
                 return herbi ? CADAVER : MANFOOD;

--- a/src/eat.c
+++ b/src/eat.c
@@ -3801,7 +3801,7 @@ Popeye(int threat)
                           && (mndx == PM_LIZARD || acidic(&mons[mndx])));
     /* polymorph into a fiery monster */
     case SLIMED:
-        return (boolean) polyfodder(otin);
+        return (boolean) polyfood(otin);
     /* no tins can cure these (yet?) */
     case SICK:
     case VOMITING:

--- a/src/mon.c
+++ b/src/mon.c
@@ -1191,7 +1191,7 @@ m_consume_obj(struct monst *mtmp, struct obj *otmp)
                                               || corpsenm == PM_LARGE_MIMIC
                                               || corpsenm == PM_GIANT_MIMIC));
         slimer = (otmp->otyp == GLOB_OF_GREEN_SLIME);
-        poly = polyfodder(otmp);
+        poly = polyfood(otmp);
         grow = mlevelgain(otmp);
         heal = mhealup(otmp);
         eyes = (otmp->otyp == CARROT);


### PR DESCRIPTION
Don't limit the hestitation to eat a corpse to shapeshifter corpses; apply it
to all corpses that will polymorph the creature eating them.  Fixes #1183.

- Rename polyfodder() to polyfood()
- Make pets unwilling to eat all polyfood() corpses
