### PR TITLE
Always have doors allocated

### DIFF
--- a/src/mklev.c
+++ b/src/mklev.c
@@ -1078,6 +1078,8 @@ makelevel(void)
     oinit(); /* assign level dependent obj probabilities */
     clear_level_structures();
 
+    alloc_doors();
+
     /* check for special levels */
     if (slev && !Is_rogue_level(&u.uz)) {
         makemaz(slev->proto);


### PR DESCRIPTION
save assumes that there is gd.doors allocated. If there is level without any doors, gd.doors is NULL as no doors were added.

Fix this by always having gd.doors allocated when level is created.

Prevents: 
