### PR TITLE
Fix out of bound access in uhpinc and ueninc.

### DIFF
--- a/include/you.h
+++ b/include/you.h
@@ -463,8 +463,8 @@ struct you {
         uhppeak;             /* highest value of uhpmax so far */
     int uen, uenmax,         /* magical energy, aka spell power */
         uenpeak;             /* highest value of uenmax so far */
-    xint16 uhpinc[MAXULEV],  /* increases to uhpmax for each level gain */
-          ueninc[MAXULEV];   /* increases to uenmax for each level gain */
+    xint16 uhpinc[MAXULEV + 1],  /* increases to uhpmax for each level gain */
+          ueninc[MAXULEV + 1];   /* increases to uenmax for each level gain */
     int ugangr;              /* if the gods are angry at you */
     int ugifts;              /* number of artifacts bestowed */
     int ublessed, ublesscnt; /* blessing/duration from #pray */


### PR DESCRIPTION
uhpinc and ueninc are indexed by u.ulevel. ulevel can reach MAXULEVEL (30), which means that the 0-29 range of uhpinc and ueninc arrays is not enough and out of bounds by one will result:

exper.c:245:25: runtime error: index 30 out of bounds for type 'xint16 [30]'
exper.c:263:25: runtime error: index 30 out of bounds for type 'xint16 [30]'

Fix this by increasing both arrays by one, which allows u.ulevel indexing (and leaving index 0 as unused)