### PR TITLE
dothrow: Check for LOW_PM before accessing mon array

### DIFF
--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -1263,6 +1263,7 @@ toss_up(struct obj *obj, boolean hitsroof)
     const char *action;
     int otyp = obj->otyp;
     boolean petrifier = ((otyp == EGG || otyp == CORPSE)
+                         && obj->corpsenm >= LOW_PM
                          && touch_petrifies(&mons[obj->corpsenm]));
     /* note: obj->quan == 1 */
 


### PR DESCRIPTION
on toss_up() when checking for touch_petrifies, add a check for corpsenm >= LOW_PM as EGG can be without corpse reference.

This prevents:
dothrow.c:1266:29: runtime error: index -1 out of bounds for type 'permonst [384]'

Full trace:
dothrow.c:1266:29: runtime error: index -1 out of bounds for type 'permonst [384]'
    #0 0x555556c87a17 in toss_up /home/miku/src/NetHack/src/dothrow.c:1266
    #1 0x555556c93fcf in throwit /home/miku/src/NetHack/src/dothrow.c:1533
    #2 0x555556c73c2e in throw_obj /home/miku/src/NetHack/src/dothrow.c:264
    #3 0x555556c7c7d2 in dofire /home/miku/src/NetHack/src/dothrow.c:571
    #4 0x555556ad353e in rhack /home/miku/src/NetHack/src/cmd.c:4999
    #5 0x5555569b2994 in moveloop_core /home/miku/src/NetHack/src/allmain.c:494
    #6 0x5555569b33c3 in moveloop /home/miku/src/NetHack/src/allmain.c:547
    #7 0x555557703c22 in main ../sys/unix/unixmain.c:310
    #8 0x7ffff74280cf in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #9 0x7ffff7428188 in __libc_start_main_impl ../csu/libc-start.c:360
    #10 0x5555568a07e4 in _start (/home/miku/src/NetHack/src/nethack+0x134c7e4) (BuildId: 2859e16e0bfb335e7769d0a0eb34c115734c0345)