### PR TITLE
Refactor give_u_to_m_resistances

### DIFF
--- a/include/monflag.h
+++ b/include/monflag.h
@@ -67,6 +67,9 @@ enum ms_sounds {
 #define MR_POISON       0x20 /* resists poison */
 #define MR_ACID         0x40 /* resists acid */
 #define MR_STONE        0x80 /* resists petrification */
+/* NB: the above resistances correspond to the first 8 hero properties in
+   prop_types (FIRE_RES through STONE_RES), which can be converted to their
+   MR_foo equivalents with the macro res_to_mr() defined in prop.h */
 /* other resistances: magic, sickness */
 /* other conveyances: teleport, teleport control, telepathy */
 

--- a/include/prop.h
+++ b/include/prop.h
@@ -20,7 +20,10 @@ enum prop_types {
     POISON_RES        =  6,
     ACID_RES          =  7,
     STONE_RES         =  8,
-    /* note: for the first eight properties, MR_xxx == (1 << (xxx_RES - 1)) */
+    /* note: the first eight properties above are equivalent to MR_xxx bits
+     * MR_FIRE through MR_STONE, and can be directly converted to them: */
+#define res_to_mr(r) \
+    ((FIRE_RES <= (r) && (r) <= STONE_RES) ? (uchar) (1 << ((r) - 1)) : 0x00)
     DRAIN_RES         =  9,
     SICK_RES          = 10,
     INVULNERABLE      = 11,

--- a/src/mon.c
+++ b/src/mon.c
@@ -1502,33 +1502,28 @@ mon_give_prop(struct monst *mtmp, int prop)
        control or whatever, ignore it. */
     switch (prop) {
     case FIRE_RES:
-        intrinsic = MR_FIRE;
         msg = "%s shivers slightly.";
         break;
     case COLD_RES:
-        intrinsic = MR_COLD;
         msg = "%s looks quite warm.";
         break;
     case SLEEP_RES:
-        intrinsic = MR_SLEEP;
         msg = "%s looks wide awake.";
         break;
     case DISINT_RES:
-        intrinsic = MR_DISINT;
         msg = "%s looks very firm.";
         break;
     case SHOCK_RES:
-        intrinsic = MR_ELEC;
         msg = "%s crackles with static electricity.";
         break;
     case POISON_RES:
-        intrinsic = MR_POISON;
         msg = "%s looks healthy.";
         break;
     default:
         return; /* can't give it */
         break;
     }
+    intrinsic = res_to_mr(prop);
 
     /* Don't give message if it already had this property intrinsically, but
        still do grant the intrinsic if it only had it from mresists.

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -1484,20 +1484,14 @@ monstunseesu(unsigned long seenres)
 void
 give_u_to_m_resistances(struct monst *mtmp)
 {
-    const struct {
-        int u;
-        unsigned short m;
-    } u_to_m_res[] = {
-        { FIRE_RES, MR_FIRE }, { COLD_RES, MR_COLD },
-        { SLEEP_RES, MR_SLEEP }, { DISINT_RES, MR_DISINT },
-        { SHOCK_RES, MR_ELEC }, { POISON_RES, MR_POISON },
-        { ACID_RES, MR_ACID }, { STONE_RES, MR_STONE },
-    };
-    int i;
+    int intr;
 
-    for (i = 0; i < SIZE(u_to_m_res); i++) {
-        if ((u.uprops[u_to_m_res[i].u].intrinsic & INTRINSIC) != 0L) {
-            mtmp->mintrinsics |= u_to_m_res[i].m;
+    /* convert the hero's current set of intrinsics to their monster
+       equivalents -- FIRE_RES to MR_FIRE, COLD_RES to MR_COLD, etc -- and
+       add each to the mintrinsics field for the given monster */
+    for (intr = FIRE_RES; intr <= STONE_RES; intr++) {
+        if ((u.uprops[intr].intrinsic & INTRINSIC) != 0L) {
+            mtmp->mintrinsics |= (unsigned short) res_to_mr(intr);
         }
     }
 }

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -1484,13 +1484,22 @@ monstunseesu(unsigned long seenres)
 void
 give_u_to_m_resistances(struct monst *mtmp)
 {
-    const int u_intrins[] = { FIRE_RES, COLD_RES, SLEEP_RES, DISINT_RES, SHOCK_RES, POISON_RES, ACID_RES, STONE_RES };
-    const int m_intrins[] = { MR_FIRE,  MR_COLD,  MR_SLEEP,  MR_DISINT,  MR_ELEC,   MR_POISON,  MR_ACID,  MR_STONE };
+    const struct {
+        int u;
+        unsigned short m;
+    } u_to_m_res[] = {
+        { FIRE_RES, MR_FIRE }, { COLD_RES, MR_COLD },
+        { SLEEP_RES, MR_SLEEP }, { DISINT_RES, MR_DISINT },
+        { SHOCK_RES, MR_ELEC }, { POISON_RES, MR_POISON },
+        { ACID_RES, MR_ACID }, { STONE_RES, MR_STONE },
+    };
     int i;
 
-    for (i = 0; i < SIZE(u_intrins); i++)
-        if (u.uprops[u_intrins[i]].intrinsic & INTRINSIC)
-            mtmp->mintrinsics |= m_intrins[i];
+    for (i = 0; i < SIZE(u_to_m_res); i++) {
+        if ((u.uprops[u_to_m_res[i].u].intrinsic & INTRINSIC) != 0L) {
+            mtmp->mintrinsics |= u_to_m_res[i].m;
+        }
+    }
 }
 
 /* Can monster resist conflict caused by hero?

--- a/src/worn.c
+++ b/src/worn.c
@@ -404,12 +404,7 @@ update_mon_extrinsics(
         case JUMPING:
             break;
         default:
-            /* 1 through 8 correspond to MR_xxx mask values */
-            if (which >= 1 && which <= 8) {
-                /* FIRE,COLD,SLEEP,DISINT,SHOCK,POISON,ACID,STONE */
-                mask = (uchar) (1 << (which - 1));
-                mon->mextrinsics |= (unsigned short) mask;
-            }
+            mon->mextrinsics |= (unsigned short) res_to_mr(which);
             break;
         }
     } else { /* off */
@@ -446,7 +441,7 @@ update_mon_extrinsics(
              * only one pass but a worn alchemy smock will be an
              * alternate source for either of those two resistances.
              */
-            mask = (uchar) (1 << (which - 1));
+            mask = res_to_mr(which);
             for (otmp = mon->minvent; otmp; otmp = otmp->nobj) {
                 if (otmp == obj || !otmp->owornmask)
                     continue;


### PR DESCRIPTION
I think that using two arrays in tandem like give_u_to_m_resistances
originally did is frequently considered a bad idea, because one can
easily be added to or subtracted from without modifying the other --
that could obviously cause problems.