### PR TITLE
Guard against out of bounds access to level locations

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -216,8 +216,8 @@
  * "cover" any objects or traps that might be there.
  */
 #define covers_objects(xx, yy) \
-    ((is_pool(xx, yy) && !Underwater) || (levl[xx][yy].typ == LAVAPOOL) \
-      || (levl[xx][yy].typ == LAVAWALL))
+    ((is_pool(xx, yy) && !Underwater) || (loc(xx, yy)->typ == LAVAPOOL)  \
+     || (loc(xx, yy)->typ == LAVAWALL))
 
 #define covers_traps(xx, yy) covers_objects(xx, yy)
 

--- a/include/engrave.h
+++ b/include/engrave.h
@@ -42,12 +42,12 @@ struct engr {
 #define dealloc_engr(engr) free((genericptr_t) (engr))
 
 #define engraving_to_defsym(ep) \
-    ((levl[(ep)->engr_x][(ep)->engr_y].typ == CORR) ? S_engrcorr : S_engroom)
+    ((loc((ep)->engr_x, (ep)->engr_y)->typ == CORR) ? S_engrcorr : S_engroom)
 
 #define spot_shows_engravings(x,y) \
-    (levl[(x)][(y)].typ == CORR         \
-     || levl[(x)][(y)].typ == SCORR     \
-     || levl[(x)][(y)].typ == ICE       \
-     || levl[(x)][(y)].typ == ROOM )
+    (loc(x, y)->typ == CORR             \
+     || loc(x, y)->typ == SCORR         \
+     || loc(x, y)->typ == ICE           \
+     || loc(x, y)->typ == ROOM )
 
 #endif /* ENGRAVE_H */

--- a/include/rm.h
+++ b/include/rm.h
@@ -130,9 +130,9 @@ enum levl_typ_types {
    current surface at that spot; caveat: this evaluates its arguments more
    than once and might make a function call */
 #define SURFACE_AT(x,y) \
-    ((levl[x][y].typ == DRAWBRIDGE_UP)            \
-     ? db_under_typ(levl[x][y].drawbridgemask)    \
-     : levl[x][y].typ)
+    ((loc(x, y)->typ == DRAWBRIDGE_UP)               \
+     ? db_under_typ(loc(x, y)->drawbridgemask)       \
+     : loc(x, y)->typ)
 
 /*
  *      Note:  secret doors (SDOOR) want to use both rm.doormask and
@@ -180,12 +180,12 @@ enum levl_typ_types {
  */
 #define F_LOOTED 1
 #define F_WARNED 2
-#define FOUNTAIN_IS_WARNED(x, y) (levl[x][y].looted & F_WARNED)
-#define FOUNTAIN_IS_LOOTED(x, y) (levl[x][y].looted & F_LOOTED)
-#define SET_FOUNTAIN_WARNED(x, y) levl[x][y].looted |= F_WARNED;
-#define SET_FOUNTAIN_LOOTED(x, y) levl[x][y].looted |= F_LOOTED;
-#define CLEAR_FOUNTAIN_WARNED(x, y) levl[x][y].looted &= ~F_WARNED;
-#define CLEAR_FOUNTAIN_LOOTED(x, y) levl[x][y].looted &= ~F_LOOTED;
+#define FOUNTAIN_IS_WARNED(x, y) (loc(x, y)->looted & F_WARNED)
+#define FOUNTAIN_IS_LOOTED(x, y) (loc(x, y)->looted & F_LOOTED)
+#define SET_FOUNTAIN_WARNED(x, y) loc(x, y)->looted |= F_WARNED;
+#define SET_FOUNTAIN_LOOTED(x, y) loc(x, y)->looted |= F_LOOTED;
+#define CLEAR_FOUNTAIN_WARNED(x, y) loc(x, y)->looted &= ~F_WARNED;
+#define CLEAR_FOUNTAIN_LOOTED(x, y) loc(x, y)->looted &= ~F_LOOTED;
 
 /*
  * doors are even worse :-) The special warning has a side effect
@@ -441,9 +441,28 @@ typedef struct {
 /*
  * Macros for compatibility with old code. Someday these will go away.
  */
-#define levl gl.level.locations
 #define fobj gl.level.objlist
 #define fmon gl.level.monlist
+
+#ifdef DEBUG
+#define assert_level_location(x, y) { \
+    assert (x >= 0); \
+    assert (x < COLNO); \
+    assert (y >= 0); \
+    assert (y < ROWNO); \
+    }
+#else
+#define assert_level_location(x, y) { }
+#endif
+
+static inline struct rm *
+_level_locations(dlevel_t * const level, const coordxy x, const coordxy y)
+{
+    assert_level_location(x, y);
+    return &level->locations[x][y];
+}
+
+#define loc(x, y) _level_locations(&gl.level, (x), (y))
 
 /*
  * Covert a trap number into the defsym graphics array.

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -851,7 +851,7 @@ do_positionbar(void)
     for (stway = gs.stairs; stway; stway = stway->next) {
         x = stway->sx;
         y = stway->sy;
-        glyph = levl[x][y].glyph;
+        glyph = loc(x, y)->glyph;
         symbol = glyph_to_cmap(glyph);
 
         if (is_cmap_stairs(symbol)) {

--- a/src/apply.c
+++ b/src/apply.c
@@ -436,7 +436,7 @@ use_stethoscope(struct obj *obj)
     if (unmap_invisible(rx,ry))
         pline_The("invisible monster must have moved.");
 
-    lev = &levl[rx][ry];
+    lev = loc(rx, ry);
     switch (lev->typ) {
     case SDOOR:
         Soundeffect(se_hollow_sound, 100);
@@ -799,7 +799,7 @@ use_leash(struct obj *obj)
     spotmon = canspotmon(mtmp);
  got_target:
 
-    if (!spotmon && !glyph_is_invisible(levl[cc.x][cc.y].glyph)) {
+    if (!spotmon && !glyph_is_invisible(loc(cc.x, cc.y)->glyph)) {
         /* for the unleash case, we don't verify whether this unseen
            monster is the creature attached to the current leash */
         You("fail to %sleash something.", obj->leashmon ? "un" : "");
@@ -1833,7 +1833,7 @@ static boolean
 check_jump(genericptr arg, coordxy x, coordxy y)
 {
     int traj = *(int *) arg;
-    struct rm *lev = &levl[x][y];
+    struct rm *lev = loc(x, y);
 
     if (Passes_walls)
         return TRUE;
@@ -1884,7 +1884,7 @@ is_valid_jump_pos(coordxy x, coordxy y, int magic, boolean showmsg)
         return FALSE;
     } else {
         coord uc, tc;
-        struct rm *lev = &levl[u.ux][u.uy];
+        struct rm *lev = loc(u.ux, u.uy);
         /* we want to categorize trajectory for use in determining
            passage through doorways: horizonal, vertical, or diagonal;
            since knight's jump and other irregular directions are
@@ -1930,7 +1930,7 @@ static boolean
 get_valid_jump_position(coordxy x, coordxy y)
 {
     return (isok(x, y)
-            && (ACCESSIBLE(levl[x][y].typ) || Passes_walls)
+            && (ACCESSIBLE(loc(x, y)->typ) || Passes_walls)
             && is_valid_jump_pos(x, y, gj.jumping_is_magic, FALSE));
 }
 
@@ -2495,11 +2495,11 @@ figurine_location_checks(struct obj *obj, coord *cc, boolean quietly)
             You("cannot put the figurine there.");
         return FALSE;
     }
-    if (IS_ROCK(levl[x][y].typ)
+    if (IS_ROCK(loc(x, y)->typ)
         && !(passes_walls(&mons[obj->corpsenm]) && may_passwall(x, y))) {
         if (!quietly)
             You("cannot place a figurine in %s!",
-                IS_TREE(levl[x][y].typ) ? "a tree" : "solid rock");
+                IS_TREE(loc(x, y)->typ) ? "a tree" : "solid rock");
         return FALSE;
     }
     if (sobj_at(BOULDER, x, y) && !passes_walls(&mons[obj->corpsenm])
@@ -2792,7 +2792,7 @@ use_trap(struct obj *otmp)
     int ttyp, tmp;
     const char *what = (char *) 0;
     char buf[BUFSZ];
-    int levtyp = levl[u.ux][u.uy].typ;
+    int levtyp = loc(u.ux, u.uy)->typ;
     const char *occutext = "setting the trap";
 
     if (nohands(gy.youmonst.data))
@@ -2979,10 +2979,10 @@ use_whip(struct obj *obj)
     } else if (u.dz < 0) {
         You("flick a bug off of the %s.", ceiling(u.ux, u.uy));
 
-    } else if (!u.dz && (IS_WATERWALL(levl[rx][ry].typ)
-                         || levl[rx][ry].typ == LAVAWALL)) {
+    } else if (!u.dz && (IS_WATERWALL(loc(rx, ry)->typ)
+                         || loc(rx, ry)->typ == LAVAWALL)) {
         You("cause a small splash.");
-        if (levl[rx][ry].typ == LAVAWALL)
+        if (loc(rx, ry)->typ == LAVAWALL)
             (void) fire_damage(uwep, FALSE, rx, ry);
         return ECMD_TIME;
     } else if ((!u.dx && !u.dy) || (u.dz > 0)) {
@@ -2995,8 +2995,8 @@ use_whip(struct obj *obj)
             return ECMD_TIME;
         }
         if (is_pool_or_lava(u.ux, u.uy)
-            || IS_WATERWALL(levl[rx][ry].typ)
-            || levl[rx][ry].typ == LAVAWALL) {
+            || IS_WATERWALL(loc(rx, ry)->typ)
+            || loc(rx, ry)->typ == LAVAWALL) {
             You("cause a small splash.");
             if (is_lava(u.ux, u.uy))
                 (void) fire_damage(uwep, FALSE, u.ux, u.uy);
@@ -3055,7 +3055,7 @@ use_whip(struct obj *obj)
          *    - you only end up hitting.
          */
         const char *wrapped_what = sobj_at(BOULDER, rx, ry) ? "a boulder"
-                                   : IS_FURNITURE(levl[rx][ry].typ)
+                                   : IS_FURNITURE(loc(rx, ry)->typ)
                                      ? something : (char *) 0;
 
         if (mtmp) {
@@ -3103,7 +3103,7 @@ use_whip(struct obj *obj)
                brought out of hiding has exposed it (might not if hero is
                blind or formerly hidden monster is also invisible) */
             spotitnow = canspotmon(mtmp);
-            if (spotitnow || !glyph_is_invisible(levl[rx][ry].glyph)) {
+            if (spotitnow || !glyph_is_invisible(loc(rx, ry)->glyph)) {
                 pline("%s is there that you %s.",
                       !spotitnow ? "A monster" : Amonnam(mtmp),
                       !Blind ? "couldn't see" : "hadn't noticed");
@@ -3450,12 +3450,12 @@ use_pole(struct obj *obj, boolean autohit)
             pline(thump, "boulder");
             wake_nearto(gb.bhitpos.x, gb.bhitpos.y, 25);
         } else if (!accessible(gb.bhitpos.x, gb.bhitpos.y)
-                   || IS_FURNITURE(levl[gb.bhitpos.x][gb.bhitpos.y].typ)) {
+                   || IS_FURNITURE(loc(gb.bhitpos.x, gb.bhitpos.y)->typ)) {
             /* similar to 'F'orcefight with a melee weapon; we know that
                the spot can be seen or we wouldn't have gotten this far */
             You("uselessly attack %s.",
-                (levl[gb.bhitpos.x][gb.bhitpos.y].typ == STONE
-                 || levl[gb.bhitpos.x][gb.bhitpos.y].typ == SCORR)
+                (loc(gb.bhitpos.x, gb.bhitpos.y)->typ == STONE
+                 || loc(gb.bhitpos.x, gb.bhitpos.y)->typ == SCORR)
                 ? "stone"
                 : glyph_is_cmap(glyph)
                   ? the(defsyms[glyph_to_cmap(glyph)].explanation)
@@ -3756,7 +3756,7 @@ use_grapple(struct obj *obj)
         }
     /*FALLTHRU*/
     case 3: /* Surface */
-        if (IS_AIR(levl[cc.x][cc.y].typ) || is_pool(cc.x, cc.y))
+        if (IS_AIR(loc(cc.x, cc.y)->typ) || is_pool(cc.x, cc.y))
             pline_The("hook slices through the %s.", surface(cc.x, cc.y));
         else {
             You("are yanked toward the %s!", surface(cc.x, cc.y));
@@ -3934,7 +3934,7 @@ do_break_wand(struct obj *obj)
             schar typ;
 
             if (dig_check(BY_OBJECT, FALSE, x, y)) {
-                if (IS_WALL(levl[x][y].typ) || IS_DOOR(levl[x][y].typ)) {
+                if (IS_WALL(loc(x, y)->typ) || IS_DOOR(loc(x, y)->typ)) {
                     /* normally, pits and holes don't anger guards, but they
                      * do if it's a wall or door that's being dug */
                     watch_dig((struct monst *) 0, x, y, TRUE);
@@ -3948,7 +3948,8 @@ do_break_wand(struct obj *obj)
                  */
                 typ = fillholetyp(x, y, FALSE);
                 if (typ != ROOM) {
-                    levl[x][y].typ = typ, levl[x][y].flags = 0;
+                    loc(x, y)->typ = typ;
+                    loc(x, y)->flags = 0;
                     liquid_flow(x, y, typ, t_at(x, y),
                                 fillmsg
                                   ? (char *) 0
@@ -3958,7 +3959,7 @@ do_break_wand(struct obj *obj)
                     digactualhole(x, y, BY_OBJECT,
                                   (rn2(obj->spe) < 3
                                    || (!Can_dig_down(&u.uz)
-                                       && !levl[x][y].candig)) ? PIT : HOLE);
+                                       && !loc(x, y)->candig)) ? PIT : HOLE);
                 }
             }
             continue;

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -2314,7 +2314,7 @@ retouch_object(
         } else {
             /* dropx gives a message if a dropped item lands on an altar;
                we provide one for other terrain */
-            if (!IS_ALTAR(levl[u.ux][u.uy].typ))
+            if (!IS_ALTAR(loc(u.ux, u.uy)->typ))
                 pline("%s to the %s.", Tobjnam(obj, "fall"),
                       surface(u.ux, u.uy));
             dropx(obj);
@@ -2463,7 +2463,7 @@ count_surround_traps(coordxy x, coordxy y)
                 ++ret;
                 continue;
             }
-            levp = &levl[dx][dy];
+            levp = loc(dx, dy);
             if (IS_DOOR(levp->typ) && (levp->doormask & D_TRAPPED) != 0) {
                 ++ret;
                 continue;

--- a/src/ball.c
+++ b/src/ball.c
@@ -137,7 +137,7 @@ placebc_core(void)
 
     place_object(uchain, u.ux, u.uy);
 
-    u.bglyph = u.cglyph = levl[u.ux][u.uy].glyph; /* pick up glyph */
+    u.bglyph = u.cglyph = loc(u.ux, u.uy)->glyph; /* pick up glyph */
 
     newsym(u.ux, u.uy);
     bcrestriction = 0;
@@ -163,13 +163,13 @@ unplacebc_core(void)
     if (!carried(uball)) {
         obj_extract_self(uball);
         if (Blind && (u.bc_felt & BC_BALL)) /* drop glyph */
-            levl[uball->ox][uball->oy].glyph = u.bglyph;
+            loc(uball->ox, uball->oy)->glyph = u.bglyph;
         maybe_unhide_at(uball->ox, uball->oy);
         newsym(uball->ox, uball->oy);
     }
     obj_extract_self(uchain);
     if (Blind && (u.bc_felt & BC_CHAIN)) /* drop glyph */
-        levl[uchain->ox][uchain->oy].glyph = u.cglyph;
+        loc(uchain->ox, uchain->oy)->glyph = u.cglyph;
     maybe_unhide_at(uchain->ox, uchain->oy);
 
     newsym(uchain->ox, uchain->oy);
@@ -385,7 +385,7 @@ set_bc(int already_blind)
     u.bc_felt = ball_on_floor ? BC_BALL | BC_CHAIN : BC_CHAIN; /* felt */
 
     if (already_blind || u.uswallow) {
-        u.cglyph = u.bglyph = levl[u.ux][u.uy].glyph;
+        u.cglyph = u.bglyph = loc(u.ux, u.uy)->glyph;
         return;
     }
 
@@ -399,14 +399,14 @@ set_bc(int already_blind)
         remove_object(uball);
 
     newsym(uchain->ox, uchain->oy);
-    u.cglyph = levl[uchain->ox][uchain->oy].glyph;
+    u.cglyph = loc(uchain->ox, uchain->oy)->glyph;
 
     if (u.bc_order == BCPOS_DIFFER) { /* different locations */
         place_object(uchain, uchain->ox, uchain->oy);
         newsym(uchain->ox, uchain->oy);
         if (ball_on_floor) {
             newsym(uball->ox, uball->oy); /* see under ball */
-            u.bglyph = levl[uball->ox][uball->oy].glyph;
+            u.bglyph = loc(uball->ox, uball->oy)->glyph;
             place_object(uball, uball->ox, uball->oy);
             newsym(uball->ox, uball->oy); /* restore ball */
         }
@@ -454,26 +454,26 @@ move_bc(int before, int control, coordxy ballx, coordxy bally,
                  *  Both ball and chain moved.  If felt, drop glyph.
                  */
                 if (u.bc_felt & BC_BALL)
-                    levl[uball->ox][uball->oy].glyph = u.bglyph;
+                    loc(uball->ox, uball->oy)->glyph = u.bglyph;
                 if (u.bc_felt & BC_CHAIN)
-                    levl[uchain->ox][uchain->oy].glyph = u.cglyph;
+                    loc(uchain->ox, uchain->oy)->glyph = u.cglyph;
                 u.bc_felt = 0;
 
                 /* Pick up glyph at new location. */
-                u.bglyph = levl[ballx][bally].glyph;
-                u.cglyph = levl[chainx][chainy].glyph;
+                u.bglyph = loc(ballx, bally)->glyph;
+                u.cglyph = loc(chainx, chainy)->glyph;
 
                 movobj(uball, ballx, bally);
                 movobj(uchain, chainx, chainy);
             } else if (control & BC_BALL) {
                 if (u.bc_felt & BC_BALL) {
                     if (u.bc_order == BCPOS_DIFFER) { /* ball by itself */
-                        levl[uball->ox][uball->oy].glyph = u.bglyph;
+                        loc(uball->ox, uball->oy)->glyph = u.bglyph;
                     } else if (u.bc_order == BCPOS_BALL) {
                         if (u.bc_felt & BC_CHAIN) { /* know chain is there */
                             map_object(uchain, 0);
                         } else {
-                            levl[uball->ox][uball->oy].glyph = u.bglyph;
+                            loc(uball->ox, uball->oy)->glyph = u.bglyph;
                         }
                     }
                     u.bc_felt &= ~BC_BALL; /* no longer feel the ball */
@@ -481,26 +481,26 @@ move_bc(int before, int control, coordxy ballx, coordxy bally,
 
                 /* Pick up glyph at new position. */
                 u.bglyph = (ballx != chainx || bally != chainy)
-                               ? levl[ballx][bally].glyph
+                               ? loc(ballx, bally)->glyph
                                : u.cglyph;
 
                 movobj(uball, ballx, bally);
             } else if (control & BC_CHAIN) {
                 if (u.bc_felt & BC_CHAIN) {
                     if (u.bc_order == BCPOS_DIFFER) {
-                        levl[uchain->ox][uchain->oy].glyph = u.cglyph;
+                        loc(uchain->ox, uchain->oy)->glyph = u.cglyph;
                     } else if (u.bc_order == BCPOS_CHAIN) {
                         if (u.bc_felt & BC_BALL) {
                             map_object(uball, 0);
                         } else {
-                            levl[uchain->ox][uchain->oy].glyph = u.cglyph;
+                            loc(uchain->ox, uchain->oy)->glyph = u.cglyph;
                         }
                     }
                     u.bc_felt &= ~BC_CHAIN;
                 }
                 /* Pick up glyph at new position. */
                 u.cglyph = (ballx != chainx || bally != chainy)
-                               ? levl[chainx][chainy].glyph
+                               ? loc(chainx, chainy)->glyph
                                : u.bglyph;
 
                 movobj(uchain, chainx, chainy);
@@ -609,9 +609,9 @@ drag_ball(coordxy x, coordxy y, int *bc_control,
     (distmin(x, y, chx, chy) <= 1 \
      && distmin(chx, chy, uball->ox, uball->oy) <= 1)
 #define IS_CHAIN_ROCK(x, y)      \
-    (IS_ROCK(levl[x][y].typ)     \
-     || (IS_DOOR(levl[x][y].typ) \
-         && (levl[x][y].doormask & (D_CLOSED | D_LOCKED))))
+    (IS_ROCK(loc(x, y)->typ)     \
+     || (IS_DOOR(loc(x, y)->typ) \
+         && (loc(x, y)->doormask & (D_CLOSED | D_LOCKED))))
     /*
      * Don't ever move the chain into solid rock.  If we have to, then
      * instead undo the move_bc() and jump to the drag ball code.  Note
@@ -781,9 +781,9 @@ drag_ball(coordxy x, coordxy y, int *bc_control,
 
     if ((is_pool(uchain->ox, uchain->oy)
          /* water not mere continuation of previous water */
-         && (levl[uchain->ox][uchain->oy].typ == POOL
+         && (loc(uchain->ox, uchain->oy)->typ == POOL
              || !is_pool(uball->ox, uball->oy)
-             || levl[uball->ox][uball->oy].typ == POOL))
+             || loc(uball->ox, uball->oy)->typ == POOL))
         || ((t = t_at(uchain->ox, uchain->oy))
             && (is_pit(t->ttyp) || is_hole(t->ttyp)))) {
         if (Levitation) {
@@ -886,7 +886,7 @@ drop_ball(coordxy x, coordxy y)
         /* get the order */
         u.bc_order = bc_order();
         /* pick up glyph */
-        u.bglyph = (u.bc_order) ? u.cglyph : levl[x][y].glyph;
+        u.bglyph = (u.bc_order) ? u.cglyph : loc(x, y)->glyph;
     }
 
     if (x != u.ux || y != u.uy) {
@@ -945,10 +945,10 @@ drop_ball(coordxy x, coordxy y)
         if (Blind) {
             /* drop glyph under the chain */
             if (u.bc_felt & BC_CHAIN)
-                levl[uchain->ox][uchain->oy].glyph = u.cglyph;
+                loc(uchain->ox, uchain->oy)->glyph = u.cglyph;
             u.bc_felt = 0; /* feel nothing */
             /* pick up new glyph */
-            u.cglyph = (u.bc_order) ? u.bglyph : levl[u.ux][u.uy].glyph;
+            u.cglyph = (u.bc_order) ? u.bglyph : loc(u.ux, u.uy)->glyph;
         }
         movobj(uchain, u.ux, u.uy); /* has a newsym */
         if (Blind) {

--- a/src/bones.c
+++ b/src/bones.c
@@ -316,7 +316,7 @@ fixuporacle(struct monst *oracle)
         return FALSE;
 
     oracle->mpeaceful = 1; /* for behavior toward next character */
-    o_ridx = levl[oracle->mx][oracle->my].roomno - ROOMOFFSET;
+    o_ridx = loc(oracle->mx, oracle->my)->roomno - ROOMOFFSET;
     if (o_ridx >= 0 && gr.rooms[o_ridx].rtype == DELPHI)
         return TRUE; /* no fixup needed */
 
@@ -338,7 +338,7 @@ fixuporacle(struct monst *oracle)
         cc.y = (gr.rooms[ridx].ly + gr.rooms[ridx].hy) / 2;
         if (enexto(&cc, cc.x, cc.y, oracle->data)) {
             rloc_to(oracle, cc.x, cc.y);
-            o_ridx = levl[oracle->mx][oracle->my].roomno - ROOMOFFSET;
+            o_ridx = loc(oracle->mx, oracle->my)->roomno - ROOMOFFSET;
         }
         /* [if her room is already full, she might end up outside;
            that's ok, next hero just won't get any welcome message,
@@ -531,9 +531,9 @@ savebones(int how, time_t when, struct obj *corpse)
     /* Clear all memory from the level. */
     for (x = 1; x < COLNO; x++)
         for (y = 0; y < ROWNO; y++) {
-            levl[x][y].seenv = 0;
-            levl[x][y].waslit = 0;
-            levl[x][y].glyph = GLYPH_UNEXPLORED;
+            loc(x, y)->seenv = 0;
+            loc(x, y)->waslit = 0;
+            loc(x, y)->glyph = GLYPH_UNEXPLORED;
             gl.lastseentyp[x][y] = 0;
         }
 

--- a/src/botl.c
+++ b/src/botl.c
@@ -955,7 +955,7 @@ bot_via_windowport(void)
     condtests[bl_submerged].test = (Underwater) ? TRUE : FALSE;
     test_if_enabled(bl_elf_iron) = (FALSE);
     test_if_enabled(bl_bareh)    = (!uarmg && !uwep);
-    test_if_enabled(bl_icy)      = (levl[u.ux][u.uy].typ == ICE);
+    test_if_enabled(bl_icy)      = (loc(u.ux, u.uy)->typ == ICE);
     test_if_enabled(bl_slippery) = (Glib) ? TRUE : FALSE;
     test_if_enabled(bl_woundedl) = (Wounded_legs) ? TRUE : FALSE;
 

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -933,7 +933,7 @@ domonability(void)
     else if (is_mind_flayer(uptr))
         return domindblast();
     else if (u.umonnum == PM_GREMLIN) {
-        if (IS_FOUNTAIN(levl[u.ux][u.uy].typ)) {
+        if (IS_FOUNTAIN(loc(u.ux, u.uy)->typ)) {
             if (split_mon(&gy.youmonst, (struct monst *) 0))
                 dryup(u.ux, u.uy, TRUE);
         } else
@@ -1624,7 +1624,7 @@ wiz_show_seenv(void)
             if (u_at(x, y)) {
                 row[curx] = row[curx + 1] = '@';
             } else {
-                v = levl[x][y].seenv & 0xff;
+                v = loc(x, y)->seenv & 0xff;
                 if (v == 0)
                     row[curx] = row[curx + 1] = ' ';
                 else
@@ -1695,7 +1695,7 @@ wiz_show_wmodes(void)
         putstr(win, 0, ""); /* tty only: blank top line */
     for (y = 0; y < ROWNO; y++) {
         for (x = 0; x < COLNO; x++) {
-            lev = &levl[x][y];
+            lev = loc(x, y);
             if (u_at(x, y))
                 row[x] = '@';
             else if (IS_WALL(lev->typ) || lev->typ == SDOOR)
@@ -1708,7 +1708,7 @@ wiz_show_wmodes(void)
                 row[x] = 'x';
         }
         row[COLNO] = '\0';
-        /* map column 0, levl[0][], is off the left edge of the screen */
+        /* map column 0, loc(0, )-> is off the left edge of the screen */
         putstr(win, 0, &row[1]);
     }
     display_nhwindow(win, TRUE);
@@ -1716,7 +1716,7 @@ wiz_show_wmodes(void)
     return ECMD_OK;
 }
 
-/* wizard mode variant of #terrain; internal levl[][].typ values in base-36 */
+/* wizard mode variant of #terrain; internal loc(, )->typ values in base-36 */
 static void
 wiz_map_levltyp(void)
 {
@@ -1727,14 +1727,14 @@ wiz_map_levltyp(void)
     boolean istty = !strcmp(windowprocs.name, "tty");
 
     win = create_nhwindow(NHW_TEXT);
-    /* map row 0, levl[][0], is drawn on the second line of tty screen */
+    /* map row 0, loc(, 0)-> is drawn on the second line of tty screen */
     if (istty)
         putstr(win, 0, ""); /* tty only: blank top line */
     for (y = 0; y < ROWNO; y++) {
-        /* map column 0, levl[0][], is off the left edge of the screen;
+        /* map column 0, loc(0, )-> is off the left edge of the screen;
            it should always have terrain type "undiggable stone" */
         for (x = 1; x < COLNO; x++) {
-            terrain = levl[x][y].typ;
+            terrain = loc(x, y)->typ;
             /* assumes there aren't more than 10+26+26 terrain types */
             row[x - 1] = (char) ((terrain == STONE && !may_dig(x, y))
                                     ? '*'
@@ -1745,7 +1745,7 @@ wiz_map_levltyp(void)
                                           : 'A' + terrain - 36);
         }
         x--;
-        if (levl[0][y].typ != STONE || may_dig(0, y))
+        if (loc(0, y)->typ != STONE || may_dig(0, y))
             row[x++] = '!';
         row[x] = '\0';
         putstr(win, 0, row);
@@ -2176,8 +2176,8 @@ doterrain(void)
      *  known map without mons (to see objects under monsters);
      * explore mode: normal choices plus full map (w/o mons, objs, traps);
      * wizard mode: normal and explore choices plus
-     *  a dump of the internal levl[][].typ codes w/ level flags, or
-     *  a legend for the levl[][].typ codes dump
+     *  a dump of the internal loc(, )->typ codes w/ level flags, or
+     *  a legend for the loc(, )->typ codes dump
      */
     men = create_nhwindow(NHW_MENU);
     start_menu(men, MENU_BEHAVE_STANDARD);
@@ -2202,11 +2202,11 @@ doterrain(void)
         if (wizard) {
             any.a_int = 5;
             add_menu(men, &nul_glyphinfo, &any, 0, 0, ATR_NONE,
-                     clr, "internal levl[][].typ codes in base-36",
+                     clr, "internal loc(, )->typ codes in base-36",
                      MENU_ITEMFLAGS_NONE);
             any.a_int = 6;
             add_menu(men, &nul_glyphinfo, &any, 0, 0, ATR_NONE,
-                     clr, "legend of base-36 levl[][].typ codes",
+                     clr, "legend of base-36 loc(, )->typ codes",
                      MENU_ITEMFLAGS_NONE);
         }
     }
@@ -5662,7 +5662,7 @@ there_cmd_menu_self(winid win, coordxy x, coordxy y, int *act UNUSED)
 {
     int K = 0;
     char buf[BUFSZ];
-    schar typ = levl[x][y].typ;
+    schar typ = loc(x, y)->typ;
     stairway *stway = stairway_at(x, y);
     struct trap *ttmp;
 
@@ -5755,7 +5755,7 @@ there_cmd_menu_next2u(
 {
     int K = 0;
     char buf[BUFSZ];
-    schar typ = levl[x][y].typ;
+    schar typ = loc(x, y)->typ;
     struct trap *ttmp;
     struct monst *mtmp;
 
@@ -5764,7 +5764,7 @@ there_cmd_menu_next2u(
 
     if (IS_DOOR(typ)) {
         boolean key_or_pick, card;
-        int dm = levl[x][y].doormask;
+        int dm = loc(x, y)->doormask;
 
         if ((dm & (D_CLOSED | D_LOCKED))) {
             mcmd_addmenu(win, MCMD_OPEN_DOOR, "Open the door"), ++K;
@@ -5799,7 +5799,7 @@ there_cmd_menu_next2u(
         mcmd_addmenu(win, MCMD_MOVE_DIR, "Move on the trap"), ++K;
     }
 
-    if (levl[x][y].glyph == objnum_to_glyph(BOULDER))
+    if (loc(x, y)->glyph == objnum_to_glyph(BOULDER))
         mcmd_addmenu(win, MCMD_MOVE_DIR, "Push the boulder"), ++K;
 
     mtmp = m_at(x, y);
@@ -6160,11 +6160,11 @@ domouseaction(void)
 
         if (x == 0 && y == 0) {
             /* here */
-            if (IS_FOUNTAIN(levl[u.ux][u.uy].typ)
-                || IS_SINK(levl[u.ux][u.uy].typ)) {
+            if (IS_FOUNTAIN(loc(u.ux, u.uy)->typ)
+                || IS_SINK(loc(u.ux, u.uy)->typ)) {
                 cmdq_add_ec(CQ_CANNED, dodrink);
                 return ECMD_OK;
-            } else if (IS_THRONE(levl[u.ux][u.uy].typ)) {
+            } else if (IS_THRONE(loc(u.ux, u.uy)->typ)) {
                 cmdq_add_ec(CQ_CANNED, dosit);
                 return ECMD_OK;
             } else if (On_stairs_up(u.ux, u.uy)) {
@@ -6187,18 +6187,18 @@ domouseaction(void)
         dir = xytod(x, y);
         if (!m_at(u.ux + x, u.uy + y)
             && !test_move(u.ux, u.uy, x, y, TEST_MOVE)) {
-            if (IS_DOOR(levl[u.ux + x][u.uy + y].typ)) {
+            if (IS_DOOR(loc(u.ux + x, u.uy + y)->typ)) {
                 /* slight assistance to player: choose kick/open for them */
-                if (levl[u.ux + x][u.uy + y].doormask & D_LOCKED) {
+                if (loc(u.ux + x, u.uy + y)->doormask & D_LOCKED) {
                     cmdq_add_ec(CQ_CANNED, dokick);
                     return ECMD_OK;
                 }
-                if (levl[u.ux + x][u.uy + y].doormask & D_CLOSED) {
+                if (loc(u.ux + x, u.uy + y)->doormask & D_CLOSED) {
                     cmdq_add_ec(CQ_CANNED, doopen);
                     return ECMD_OK;
                 }
             }
-            if (levl[u.ux + x][u.uy + y].typ <= SCORR) {
+            if (loc(u.ux + x, u.uy + y)->typ <= SCORR) {
                 cmdq_add_ec(CQ_CANNED, dosearch);
                 return ECMD_OK;
             }

--- a/src/dbridge.c
+++ b/src/dbridge.c
@@ -37,7 +37,7 @@ static void nokiller(void);
 boolean
 is_waterwall(coordxy x, coordxy y)
 {
-    if (isok(x, y) && IS_WATERWALL(levl[x][y].typ))
+    if (isok(x, y) && IS_WATERWALL(loc(x, y)->typ))
         return TRUE;
     return FALSE;
 }
@@ -49,7 +49,7 @@ is_pool(coordxy x, coordxy y)
 
     if (!isok(x, y))
         return FALSE;
-    ltyp = levl[x][y].typ;
+    ltyp = loc(x, y)->typ;
     /* The ltyp == MOAT is not redundant with is_moat, because the
      * Juiblex level does not have moats, although it has MOATs. There
      * is probably a better way to express this. */
@@ -65,10 +65,10 @@ is_lava(coordxy x, coordxy y)
 
     if (!isok(x, y))
         return FALSE;
-    ltyp = levl[x][y].typ;
+    ltyp = loc(x, y)->typ;
     if (ltyp == LAVAPOOL || ltyp == LAVAWALL
         || (ltyp == DRAWBRIDGE_UP
-            && (levl[x][y].drawbridgemask & DB_UNDER) == DB_LAVA))
+            && (loc(x, y)->drawbridgemask & DB_UNDER) == DB_LAVA))
         return TRUE;
     return FALSE;
 }
@@ -89,9 +89,9 @@ is_ice(coordxy x, coordxy y)
 
     if (!isok(x, y))
         return FALSE;
-    ltyp = levl[x][y].typ;
+    ltyp = loc(x, y)->typ;
     if (ltyp == ICE || (ltyp == DRAWBRIDGE_UP
-                        && (levl[x][y].drawbridgemask & DB_UNDER) == DB_ICE))
+                        && (loc(x, y)->drawbridgemask & DB_UNDER) == DB_ICE))
         return TRUE;
     return FALSE;
 }
@@ -103,11 +103,11 @@ is_moat(coordxy x, coordxy y)
 
     if (!isok(x, y))
         return FALSE;
-    ltyp = levl[x][y].typ;
+    ltyp = loc(x, y)->typ;
     if (!Is_juiblex_level(&u.uz)
         && (ltyp == MOAT
             || (ltyp == DRAWBRIDGE_UP
-                && (levl[x][y].drawbridgemask & DB_UNDER) == DB_MOAT)))
+                && (loc(x, y)->drawbridgemask & DB_UNDER) == DB_MOAT)))
         return TRUE;
     return FALSE;
 }
@@ -139,21 +139,21 @@ is_drawbridge_wall(coordxy x, coordxy y)
 {
     struct rm *lev;
 
-    lev = &levl[x][y];
+    lev = loc(x, y);
     if (lev->typ != DOOR && lev->typ != DBWALL)
         return -1;
 
-    if (IS_DRAWBRIDGE(levl[x + 1][y].typ)
-        && (levl[x + 1][y].drawbridgemask & DB_DIR) == DB_WEST)
+    if (IS_DRAWBRIDGE(loc(x + 1, y)->typ)
+        && (loc(x + 1, y)->drawbridgemask & DB_DIR) == DB_WEST)
         return DB_WEST;
-    if (IS_DRAWBRIDGE(levl[x - 1][y].typ)
-        && (levl[x - 1][y].drawbridgemask & DB_DIR) == DB_EAST)
+    if (IS_DRAWBRIDGE(loc(x - 1, y)->typ)
+        && (loc(x - 1, y)->drawbridgemask & DB_DIR) == DB_EAST)
         return DB_EAST;
-    if (IS_DRAWBRIDGE(levl[x][y - 1].typ)
-        && (levl[x][y - 1].drawbridgemask & DB_DIR) == DB_SOUTH)
+    if (IS_DRAWBRIDGE(loc(x, y - 1)->typ)
+        && (loc(x, y - 1)->drawbridgemask & DB_DIR) == DB_SOUTH)
         return DB_SOUTH;
-    if (IS_DRAWBRIDGE(levl[x][y + 1].typ)
-        && (levl[x][y + 1].drawbridgemask & DB_DIR) == DB_NORTH)
+    if (IS_DRAWBRIDGE(loc(x, y + 1)->typ)
+        && (loc(x, y + 1)->drawbridgemask & DB_DIR) == DB_NORTH)
         return DB_NORTH;
 
     return -1;
@@ -167,7 +167,7 @@ is_drawbridge_wall(coordxy x, coordxy y)
 boolean
 is_db_wall(coordxy x, coordxy y)
 {
-    return (boolean) (levl[x][y].typ == DBWALL);
+    return (boolean) (loc(x, y)->typ == DBWALL);
 }
 
 /*
@@ -179,7 +179,7 @@ find_drawbridge(coordxy *x, coordxy *y)
 {
     int dir;
 
-    if (IS_DRAWBRIDGE(levl[*x][*y].typ))
+    if (IS_DRAWBRIDGE(loc(*x, *y)->typ))
         return TRUE;
     dir = is_drawbridge_wall(*x, *y);
     if (dir >= 0) {
@@ -208,7 +208,7 @@ find_drawbridge(coordxy *x, coordxy *y)
 static void
 get_wall_for_db(coordxy *x, coordxy *y)
 {
-    switch (levl[*x][*y].drawbridgemask & DB_DIR) {
+    switch (loc(*x, *y)->drawbridgemask & DB_DIR) {
     case DB_NORTH:
         (*y)--;
         break;
@@ -234,7 +234,7 @@ create_drawbridge(coordxy x, coordxy y, int dir, boolean flag)
 {
     coordxy x2, y2;
     boolean horiz;
-    boolean lava = levl[x][y].typ == LAVAPOOL; /* assume initialized map */
+    boolean lava = loc(x, y)->typ == LAVAPOOL; /* assume initialized map */
 
     x2 = x;
     y2 = y;
@@ -259,23 +259,23 @@ create_drawbridge(coordxy x, coordxy y, int dir, boolean flag)
         x2--;
         break;
     }
-    if (!IS_WALL(levl[x2][y2].typ))
+    if (!IS_WALL(loc(x2, y2)->typ))
         return FALSE;
     if (flag) { /* We want the bridge open */
-        levl[x][y].typ = DRAWBRIDGE_DOWN;
-        levl[x2][y2].typ = DOOR;
-        levl[x2][y2].doormask = D_NODOOR;
+        loc(x, y)->typ = DRAWBRIDGE_DOWN;
+        loc(x2, y2)->typ = DOOR;
+        loc(x2, y2)->doormask = D_NODOOR;
     } else {
-        levl[x][y].typ = DRAWBRIDGE_UP;
-        levl[x2][y2].typ = DBWALL;
+        loc(x, y)->typ = DRAWBRIDGE_UP;
+        loc(x2, y2)->typ = DBWALL;
         /* Drawbridges are non-diggable. */
-        levl[x2][y2].wall_info = W_NONDIGGABLE;
+        loc(x2, y2)->wall_info = W_NONDIGGABLE;
     }
-    levl[x][y].horizontal = !horiz;
-    levl[x2][y2].horizontal = horiz;
-    levl[x][y].drawbridgemask = dir;
+    loc(x, y)->horizontal = !horiz;
+    loc(x2, y2)->horizontal = horiz;
+    loc(x, y)->drawbridgemask = dir;
     if (lava)
-        levl[x][y].drawbridgemask |= DB_LAVA;
+        loc(x, y)->drawbridgemask |= DB_LAVA;
     return  TRUE;
 }
 
@@ -539,7 +539,7 @@ do_entity(struct entity *etmp)
     oldx = etmp->ex;
     oldy = etmp->ey;
     at_portcullis = is_db_wall(oldx, oldy);
-    crm = &levl[oldx][oldy];
+    crm = loc(oldx, oldy);
 
     if (automiss(etmp) && e_survives_at(etmp, oldx, oldy)) {
         if (e_inview && (at_portcullis || IS_DRAWBRIDGE(crm->typ)))
@@ -752,7 +752,7 @@ close_drawbridge(coordxy x, coordxy y)
     struct trap *t;
     coordxy x2, y2;
 
-    lev1 = &levl[x][y];
+    lev1 = loc(x, y);
     if (lev1->typ != DRAWBRIDGE_DOWN)
         return;
     x2 = x;
@@ -769,7 +769,7 @@ close_drawbridge(coordxy x, coordxy y)
         You_hear("chains rattling and gears turning.");
     }
     lev1->typ = DRAWBRIDGE_UP;
-    lev2 = &levl[x2][y2];
+    lev2 = loc(x2, y2);
     lev2->typ = DBWALL;
     switch (lev1->drawbridgemask & DB_DIR) {
     case DB_NORTH:
@@ -817,7 +817,7 @@ open_drawbridge(coordxy x, coordxy y)
     struct trap *t;
     coordxy x2, y2;
 
-    lev1 = &levl[x][y];
+    lev1 = loc(x, y);
     if (lev1->typ != DRAWBRIDGE_UP)
         return;
     x2 = x;
@@ -831,7 +831,7 @@ open_drawbridge(coordxy x, coordxy y)
         You_hear("gears turning and chains rattling.");
     }
     lev1->typ = DRAWBRIDGE_DOWN;
-    lev2 = &levl[x2][y2];
+    lev2 = loc(x2, y2);
     lev2->typ = DOOR;
     lev2->doormask = D_NODOOR;
     set_entity(x, y, &(go.occupants[0]));
@@ -869,13 +869,13 @@ destroy_drawbridge(coordxy x, coordxy y)
     boolean e_inview;
     struct entity *etmp1 = &(go.occupants[0]), *etmp2 = &(go.occupants[1]);
 
-    lev1 = &levl[x][y];
+    lev1 = loc(x, y);
     if (!IS_DRAWBRIDGE(lev1->typ))
         return;
     x2 = x;
     y2 = y;
     get_wall_for_db(&x2, &y2);
-    lev2 = &levl[x2][y2];
+    lev2 = loc(x2, y2);
     if ((lev1->drawbridgemask & DB_UNDER) == DB_MOAT
         || (lev1->drawbridgemask & DB_UNDER) == DB_LAVA) {
         struct obj *otmp2;
@@ -983,7 +983,7 @@ destroy_drawbridge(coordxy x, coordxy y)
             e_died(etmp1,
                    XKILL_NOCORPSE | (e_inview ? XKILL_GIVEMSG : XKILL_NOMSG),
                    CRUSHING); /*no corpse*/
-            if (levl[etmp1->ex][etmp1->ey].typ == MOAT)
+            if (loc(etmp1->ex, etmp1->ey)->typ == MOAT)
                 do_entity(etmp1);
         }
     }

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -363,8 +363,8 @@ cmp_coord_distu(const void *a, const void *b)
 
 #define IS_UNEXPLORED_LOC(x,y) \
     (isok((x), (y))                                             \
-     && glyph_is_unexplored(levl[(x)][(y)].glyph)               \
-     && !levl[(x)][(y)].seenv)
+     && glyph_is_unexplored(loc((x), (y))->glyph)               \
+     && !loc((x), (y))->seenv)
 
 #define GLOC_SAME_AREA(x,y) \
     (isok((x), (y))                                             \
@@ -398,7 +398,7 @@ gloc_filter_floodfill_matcharea(coordxy x, coordxy y)
 {
     int glyph = back_to_glyph(x, y);
 
-    if (!levl[x][y].seenv)
+    if (!loc(x, y)->seenv)
         return FALSE;
 
     if (glyph == gg.gloc_filter_floodfill_match_glyph)
@@ -429,7 +429,7 @@ gloc_filter_init(void)
         }
         /* special case: if we're in a doorway, try to figure out which
            direction we're moving, and use that side of the doorway */
-        if (IS_DOOR(levl[u.ux][u.uy].typ)) {
+        if (IS_DOOR(loc(u.ux, u.uy)->typ)) {
             if (u.dx || u.dy) {
                 gloc_filter_floodfill(u.ux + u.dx, u.uy + u.dy);
             } else {
@@ -1092,14 +1092,14 @@ getpos(coord *ccp, boolean force, const char *goal)
                                     /* !terrainmode: don't move to remembered
                                        trap or object if not currently shown */
                                     && !iflags.terrainmode) {
-                                    k = levl[tx][ty].glyph;
+                                    k = loc(tx, ty)->glyph;
                                     if (glyph_is_cmap(k)
                                         && matching[glyph_to_cmap(k)])
                                         goto foundc;
                                 }
                                 /* last, try actual terrain here (shouldn't
                                    we be using gl.lastseentyp[][] instead?) */
-                                if (levl[tx][ty].seenv) {
+                                if (loc(tx, ty)->seenv) {
                                     k = back_to_glyph(tx, ty);
                                     if (glyph_is_cmap(k)
                                         && matching[glyph_to_cmap(k)])

--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -529,7 +529,7 @@ dog_goal(
                     }
                 } else if (gg.gtyp == UNDEF && in_masters_sight
                            && !dog_has_minvent
-                           && (!levl[omx][omy].lit || levl[u.ux][u.uy].lit)
+                           && (!loc(omx, omy)->lit || loc(u.ux, u.uy)->lit)
                            && (otyp == MANFOOD || m_cansee(mtmp, nx, ny))
                            && edog->apport > rn2(8)
                            && can_carry(mtmp, obj) > 0) {
@@ -552,7 +552,7 @@ dog_goal(
             return -2;
         appr = (udist >= 9) ? 1 : (mtmp->mflee) ? -1 : 0;
         if (udist > 1) {
-            if (!IS_ROOM(levl[u.ux][u.uy].typ) || !rn2(4) || whappr
+            if (!IS_ROOM(loc(u.ux, u.uy)->typ) || !rn2(4) || whappr
                 || (dog_has_minvent && rn2(edog->apport)))
                 appr = 1;
         }
@@ -1259,7 +1259,7 @@ dog_move(
                don't use glyph_at() here--it would return the pet but we want
                to know whether an object is remembered at this map location */
             struct obj *o = (!Hallucination && gl.level.flags.hero_memory
-                             && glyph_is_object(levl[nix][niy].glyph))
+                             && glyph_is_object(loc(nix, niy)->glyph))
                                ? vobj_at(nix, niy) : 0;
             const char *what = o ? distant_name(o, doname) : something;
 
@@ -1349,13 +1349,13 @@ can_reach_location(struct monst *mon, coordxy mx, coordxy my, coordxy fx, coordx
                 continue;
             if (dist2(i, j, fx, fy) >= dist)
                 continue;
-            if (IS_ROCK(levl[i][j].typ) && !passes_walls(mon->data)
+            if (IS_ROCK(loc(i, j)->typ) && !passes_walls(mon->data)
                 && (!may_dig(i, j) || !tunnels(mon->data)
                     /* tunnelling monsters can't do that on the rogue level */
                     || Is_rogue_level(&u.uz)))
                 continue;
-            if (IS_DOOR(levl[i][j].typ)
-                && (levl[i][j].doormask & (D_CLOSED | D_LOCKED)))
+            if (IS_DOOR(loc(i, j)->typ)
+                && (loc(i, j)->doormask & (D_CLOSED | D_LOCKED)))
                 continue;
             if (!could_reach_item(mon, i, j))
                 continue;

--- a/src/dokick.c
+++ b/src/dokick.c
@@ -590,7 +590,7 @@ really_kick_object(coordxy x, coordxy y)
         range = 1;
 
     /* see if the object has a place to move into */
-    if (!ZAP_POS(levl[x + u.dx][y + u.dy].typ)
+    if (!ZAP_POS(loc(x + u.dx, y + u.dy)->typ)
         || closed_door(x + u.dx, y + u.dy))
         range = 1;
 
@@ -605,9 +605,9 @@ really_kick_object(coordxy x, coordxy y)
     Norep("You kick %s.",
           !isgold ? singular(gk.kickedobj, doname) : doname(gk.kickedobj));
 
-    if (IS_ROCK(levl[x][y].typ) || closed_door(x, y)) {
+    if (IS_ROCK(loc(x, y)->typ) || closed_door(x, y)) {
         if ((!martial() && rn2(20) > ACURR(A_DEX))
-            || IS_ROCK(levl[u.ux][u.uy].typ) || closed_door(u.ux, u.uy)) {
+            || IS_ROCK(loc(u.ux, u.uy)->typ) || closed_door(u.ux, u.uy)) {
             if (Blind)
                 pline("It doesn't come loose.");
             else
@@ -840,13 +840,13 @@ watchman_door_damage(struct monst *mtmp, coordxy x, coordxy y)
 {
     if (is_watch(mtmp->data) && mtmp->mpeaceful
         && couldsee(mtmp->mx, mtmp->my)) {
-        if (levl[x][y].looted & D_WARNED) {
+        if (loc(x, y)->looted & D_WARNED) {
             mon_yells(mtmp,
                       "Halt, vandal!  You're under arrest!");
             (void) angry_guards(FALSE);
         } else {
             mon_yells(mtmp, "Hey, stop damaging that door!");
-            levl[x][y].looted |= D_WARNED;
+            loc(x, y)->looted |= D_WARNED;
         }
         return TRUE;
     }
@@ -886,7 +886,7 @@ kick_ouch(coordxy x, coordxy y, const char *kickobjnam)
             pline_The("drawbridge is unaffected.");
             /* update maploc to refer to the drawbridge */
             (void) find_drawbridge(&x, &y);
-            gm.maploc = &levl[x][y];
+            gm.maploc = loc(x, y);
         }
         wake_nearto(x, y, 5 * 5);
     }
@@ -1347,8 +1347,8 @@ dokick(void)
          * reachable for bracing purposes
          * Possible extension: allow bracing against stuff on the side?
          */
-        if (isok(xx, yy) && !IS_ROCK(levl[xx][yy].typ)
-            && !IS_DOOR(levl[xx][yy].typ)
+        if (isok(xx, yy) && !IS_ROCK(loc(xx, yy)->typ)
+            && !IS_DOOR(loc(xx, yy)->typ)
             && (!Is_airlevel(&u.uz) || !OBJ_AT(xx, yy))) {
             You("have nothing to brace yourself against.");
             return ECMD_OK;
@@ -1374,7 +1374,7 @@ dokick(void)
         kick_ouch(x, y, "");
         return ECMD_TIME;
     }
-    gm.maploc = &levl[x][y];
+    gm.maploc = loc(x, y);
 
     /*
      * The next five tests should stay in their present order:
@@ -1807,7 +1807,7 @@ obj_delivery(boolean near_hero)
         otmp->omigr_from_dlevel = 0;
         if (nx > 0) {
             place_object(otmp, nx, ny);
-            if (!nobreak && !IS_SOFT(levl[nx][ny].typ)) {
+            if (!nobreak && !IS_SOFT(loc(nx, ny)->typ)) {
                 if (where == MIGR_WITH_HERO) {
                     if (breaks(otmp, nx, ny))
                         continue;

--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -596,11 +596,11 @@ hitfloor(
     struct obj *obj,
     boolean verbosely) /* usually True; False if caller has given drop mesg */
 {
-    if (IS_SOFT(levl[u.ux][u.uy].typ) || u.uinwater || u.uswallow) {
+    if (IS_SOFT(loc(u.ux, u.uy)->typ) || u.uinwater || u.uswallow) {
         dropy(obj);
         return;
     }
-    if (IS_ALTAR(levl[u.ux][u.uy].typ)) {
+    if (IS_ALTAR(loc(u.ux, u.uy)->typ)) {
         doaltarobj(obj);
     } else if (verbosely) {
         const char *surf = surface(u.ux, u.uy);
@@ -779,19 +779,19 @@ hurtle_step(genericptr_t arg, coordxy x, coordxy y)
     stopping_short = (via_jumping && *range < 2);
 
     if (!Passes_walls || !(may_pass = may_passwall(x, y))) {
-        boolean odoor_diag = (IS_DOOR(levl[x][y].typ)
-                              && (levl[x][y].doormask & D_ISOPEN)
+        boolean odoor_diag = (IS_DOOR(loc(x, y)->typ)
+                              && (loc(x, y)->doormask & D_ISOPEN)
                               && (u.ux - x) && (u.uy - y));
 
-        if (IS_ROCK(levl[x][y].typ) || closed_door(x, y) || odoor_diag) {
+        if (IS_ROCK(loc(x, y)->typ) || closed_door(x, y) || odoor_diag) {
             const char *s;
 
             if (odoor_diag)
                 You("hit the door edge!");
             pline("Ouch!");
-            if (IS_TREE(levl[x][y].typ))
+            if (IS_TREE(loc(x, y)->typ))
                 s = "bumping into a tree";
-            else if (IS_ROCK(levl[x][y].typ))
+            else if (IS_ROCK(loc(x, y)->typ))
                 s = "bumping into a wall";
             else
                 s = "bumping into a door";
@@ -800,7 +800,7 @@ hurtle_step(genericptr_t arg, coordxy x, coordxy y)
             wake_nearto(x,y, 10);
             return FALSE;
         }
-        if (levl[x][y].typ == IRONBARS) {
+        if (loc(x, y)->typ == IRONBARS) {
             You("crash into some iron bars.  Ouch!");
             dmg = rnd(2 + *range);
             losehp(Maybe_Half_Phys(dmg), "crashing into iron bars",
@@ -916,7 +916,7 @@ hurtle_step(genericptr_t arg, coordxy x, coordxy y)
     /* if terrain type changes, levitation or flying might become blocked
        or unblocked; might issue message, so do this after map+vision has
        been updated for new location instead of right after u_on_newpos() */
-    if (levl[u.ux][u.uy].typ != levl[ox][oy].typ)
+    if (loc(u.ux, u.uy)->typ != loc(ox, oy)->typ)
         switch_terrain();
 
     /* might be entering a special room (treasure zoo, thrown room, &c) that
@@ -1734,7 +1734,7 @@ throwit(struct obj *obj,
             }
         }
 
-        if ((!IS_SOFT(levl[gb.bhitpos.x][gb.bhitpos.y].typ) && breaktest(obj))
+        if ((!IS_SOFT(loc(gb.bhitpos.x, gb.bhitpos.y)->typ) && breaktest(obj))
             /* venom [via #monster to spit while poly'd] fails breaktest()
                but we want to force breakage even when location IS_SOFT() */
             || obj->oclass == VENOM_CLASS) {
@@ -1780,7 +1780,7 @@ throwit(struct obj *obj,
         /* container contents might break;
            do so before turning ownership of gt.thrownobj over to shk
            (container_impact_dmg handles item already owned by shop) */
-        if (!IS_SOFT(levl[gb.bhitpos.x][gb.bhitpos.y].typ)) {
+        if (!IS_SOFT(loc(gb.bhitpos.x, gb.bhitpos.y)->typ)) {
             /* <x,y> is spot where you initiated throw, not gb.bhitpos */
             container_impact_dmg(obj, u.ux, u.uy);
             impact_disturbs_zombies(obj, TRUE);
@@ -2647,7 +2647,7 @@ throw_gold(struct obj *obj)
         /* see if the gold has a place to move into */
         odx = u.ux + u.dx;
         ody = u.uy + u.dy;
-        if (!ZAP_POS(levl[odx][ody].typ) || closed_door(odx, ody)) {
+        if (!ZAP_POS(loc(odx, ody)->typ) || closed_door(odx, ody)) {
             gb.bhitpos.x = u.ux;
             gb.bhitpos.y = u.uy;
         } else {

--- a/src/drawing.c
+++ b/src/drawing.c
@@ -113,7 +113,7 @@ int
 def_char_is_furniture(char ch)
 {
     /* note: these refer to defsyms[] order which is much different from
-       levl[][].typ order but both keep furniture in a contiguous block */
+       loc(, )->typ order but both keep furniture in a contiguous block */
     static const char first_furniture[] = "stair", /* "staircase up" */
                       last_furniture[] = "fountain";
     int i;

--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -1846,7 +1846,7 @@ avoid_ceiling(d_level *lev)
 const char *
 ceiling(coordxy x, coordxy y)
 {
-    struct rm *lev = &levl[x][y];
+    struct rm *lev = loc(x, y);
     const char *what;
 
     /* other room types will no longer exist when we're interested --
@@ -1882,7 +1882,7 @@ ceiling(coordxy x, coordxy y)
 const char *
 surface(coordxy x, coordxy y)
 {
-    struct rm *lev = &levl[x][y];
+    struct rm *lev = loc(x, y);
     int levtyp = SURFACE_AT(x, y);
 
     if (u_at(x, y) && u.uswallow && is_animal(u.ustuck->data))
@@ -3123,10 +3123,10 @@ void
 update_lastseentyp(coordxy x, coordxy y)
 {
     struct monst *mtmp;
-    int ltyp = levl[x][y].typ;
+    int ltyp = loc(x, y)->typ;
 
     if (ltyp == DRAWBRIDGE_UP)
-        ltyp = db_under_typ(levl[x][y].drawbridgemask);
+        ltyp = db_under_typ(loc(x, y)->drawbridgemask);
     if ((mtmp = m_at(x, y)) != 0
         && M_AP_TYPE(mtmp) == M_AP_FURNITURE && canseemon(mtmp))
         ltyp = cmap_to_type(mtmp->mappearance);
@@ -3206,7 +3206,7 @@ count_feat_lastseentyp(
         /* get the altarmask for this location; might be a mimic */
         atmp = altarmask_at(x, y);
         /* convert to index: 0..3 */
-        atmp = (Is_astralevel(&u.uz) && (levl[x][y].seenv & SVALL) != SVALL)
+        atmp = (Is_astralevel(&u.uz) && (loc(x, y)->seenv & SVALL) != SVALL)
                ? MSA_NONE
                : Amask2msa(atmp);
         if (!mptr->feat.naltar)
@@ -3246,7 +3246,7 @@ count_feat_lastseentyp(
              * both throne and door on the lower of the two rows.
              */
             for (ty = y - 1; ty <= y + 1; ++ty)
-                if (isok(tx, ty) && IS_THRONE(levl[tx][ty].typ)) {
+                if (isok(tx, ty) && IS_THRONE(loc(tx, ty)->typ)) {
                     mptr->flags.ludios = 1;
                     break;
                 }

--- a/src/eat.c
+++ b/src/eat.c
@@ -2749,7 +2749,7 @@ doeat(void)
         /* hero in metallivore form is eating [diggable] iron bars
            at current location so skip the other assorted checks;
            operates as if digging rather than via the eat occupation */
-        if (still_chewing(u.ux, u.uy) && levl[u.ux][u.uy].typ == IRONBARS) {
+        if (still_chewing(u.ux, u.uy) && loc(u.ux, u.uy)->typ == IRONBARS) {
             /* this is verbose, but player will see the hero rather than the
                bars so wouldn't know that more turns of eating are required */
             You("pause to swallow.");
@@ -3516,9 +3516,9 @@ floorfood(
             }
             ++getobj_else;
         }
-        if (levl[u.ux][u.uy].typ == IRONBARS) {
+        if (loc(u.ux, u.uy)->typ == IRONBARS) {
             /* already verified that hero is metallivorous above */
-            boolean nodig = (levl[u.ux][u.uy].wall_info & W_NONDIGGABLE) != 0;
+            boolean nodig = (loc(u.ux, u.uy)->wall_info & W_NONDIGGABLE) != 0;
 
             c = 'n';
             Strcpy(qbuf, "There are iron bars here");
@@ -3657,7 +3657,7 @@ vomit(void) /* A good idea from David Neves */
             ubreatheu(mattk);
         }
         /* vomiting on an altar is, all things considered, rather impolite */
-        if (IS_ALTAR(levl[u.ux][u.uy].typ))
+        if (IS_ALTAR(loc(u.ux, u.uy)->typ))
             altar_wrath(u.ux, u.uy);
         /* if poly'd into acidic form, stomach acid is stronger than normal */
         if (acidic(gy.youmonst.data)) {

--- a/src/end.c
+++ b/src/end.c
@@ -1975,14 +1975,14 @@ really_done(int how)
         /* Base corpse on race when not poly'd since original u.umonnum
            is based on role, and all role monsters are human. */
         int mnum = !Upolyd ? gu.urace.mnum : u.umonnum,
-            was_already_grave = IS_GRAVE(levl[u.ux][u.uy].typ);
+            was_already_grave = IS_GRAVE(loc(u.ux, u.uy)->typ);
 
         corpse = mk_named_object(CORPSE, &mons[mnum], u.ux, u.uy, gp.plname);
         Sprintf(pbuf, "%s, ", gp.plname);
         formatkiller(eos(pbuf), sizeof pbuf - Strlen(pbuf), how, TRUE);
         make_grave(u.ux, u.uy, pbuf);
-        if (IS_GRAVE(levl[u.ux][u.uy].typ) && !was_already_grave)
-            levl[u.ux][u.uy].emptygrave = 1; /* corpse isn't buried */
+        if (IS_GRAVE(loc(u.ux, u.uy)->typ) && !was_already_grave)
+            loc(u.ux, u.uy)->emptygrave = 1; /* corpse isn't buried */
     }
     pbuf[0] = '\0'; /* clear grave text; also lint suppression */
 

--- a/src/engrave.c
+++ b/src/engrave.c
@@ -638,7 +638,7 @@ doengrave_sfx_item_WAN(struct _doengrave_ctx *de)
                ? "You hear drilling!"    /* Deaf-aware */
                : Blind
                   ? "You feel tremors."
-                  : IS_GRAVE(levl[u.ux][u.uy].typ)
+                  : IS_GRAVE(loc(u.ux, u.uy)->typ)
                      ? "Chips fly out from the headstone."
                      : de->frosted
                         ? "Ice chips fly up from the ice surface!"
@@ -938,19 +938,19 @@ doengrave(void)
         cant_reach_floor(u.ux, u.uy, FALSE, TRUE);
         goto doengr_exit;
     }
-    if (IS_ALTAR(levl[u.ux][u.uy].typ)) {
+    if (IS_ALTAR(loc(u.ux, u.uy)->typ)) {                                                                      
         You("make a motion towards the altar with %s.", de->writer);
         altar_wrath(u.ux, u.uy);
         goto doengr_exit;
     }
-    if (IS_GRAVE(levl[u.ux][u.uy].typ)) {
+    if (IS_GRAVE(loc(u.ux, u.uy)->typ)) {
         if (de->otmp == &hands_obj) { /* using only finger */
             You("would only make a small smudge on the %s.",
                 surface(u.ux, u.uy));
             goto doengr_exit;
-        } else if (!levl[u.ux][u.uy].disturbed) {
+        } else if (!loc(u.ux, u.uy)->disturbed) {
             /* disturb the grave: summon a ghoul, same as sometimes
-               happens when kicking; sets levl[ux][uy]->disturbed so
+               happens when kicking; sets loc(ux, uy)->>disturbed so
                that it'll only happen once */
             disturb_grave(u.ux, u.uy);
             goto doengr_exit;
@@ -961,7 +961,7 @@ doengrave(void)
     if (!doengrave_sfx_item(de))
         goto doengr_exit;
 
-    if (IS_GRAVE(levl[u.ux][u.uy].typ)) {
+    if (IS_GRAVE(loc(u.ux, u.uy)->typ)) {
         if (de->type == ENGRAVE || de->type == 0) {
             de->type = HEADSTONE;
         } else {
@@ -1012,7 +1012,7 @@ doengrave(void)
     if (de->zapwand && (de->otmp->spe < 0)) {
         pline("%s %sturns to dust.", The(xname(de->otmp)),
               Blind ? "" : "glows violently, then ");
-        if (!IS_GRAVE(levl[u.ux][u.uy].typ))
+        if (!IS_GRAVE(loc(u.ux, u.uy)->typ))
             You(
     "are not going to get anywhere trying to write in the %s with your dust.",
                 de->frosted ? "frost" : "dust");
@@ -1551,7 +1551,7 @@ make_grave(coordxy x, coordxy y, const char *str)
     char buf[BUFSZ];
 
     /* Can we put a grave here? */
-    if ((levl[x][y].typ != ROOM && levl[x][y].typ != GRAVE) || t_at(x, y))
+    if ((loc(x, y)->typ != ROOM && loc(x, y)->typ != GRAVE) || t_at(x, y))
         return;
     /* Make the grave */
     if (!set_levltyp(x, y, GRAVE))
@@ -1568,7 +1568,7 @@ make_grave(coordxy x, coordxy y, const char *str)
 void
 disturb_grave(coordxy x, coordxy y)
 {
-    struct rm *lev = &levl[x][y];
+    struct rm *lev = loc(x, y);
 
     if (!IS_GRAVE(lev->typ)) {
         impossible("Disturing grave that isn't a grave? (%d)", lev->typ);

--- a/src/explode.c
+++ b/src/explode.c
@@ -840,7 +840,7 @@ scatter(coordxy sx, coordxy sy,  /* location of objects to scatter */
                 gt.thrownobj = stmp->obj; /* mainly in case it kills hero */
                 gb.bhitpos.x = stmp->ox + stmp->dx;
                 gb.bhitpos.y = stmp->oy + stmp->dy;
-                typ = levl[gb.bhitpos.x][gb.bhitpos.y].typ;
+                typ = loc(gb.bhitpos.x, gb.bhitpos.y)->typ;
                 if (!isok(gb.bhitpos.x, gb.bhitpos.y)) {
                     gb.bhitpos.x -= stmp->dx;
                     gb.bhitpos.y -= stmp->dy;
@@ -884,7 +884,7 @@ scatter(coordxy sx, coordxy sy,  /* location of objects to scatter */
                 }
                 stmp->ox = gb.bhitpos.x;
                 stmp->oy = gb.bhitpos.y;
-                if (IS_SINK(levl[stmp->ox][stmp->oy].typ))
+                if (IS_SINK(loc(stmp->ox, stmp->oy)->typ))
                     stmp->stopped = TRUE;
                 gt.thrownobj = (struct obj *) 0;
             }

--- a/src/extralev.c
+++ b/src/extralev.c
@@ -60,10 +60,10 @@ roguecorr(coordxy x, coordxy y, int dir)
             fromy = gr.r[x][y].rly + gr.r[x][y].dy;
             fromx += 1 + 26 * x;
             fromy += 7 * y;
-            if (!IS_WALL(levl[fromx][fromy].typ))
+            if (!IS_WALL(loc(fromx, fromy)->typ))
                 impossible("down: no wall at %d,%d?", fromx, fromy);
             dodoor(fromx, fromy, &gr.rooms[gr.r[x][y].nroom]);
-            levl[fromx][fromy].doormask = D_NODOOR;
+            loc(fromx, fromy)->doormask = D_NODOOR;
             fromy++;
         }
         if (y >= 2) {
@@ -82,10 +82,10 @@ roguecorr(coordxy x, coordxy y, int dir)
             toy = gr.r[x][y].rly - 1;
             tox += 1 + 26 * x;
             toy += 7 * y;
-            if (!IS_WALL(levl[tox][toy].typ))
+            if (!IS_WALL(loc(tox, toy)->typ))
                 impossible("up: no wall at %d,%d?", tox, toy);
             dodoor(tox, toy, &gr.rooms[gr.r[x][y].nroom]);
-            levl[tox][toy].doormask = D_NODOOR;
+            loc(tox, toy)->doormask = D_NODOOR;
             toy--;
         }
         roguejoin(fromx, fromy, tox, toy, FALSE);
@@ -102,10 +102,10 @@ roguecorr(coordxy x, coordxy y, int dir)
             fromy = gr.r[x][y].rly + rn2(gr.r[x][y].dy);
             fromx += 1 + 26 * x;
             fromy += 7 * y;
-            if (!IS_WALL(levl[fromx][fromy].typ))
+            if (!IS_WALL(loc(fromx, fromy)->typ))
                 impossible("down: no wall at %d,%d?", fromx, fromy);
             dodoor(fromx, fromy, &gr.rooms[gr.r[x][y].nroom]);
-            levl[fromx][fromy].doormask = D_NODOOR;
+            loc(fromx, fromy)->doormask = D_NODOOR;
             fromx++;
         }
         if (x >= 2) {
@@ -124,10 +124,10 @@ roguecorr(coordxy x, coordxy y, int dir)
             toy = gr.r[x][y].rly + rn2(gr.r[x][y].dy);
             tox += 1 + 26 * x;
             toy += 7 * y;
-            if (!IS_WALL(levl[tox][toy].typ))
+            if (!IS_WALL(loc(tox, toy)->typ))
                 impossible("left: no wall at %d,%d?", tox, toy);
             dodoor(tox, toy, &gr.rooms[gr.r[x][y].nroom]);
-            levl[tox][toy].doormask = D_NODOOR;
+            loc(tox, toy)->doormask = D_NODOOR;
             tox--;
         }
         roguejoin(fromx, fromy, tox, toy, TRUE);
@@ -281,9 +281,9 @@ void
 corr(coordxy x, coordxy y)
 {
     if (rn2(50)) {
-        levl[x][y].typ = CORR;
+        loc(x, y)->typ = CORR;
     } else {
-        levl[x][y].typ = SCORR;
+        loc(x, y)->typ = SCORR;
     }
 }
 

--- a/src/fountain.c
+++ b/src/fountain.c
@@ -137,7 +137,7 @@ gush(coordxy x, coordxy y, genericptr_t poolcnt)
     struct trap *ttmp;
 
     if (((x + y) % 2) || u_at(x, y)
-        || (rn2(1 + distmin(u.ux, u.uy, x, y))) || (levl[x][y].typ != ROOM)
+        || (rn2(1 + distmin(u.ux, u.uy, x, y))) || (loc(x, y)->typ != ROOM)
         || (sobj_at(BOULDER, x, y)) || nexttodoor(x, y))
         return;
 
@@ -149,7 +149,7 @@ gush(coordxy x, coordxy y, genericptr_t poolcnt)
 
     /* Put a pool at x, y */
     set_levltyp(x, y, POOL);
-    levl[x][y].flags = 0;
+    loc(x, y)->flags = 0;
     /* No kelp! */
     del_engr_at(x, y);
     water_damage_chain(gl.level.objects[x][y], TRUE);
@@ -200,7 +200,7 @@ watchman_warn_fountain(struct monst *mtmp)
 void
 dryup(coordxy x, coordxy y, boolean isyou)
 {
-    if (IS_FOUNTAIN(levl[x][y].typ)
+    if (IS_FOUNTAIN(loc(x, y)->typ)
         && (!rn2(3) || FOUNTAIN_IS_WARNED(x, y))) {
         if (isyou && in_town(x, y) && !FOUNTAIN_IS_WARNED(x, y)) {
             struct monst *mtmp;
@@ -228,8 +228,8 @@ dryup(coordxy x, coordxy y, boolean isyou)
         }
         /* replace the fountain with ordinary floor */
         set_levltyp(x, y, ROOM); /* updates level.flags.nfountains */
-        levl[x][y].flags = 0;
-        levl[x][y].blessedftn = 0;
+        loc(x, y)->flags = 0;
+        loc(x, y)->blessedftn = 0;
         /* The location is seen if the hero/monster is invisible
            or felt if the hero is blind. */
         newsym(x, y);
@@ -243,7 +243,7 @@ void
 drinkfountain(void)
 {
     /* What happens when you drink from a fountain? */
-    boolean mgkftn = (levl[u.ux][u.uy].blessedftn == 1);
+    const boolean mgkftn = (loc(u.ux, u.uy)->blessedftn == 1);
     int fate = rnd(30);
 
     if (Levitation) {
@@ -272,7 +272,7 @@ drinkfountain(void)
         display_nhwindow(WIN_MESSAGE, FALSE);
         pline("A wisp of vapor escapes the fountain...");
         exercise(A_WIS, TRUE);
-        levl[u.ux][u.uy].blessedftn = 0;
+        loc(u.ux, u.uy)->blessedftn = 0;
         return;
     }
 
@@ -435,7 +435,7 @@ dipfountain(struct obj *obj)
         }
         update_inventory();
         set_levltyp(u.ux, u.uy, ROOM); /* updates level.flags.nfountains */
-        levl[u.ux][u.uy].flags = 0;
+        loc(u.ux, u.uy)->flags = 0;
         newsym(u.ux, u.uy);
         if (in_town(u.ux, u.uy))
             (void) angry_guards(FALSE);
@@ -576,8 +576,8 @@ breaksink(coordxy x, coordxy y)
         pline_The("pipes break!  Water spurts out!");
     /* updates level.flags.nsinks and level.flags.nfountains */
     set_levltyp(x, y, FOUNTAIN);
-    levl[x][y].looted = 0;
-    levl[x][y].blessedftn = 0;
+    loc(x, y)->looted = 0;
+    loc(x, y)->blessedftn = 0;
     SET_FOUNTAIN_LOOTED(x, y);
     newsym(x, y);
 }
@@ -640,10 +640,10 @@ drinksink(void)
         obfree(otmp, (struct obj *) 0);
         break;
     case 5:
-        if (!(levl[u.ux][u.uy].looted & S_LRING)) {
+        if (!(loc(u.ux, u.uy)->looted & S_LRING)) {
             You("find a ring in the sink!");
             (void) mkobj_at(RING_CLASS, u.ux, u.uy, TRUE);
-            levl[u.ux][u.uy].looted |= S_LRING;
+            loc(u.ux, u.uy)->looted |= S_LRING;
             exercise(A_WIS, TRUE);
             newsym(u.ux, u.uy);
         } else
@@ -706,7 +706,7 @@ void
 dipsink(struct obj *obj)
 {
     boolean try_call = FALSE,
-            not_looted_yet = (levl[u.ux][u.uy].looted & S_LRING) == 0,
+            not_looted_yet = (loc(u.ux, u.uy)->looted & S_LRING) == 0,
             is_hands = (obj == &hands_obj || (uarmg && obj == uarmg));
 
     if (!rn2(not_looted_yet ? 25 : 15)) {
@@ -759,7 +759,7 @@ dipsink(struct obj *obj)
         try_call = TRUE;
         break;
     case POT_OBJECT_DETECTION:
-        if (!(levl[u.ux][u.uy].looted & S_LRING)) {
+        if (!(loc(u.ux, u.uy)->looted & S_LRING)) {
             You("sense a ring lost down the drain.");
             try_call = TRUE;
             break;
@@ -803,14 +803,14 @@ sink_backs_up(coordxy x, coordxy y)
         Sprintf(buf, "Something splashes you in the %s", body_part(FACE));
     pline("%s%s.", !Deaf ? "Flupp!  " : "", buf);
 
-    if (!(levl[x][y].looted & S_LRING)) { /* once per sink */
+    if (!(loc(x, y)->looted & S_LRING)) { /* once per sink */
         if (!Blind)
             You_see("a ring shining in its midst.");
         (void) mkobj_at(RING_CLASS, x, y, TRUE);
         newsym(x, y);
         exercise(A_DEX, TRUE);
         exercise(A_WIS, TRUE); /* a discovery! */
-        levl[x][y].looted |= S_LRING;
+        loc(x, y)->looted |= S_LRING;
     }
 }
 

--- a/src/invent.c
+++ b/src/invent.c
@@ -3242,7 +3242,7 @@ itemactions(struct obj *otmp)
                    "Adjust inventory by splitting this stack");
 
     /* O: offer sacrifice */
-    if (IS_ALTAR(levl[u.ux][u.uy].typ) && !u.uswallow) {
+    if (IS_ALTAR(loc(u.ux, u.uy)->typ) && !u.uswallow) {
         /* FIXME: this doesn't match #offer's likely candidates, which don't
            include corpses on Astral and don't include amulets off Astral */
         if (otmp->otyp == CORPSE)
@@ -4478,7 +4478,7 @@ dotypeinv(void)
 const char *
 dfeature_at(coordxy x, coordxy y, char *buf)
 {
-    struct rm *lev = &levl[x][y];
+    struct rm *lev = loc(x, y);
     int ltyp = lev->typ, cmap = -1;
     const char *dfeature = 0;
     static char altbuf[BUFSZ];

--- a/src/light.c
+++ b/src/light.c
@@ -234,7 +234,7 @@ show_transient_light(struct obj *obj, coordxy x, coordxy y)
     /* Null object indicates camera flash */
     if (!obj) {
         /* no need to temporarily light an already lit spot */
-        if (levl[x][y].lit)
+        if (loc(x, y)->lit)
             return;
 
         cameraflash = cg.zeroany;

--- a/src/lock.c
+++ b/src/lock.c
@@ -29,7 +29,7 @@ picking_lock(coordxy *x, coordxy *y)
 boolean
 picking_at(coordxy x, coordxy y)
 {
-    return (boolean) (go.occupation == picklock && gx.xlock.door == &levl[x][y]);
+    return (boolean) (go.occupation == picklock && gx.xlock.door == loc(x, y));
 }
 
 /* produce an occupation string appropriate for the current activity */
@@ -72,7 +72,7 @@ picklock(void)
             return ((gx.xlock.usedtime = 0)); /* you or it moved */
         }
     } else { /* door */
-        if (gx.xlock.door != &(levl[u.ux + u.dx][u.uy + u.dy])) {
+        if (gx.xlock.door != loc(u.ux + u.dx, u.uy + u.dy)) {
             return ((gx.xlock.usedtime = 0)); /* you moved */
         }
         switch (gx.xlock.door->doormask) {
@@ -547,7 +547,7 @@ pick_lock(
             return PICKLOCK_DID_NOTHING;
         }
 
-        door = &levl[cc.x][cc.y];
+        door = loc(cc.x, cc.y);
         mtmp = m_at(cc.x, cc.y);
         if (mtmp && canseemon(mtmp) && M_AP_TYPE(mtmp) != M_AP_FURNITURE
             && M_AP_TYPE(mtmp) != M_AP_OBJECT) {
@@ -814,7 +814,7 @@ doopen_indir(coordxy x, coordxy y)
     if (Confusion || Stunned)
         res = ECMD_TIME;
 
-    door = &levl[cc.x][cc.y];
+    door = loc(cc.x, cc.y);
     portcullis = (is_drawbridge_wall(cc.x, cc.y) >= 0);
     /* this used to be 'if (Blind)' but using a key skips that so we do too */
     {
@@ -978,7 +978,7 @@ doclose(void)
     if (Confusion || Stunned)
         res = ECMD_TIME;
 
-    door = &levl[x][y];
+    door = loc(x, y);
     portcullis = (is_drawbridge_wall(x, y) >= 0);
     if (Blind) {
         int oldglyph = door->glyph;
@@ -1087,7 +1087,7 @@ boxlock(struct obj *obj, struct obj *otmp) /* obj *is* a box */
 boolean
 doorlock(struct obj *otmp, coordxy x, coordxy y)
 {
-    struct rm *door = &levl[x][y];
+    struct rm * const door = loc(x, y);
     boolean res = TRUE;
     int loudness = 0;
     const char *msg = (const char *) 0;

--- a/src/mail.c
+++ b/src/mail.c
@@ -312,7 +312,7 @@ md_rush(struct monst *md,
         for (dx = -1; dx <= 1; dx++)
             for (dy = -1; dy <= 1; dy++)
                 if ((dx || dy) && isok(fx + dx, fy + dy)
-                    && !IS_STWALL(levl[fx + dx][fy + dy].typ)) {
+                    && !IS_STWALL(loc(fx + dx, fy + dy)->typ)) {
                     d2 = dist2(fx + dx, fy + dy, tx, ty);
                     if (d2 < d1) {
                         d1 = d2;

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -798,7 +798,7 @@ m_initinv(struct monst *mtmp)
             otmp = mksobj(rn2(4) ? TALLOW_CANDLE : WAX_CANDLE, TRUE, FALSE);
             otmp->quan = 1;
             otmp->owt = weight(otmp);
-            if (!mpickobj(mtmp, otmp) && !levl[mtmp->mx][mtmp->my].lit)
+            if (!mpickobj(mtmp, otmp) && !loc(mtmp->mx, mtmp->my)->lit)
                 begin_burn(otmp, FALSE);
         }
         break;
@@ -2254,9 +2254,9 @@ set_mimic_sym(struct monst *mtmp)
         return;
     mx = mtmp->mx;
     my = mtmp->my;
-    typ = levl[mx][my].typ;
+    typ = loc(mx, my)->typ;
     /* only valid for INSIDE of room */
-    roomno = levl[mx][my].roomno - ROOMOFFSET;
+    roomno = loc(mx, my)->roomno - ROOMOFFSET;
     if (roomno >= 0)
         rt = gr.rooms[roomno].rtype;
 #ifdef SPECIALIZATION
@@ -2278,13 +2278,13 @@ set_mimic_sym(struct monst *mtmp)
          *  Since rogue has no closed doors, mimic a wall there
          *  (yes, mimics can end up on this level by various means).
          */
-        if (mx != 0 && (levl[mx - 1][my].typ == HWALL
-                        || levl[mx - 1][my].typ == TLCORNER
-                        || levl[mx - 1][my].typ == TRWALL
-                        || levl[mx - 1][my].typ == BLCORNER
-                        || levl[mx - 1][my].typ == TDWALL
-                        || levl[mx - 1][my].typ == CROSSWALL
-                        || levl[mx - 1][my].typ == TUWALL))
+        if (mx != 0 && (loc(mx - 1, my)->typ == HWALL
+                        || loc(mx - 1, my)->typ == TLCORNER
+                        || loc(mx - 1, my)->typ == TRWALL
+                        || loc(mx - 1, my)->typ == BLCORNER
+                        || loc(mx - 1, my)->typ == TDWALL
+                        || loc(mx - 1, my)->typ == CROSSWALL
+                        || loc(mx - 1, my)->typ == TUWALL))
             appear = Is_rogue_level(&u.uz) ? S_hwall : S_hcdoor;
         else
             appear = Is_rogue_level(&u.uz) ? S_vwall : S_vcdoor;
@@ -2397,7 +2397,7 @@ set_mimic_sym(struct monst *mtmp)
         MCORPSENM(mtmp) = NON_PM;
     }
 
-    if (does_block(mx, my, &levl[mx][my]))
+    if (does_block(mx, my, loc(mx, my)))
         block_point(mx, my);
 }
 

--- a/src/mhitm.c
+++ b/src/mhitm.c
@@ -817,7 +817,7 @@ engulf_target(struct monst *magr, struct monst *mdef)
        the hero on top of a monster can occur */
     dx = (mdef == &gy.youmonst) ? u.ux : mdef->mx;
     dy = (mdef == &gy.youmonst) ? u.uy : mdef->my;
-    lev = &levl[dx][dy];
+    lev = loc(dx, dy);
     if (!(udef ? Passes_walls : passes_walls(mdef->data))
           && (IS_ROCK(lev->typ) || closed_door(dx, dy) || IS_TREE(lev->typ)
               /* not passes_bars(); engulfer isn't squeezing through */
@@ -825,7 +825,7 @@ engulf_target(struct monst *magr, struct monst *mdef)
         return FALSE;
     ax = (magr == &gy.youmonst) ? u.ux : magr->mx;
     ay = (magr == &gy.youmonst) ? u.uy : magr->my;
-    lev = &levl[ax][ay];
+    lev = loc(ax, ay);
     if (!(uatk ? Passes_walls : passes_walls(magr->data))
         && (IS_ROCK(lev->typ) || closed_door(ax, ay) || IS_TREE(lev->typ)
             || (lev->typ == IRONBARS && !is_whirly(mdef->data))))

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -2768,8 +2768,8 @@ hornoplenty(
                                         ? "Oops!  %s out of your reach!"
                                         : (Is_airlevel(&u.uz)
                                            || Is_waterlevel(&u.uz)
-                                           || levl[u.ux][u.uy].typ < IRONBARS
-                                           || levl[u.ux][u.uy].typ >= ICE)
+                                           || loc(u.ux, u.uy)->typ < IRONBARS
+                                           || loc(u.ux, u.uy)->typ >= ICE)
                                           ? "Oops!  %s away from you!"
                                           : "Oops!  %s to the floor!",
                                       The(aobjnam(obj, "slip")), (char *) 0);
@@ -2789,7 +2789,7 @@ hornoplenty(
             if (!can_reach_floor(TRUE)) {
                 hitfloor(obj, TRUE); /* does altar check, message, drop */
             } else {
-                if (IS_ALTAR(levl[u.ux][u.uy].typ))
+                if (IS_ALTAR(loc(u.ux, u.uy)->typ))
                     doaltarobj(obj); /* does its own drop message */
                 else
                     pline("%s %s to the %s.", Doname2(obj),

--- a/src/mkroom.c
+++ b/src/mkroom.c
@@ -177,7 +177,7 @@ mkshop(void)
 
         for (x = sroom->lx - 1; x <= sroom->hx + 1; x++)
             for (y = sroom->ly - 1; y <= sroom->hy + 1; y++)
-                levl[x][y].lit = 1;
+                loc(x, y)->lit = 1;
         sroom->rlit = 1;
     }
 
@@ -285,7 +285,7 @@ fill_zoo(struct mkroom *sroom)
         if (gl.level.flags.is_maze_lev) {
             for (tx = sroom->lx; tx <= sroom->hx; tx++)
                 for (ty = sroom->ly; ty <= sroom->hy; ty++)
-                    if (IS_THRONE(levl[tx][ty].typ))
+                    if (IS_THRONE(loc(tx, ty)->typ))
                         goto throne_placed;
         }
         i = 100;
@@ -302,7 +302,7 @@ fill_zoo(struct mkroom *sroom)
         ty = sroom->ly + (sroom->hy - sroom->ly + 1) / 2;
         if (sroom->irregular) {
             /* center might not be valid, so put queen elsewhere */
-            if ((int) levl[tx][ty].roomno != rmno || levl[tx][ty].edge) {
+            if ((int) loc(tx, ty)->roomno != rmno || loc(tx, ty)->edge) {
                 (void) somexyspace(sroom, &mm);
                 tx = mm.x;
                 ty = mm.y;
@@ -318,11 +318,11 @@ fill_zoo(struct mkroom *sroom)
     for (sx = sroom->lx; sx <= sroom->hx; sx++)
         for (sy = sroom->ly; sy <= sroom->hy; sy++) {
             if (sroom->irregular) {
-                if ((int) levl[sx][sy].roomno != rmno || levl[sx][sy].edge
+                if ((int) loc(sx, sy)->roomno != rmno || loc(sx, sy)->edge
                     || (sroom->doorct
                         && distmin(sx, sy, gd.doors[sh].x, gd.doors[sh].y) <= 1))
                     continue;
-            } else if (!SPACE_POS(levl[sx][sy].typ)
+            } else if (!SPACE_POS(loc(sx, sy)->typ)
                        || (sroom->doorct
                            && ((sx == sroom->lx && gd.doors[sh].x == sx - 1)
                                || (sx == sroom->hx && gd.doors[sh].x == sx + 1)
@@ -331,7 +331,7 @@ fill_zoo(struct mkroom *sroom)
                                    && gd.doors[sh].y == sy + 1))))
                 continue;
             /* don't place monster on explicitly placed throne */
-            if (type == COURT && IS_THRONE(levl[sx][sy].typ))
+            if (type == COURT && IS_THRONE(loc(sx, sy)->typ))
                 continue;
             mon = makemon((type == COURT)
                            ? courtmon()
@@ -411,7 +411,7 @@ fill_zoo(struct mkroom *sroom)
     switch (type) {
     case COURT: {
         struct obj *chest, *gold;
-        levl[tx][ty].typ = THRONE;
+        loc(tx, ty)->typ = THRONE;
         (void) somexyspace(sroom, &mm);
         gold = mksobj(GOLD_PIECE, TRUE, FALSE);
         gold->quan = (long) rn1(50 * level_difficulty(), 10);
@@ -537,14 +537,14 @@ mkswamp(void) /* Michiel Huisjes & Fred de Wilde */
         sroom->rtype = SWAMP;
         for (sx = sroom->lx; sx <= sroom->hx; sx++)
             for (sy = sroom->ly; sy <= sroom->hy; sy++) {
-                if (!IS_ROOM(levl[sx][sy].typ)
-                    || (int) levl[sx][sy].roomno != rmno)
+                if (!IS_ROOM(loc(sx, sy)->typ)
+                    || (int) loc(sx, sy)->roomno != rmno)
                     continue;
                 if (!OBJ_AT(sx, sy) && !MON_AT(sx, sy) && !t_at(sx, sy)
                     && !nexttodoor(sx, sy)) {
                     if ((sx + sy) % 2) {
                         del_engr_at(sx, sy);
-                        levl[sx][sy].typ = POOL;
+                        loc(sx, sy)->typ = POOL;
                         if (!eelct || !rn2(4)) {
                             /* mkclass() won't do, as we might get kraken */
                             (void) makemon(rn2(5)
@@ -602,7 +602,7 @@ mktemple(void)
      * located in the center of the room
      */
     shrine_spot = shrine_pos((int) ((sroom - gr.rooms) + ROOMOFFSET));
-    lev = &levl[shrine_spot->x][shrine_spot->y];
+    lev = loc(shrine_spot->x, shrine_spot->y);
     lev->typ = ALTAR;
     lev->altarmask = induced_align(80);
     priestini(&u.uz, sroom, shrine_spot->x, shrine_spot->y, FALSE);
@@ -620,7 +620,7 @@ nexttodoor(int sx, int sy)
         for (dy = -1; dy <= 1; dy++) {
             if (!isok(sx + dx, sy + dy))
                 continue;
-            lev = &levl[sx + dx][sy + dy];
+            lev = loc(sx + dx, sy + dy);
             if (IS_DOOR(lev->typ) || lev->typ == SDOOR)
                 return TRUE;
         }
@@ -670,7 +670,7 @@ inside_room(struct mkroom *croom, coordxy x, coordxy y)
 {
     if (croom->irregular) {
         int i = (int) ((croom - gr.rooms) + ROOMOFFSET);
-        return (!levl[x][y].edge && (int) levl[x][y].roomno == i);
+        return (!loc(x, y)->edge && (int) loc(x, y)->roomno == i);
     }
 
     return (boolean) (x >= croom->lx - 1 && x <= croom->hx + 1
@@ -693,14 +693,14 @@ somexy(struct mkroom *croom, coord *c)
         while (try_cnt++ < 100) {
             c->x = somex(croom);
             c->y = somey(croom);
-            if (!levl[c->x][c->y].edge && (int) levl[c->x][c->y].roomno == i)
+            if (!loc(c->x, c->y)->edge && (int) loc(c->x, c->y)->roomno == i)
                 return TRUE;
         }
         /* try harder; exhaustively search until one is found */
         for (c->x = croom->lx; c->x <= croom->hx; c->x++)
             for (c->y = croom->ly; c->y <= croom->hy; c->y++)
-                if (!levl[c->x][c->y].edge
-                    && (int) levl[c->x][c->y].roomno == i)
+                if (!loc(c->x, c->y)->edge
+                    && (int) loc(c->x, c->y)->roomno == i)
                     return TRUE;
         return FALSE;
     }
@@ -716,7 +716,7 @@ somexy(struct mkroom *croom, coord *c)
     while (try_cnt++ < 100) {
         c->x = somex(croom);
         c->y = somey(croom);
-        if (IS_WALL(levl[c->x][c->y].typ))
+        if (IS_WALL(loc(c->x, c->y)->typ))
             continue;
         for (i = 0; i < croom->nsubrooms; i++)
             if (inside_room(croom->sbrooms[i], c->x, c->y))
@@ -739,9 +739,9 @@ somexyspace(struct mkroom* croom, coord *c)
 
     do {
         okay = somexy(croom, c) && isok(c->x, c->y) && !occupied(c->x, c->y)
-            && (levl[c->x][c->y].typ == ROOM
-                || levl[c->x][c->y].typ == CORR
-                || levl[c->x][c->y].typ == ICE);
+            && (loc(c->x, c->y)->typ == ROOM
+                || loc(c->x, c->y)->typ == CORR
+                || loc(c->x, c->y)->typ == ICE);
     } while (trycnt++ < 100 && !okay);
     return okay;
 }
@@ -1052,7 +1052,7 @@ invalid_shop_shape(struct mkroom *sroom)
          x <= min(doorx + 1, sroom->hx); x++) {
         for (y = max(doory - 1, sroom->ly);
              y <= min(doory + 1, sroom->hy); y++) {
-            if (levl[x][y].typ == ROOM) {
+            if (loc(x, y)->typ == ROOM) {
                 insidex = x;
                 insidey = y;
                 insidect++;
@@ -1075,7 +1075,7 @@ invalid_shop_shape(struct mkroom *sroom)
                  y <= min(insidey + 1, sroom->hy); y++) {
                 if (x == insidex && y == insidey)
                     continue;
-                if (levl[x][y].typ == ROOM)
+                if (loc(x, y)->typ == ROOM)
                     insidect++;
             }
         }

--- a/src/mon.c
+++ b/src/mon.c
@@ -158,11 +158,11 @@ sanity_check_single_mon(
             /* normally !accessible would be overridable with passes_walls,
                but not for hiding on the ceiling */
             && (!has_ceiling(&u.uz)
-                || !(levl[mx][my].typ == POOL
-                     || levl[mx][my].typ == MOAT
-                     || levl[mx][my].typ == WATER
-                     || levl[mx][my].typ == LAVAPOOL
-                     || levl[mx][my].typ == LAVAWALL
+                || !(loc(mx, my)->typ == POOL
+                     || loc(mx, my)->typ == MOAT
+                     || loc(mx, my)->typ == WATER
+                     || loc(mx, my)->typ == LAVAPOOL
+                     || loc(mx, my)->typ == LAVAWALL
                      || accessible(mx, my))))
             impossible("ceiling hider hiding %s (%s)",
                        !has_ceiling(&u.uz) ? "without ceiling"
@@ -197,10 +197,10 @@ sanity_check_single_mon(
 #if 0   /* mimics who end up in strange locations do still hide while there */
         if (!(accessible(mx, my) || passes_walls(mptr))) {
             char buf[BUFSZ];
-            const char *typnam = levltyp_to_name(levl[mx][my].typ);
+            const char *typnam = levltyp_to_name(loc(mx, my)->typ);
 
             if (!typnam) {
-                Sprintf(buf, "[%d]", levl[mx][my].typ);
+                Sprintf(buf, "[%d]", loc(mx, my)->typ);
                 typnam = buf;
             }
             impossible("mimic%s concealed in inaccessible location: %s (%s)",
@@ -759,7 +759,7 @@ minliquid_core(struct monst *mtmp)
                   || Is_waterlevel(&u.uz)));
     inlava = (is_lava(mtmp->mx, mtmp->my)
               && !(is_flyer(mtmp->data) || is_floater(mtmp->data)));
-    infountain = IS_FOUNTAIN(levl[mtmp->mx][mtmp->my].typ);
+    infountain = IS_FOUNTAIN(loc(mtmp->mx, mtmp->my)->typ);
 
     /* Flying and levitation keeps our steed out of the liquid
        (but not water-walking or swimming; note: if hero is in a
@@ -1929,7 +1929,7 @@ mfndpos(
 
     x = mon->mx;
     y = mon->my;
-    nowtyp = levl[x][y].typ;
+    nowtyp = loc(x, y)->typ;
 
     nodiag = NODIAG(mdat - mons);
     wantpool = (mdat->mlet == S_EEL);
@@ -1980,7 +1980,7 @@ mfndpos(
         for (ny = max(0, y - 1); ny <= maxy; ny++) {
             if (nx == x && ny == y)
                 continue;
-            ntyp = levl[nx][ny].typ;
+            ntyp = loc(nx, ny)->typ;
             if (IS_ROCK(ntyp)
                 && !((flag & ALLOW_WALL) && may_passwall(nx, ny))
                 && !((IS_TREE(ntyp) ? treeok : rockok) && may_dig(nx, ny)))
@@ -1996,7 +1996,7 @@ mfndpos(
             /* KMH -- Added iron bars */
             if (ntyp == IRONBARS
                 && (!(flag & ALLOW_BARS)
-                    || ((levl[nx][ny].wall_info & W_NONDIGGABLE)
+                    || ((loc(nx, ny)->wall_info & W_NONDIGGABLE)
                         && (dmgtype(mdat, AD_RUST)
                             || dmgtype(mdat, AD_CORR)))))
                 continue;
@@ -2005,8 +2005,8 @@ mfndpos(
                    closed door if it doesn't currently have hero engulfed */
                 && !((amorphous(mdat) || can_fog(mon))
                      && (mon != u.ustuck || !u.uswallow))
-                && (((levl[nx][ny].doormask & D_CLOSED) && !(flag & OPENDOOR))
-                    || ((levl[nx][ny].doormask & D_LOCKED)
+                && (((loc(nx, ny)->doormask & D_CLOSED) && !(flag & OPENDOOR))
+                    || ((loc(nx, ny)->doormask & D_LOCKED)
                         && !(flag & UNLOCKDOOR))) && !thrudoor)
                 continue;
             /* avoid poison gas? */
@@ -2017,8 +2017,8 @@ mfndpos(
             /* first diagonal checks (tight squeezes handled below) */
             if (nx != x && ny != y
                 && (nodiag
-                    || (IS_DOOR(nowtyp) && (levl[x][y].doormask & ~D_BROKEN))
-                    || (IS_DOOR(ntyp) && (levl[nx][ny].doormask & ~D_BROKEN))
+                    || (IS_DOOR(nowtyp) && (loc(x, y)->doormask & ~D_BROKEN))
+                    || (IS_DOOR(ntyp) && (loc(nx, ny)->doormask & ~D_BROKEN))
                     || ((IS_DOOR(nowtyp) || IS_DOOR(ntyp))
                         && Is_rogue_level(&u.uz))
                     /* mustn't pass between adjacent long worm segments,
@@ -2861,7 +2861,7 @@ mondead(struct monst *mtmp)
     /* achievement and/or livelog */
     logdeadmon(mtmp, mndx);
 
-    if (glyph_is_invisible(levl[mtmp->mx][mtmp->my].glyph))
+    if (glyph_is_invisible(loc(mtmp->mx, mtmp->my)->glyph))
         unmap_object(mtmp->mx, mtmp->my);
 
     /* remove 'mtmp' from play; it will stay on the fmon list until end of
@@ -3041,7 +3041,7 @@ monstone(struct monst *mdef)
 
     stackobj(otmp);
     /* mondead() already does this, but we must do it before the newsym */
-    if (glyph_is_invisible(levl[x][y].glyph))
+    if (glyph_is_invisible(loc(x, y)->glyph))
         unmap_object(x, y);
     if (cansee(x, y))
         newsym(x, y);
@@ -4061,7 +4061,7 @@ seemimic(struct monst *mtmp)
      *  Discovered mimics don't block light.
      */
     if (is_blocker_appear
-        && !does_block(mtmp->mx, mtmp->my, &levl[mtmp->mx][mtmp->my]))
+        && !does_block(mtmp->mx, mtmp->my, loc(mtmp->mx, mtmp->my)))
         unblock_point(mtmp->mx, mtmp->my);
 
     newsym(mtmp->mx, mtmp->my);
@@ -4280,7 +4280,7 @@ restrap(struct monst *mtmp)
     if (mtmp->data->mlet == S_MIMIC) {
         set_mimic_sym(mtmp);
         return TRUE;
-    } else if (levl[mtmp->mx][mtmp->my].typ == ROOM) {
+    } else if (loc(mtmp->mx, mtmp->my)->typ == ROOM) {
         mtmp->mundetected = 1;
         return TRUE;
     }

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -1538,7 +1538,7 @@ mons_see_trap(struct trap *ttmp)
 {
     struct monst *mtmp;
     coordxy tx = ttmp->tx, ty = ttmp->ty;
-    int maxdist = levl[tx][ty].lit ? 7*7 : 2;
+    int maxdist = loc(tx, ty)->lit ? 7*7 : 2;
 
     for (mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
         if (is_animal(mtmp->data) || mindless(mtmp->data)

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -164,15 +164,15 @@ watch_on_duty(struct monst *mtmp)
 
     if (mtmp->mpeaceful && in_town(u.ux + u.dx, u.uy + u.dy)
         && mtmp->mcansee && m_canseeu(mtmp) && !rn2(3)) {
-        if (picking_lock(&x, &y) && IS_DOOR(levl[x][y].typ)
-            && (levl[x][y].doormask & D_LOCKED)) {
+        if (picking_lock(&x, &y) && IS_DOOR(loc(x, y)->typ)
+            && (loc(x, y)->doormask & D_LOCKED)) {
             if (couldsee(mtmp->mx, mtmp->my)) {
-                if (levl[x][y].looted & D_WARNED) {
+                if (loc(x, y)->looted & D_WARNED) {
                     mon_yells(mtmp, "Halt, thief!  You're under arrest!");
                     (void) angry_guards(!!Deaf);
                 } else {
                     mon_yells(mtmp, "Hey, stop picking that lock!");
-                    levl[x][y].looted |= D_WARNED;
+                    loc(x, y)->looted |= D_WARNED;
                 }
                 stop_occupation();
             }
@@ -245,7 +245,7 @@ onscary(coordxy x, coordxy y, struct monst *mtmp)
         return TRUE;
 
     /* should this still be true for defiled/molochian altars? */
-    if (IS_ALTAR(levl[x][y].typ)
+    if (IS_ALTAR(loc(x, y)->typ)
         && (mtmp->data->mlet == S_VAMPIRE || is_vampshifter(mtmp)))
         return TRUE;
 
@@ -1037,10 +1037,10 @@ m_digweapon_check(
         if (closed_door(nix, niy)) {
             if (!mw_tmp || !is_pick(mw_tmp) || !is_axe(mw_tmp))
                 mtmp->weapon_check = NEED_PICK_OR_AXE;
-        } else if (IS_TREE(levl[nix][niy].typ)) {
+        } else if (IS_TREE(loc(nix, niy)->typ)) {
             if (!mw_tmp || !is_axe(mw_tmp))
                 mtmp->weapon_check = NEED_AXE;
-        } else if (IS_STWALL(levl[nix][niy].typ)) {
+        } else if (IS_STWALL(loc(nix, niy)->typ)) {
             if (!mw_tmp || !is_pick(mw_tmp))
                 mtmp->weapon_check = NEED_PICK_AXE;
         }
@@ -1075,7 +1075,7 @@ leppie_stash(struct monst *mtmp)
         && !DEADMONSTER(mtmp)
         && !m_canseeu(mtmp)
         && !*in_rooms(mtmp->mx, mtmp->my, SHOPBASE)
-        && levl[mtmp->mx][mtmp->my].typ == ROOM
+        && loc(mtmp->mx, mtmp->my)->typ == ROOM
         && !t_at(mtmp->mx, mtmp->my)
         && rn2(4)
         && (gold = findgold(mtmp->minvent)) != 0) {
@@ -1120,10 +1120,10 @@ holds_up_web(coordxy x, coordxy y)
     stairway *sway;
 
     if (!isok(x, y)
-        || IS_ROCK(levl[x][y].typ)
-        || ((levl[x][y].typ == STAIRS || levl[x][y].typ == LADDER)
+        || IS_ROCK(loc(x, y)->typ)
+        || ((loc(x, y)->typ == STAIRS || loc(x, y)->typ == LADDER)
             && (sway = stairway_at(x, y)) != 0 && sway->up)
-        || levl[x][y].typ == IRONBARS)
+        || loc(x, y)->typ == IRONBARS)
         return TRUE;
 
     return FALSE;
@@ -1344,8 +1344,8 @@ postmov(
            [if we did the shift sooner, before moving the monster,
            we would need to duplicate it in dog_move()...] */
         if (is_vampshifter(mtmp) && !amorphous(mtmp->data)
-            && IS_DOOR(levl[nix][niy].typ)
-            && ((levl[nix][niy].doormask & (D_LOCKED | D_CLOSED)) != 0)
+            && IS_DOOR(loc(nix, niy)->typ)
+            && ((loc(nix, niy)->doormask & (D_LOCKED | D_CLOSED)) != 0)
             && can_fog(mtmp)) {
             if (sawmon) {
                 remove_monster(nix, niy);
@@ -1372,10 +1372,10 @@ postmov(
         ptr = mtmp->data; /* in case mintrap() caused polymorph */
 
         /* open a door, or crash through it, if 'mtmp' can */
-        if (IS_DOOR(levl[mtmp->mx][mtmp->my].typ)
+        if (IS_DOOR(loc(mtmp->mx, mtmp->my)->typ)
             && !passes_walls(ptr) /* doesn't need to open doors */
             && !can_tunnel) {     /* taken care of below */
-            struct rm *here = &levl[mtmp->mx][mtmp->my];
+            struct rm *here = loc(mtmp->mx, mtmp->my);
             boolean btrapped = (here->doormask & D_TRAPPED) != 0;
 
     /* used after monster 'who' has been moved to closed door spot 'where'
@@ -1475,11 +1475,11 @@ postmov(
             }
 #undef UnblockDoor
 
-        } else if (levl[mtmp->mx][mtmp->my].typ == IRONBARS) {
+        } else if (loc(mtmp->mx, mtmp->my)->typ == IRONBARS) {
             /* 3.6.2: was using may_dig() but that doesn't handle bars;
                AD_RUST catches rust monsters but metallivorous() is
                    needed for xorns and rock moles */
-            if (!(levl[mtmp->mx][mtmp->my].wall_info & W_NONDIGGABLE)
+            if (!(loc(mtmp->mx, mtmp->my)->wall_info & W_NONDIGGABLE)
                 && (dmgtype(ptr, AD_RUST) || dmgtype(ptr, AD_CORR)
                     || metallivorous(ptr))) {
                 if (canseemon(mtmp))
@@ -1707,7 +1707,7 @@ m_move(struct monst *mtmp, int after)
         appr = 0;
     } else {
         boolean should_see = (couldsee(omx, omy)
-                              && (levl[ggx][ggy].lit || !levl[omx][omy].lit)
+                              && (loc(ggx, ggy)->lit || !loc(omx, omy)->lit)
                               && (dist2(omx, omy, ggx, ggy) <= 36));
 
         if (!mtmp->mcansee
@@ -2009,9 +2009,9 @@ can_hide_under_obj(struct obj *obj)
 void
 dissolve_bars(coordxy x, coordxy y)
 {
-    levl[x][y].typ = (levl[x][y].edge == 1) ? DOOR
+    loc(x, y)->typ = (loc(x, y)->edge == 1) ? DOOR
         : (Is_special(&u.uz) || *in_rooms(x, y, 0)) ? ROOM : CORR;
-    levl[x][y].flags = 0; /* doormask = D_NODOOR */
+    loc(x, y)->flags = 0; /* doormask = D_NODOOR */
     newsym(x, y);
     if (u_at(x, y))
         switch_terrain();
@@ -2020,8 +2020,8 @@ dissolve_bars(coordxy x, coordxy y)
 boolean
 closed_door(coordxy x, coordxy y)
 {
-    return (boolean) (IS_DOOR(levl[x][y].typ)
-                      && (levl[x][y].doormask & (D_LOCKED | D_CLOSED)));
+    return (boolean) (IS_DOOR(loc(x, y)->typ)
+                      && (loc(x, y)->doormask & (D_LOCKED | D_CLOSED)));
 }
 
 boolean

--- a/src/mthrowu.c
+++ b/src/mthrowu.c
@@ -528,19 +528,19 @@ ucatchgem(
     (/* missile hits edge of screen */                                 \
      !isok(gb.bhitpos.x + dx, gb.bhitpos.y + dy)                       \
      /* missile hits the wall */                                       \
-     || IS_ROCK(levl[gb.bhitpos.x + dx][gb.bhitpos.y + dy].typ)        \
+     || IS_ROCK(loc(gb.bhitpos.x + dx, gb.bhitpos.y + dy)->typ)        \
      /* missile hit closed door */                                     \
      || closed_door(gb.bhitpos.x + dx, gb.bhitpos.y + dy)              \
      /* missile might hit iron bars */                                 \
      /* the random chance for small objects hitting bars is */         \
      /* skipped when reaching them at point blank range */             \
-     || (levl[gb.bhitpos.x + dx][gb.bhitpos.y + dy].typ == IRONBARS    \
+     || (loc(gb.bhitpos.x + dx, gb.bhitpos.y + dy)->typ == IRONBARS    \
          && hits_bars(&singleobj,                                      \
                       gb.bhitpos.x, gb.bhitpos.y,                      \
                       gb.bhitpos.x + dx, gb.bhitpos.y + dy,            \
                       ((pre) ? 0 : forcehit), 0))                      \
      /* Thrown objects "sink" */                                       \
-     || (!(pre) && IS_SINK(levl[gb.bhitpos.x][gb.bhitpos.y].typ))      \
+     || (!(pre) && IS_SINK(loc(gb.bhitpos.x, gb.bhitpos.y)->typ))      \
      )
 
 void
@@ -739,7 +739,7 @@ m_throw(
                 /* note: pline(The(missile)) rather than pline_The(missile)
                    in order to get "Grimtooth" rather than "The Grimtooth" */
                 if (range && cansee(gb.bhitpos.x, gb.bhitpos.y)
-                    && IS_SINK(levl[gb.bhitpos.x][gb.bhitpos.y].typ))
+                    && IS_SINK(loc(gb.bhitpos.x, gb.bhitpos.y)->typ))
                     pline("%s %s onto the sink.", The(mshot_xname(singleobj)),
                           otense(singleobj, Hallucination ? "plop" : "drop"));
                 else if (gm.m_shot.n > 1
@@ -1081,8 +1081,8 @@ breamu(struct monst *mtmp, struct attack *mattk)
 static boolean
 blocking_terrain(coordxy x, coordxy y)
 {
-    if (!isok(x, y) || IS_ROCK(levl[x][y].typ) || closed_door(x, y)
-        || is_waterwall(x, y) || levl[x][y].typ == LAVAWALL)
+    if (!isok(x, y) || IS_ROCK(loc(x, y)->typ) || closed_door(x, y)
+        || is_waterwall(x, y) || loc(x, y)->typ == LAVAWALL)
         return TRUE;
     return FALSE;
 }
@@ -1222,7 +1222,7 @@ hit_bars(
 {
     struct obj *otmp = *objp;
     int obj_type = otmp->otyp;
-    boolean nodissolve = (levl[barsx][barsy].wall_info & W_NONDIGGABLE) != 0,
+    boolean nodissolve = (loc(barsx, barsy)->wall_info & W_NONDIGGABLE) != 0,
             your_fault = (breakflags & BRK_BY_HERO) != 0,
             melee_attk = (breakflags & BRK_MELEE) != 0;
     int noise = 0;

--- a/src/muse.c
+++ b/src/muse.c
@@ -544,7 +544,7 @@ find_defensive(struct monst *mtmp, boolean tryescape)
 
     if (stuck || immobile || mtmp->mtrapped) {
         ; /* fleeing by stairs or traps is not possible */
-    } else if (levl[x][y].typ == STAIRS) {
+    } else if (loc(x, y)->typ == STAIRS) {
         stway = stairway_at(x,y);
         if (stway && !stway->up && stway->tolev.dnum == u.uz.dnum) {
             if (!is_floater(mtmp->data))
@@ -555,7 +555,7 @@ find_defensive(struct monst *mtmp, boolean tryescape)
             if (stway->up || !is_floater(mtmp->data))
                 gm.m.has_defense = MUSE_SSTAIRS;
         }
-    } else if (levl[x][y].typ == LADDER) {
+    } else if (loc(x, y)->typ == LADDER) {
         stway = stairway_at(x,y);
         if (stway && stway->up && stway->tolev.dnum == u.uz.dnum) {
             gm.m.has_defense = MUSE_UP_LADDER;
@@ -655,7 +655,7 @@ find_defensive(struct monst *mtmp, boolean tryescape)
             /* monsters digging in Sokoban can ruin things */
             && !Sokoban
             /* digging wouldn't be effective; assume they know that */
-            && !(levl[x][y].wall_info & W_NONDIGGABLE)
+            && !(loc(x, y)->wall_info & W_NONDIGGABLE)
             && !(Is_botlevel(&u.uz) || In_endgame(&u.uz))
             && !(is_ice(x, y) || is_pool(x, y) || is_lava(x, y))
             && !(is_Vlad(mtmp) && In_V_tower(&u.uz))) {
@@ -743,7 +743,7 @@ find_defensive(struct monst *mtmp, boolean tryescape)
 static void
 reveal_trap(struct trap *t, boolean seeit)
 {
-    struct rm *lev = &levl[t->tx][t->ty];
+    struct rm *lev = loc(t->tx, t->ty);
 
     if (lev->typ == SCORR) {
         lev->typ = CORR, lev->flags = 0; /* set_levltyp(,,CORR) */
@@ -873,14 +873,14 @@ use_defensive(struct monst *mtmp)
         mzapwand(mtmp, otmp, FALSE);
         if (oseen)
             makeknown(WAN_DIGGING);
-        if (IS_FURNITURE(levl[mtmp->mx][mtmp->my].typ)
-            || IS_DRAWBRIDGE(levl[mtmp->mx][mtmp->my].typ)
+        if (IS_FURNITURE(loc(mtmp->mx, mtmp->my)->typ)
+            || IS_DRAWBRIDGE(loc(mtmp->mx, mtmp->my)->typ)
             || (is_drawbridge_wall(mtmp->mx, mtmp->my) >= 0)
             || stairway_at(mtmp->mx, mtmp->my)) {
             pline_The("digging ray is ineffective.");
             return 2;
         }
-        if (!Can_dig_down(&u.uz) && !levl[mtmp->mx][mtmp->my].candig) {
+        if (!Can_dig_down(&u.uz) && !loc(mtmp->mx, mtmp->my)->candig) {
             /* can't dig further if there's already a pit (or other trap)
                here, or if pit creation fails for some reason */
             if (t_at(mtmp->mx, mtmp->my)
@@ -1678,10 +1678,10 @@ mbhit(
             if (hitanything)
                 range--;
         }
-        ltyp = levl[gb.bhitpos.x][gb.bhitpos.y].typ;
+        ltyp = loc(gb.bhitpos.x, gb.bhitpos.y)->typ;
         dbx = x, dby = y;
         if (otyp == WAN_STRIKING
-            /* if levl[x][y].typ is DRAWBRIDGE_UP then the zap is passing
+            /* if loc(x, y)->typ is DRAWBRIDGE_UP then the zap is passing
                over the moat in front of a closed drawbridge and doesn't
                hit any part of the bridge's mechanism */
             && ltyp != DRAWBRIDGE_UP && find_drawbridge(&dbx, &dby)) {
@@ -1718,7 +1718,7 @@ mbhit(
                         makeknown(otyp);
                     /* if a shop door gets broken, add it to
                        the shk's fix list (no cost to player) */
-                    if (levl[gb.bhitpos.x][gb.bhitpos.y].doormask == D_BROKEN
+                    if (loc(gb.bhitpos.x, gb.bhitpos.y)->doormask == D_BROKEN
                         && *in_rooms(gb.bhitpos.x, gb.bhitpos.y, SHOPBASE))
                         add_damage(gb.bhitpos.x, gb.bhitpos.y, 0L);
                 }
@@ -1726,7 +1726,7 @@ mbhit(
             }
         }
         if (!ZAP_POS(ltyp)
-            || (IS_DOOR(ltyp) && (levl[gb.bhitpos.x][gb.bhitpos.y].doormask
+            || (IS_DOOR(ltyp) && (loc(gb.bhitpos.x, gb.bhitpos.y)->doormask
                                   & (D_LOCKED | D_CLOSED)))) {
             gb.bhitpos.x -= ddx;
             gb.bhitpos.y -= ddy;
@@ -1827,7 +1827,7 @@ use_offensive(struct monst *mtmp)
             for (y = mmy - 1; y <= mmy + 1; y++) {
                 /* Is this a suitable spot? */
                 if (isok(x, y) && !closed_door(x, y)
-                    && !IS_ROCK(levl[x][y].typ) && !IS_AIR(levl[x][y].typ)
+                    && !IS_ROCK(loc(x, y)->typ) && !IS_AIR(loc(x, y)->typ)
                     && (((x == mmx) && (y == mmy)) ? !is_blessed : !is_cursed)
                     && (x != u.ux || y != u.uy)) {
                     (void) drop_boulder_on_monster(x, y, confused, FALSE);

--- a/src/music.c
+++ b/src/music.c
@@ -285,7 +285,7 @@ do_earthquake(int force)
         *   move the pit code to after the switch.
         */
 
-            switch (levl[x][y].typ) {
+            switch (loc(x, y)->typ) {
             case FOUNTAIN: /* make the fountain disappear */
                 if (cansee(x, y))
                     pline_The("fountain falls%s.", into_a_chasm);
@@ -314,7 +314,7 @@ do_earthquake(int force)
                     pline_The("throne falls%s.", into_a_chasm);
                 goto do_pit;
             case SCORR:
-                levl[x][y].typ = CORR;
+                loc(x, y)->typ = CORR;
                 unblock_point(x, y);
                 if (cansee(x, y))
                     pline("A secret corridor is revealed.");
@@ -344,7 +344,7 @@ do_earthquake(int force)
                    wand of digging if you alter this sequence. */
                 filltype = fillholetyp(x, y, FALSE);
                 if (filltype != ROOM) {
-                    set_levltyp(x, y, filltype); /* levl[x][y] = filltype; */
+                    set_levltyp(x, y, filltype); /* loc(x, y) = filltype; */
                     liquid_flow(x, y, filltype, chasm, (char *) 0);
                     /* liquid_flow() deletes trap, might kill mtmp */
                     if ((chasm = t_at(x, y)) == NULL)
@@ -434,16 +434,16 @@ do_earthquake(int force)
                 }
                 break;
             case SDOOR:
-                cvt_sdoor_to_door(&levl[x][y]); /* .typ = DOOR */
+                cvt_sdoor_to_door(loc(x, y)); /* .typ = DOOR */
                 if (cansee(x, y))
                     pline("A secret door is revealed.");
                 /*FALLTHRU*/
             case DOOR: /* make the door collapse */
                 /* if already doorless, treat like room or corridor */
-                if (levl[x][y].doormask == D_NODOOR)
+                if (loc(x, y)->doormask == D_NODOOR)
                     goto do_pit;
                 /* wasn't doorless, now it will be */
-                levl[x][y].doormask = D_NODOOR;
+                loc(x, y)->doormask = D_NODOOR;
                 unblock_point(x, y);
                 newsym(x, y); /* before pline */
                 if (cansee(x, y))
@@ -803,7 +803,7 @@ do_play_instrument(struct obj *instr)
                         /* tune now fully known */
                         u.uevent.uheard_tune = 2;
                         record_achievement(ACH_TUNE);
-                        if (levl[x][y].typ == DRAWBRIDGE_DOWN)
+                        if (loc(x, y)->typ == DRAWBRIDGE_DOWN)
                             close_drawbridge(x, y);
                         else
                             open_drawbridge(x, y);
@@ -820,7 +820,7 @@ do_play_instrument(struct obj *instr)
             for (y = u.uy - 1; y <= u.uy + 1 && !ok; y++)
                 for (x = u.ux - 1; x <= u.ux + 1 && !ok; x++)
                     if (isok(x, y))
-                        if (IS_DRAWBRIDGE(levl[x][y].typ)
+                        if (IS_DRAWBRIDGE(loc(x, y)->typ)
                             || is_drawbridge_wall(x, y) >= 0)
                             ok = TRUE;
             if (ok) { /* There is a drawbridge near */

--- a/src/nhlsel.c
+++ b/src/nhlsel.c
@@ -727,7 +727,7 @@ l_selection_flood(lua_State *L)
                        gc.coder ? gc.coder->croom : NULL, SP_COORD_PACK(x, y));
 
     if (isok(x, y)) {
-        set_floodfillchk_match_under(levl[x][y].typ);
+        set_floodfillchk_match_under(loc(x, y)->typ);
         selection_floodfill(sel, x, y, diagonals);
     }
     return 1;

--- a/src/nhlua.c
+++ b/src/nhlua.c
@@ -527,63 +527,63 @@ nhl_getmap(lua_State *L)
         lua_newtable(L);
 
         /* FIXME: some should be boolean values */
-        nhl_add_table_entry_int(L, "glyph", levl[x][y].glyph);
-        nhl_add_table_entry_int(L, "typ", levl[x][y].typ);
+        nhl_add_table_entry_int(L, "glyph", loc(x, y)->glyph);
+        nhl_add_table_entry_int(L, "typ", loc(x, y)->typ);
         nhl_add_table_entry_str(L, "typ_name",
-                                levltyp_to_name(levl[x][y].typ));
-        Sprintf(buf, "%c", splev_typ2chr(levl[x][y].typ));
+                                levltyp_to_name(loc(x, y)->typ));
+        Sprintf(buf, "%c", splev_typ2chr(loc(x, y)->typ));
         nhl_add_table_entry_str(L, "mapchr", buf);
-        nhl_add_table_entry_int(L, "seenv", levl[x][y].seenv);
-        nhl_add_table_entry_bool(L, "horizontal", levl[x][y].horizontal);
-        nhl_add_table_entry_bool(L, "lit", levl[x][y].lit);
-        nhl_add_table_entry_bool(L, "waslit", levl[x][y].waslit);
-        nhl_add_table_entry_int(L, "roomno", levl[x][y].roomno);
-        nhl_add_table_entry_bool(L, "edge", levl[x][y].edge);
-        nhl_add_table_entry_bool(L, "candig", levl[x][y].candig);
+        nhl_add_table_entry_int(L, "seenv", loc(x, y)->seenv);
+        nhl_add_table_entry_bool(L, "horizontal", loc(x, y)->horizontal);
+        nhl_add_table_entry_bool(L, "lit", loc(x, y)->lit);
+        nhl_add_table_entry_bool(L, "waslit", loc(x, y)->waslit);
+        nhl_add_table_entry_int(L, "roomno", loc(x, y)->roomno);
+        nhl_add_table_entry_bool(L, "edge", loc(x, y)->edge);
+        nhl_add_table_entry_bool(L, "candig", loc(x, y)->candig);
 
         nhl_add_table_entry_bool(L, "has_trap", t_at(x, y) ? 1 : 0);
 
-        /* TODO: FIXME: levl[x][y].flags */
+        /* TODO: FIXME: loc(x, y)->flags */
 
         lua_pushliteral(L, "flags");
         lua_newtable(L);
 
-        if (IS_DOOR(levl[x][y].typ)) {
+        if (IS_DOOR(loc(x, y)->typ)) {
             nhl_add_table_entry_bool(L, "nodoor",
-                                     (levl[x][y].flags == D_NODOOR));
+                                     (loc(x, y)->flags == D_NODOOR));
             nhl_add_table_entry_bool(L, "broken",
-                                     (levl[x][y].flags & D_BROKEN));
+                                     (loc(x, y)->flags & D_BROKEN));
             nhl_add_table_entry_bool(L, "isopen",
-                                     (levl[x][y].flags & D_ISOPEN));
+                                     (loc(x, y)->flags & D_ISOPEN));
             nhl_add_table_entry_bool(L, "closed",
-                                     (levl[x][y].flags & D_CLOSED));
+                                     (loc(x, y)->flags & D_CLOSED));
             nhl_add_table_entry_bool(L, "locked",
-                                     (levl[x][y].flags & D_LOCKED));
+                                     (loc(x, y)->flags & D_LOCKED));
             nhl_add_table_entry_bool(L, "trapped",
-                                     (levl[x][y].flags & D_TRAPPED));
-        } else if (IS_ALTAR(levl[x][y].typ)) {
+                                     (loc(x, y)->flags & D_TRAPPED));
+        } else if (IS_ALTAR(loc(x, y)->typ)) {
             /* TODO: bits 0, 1, 2 */
             nhl_add_table_entry_bool(L, "shrine",
-                                     (levl[x][y].flags & AM_SHRINE));
-        } else if (IS_THRONE(levl[x][y].typ)) {
+                                     (loc(x, y)->flags & AM_SHRINE));
+        } else if (IS_THRONE(loc(x, y)->typ)) {
             nhl_add_table_entry_bool(L, "looted",
-                                     (levl[x][y].flags & T_LOOTED));
-        } else if (levl[x][y].typ == TREE) {
+                                     (loc(x, y)->flags & T_LOOTED));
+        } else if (loc(x, y)->typ == TREE) {
             nhl_add_table_entry_bool(L, "looted",
-                                     (levl[x][y].flags & TREE_LOOTED));
+                                     (loc(x, y)->flags & TREE_LOOTED));
             nhl_add_table_entry_bool(L, "swarm",
-                                     (levl[x][y].flags & TREE_SWARM));
-        } else if (IS_FOUNTAIN(levl[x][y].typ)) {
+                                     (loc(x, y)->flags & TREE_SWARM));
+        } else if (IS_FOUNTAIN(loc(x, y)->typ)) {
             nhl_add_table_entry_bool(L, "looted",
-                                     (levl[x][y].flags & F_LOOTED));
+                                     (loc(x, y)->flags & F_LOOTED));
             nhl_add_table_entry_bool(L, "warned",
-                                     (levl[x][y].flags & F_WARNED));
-        } else if (IS_SINK(levl[x][y].typ)) {
+                                     (loc(x, y)->flags & F_WARNED));
+        } else if (IS_SINK(loc(x, y)->typ)) {
             nhl_add_table_entry_bool(L, "pudding",
-                                     (levl[x][y].flags & S_LPUDDING));
+                                     (loc(x, y)->flags & S_LPUDDING));
             nhl_add_table_entry_bool(L, "dishwasher",
-                                     (levl[x][y].flags & S_LDWASHER));
-            nhl_add_table_entry_bool(L, "ring", (levl[x][y].flags & S_LRING));
+                                     (loc(x, y)->flags & S_LDWASHER));
+            nhl_add_table_entry_bool(L, "ring", (loc(x, y)->flags & S_LRING));
         }
         /* TODO: drawbridges, walls, ladders, room=>ICED_xxx */
 

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -3458,7 +3458,7 @@ wizterrainwish(struct _readobjnam_data *d)
 
     /* furniture and terrain (use at your own risk; can clobber stairs
        or place furniture on existing traps which shouldn't be allowed) */
-    lev = &levl[x][y];
+    lev = loc(x, y);
     oldtyp = lev->typ;
     is_dbridge = (oldtyp == DRAWBRIDGE_DOWN || oldtyp == DRAWBRIDGE_UP);
     didblock = does_block(x, y, lev);
@@ -3698,8 +3698,8 @@ wizterrainwish(struct _readobjnam_data *d)
                          && (bp == p - 4 || p[-4] == ' ')) {
         schar wall = HWALL;
 
-        if ((isok(u.ux, u.uy-1) && IS_WALL(levl[u.ux][u.uy-1].typ))
-            || (isok(u.ux, u.uy+1) && IS_WALL(levl[u.ux][u.uy+1].typ)))
+        if ((isok(u.ux, u.uy-1) && IS_WALL(loc(u.ux, u.uy-1)->typ))
+            || (isok(u.ux, u.uy+1) && IS_WALL(loc(u.ux, u.uy+1)->typ)))
             wall = VWALL;
         madeterrain = TRUE;
         lev->typ = wall;
@@ -3802,7 +3802,7 @@ dbterrainmesg(
     coordxy x, coordxy y)
 {
     pline("%s %s the drawbridge.", newtype,
-          (levl[x][y].typ == DRAWBRIDGE_UP) ? "in front of" : "under");
+          (loc(x, y)->typ == DRAWBRIDGE_UP) ? "in front of" : "under");
 }
 
 #define TIN_UNDEFINED 0

--- a/src/pager.c
+++ b/src/pager.c
@@ -187,7 +187,7 @@ mhidden_description(
     struct obj *otmp;
     boolean fakeobj, isyou = (mon == &gy.youmonst);
     coordxy x = isyou ? u.ux : mon->mx, y = isyou ? u.uy : mon->my;
-    int glyph = (gl.level.flags.hero_memory && !isyou) ? levl[x][y].glyph
+    int glyph = (gl.level.flags.hero_memory && !isyou) ? loc(x, y)->glyph
                                                       : glyph_at(x, y);
 
     *outbuf = '\0';
@@ -333,9 +333,9 @@ look_at_object(
 
     if (otmp && otmp->where == OBJ_BURIED)
         Strcat(buf, " (buried)");
-    else if (levl[x][y].typ == STONE || levl[x][y].typ == SCORR)
+    else if (loc(x, y)->typ == STONE || loc(x, y)->typ == SCORR)
         Strcat(buf, " embedded in stone");
-    else if (IS_WALL(levl[x][y].typ) || levl[x][y].typ == SDOOR)
+    else if (IS_WALL(loc(x, y)->typ) || loc(x, y)->typ == SDOOR)
         Strcat(buf, " embedded in a wall");
     else if (closed_door(x, y))
         Strcat(buf, " embedded in a door");
@@ -554,7 +554,7 @@ ice_descr(coordxy x, coordxy y, char *outbuf)
 
     iflags.ice_rating = -1; /* secondary output, for 'mention_decor' */
     if (SURFACE_AT(x, y) != ICE) {
-        Sprintf(outbuf, "[ice:%d?]", (int) levl[x][y].typ);
+        Sprintf(outbuf, "[ice:%d?]", (int) loc(x, y)->typ);
     } else if ((distu(x, y) > neardist
                 || (!cansee(x, y) && (!u_at(x, y) || Levitation)))
                && !gd.decor_levitate_override) { /* probe_decor(pickup.c) */
@@ -685,7 +685,7 @@ lookat(coordxy x, coordxy y, char *buf, char *monbuf)
         case S_ndoor:
             if (is_drawbridge_wall(x, y) >= 0)
                 Strcpy(buf, "open drawbridge portcullis");
-            else if ((levl[x][y].doormask & ~D_TRAPPED) == D_BROKEN)
+            else if ((loc(x, y)->doormask & ~D_TRAPPED) == D_BROKEN)
                 Strcpy(buf, "broken door");
             else
                 Strcpy(buf, "doorway");
@@ -705,7 +705,7 @@ lookat(coordxy x, coordxy y, char *buf, char *monbuf)
             Strcpy(buf, "engraving");
             break;
         case S_stone:
-            if (!levl[x][y].seenv) {
+            if (!loc(x, y)->seenv) {
                 Strcpy(buf, "unexplored");
                 break;
             } else if (Underwater && !Is_waterlevel(&u.uz)) {
@@ -713,7 +713,7 @@ lookat(coordxy x, coordxy y, char *buf, char *monbuf)
                    submerged; better terminology appreciated... */
                 Strcpy(buf, (next2u(x, y)) ? "land" : "unknown");
                 break;
-            } else if (levl[x][y].typ == STONE || levl[x][y].typ == SCORR) {
+            } else if (loc(x, y)->typ == STONE || loc(x, y)->typ == SCORR) {
                 Strcpy(buf, "stone");
                 break;
             }
@@ -1086,7 +1086,7 @@ add_cmap_descr(
     } else if (absidx == S_pool || idx == S_water
                || idx == S_lava || idx == S_ice) {
         /* replace some descriptions (x_str) with waterbody_name() */
-        schar save_ltyp = levl[cc.x][cc.y].typ;
+        schar save_ltyp = loc(cc.x, cc.y)->typ;
         long save_prop = EHalluc_resistance;
 
         /* grab a scratch buffer we can safely return (via *firstmatch
@@ -1094,21 +1094,21 @@ add_cmap_descr(
         mbuf = mon_nam(&gy.youmonst);
 
         if (absidx == S_pool) {
-            levl[cc.x][cc.y].typ = (idx == S_pool) ? POOL : MOAT;
+            loc(cc.x, cc.y)->typ = (idx == S_pool) ? POOL : MOAT;
             idx = S_pool; /* force fake negative moat value to be positive */
         } else {
             /* we might be examining a pool location but trying to match
                water or lava; override the terrain with what we're matching
                because that's what waterbody_name() bases its result on;
                it's not pool so must be one of water/lava/ice to get here */
-            levl[cc.x][cc.y].typ = (idx == S_water) ? WATER
+            loc(cc.x, cc.y)->typ = (idx == S_water) ? WATER
                                    : (idx == S_lava) ? LAVAPOOL
                                      : ICE;
         }
         EHalluc_resistance = 1;
         Strcpy(mbuf, waterbody_name(cc.x, cc.y));
         EHalluc_resistance = save_prop;
-        levl[cc.x][cc.y].typ = save_ltyp;
+        loc(cc.x, cc.y)->typ = save_ltyp;
 
         /* shorten the feedback for farlook/quicklook: "a pool or ..." */
         if (!strcmp(mbuf, "pool of water"))
@@ -2032,9 +2032,9 @@ look_engrs(boolean nearby)
             if (!e)
                 continue;
             glyph = glyph_at(x, y);
-            sym = ((levl[x][y].typ == GRAVE || gl.lastseentyp[x][y] == GRAVE)
+            sym = ((loc(x, y)->typ == GRAVE || gl.lastseentyp[x][y] == GRAVE)
                    ? S_grave
-                   : (levl[x][y].typ == CORR) ? S_engrcorr
+                   : (loc(x, y)->typ == CORR) ? S_engrcorr
                      : S_engroom);
             is_headstone = (sym == S_grave);
             Sprintf(lookbuf, "(%s", is_headstone ? "grave" : "engraving");

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -312,7 +312,7 @@ force_decor(boolean via_probing)
     iflags.prev_decor = STONE;
     (void) describe_decor();
     gd.decor_fumble_override = gd.decor_levitate_override = FALSE;
-    gl.lastseentyp[u.ux][u.uy] = levl[u.ux][u.uy].typ;
+    gl.lastseentyp[u.ux][u.uy] = loc(u.ux, u.uy)->typ;
 }
 
 void
@@ -2264,7 +2264,7 @@ doloot_core(void)
             if (anyfound)
                 c = 'y';
         }
-    } else if (IS_GRAVE(levl[cc.x][cc.y].typ)) {
+    } else if (IS_GRAVE(loc(cc.x, cc.y)->typ)) {
         You("need to dig up the grave to effectively loot it...");
     }
 
@@ -2358,7 +2358,7 @@ reverse_loot(void)
        expects caller to do that; do so now */
     remove_worn_item(goldob, FALSE);
 
-    if (!IS_THRONE(levl[x][y].typ)) {
+    if (!IS_THRONE(loc(x, y)->typ)) {
         dropx(goldob);
         /* the dropped gold might have fallen to lower level */
         if (g_at(x, y))
@@ -2388,13 +2388,13 @@ reverse_loot(void)
                 boxdummy = cg.zeroobj, boxdummy.otyp = SPE_WIZARD_LOCK;
                 (void) boxlock(coffers, &boxdummy);
             }
-        } else if (levl[x][y].looted != T_LOOTED
+        } else if (loc(x, y)->looted != T_LOOTED
                    && (mon = makemon(courtmon(), x, y, NO_MM_FLAGS)) != 0) {
             freeinv(goldob);
             add_to_minv(mon, goldob);
             pline("The exchequer accepts your contribution.");
             if (!rn2(10))
-                levl[x][y].looted = T_LOOTED;
+                loc(x, y)->looted = T_LOOTED;
         } else {
             You("drop %s.", doname(goldob));
             dropx(goldob);
@@ -3686,7 +3686,7 @@ tipcontainer(struct obj *box) /* or bag */
     {
         struct obj *otmp, *nobj;
         boolean terse, highdrop = !can_reach_floor(TRUE),
-                altarizing = IS_ALTAR(levl[ox][oy].typ),
+                altarizing = IS_ALTAR(loc(ox, oy)->typ),
                 cursed_mbag = (Is_mbag(box) && box->cursed);
         long loss = 0L;
 

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -1472,7 +1472,7 @@ dospinweb(void)
     coordxy x = u.ux, y = u.uy;
     struct trap *ttmp = t_at(x, y);
     /* disallow webs on water, lava, air & cloud */
-    boolean reject_terrain = is_pool_or_lava(x, y) || IS_AIR(levl[x][y].typ);
+    boolean reject_terrain = is_pool_or_lava(x, y) || IS_AIR(loc(x, y)->typ);
 
     /* [at the time this was written, it was not possible to be both a
        webmaker and a flyer, but with the advent of amulet of flying that
@@ -1579,7 +1579,7 @@ dospinweb(void)
     } else if (On_stairs(x, y)) {
         /* cop out: don't let them hide the stairs */
         Your("web fails to impede access to the %s.",
-             (levl[x][y].typ == STAIRS) ? "stairs" : "ladder");
+             (loc(x, y)->typ == STAIRS) ? "stairs" : "ladder");
         return ECMD_TIME;
     }
     ttmp = maketrap(x, y, WEB);
@@ -1772,7 +1772,7 @@ dohide(void)
     /* note: hero-as-eel handling is incomplete but unnecessary;
        such critters aren't offered the option of hiding via #monster */
     if (gy.youmonst.data->mlet == S_EEL && !is_pool(u.ux, u.uy)) {
-        if (IS_FOUNTAIN(levl[u.ux][u.uy].typ))
+        if (IS_FOUNTAIN(loc(u.ux, u.uy)->typ))
             pline_The("fountain is not deep enough to hide in.");
         else
             There("is no %s to hide in here.", hliquid("water"));

--- a/src/potion.c
+++ b/src/potion.c
@@ -537,7 +537,7 @@ dodrink(void)
        context-sensitive inventory item action 'quaff' */
     if (!iflags.menu_requested) {
         /* Is there a fountain to drink from here? */
-        if (IS_FOUNTAIN(levl[u.ux][u.uy].typ)
+        if (IS_FOUNTAIN(loc(u.ux, u.uy)->typ)
             /* not as low as floor level but similar restrictions apply */
             && can_reach_floor(FALSE)) {
             if (y_n("Drink from the fountain?") == 'y') {
@@ -547,7 +547,7 @@ dodrink(void)
             ++drink_ok_extra;
         }
         /* Or a kitchen sink? */
-        if (IS_SINK(levl[u.ux][u.uy].typ)
+        if (IS_SINK(loc(u.ux, u.uy)->typ)
             /* not as low as floor level but similar restrictions apply */
             && can_reach_floor(FALSE)) {
             if (y_n("Drink from the sink?") == 'y') {
@@ -909,7 +909,7 @@ peffect_monster_detection(struct obj *otmp)
         incr_itimeout(&HDetect_monsters, i);
         for (x = 1; x < COLNO; x++) {
             for (y = 0; y < ROWNO; y++) {
-                if (levl[x][y].glyph == GLYPH_INVISIBLE) {
+                if (loc(x, y)->glyph == GLYPH_INVISIBLE) {
                     unmap_object(x, y);
                     newsym(x, y);
                 }
@@ -1194,7 +1194,7 @@ peffect_levitation(struct obj *otmp)
     } else /* timeout is already at least 1 */
         incr_itimeout(&HLevitation, rn1(140, 10));
 
-    if (Levitation && IS_SINK(levl[u.ux][u.uy].typ))
+    if (Levitation && IS_SINK(loc(u.ux, u.uy)->typ))
         spoteffects(FALSE);
     /* levitating blocks flying */
     float_vs_flight();
@@ -2234,7 +2234,7 @@ dodip(void)
     struct obj *potion, *obj;
     char qbuf[QBUFSZ], obuf[QBUFSZ];
     const char *shortestname; /* last resort obj name for prompt */
-    uchar here = levl[u.ux][u.uy].typ;
+    uchar here = loc(u.ux, u.uy)->typ;
     boolean is_hands, at_pool = is_pool(u.ux, u.uy),
             at_fountain = IS_FOUNTAIN(here), at_sink = IS_SINK(here),
             at_here = (!iflags.menu_requested

--- a/src/pray.c
+++ b/src/pray.c
@@ -98,9 +98,9 @@ static const char *const godvoices[] = {
 
 
 #define ugod_is_angry() (u.ualign.record < 0)
-#define on_altar() IS_ALTAR(levl[u.ux][u.uy].typ)
-#define on_shrine() ((levl[u.ux][u.uy].altarmask & AM_SHRINE) != 0)
-#define a_align(x, y) ((aligntyp) Amask2align(levl[x][y].altarmask & AM_MASK))
+#define on_altar() IS_ALTAR(loc(u.ux, u.uy)->typ)
+#define on_shrine() ((loc(u.ux, u.uy)->altarmask & AM_SHRINE) != 0)
+#define a_align(x, y) ((aligntyp) Amask2align(loc(x, y)->altarmask & AM_MASK))
 
 /* used by turn undead iteration function; always reinitialized
    before iterating that, so don't need to be globals */
@@ -167,8 +167,8 @@ stuck_in_wall(void)
                 continue;
             y = u.uy + j;
             if (!isok(x, y)
-                || (IS_ROCK(levl[x][y].typ)
-                    && (levl[x][y].typ != SDOOR && levl[x][y].typ != SCORR))
+                || (IS_ROCK(loc(x, y)->typ)
+                    && (loc(x, y)->typ != SDOOR && loc(x, y)->typ != SCORR))
                 || (blocked_boulder(i, j) && !throws_rocks(gy.youmonst.data)))
                 ++count;
         }
@@ -1643,9 +1643,9 @@ offer_different_alignment_altar(
             exercise(A_WIS, TRUE);
             change_luck(1);
             shrine = on_shrine();
-            levl[u.ux][u.uy].altarmask = Align2amask(u.ualign.type);
+            loc(u.ux, u.uy)->altarmask = Align2amask(u.ualign.type);
             if (shrine)
-                levl[u.ux][u.uy].altarmask |= AM_SHRINE;
+                loc(u.ux, u.uy)->altarmask |= AM_SHRINE;
             newsym(u.ux, u.uy); /* in case Invisible to self */
             if (!Blind)
                 pline_The("altar glows %s.",
@@ -1694,7 +1694,7 @@ sacrifice_your_race(
     } else if (altaralign != A_CHAOTIC && altaralign != A_NONE) {
         /* curse the lawful/neutral altar */
         pline_The("altar is stained with %s blood.", gu.urace.adj);
-        levl[u.ux][u.uy].altarmask = AM_CHAOTIC;
+        loc(u.ux, u.uy)->altarmask = AM_CHAOTIC;
         newsym(u.ux, u.uy); /* in case Invisible to self */
         angry_priest();
     } else {
@@ -1707,8 +1707,8 @@ sacrifice_your_race(
             pline(
             "The blood floods the altar, which vanishes in %s cloud!",
                     an(hcolor(NH_BLACK)));
-            levl[u.ux][u.uy].typ = ROOM;
-            levl[u.ux][u.uy].altarmask = 0;
+            loc(u.ux, u.uy)->typ = ROOM;
+            loc(u.ux, u.uy)->altarmask = 0;
             newsym(u.ux, u.uy);
             angry_priest();
             demonless_msg = "cloud dissipates";
@@ -1820,7 +1820,7 @@ dosacrifice(void)
         You("are too impaired to perform the rite.");
         return ECMD_OK;
     }
-    highaltar = (levl[u.ux][u.uy].altarmask & AM_SANCTUM);
+    highaltar = (loc(u.ux, u.uy)->altarmask & AM_SANCTUM);
 
     otmp = floorfood("sacrifice", 1);
     if (!otmp)
@@ -2402,8 +2402,8 @@ altarmask_at(coordxy x, coordxy y)
         if (mon && M_AP_TYPE(mon) == M_AP_FURNITURE
             && mon->mappearance == S_altar)
             res = has_mcorpsenm(mon) ? MCORPSENM(mon) : 0;
-        else if (IS_ALTAR(levl[x][y].typ))
-            res = levl[x][y].altarmask;
+        else if (IS_ALTAR(loc(x, y)->typ))
+            res = loc(x, y)->altarmask;
     }
     return res;
 }
@@ -2418,7 +2418,7 @@ a_gname(void)
 const char *
 a_gname_at(coordxy x, coordxy y)
 {
-    if (!IS_ALTAR(levl[x][y].typ))
+    if (!IS_ALTAR(loc(x, y)->typ))
         return (char *) 0;
 
     return align_gname(a_align(x, y));
@@ -2614,7 +2614,7 @@ blocked_boulder(int dx, int dy)
         return TRUE;
     if (!isok(nx, ny))
         return TRUE;
-    if (IS_ROCK(levl[nx][ny].typ))
+    if (IS_ROCK(loc(nx, ny)->typ))
         return TRUE;
     if (sobj_at(BOULDER, nx, ny))
         return TRUE;

--- a/src/priest.c
+++ b/src/priest.c
@@ -78,7 +78,7 @@ move_special(struct monst *mtmp, boolean in_his_shop, schar appr,
     for (i = 0; i < cnt; i++) {
         nx = poss[i].x;
         ny = poss[i].y;
-        if (IS_ROOM(levl[nx][ny].typ)
+        if (IS_ROOM(loc(nx, ny)->typ)
             || (mtmp->isshk && (!in_his_shop || ESHK(mtmp)->following))) {
             if (avoid && (info[i] & NOTONL) && !(info[i] & ALLOW_M))
                 continue;
@@ -244,7 +244,7 @@ priestini(
     priest = makemon(prim, px, py, MM_EPRI);
     if (priest) {
         EPRI(priest)->shroom = (schar) ((sroom - gr.rooms) + ROOMOFFSET);
-        EPRI(priest)->shralign = Amask2align(levl[sx][sy].altarmask);
+        EPRI(priest)->shralign = Amask2align(loc(sx, sy)->altarmask);
         EPRI(priest)->shrpos.x = sx;
         EPRI(priest)->shrpos.y = sy;
         assign_level(&(EPRI(priest)->shrlevel), lvl);
@@ -386,7 +386,7 @@ has_shrine(struct monst *pri)
     if (!pri || !pri->ispriest)
         return FALSE;
     epri_p = EPRI(pri);
-    lev = &levl[epri_p->shrpos.x][epri_p->shrpos.y];
+    lev = loc(epri_p->shrpos.x, epri_p->shrpos.y);
     if (!IS_ALTAR(lev->typ) || !(lev->altarmask & AM_SHRINE))
         return FALSE;
     return (boolean) (epri_p->shralign
@@ -772,7 +772,7 @@ ghod_hitsu(struct monst *priest)
     troom = &gr.rooms[roomno - ROOMOFFSET];
 
     if (u_at(x, y) || !linedup(u.ux, u.uy, x, y, 1)) {
-        if (IS_DOOR(levl[u.ux][u.uy].typ)) {
+        if (IS_DOOR(loc(u.ux, u.uy)->typ)) {
             if (u.ux == troom->lx - 1) {
                 x = troom->hx;
                 y = u.uy;
@@ -854,7 +854,7 @@ angry_priest(void)
          * a fresh corpse nearby, the priest ought to have an
          * opportunity to try converting it back; maybe someday...)
          */
-        lev = &levl[eprip->shrpos.x][eprip->shrpos.y];
+        lev = loc(eprip->shrpos.x, eprip->shrpos.y);
         if (!IS_ALTAR(lev->typ)
             || ((aligntyp) Amask2align(lev->altarmask & AM_MASK)
                 != eprip->shralign)) {

--- a/src/read.c
+++ b/src/read.c
@@ -1051,7 +1051,7 @@ valid_cloud_pos(coordxy x, coordxy y)
 {
     if (!isok(x,y))
         return FALSE;
-    return ACCESSIBLE(levl[x][y].typ) || is_pool(x, y) || is_lava(x, y);
+    return ACCESSIBLE(loc(x, y)->typ) || is_pool(x, y) || is_lava(x, y);
 }
 
 /* Callback for getpos_sethilite, also used in determining whether a scroll
@@ -1847,8 +1847,8 @@ seffect_earth(struct obj **sobjp)
                 for (y = u.uy - 1; y <= u.uy + 1; y++) {
                     /* Is this a suitable spot? */
                     if (isok(x, y) && !closed_door(x, y)
-                        && !IS_ROCK(levl[x][y].typ)
-                        && !IS_AIR(levl[x][y].typ)
+                        && !IS_ROCK(loc(x, y)->typ)
+                        && !IS_AIR(loc(x, y)->typ)
                         && (x != u.ux || y != u.uy)) {
                         nboulders +=
                             drop_boulder_on_monster(x, y, confused, TRUE);
@@ -2014,8 +2014,8 @@ seffect_magic_mapping(struct obj **sobjp)
 
             for (x = 1; x < COLNO; x++)
                 for (y = 0; y < ROWNO; y++)
-                    if (levl[x][y].typ == SDOOR)
-                        cvt_sdoor_to_door(&levl[x][y]);
+                    if (loc(x, y)->typ == SDOOR)
+                        cvt_sdoor_to_door(loc(x, y));
             /* do_mapping() already reveals secret passages */
         }
         gk.known = TRUE;
@@ -2359,7 +2359,7 @@ set_lit(coordxy x, coordxy y, genericptr_t val)
     struct litmon *gremlin;
 
     if (val) {
-        levl[x][y].lit = 1;
+        loc(x, y)->lit = 1;
         if ((mtmp = m_at(x, y)) != 0 && mtmp->data == &mons[PM_GREMLIN]) {
             gremlin = (struct litmon *) alloc(sizeof *gremlin);
             gremlin->mon = mtmp;
@@ -2367,7 +2367,7 @@ set_lit(coordxy x, coordxy y, genericptr_t val)
             gremlins = gremlin;
         }
     } else {
-        levl[x][y].lit = 0;
+        loc(x, y)->lit = 0;
         snuff_light_source(x, y);
     }
 }
@@ -2460,7 +2460,7 @@ litroom(
     if (Is_rogue_level(&u.uz)) {
         /* Can't use do_clear_area because MAX_RADIUS is too small */
         /* rogue lighting must light the entire room */
-        int rnum = levl[u.ux][u.uy].roomno - ROOMOFFSET;
+        int rnum = loc(u.ux, u.uy)->roomno - ROOMOFFSET;
         int rx, ry;
 
         if (rnum >= 0) {

--- a/src/region.c
+++ b/src/region.c
@@ -365,7 +365,7 @@ remove_region(NhRegion *reg)
                 for (y = reg->bounding_box.ly; y <= reg->bounding_box.hy; y++)
                     if (isok(x, y) && inside_region(reg, x, y)) {
                         if (pass == 1) {
-                            if (!does_block(x, y, &levl[x][y]))
+                            if (!does_block(x, y, loc(x, y)))
                                 unblock_point(x, y);
                         } else { /* pass==2 */
                             if (cansee(x, y))
@@ -1019,7 +1019,7 @@ expire_gas_cloud(genericptr_t p1, genericptr_t p2 UNUSED)
             for (y = reg->bounding_box.ly; y <= reg->bounding_box.hy; y++) {
                 if (inside_region(reg, x, y)) {
                     if (pass == 1) {
-                        if (!does_block(x, y, &levl[x][y]))
+                        if (!does_block(x, y, loc(x, y)))
                             unblock_point(x, y);
                         if (u_at(x, y))
                             gg.gas_cloud_diss_within = TRUE;

--- a/src/restore.c
+++ b/src/restore.c
@@ -960,7 +960,7 @@ rest_levl(
         while (i < ROWNO) {
             while (j < COLNO) {
                 if (len > 0) {
-                    levl[j][i] = r;
+                    *loc(j, i) = r;
                     len -= 1;
                     j += 1;
                 } else {
@@ -977,7 +977,7 @@ rest_levl(
     }
 #endif /* RLECOMP */
     if (nhfp->structlevel) {
-        Mread(nhfp->fd, levl, sizeof levl);
+        Mread(nhfp->fd, gl.level.locations, sizeof gl.level.locations);
     }
 }
 
@@ -1181,7 +1181,7 @@ getlev(NHFILE *nhfp, int pid, xint8 lev)
 
             mazexy(&cc);
             stairway_add(cc.x, cc.y, FALSE, FALSE, &dest);
-            levl[cc.x][cc.y].typ = STAIRS;
+            loc(cc.x, cc.y)->typ = STAIRS;
         }
 
         br = Is_branchlev(&u.uz);

--- a/src/save.c
+++ b/src/save.c
@@ -585,12 +585,12 @@ savelevl(NHFILE *nhfp, boolean rlecomp)
     if (rlecomp) {
         /* perform run-length encoding of rm structs */
 
-        rgrm = &levl[0][0]; /* start matching at first rm */
+        rgrm = &loc(0, 0)-> /* start matching at first rm */
         match = 0;
 
         for (y = 0; y < ROWNO; y++) {
             for (x = 0; x < COLNO; x++) {
-                prm = &levl[x][y];
+                prm = &loc(x, y)->
                 if (prm->glyph == rgrm->glyph && prm->typ == rgrm->typ
                     && prm->seenv == rgrm->seenv
                     && prm->horizontal == rgrm->horizontal
@@ -629,7 +629,7 @@ savelevl(NHFILE *nhfp, boolean rlecomp)
     nhUse(rlecomp);
 #endif /* ?RLECOMP */
     if (nhfp->structlevel) {
-        bwrite(nhfp->fd, (genericptr_t) levl, sizeof levl);
+        bwrite(nhfp->fd, (genericptr_t) gl.level.locations, sizeof gl.level.locations);
     }
     return;
 }

--- a/src/shknam.c
+++ b/src/shknam.c
@@ -588,17 +588,17 @@ good_shopdoor(struct mkroom *sroom, coordxy *sx, coordxy *sy)
         if (sroom->irregular) {
             int rmno = (int) ((sroom - gr.rooms) + ROOMOFFSET);
 
-            if (isok(*sx - 1, *sy) && !levl[*sx - 1][*sy].edge
-                && (int) levl[*sx - 1][*sy].roomno == rmno)
+            if (isok(*sx - 1, *sy) && !loc(*sx - 1, *sy)->edge
+                && (int) loc(*sx - 1, *sy)->roomno == rmno)
                 (*sx)--;
-            else if (isok(*sx + 1, *sy) && !levl[*sx + 1][*sy].edge
-                     && (int) levl[*sx + 1][*sy].roomno == rmno)
+            else if (isok(*sx + 1, *sy) && !loc(*sx + 1, *sy)->edge
+                     && (int) loc(*sx + 1, *sy)->roomno == rmno)
                 (*sx)++;
-            else if (isok(*sx, *sy - 1) && !levl[*sx][*sy - 1].edge
-                     && (int) levl[*sx][*sy - 1].roomno == rmno)
+            else if (isok(*sx, *sy - 1) && !loc(*sx, *sy - 1)->edge
+                     && (int) loc(*sx, *sy - 1)->roomno == rmno)
                 (*sy)--;
-            else if (isok(*sx, *sy + 1) && !levl[*sx][*sy + 1].edge
-                     && (int) levl[*sx][*sy + 1].roomno == rmno)
+            else if (isok(*sx, *sy + 1) && !loc(*sx, *sy + 1)->edge
+                     && (int) loc(*sx, *sy + 1)->roomno == rmno)
                 (*sy)++;
             else
                 continue;
@@ -686,8 +686,8 @@ static boolean
 stock_room_goodpos(struct mkroom *sroom, int rmno, int sh, int sx, int sy)
 {
     if (sroom->irregular) {
-        if (levl[sx][sy].edge
-            || (int) levl[sx][sy].roomno != rmno
+        if (loc(sx, sy)->edge
+            || (int) loc(sx, sy)->roomno != rmno
             || distmin(sx, sy, gd.doors[sh].x, gd.doors[sh].y) <= 1)
             return FALSE;
     } else if ((sx == sroom->lx && gd.doors[sh].x == sx - 1)
@@ -697,7 +697,7 @@ stock_room_goodpos(struct mkroom *sroom, int rmno, int sh, int sx, int sy)
         return FALSE;
 
     /* only generate items on solid floor squares */
-    if (!IS_ROOM(levl[sx][sy].typ)) {
+    if (!IS_ROOM(loc(sx, sy)->typ)) {
         return FALSE;
     }
 
@@ -727,18 +727,18 @@ stock_room(int shp_indx, struct mkroom *sroom)
     /* make sure no doorways without doors, and no trapped doors, in shops */
     sx = gd.doors[sroom->fdoor].x;
     sy = gd.doors[sroom->fdoor].y;
-    if (levl[sx][sy].doormask == D_NODOOR) {
-        levl[sx][sy].doormask = D_ISOPEN;
+    if (loc(sx, sy)->doormask == D_NODOOR) {
+        loc(sx, sy)->doormask = D_ISOPEN;
         newsym(sx, sy);
     }
-    if (levl[sx][sy].typ == SDOOR) {
-        cvt_sdoor_to_door(&levl[sx][sy]); /* .typ = DOOR */
+    if (loc(sx, sy)->typ == SDOOR) {
+        cvt_sdoor_to_door(loc(sx, sy)); /* .typ = DOOR */
         newsym(sx, sy);
     }
-    if (levl[sx][sy].doormask & D_TRAPPED)
-        levl[sx][sy].doormask = D_LOCKED;
+    if (loc(sx, sy)->doormask & D_TRAPPED)
+        loc(sx, sy)->doormask = D_LOCKED;
 
-    if (levl[sx][sy].doormask == D_LOCKED) {
+    if (loc(sx, sy)->doormask == D_LOCKED) {
         int m = sx, n = sy;
 
         if (inside_shop(sx + 1, sy))
@@ -751,8 +751,8 @@ stock_room(int shp_indx, struct mkroom *sroom)
             n++;
         Sprintf(buf, "Closed for inventory");
         make_engr_at(m, n, buf, 0L, DUST);
-        if (levl[m][n].typ != CORR && levl[m][n].typ != ROOM)
-            levl[m][n].typ = (Is_special(&u.uz)
+        if (loc(m, n)->typ != CORR && loc(m, n)->typ != ROOM)
+            loc(m, n)->typ = (Is_special(&u.uz)
                               || *in_rooms(m, n, 0)) ? ROOM : CORR;
     }
 

--- a/src/sit.c
+++ b/src/sit.c
@@ -185,9 +185,10 @@ throne_sit_effect(void)
             You_feel("somehow out of place...");
     }
 
-    if (!rn2(3) && IS_THRONE(levl[u.ux][u.uy].typ)) {
+    if (!rn2(3) && IS_THRONE(loc(u.ux, u.uy)->typ)) {
         /* may have teleported */
-        levl[u.ux][u.uy].typ = ROOM, levl[u.ux][u.uy].flags = 0;
+        loc(u.ux, u.uy)->typ = ROOM;
+        loc(u.ux, u.uy)->flags = 0;
         pline_The("throne vanishes in a puff of logic.");
         newsym(u.ux, u.uy);
     }
@@ -240,7 +241,7 @@ dosit(void)
 {
     static const char sit_message[] = "sit on the %s.";
     struct trap *trap = t_at(u.ux, u.uy);
-    int typ = levl[u.ux][u.uy].typ;
+    const int typ = loc(u.ux, u.uy)->typ;
 
     if (u.usteed) {
         You("are already sitting on %s.", mon_nam(u.usteed));

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -19,7 +19,7 @@ static int mon_in_room(struct monst *, int);
 static int
 mon_in_room(struct monst *mon, int rmtyp)
 {
-    int rno = levl[mon->mx][mon->my].roomno;
+    int rno = loc(mon->mx, mon->my)->roomno;
     if (rno >= ROOMOFFSET)
         return gr.rooms[rno - ROOMOFFSET].rtype == rmtyp;
     return FALSE;
@@ -1333,7 +1333,7 @@ dochat(void)
                           Hallucination ? rndmonnam((char *) 0) : "statue");
             return ECMD_OK;
         }
-        if (!Deaf && (IS_WALL(levl[tx][ty].typ) || levl[tx][ty].typ == SDOOR)) {
+        if (!Deaf && (IS_WALL(loc(tx, ty)->typ) || loc(tx, ty)->typ == SDOOR)) {
             /* Talking to a wall; secret door remains hidden by behaving
                like a wall; IS_WALL() test excludes solid rock even when
                that serves as a wall bordering a corridor */
@@ -1481,7 +1481,7 @@ tiphat(void)
                 && !is_silent(mtmp->data))
             /* we check accessible() after m_at() in case there's a
                visible monster phazing through a wall here */
-            || !(accessible(x, y) || levl[x][y].typ == IRONBARS))
+            || !(accessible(x, y) || loc(x, y)->typ == IRONBARS))
             break;
     }
 

--- a/src/spell.c
+++ b/src/spell.c
@@ -889,9 +889,9 @@ skill_based_spellbook_id(void)
    they would be earthed */
 #define CHAIN_LIGHTNING_TYP(typ) (IS_POOL(typ) || SPACE_POS(typ))
 #define CHAIN_LIGHTNING_POS(x, y)                                       \
-    (isok(x, y) && (CHAIN_LIGHTNING_TYP(levl[x][y].typ) ||              \
-                    (IS_DOOR(levl[x][y].typ) &&                         \
-                     !(levl[x][y].doormask & (D_CLOSED | D_LOCKED)))))
+    (isok(x, y) && (CHAIN_LIGHTNING_TYP(loc(x, y)->typ) ||              \
+                    (IS_DOOR(loc(x, y)->typ) &&                         \
+                     !(loc(x, y)->doormask & (D_CLOSED | D_LOCKED)))))
 
 struct chain_lightning_zap {
     /* direction in which this zap is currently moving; this is an
@@ -1098,7 +1098,7 @@ cast_protection(void)
             } else {
                 struct permonst *pm = u.ustuck ? u.ustuck->data : 0;
 
-                rmtyp = levl[u.ux][u.uy].typ;
+                rmtyp = loc(u.ux, u.uy)->typ;
                 atmosphere = (pm && u.uswallow)
                                 ? ((pm == &mons[PM_FOG_CLOUD]) ? "mist"
                                    : is_whirly(pm) ? "maelstrom"
@@ -1391,7 +1391,7 @@ spelleffects(int spell_otyp, boolean atme, boolean force)
                     u.dx = cc.x + rnd(3) - 2;
                     u.dy = cc.y + rnd(3) - 2;
                     if (!isok(u.dx, u.dy) || !cansee(u.dx, u.dy)
-                        || IS_STWALL(levl[u.dx][u.dy].typ) || u.uswallow) {
+                        || IS_STWALL(loc(u.dx, u.dy)->typ) || u.uswallow) {
                         /* Spell is reflected back to center */
                         u.dx = cc.x;
                         u.dy = cc.y;
@@ -1542,8 +1542,8 @@ spell_aim_step(genericptr_t arg UNUSED, coordxy x, coordxy y)
 {
     if (!isok(x,y))
         return FALSE;
-    if (!ZAP_POS(levl[x][y].typ)
-        && !(IS_DOOR(levl[x][y].typ) && (levl[x][y].doormask & D_ISOPEN)))
+    if (!ZAP_POS(loc(x, y)->typ)
+        && !(IS_DOOR(loc(x, y)->typ) && (loc(x, y)->doormask & D_ISOPEN)))
         return FALSE;
     return TRUE;
 }
@@ -1554,7 +1554,7 @@ can_center_spell_location(coordxy x, coordxy y)
 {
     if (distmin(u.ux, u.uy, x, y) > 10)
         return FALSE;
-    return (isok(x, y) && cansee(x, y) && !(IS_STWALL(levl[x][y].typ)));
+    return (isok(x, y) && cansee(x, y) && !(IS_STWALL(loc(x, y)->typ)));
 }
 
 static void
@@ -1620,7 +1620,7 @@ throwspell(void)
         return 1;
     } else if (((cc.x != u.ux || cc.y != u.uy) && !cansee(cc.x, cc.y)
                 && (!(mtmp = m_at(cc.x, cc.y)) || !canspotmon(mtmp)))
-               || IS_STWALL(levl[cc.x][cc.y].typ)) {
+               || IS_STWALL(loc(cc.x, cc.y)->typ)) {
         Your("mind fails to lock onto that location!");
         return 0;
     }

--- a/src/steal.c
+++ b/src/steal.c
@@ -841,7 +841,7 @@ mdrop_obj(
     if (unwornmask && mon->mtame && (unwornmask & W_SADDLE) != 0L
         && !obj->unpaid && costly_spot(omx, omy)
         /* being at costly_spot guarantees lev->roomno is not 0 */
-        && strchr(in_rooms(u.ux, u.uy, SHOPBASE), levl[omx][omy].roomno)) {
+        && strchr(in_rooms(u.ux, u.uy, SHOPBASE), loc(omx, omy)->roomno)) {
         obj->no_charge = 1;
     }
     /* obj_no_longer_held(obj); -- done by place_object */

--- a/src/teleport.c
+++ b/src/teleport.c
@@ -53,7 +53,7 @@ goodpos_onscary(
         || is_rider(mptr) || unique_corpstat(mptr))
         return FALSE;
     /* onscary() checks for vampshifted vampire bats/fog clouds/wolves too */
-    if (IS_ALTAR(levl[x][y].typ) && mptr->mlet == S_VAMPIRE)
+    if (IS_ALTAR(loc(x, y)->typ) && mptr->mlet == S_VAMPIRE)
         return TRUE;
     /* scare monster scroll doesn't have any of the below restrictions,
        being its own source of power */
@@ -524,7 +524,7 @@ teleds(coordxy nux, coordxy nuy, int teleds_flags)
     /* if terrain type changes, levitation or flying might become blocked
        or unblocked; might issue message, so do this after map+vision has
        been updated for new location instead of right after u_on_newpos() */
-    if (levl[u.ux][u.uy].typ != levl[u.ux0][u.uy0].typ)
+    if (loc(u.ux, u.uy)->typ != loc(u.ux0, u.uy0)->typ)
         switch_terrain();
     /* sequencing issue:  we want guard's alarm, if any, to occur before
        room entry message, if any, so need to check for vault exit prior
@@ -660,7 +660,7 @@ collect_coords(
                 if ((skip_mons && m_at(x, y))
                     /* note: !ACCESSIBLE() would reject water and lava;
                        !ZAP_POS() accepts them; caller needs to handle such */
-                    || (skip_inaccessible && !ZAP_POS(levl[x][y].typ)))
+                    || (skip_inaccessible && !ZAP_POS(loc(x, y)->typ)))
                     continue; /* quick filters */
                 if (filter && !(*filter)(x, y))
                     continue;
@@ -1530,10 +1530,10 @@ rloc_pos_ok(
            sent out of his room (caller might resort to goodpos() if
            we report failure here, so this isn't full prevention) */
         if (mtmp->isshk && inhishop(mtmp)) {
-            if (levl[x][y].roomno != (unsigned char) ESHK(mtmp)->shoproom)
+            if (loc(x, y)->roomno != (unsigned char) ESHK(mtmp)->shoproom)
                 return FALSE;
         } else if (mtmp->ispriest && inhistemple(mtmp)) {
-            if (levl[x][y].roomno !=  (unsigned char) EPRI(mtmp)->shroom)
+            if (loc(x, y)->roomno !=  (unsigned char) EPRI(mtmp)->shroom)
                 return FALSE;
         }
         /* current location is <xx,yy> */

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -353,7 +353,7 @@ levitation_dialogue(void)
     if (ELevitation)
         return;
 
-    if (!ACCESSIBLE(levl[u.ux][u.uy].typ)
+    if (!ACCESSIBLE(loc(u.ux, u.uy)->typ)
         && !is_pool_or_lava(u.ux,u.uy))
         return;
 
@@ -1796,7 +1796,7 @@ do_storms(void)
         do {
             x = rnd(COLNO - 1);
             y = rn2(ROWNO);
-        } while (++count < 100 && levl[x][y].typ != CLOUD);
+        } while (++count < 100 && loc(x, y)->typ != CLOUD);
 
         if (count < 100) {
             dirx = rn2(3) - 1;
@@ -1809,7 +1809,7 @@ do_storms(void)
         }
     }
 
-    if (levl[u.ux][u.uy].typ == CLOUD) {
+    if (loc(u.ux, u.uy)->typ == CLOUD) {
         /* Inside a cloud during a thunder storm is deafening. */
         /* Even if already deaf, we sense the thunder's vibrations. */
         Soundeffect(se_kaboom_boom_boom, 80);
@@ -2103,7 +2103,7 @@ timer_sanity_check(void)
             if (isok(x, y)) {
                 /* replicate isok() in order to convince static analysis
                    that the decoding via '& 0xFFFF' hasn't produced a value
-                   too big for levl[][] and that the cast to a narrower type
+                   too big for loc(, )->and that the cast to a narrower type
                    hasn't intruded on the sign bit to yield a negative value;
                    the analyzer isn't aware that isok() filters such things */
                 assert(x > 0 && x < COLNO && y >= 0 && y < ROWNO);
@@ -2111,7 +2111,7 @@ timer_sanity_check(void)
                 if (curr->func_index == MELT_ICE_AWAY && !is_ice(x, y))
                     impossible(
                          "timer sanity: melt timer %lu on non-ice %d <%d,%d>",
-                               t_id, levl[x][y].typ, x, y);
+                               t_id, loc(x, y)->typ, x, y);
             } else {
                 impossible("timer sanity: spot timer %lu at <%d,%d>",
                            t_id, x, y);

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -203,7 +203,7 @@ attack_checks(
          * not stay there, so the player will have suddenly forgotten
          * the square's contents for no apparent reason.
         if (!canspotmon(mtmp)
-            && !glyph_is_invisible(levl[gb.bhitpos.x][gb.bhitpos.y].glyph))
+            && !glyph_is_invisible(loc(gb.bhitpos.x, gb.bhitpos.y)->glyph))
             map_invisible(gb.bhitpos.x, gb.bhitpos.y);
          */
         return FALSE;
@@ -468,7 +468,7 @@ do_attack(struct monst *mtmp)
              */
             boolean foo = (Punished || !rn2(7)
                            || (is_longworm(mtmp->data) && mtmp->wormno)
-                           || (IS_ROCK(levl[u.ux][u.uy].typ)
+                           || (IS_ROCK(loc(u.ux, u.uy)->typ)
                                && !passes_walls(mtmp->data))),
                     inshop = FALSE;
             char *p;
@@ -570,7 +570,7 @@ do_attack(struct monst *mtmp)
      * evade.
      */
     if (gc.context.forcefight && !DEADMONSTER(mtmp) && !canspotmon(mtmp)
-        && !glyph_is_invisible(levl[u.ux + u.dx][u.uy + u.dy].glyph)
+        && !glyph_is_invisible(loc(u.ux + u.dx, u.uy + u.dy)->glyph)
         && !engulfing_u(mtmp))
         map_invisible(u.ux + u.dx, u.uy + u.dy);
 
@@ -693,7 +693,7 @@ hitum_cleave(
             continue;
         mtmp = m_at(tx, ty);
         if (!mtmp) {
-            if (glyph_is_invisible(levl[tx][ty].glyph))
+            if (glyph_is_invisible(loc(tx, ty)->glyph))
                 (void) unmap_invisible(tx, ty);
             continue;
         }
@@ -3279,7 +3279,7 @@ mhitm_ad_wrap(
             } else if (u.ustuck == magr) {
                 if (is_pool(magr->mx, magr->my) && !Swimming && !Amphibious
                     && !Breathless) {
-                    boolean moat = (levl[magr->mx][magr->my].typ != POOL)
+                    boolean moat = (loc(magr->mx, magr->my)->typ != POOL)
                                    && !is_waterwall(magr->mx, magr->my)
                                    && !Is_medusa_level(&u.uz)
                                    && !Is_waterlevel(&u.uz);
@@ -6022,7 +6022,7 @@ stumble_onto_mimic(struct monst *mtmp)
         else if (M_AP_TYPE(mtmp) == M_AP_MONSTER)
             what = a_monnam(mtmp); /* differs from what was sensed */
     } else {
-        int glyph = levl[u.ux + u.dx][u.uy + u.dy].glyph;
+        int glyph = loc(u.ux + u.dx, u.uy + u.dy)->glyph;
 
         if (glyph_is_cmap(glyph) && (glyph_to_cmap(glyph) == S_hcdoor
                                      || glyph_to_cmap(glyph) == S_vcdoor))
@@ -6044,7 +6044,7 @@ stumble_onto_mimic(struct monst *mtmp)
     /* if hero is blind, wakeup() won't display the monster even though
        it's no longer concealed */
     if (!canspotmon(mtmp)
-        && !glyph_is_invisible(levl[mtmp->mx][mtmp->my].glyph))
+        && !glyph_is_invisible(loc(mtmp->mx, mtmp->my)->glyph))
         map_invisible(mtmp->mx, mtmp->my);
 }
 
@@ -6085,7 +6085,7 @@ flash_hits_mon(struct monst *mtmp,
 
     if (gn.notonhead)
         return 0;
-    lev = &levl[mtmp->mx][mtmp->my];
+    lev = loc(mtmp->mx, mtmp->my);
     useeit = canseemon(mtmp);
 
     if (mtmp->msleeping && haseyes(mtmp->data)) {

--- a/src/vault.c
+++ b/src/vault.c
@@ -81,7 +81,7 @@ clear_fcorr(struct monst *grd, boolean forceshow)
                     m_into_limbo(mtmp);
             }
         }
-        lev = &levl[fcx][fcy];
+        lev = loc(fcx, fcy);
         if (lev->typ == CORR && cansee(fcx, fcy))
             sawcorridor = TRUE;
         lev->typ = egrd->fakecorr[fcbeg].ftyp;
@@ -108,7 +108,7 @@ clear_fcorr(struct monst *grd, boolean forceshow)
     /* only give encased message if hero is still alive (might get here
        via paygd() -> mongone() -> grddead() when game is over;
        died: no message, quit: message) */
-    if (IS_ROCK(levl[u.ux][u.uy].typ) && (Upolyd ? u.mh : u.uhp) > 0
+    if (IS_ROCK(loc(u.ux, u.uy)->typ) && (Upolyd ? u.mh : u.uhp) > 0
         && !silently)
         You("are encased in rock.");
     return TRUE;
@@ -128,7 +128,7 @@ blackout(coordxy x, coordxy y)
         for (j = y - 1; j <= y + 1; ++j) {
             if (!isok(i, j))
                 continue;
-            lev = &levl[i][j];
+            lev = loc(i, j);
             /* [possible bug: when (i != x || j != y), perhaps we ought
                to check whether the spot on the far side is lit instead
                of doing a blanket blackout of adjacent locations] */
@@ -293,10 +293,10 @@ find_guard_dest(struct monst *guard, coordxy *rx, coordxy *ry)
                 if (guard && ((x == guard->mx && y == guard->my)
                               || (guard->isgd && in_fcorridor(guard, x, y))))
                     continue;
-                if (levl[x][y].typ == CORR) {
+                if (loc(x, y)->typ == CORR) {
                     lx = (x < u.ux) ? x + 1 : (x > u.ux) ? x - 1 : x;
                     ly = (y < u.uy) ? y + 1 : (y > u.uy) ? y - 1 : y;
-                    if (levl[lx][ly].typ != STONE && levl[lx][ly].typ != CORR)
+                    if (loc(lx, ly)->typ != STONE && loc(lx, ly)->typ != CORR)
                         goto incr_radius;
                     *rx = x;
                     *ry = y;
@@ -346,30 +346,30 @@ invault(void)
         /* next find a good place for a door in the wall */
         x = u.ux;
         y = u.uy;
-        if (levl[x][y].typ != ROOM) { /* player dug a door and is in it */
-            if (levl[x + 1][y].typ == ROOM) {
+        if (loc(x, y)->typ != ROOM) { /* player dug a door and is in it */
+            if (loc(x + 1, y)->typ == ROOM) {
                 x = x + 1;
-            } else if (levl[x][y + 1].typ == ROOM) {
+            } else if (loc(x, y + 1)->typ == ROOM) {
                 y = y + 1;
-            } else if (levl[x - 1][y].typ == ROOM) {
+            } else if (loc(x - 1, y)->typ == ROOM) {
                 x = x - 1;
-            } else if (levl[x][y - 1].typ == ROOM) {
+            } else if (loc(x, y - 1)->typ == ROOM) {
                 y = y - 1;
-            } else if (levl[x + 1][y + 1].typ == ROOM) {
+            } else if (loc(x + 1, y + 1)->typ == ROOM) {
                 x = x + 1;
                 y = y + 1;
-            } else if (levl[x - 1][y - 1].typ == ROOM) {
+            } else if (loc(x - 1, y - 1)->typ == ROOM) {
                 x = x - 1;
                 y = y - 1;
-            } else if (levl[x + 1][y - 1].typ == ROOM) {
+            } else if (loc(x + 1, y - 1)->typ == ROOM) {
                 x = x + 1;
                 y = y - 1;
-            } else if (levl[x - 1][y + 1].typ == ROOM) {
+            } else if (loc(x - 1, y + 1)->typ == ROOM) {
                 x = x - 1;
                 y = y + 1;
             }
         }
-        while (levl[x][y].typ == ROOM) {
+        while (loc(x, y)->typ == ROOM) {
             int dx, dy;
 
             dx = (gdx > x) ? 1 : (gdx < x) ? -1 : 0;
@@ -380,16 +380,16 @@ invault(void)
                 y += dy;
         }
         if (u_at(x, y)) {
-            if (levl[x + 1][y].typ == HWALL || levl[x + 1][y].typ == DOOR)
+            if (loc(x + 1, y)->typ == HWALL || loc(x + 1, y)->typ == DOOR)
                 x = x + 1;
-            else if (levl[x - 1][y].typ == HWALL
-                     || levl[x - 1][y].typ == DOOR)
+            else if (loc(x - 1, y)->typ == HWALL
+                     || loc(x - 1, y)->typ == DOOR)
                 x = x - 1;
-            else if (levl[x][y + 1].typ == VWALL
-                     || levl[x][y + 1].typ == DOOR)
+            else if (loc(x, y + 1)->typ == VWALL
+                     || loc(x, y + 1)->typ == DOOR)
                 y = y + 1;
-            else if (levl[x][y - 1].typ == VWALL
-                     || levl[x][y - 1].typ == DOOR)
+            else if (loc(x, y - 1)->typ == VWALL
+                     || loc(x, y - 1)->typ == DOOR)
                 y = y - 1;
             else
                 return;
@@ -576,7 +576,7 @@ invault(void)
         EGD(guard)->fcbeg = 0;
         EGD(guard)->fakecorr[0].fx = x;
         EGD(guard)->fakecorr[0].fy = y;
-        typ = levl[x][y].typ;
+        typ = loc(x, y)->typ;
         if (!IS_WALL(typ)) {
             /* guard arriving at non-wall implies a door; vault wall was
                dug into an empty doorway (which could subsequently have
@@ -600,15 +600,15 @@ invault(void)
 
             /* we lack access to the original wall_info bit mask for this
                former wall location so recreate it */
-            levl[x][y].typ = typ; /* wall; will be changed to door below */
-            levl[x][y].wall_info = 0; /* will be reset too via doormask */
+            loc(x, y)->typ = typ; /* wall; will be changed to door below */
+            loc(x, y)->wall_info = 0; /* will be reset too via doormask */
             xy_set_wall_state(x, y); /* set WA_MASK bits in .wall_info */
         }
         EGD(guard)->fakecorr[0].ftyp = typ;
-        EGD(guard)->fakecorr[0].flags = levl[x][y].flags;
+        EGD(guard)->fakecorr[0].flags = loc(x, y)->flags;
         /* guard's entry point where confrontation with hero takes place */
-        levl[x][y].typ = DOOR;
-        levl[x][y].doormask = D_NODOOR;
+        loc(x, y)->typ = DOOR;
+        loc(x, y)->doormask = D_NODOOR;
         unblock_point(x, y); /* empty doorway doesn't block light */
         EGD(guard)->fcend = 1;
         EGD(guard)->warncnt = 1;
@@ -650,7 +650,7 @@ wallify_vault(struct monst *grd)
             if (x != lox && x != hix && y != loy && y != hiy)
                 continue;
 
-            if ((!IS_WALL(levl[x][y].typ) || g_at(x, y)
+            if ((!IS_WALL(loc(x, y)->typ) || g_at(x, y)
                  || sobj_at(ROCK, x, y) || sobj_at(BOULDER, x, y))
                 && !in_fcorridor(grd, x, y)) {
                 if ((mon = m_at(x, y)) != 0 && mon != grd) {
@@ -687,8 +687,8 @@ wallify_vault(struct monst *grd)
                 else /* not left or right side, must be top or bottom */
                     typ = HWALL;
 
-                levl[x][y].typ = typ;
-                levl[x][y].wall_info = 0;
+                loc(x, y)->typ = typ;
+                loc(x, y)->wall_info = 0;
                 xy_set_wall_state(x, y); /* set WA_MASK bits in .wall_info */
                 del_engr_at(x, y);
                 /*
@@ -954,8 +954,8 @@ gd_move(struct monst *grd)
                 }
                 grd->mpeaceful = 0;
                 mnexto(grd, RLOC_NOMSG);
-                levl[m][n].typ = egrd->fakecorr[0].ftyp;
-                levl[m][n].flags = egrd->fakecorr[0].flags;
+                loc(m, n)->typ = egrd->fakecorr[0].ftyp;
+                loc(m, n)->flags = egrd->fakecorr[0].flags;
                 del_engr_at(m, n);
                 newsym(m, n);
                 return -1;
@@ -971,8 +971,8 @@ gd_move(struct monst *grd)
                 m = grd->mx;
                 n = grd->my;
                 (void) rloc(grd, RLOC_MSG);
-                levl[m][n].typ = egrd->fakecorr[0].ftyp;
-                levl[m][n].flags = egrd->fakecorr[0].flags;
+                loc(m, n)->typ = egrd->fakecorr[0].ftyp;
+                loc(m, n)->flags = egrd->fakecorr[0].flags;
                 del_engr_at(m, n);
                 newsym(m, n);
                 grd->mpeaceful = 0;
@@ -992,7 +992,7 @@ gd_move(struct monst *grd)
     if (egrd->fcend > 1) {
         if (egrd->fcend > 2 && in_fcorridor(grd, grd->mx, grd->my)
             && !egrd->gddone && !in_fcorridor(grd, u.ux, u.uy)
-            && (levl[egrd->fakecorr[0].fx][egrd->fakecorr[0].fy].typ
+            && (loc(egrd->fakecorr[0].fx, egrd->fakecorr[0].fy)->typ
                 == egrd->fakecorr[0].ftyp)) {
             pline("%s, confused, disappears.", noit_Monnam(grd));
             return gd_move_cleanup(grd, semi_dead, TRUE);
@@ -1065,7 +1065,7 @@ gd_move(struct monst *grd)
         for (ny = y - 1; ny <= y + 1; ny++) {
             if ((nx == x || ny == y) && (nx != x || ny != y)
                 && isok(nx, ny)) {
-                crm = &levl[nx][ny];
+                crm = loc(nx, ny);
                 typ = crm->typ;
                 if (!IS_STWALL(typ) && !IS_POOL(typ)) {
                     if (in_fcorridor(grd, nx, ny))
@@ -1102,12 +1102,12 @@ gd_move(struct monst *grd)
     else
         ny += dy;
 
-    while ((typ = (crm = &levl[nx][ny])->typ) != STONE) {
+    while ((typ = (crm = loc(nx, ny))->typ) != STONE) {
         ex = nx + nx - x;
         ey = ny + ny - y;
         /* in view of the above we must have IS_WALL(typ) or typ == POOL */
         /* must be a wall here */
-        if (isok(ex, ey) && IS_ROOM(levl[ex][ey].typ)) {
+        if (isok(ex, ey) && IS_ROOM(loc(ex, ey)->typ)) {
             crm->typ = DOOR;
             crm->doormask = D_NODOOR;
             del_engr_at(ex, ey);

--- a/src/vision.c
+++ b/src/vision.c
@@ -194,7 +194,7 @@ does_block(int x, int y, struct rm *lev)
 /*
  * vision_reset()
  *
- * This must be called *after* the levl[][] structure is set with the new
+ * This must be called *after* the loc(, )->structure is set with the new
  * level and the level monsters and objects are in place.
  */
 void
@@ -218,7 +218,7 @@ vision_reset(void)
     for (y = 0; y < ROWNO; y++) {
         dig_left = 0;
         block = TRUE; /* location (0,y) is always stone; it's !isok() */
-        lev = &levl[1][y];
+        lev = loc(1, y);
         for (x = 1; x < COLNO; x++, lev += ROWNO)
             if (block != (IS_ROCK(lev->typ) || does_block(x, y, lev))) {
                 if (block) {
@@ -303,7 +303,7 @@ get_unused_cs(seenV ***rows, coordxy **rmin, coordxy **rmax)
 static void
 rogue_vision(seenV **next, coordxy *rmin, coordxy *rmax)
 {
-    int rnum = levl[u.ux][u.uy].roomno - ROOMOFFSET; /* no SHARED... */
+    int rnum = loc(u.ux, u.uy)->roomno - ROOMOFFSET; /* no SHARED... */
     int start, stop, in_door, xhi, xlo, yhi, ylo;
     int zx, zy;
 
@@ -317,14 +317,14 @@ rogue_vision(seenV **next, coordxy *rmin, coordxy *rmax)
             for (zx = start; zx <= stop; zx++) {
                 if (gr.rooms[rnum].rlit) {
                     next[zy][zx] = COULD_SEE | IN_SIGHT;
-                    levl[zx][zy].seenv = SVALL; /* see the walls */
+                    loc(zx, zy)->seenv = SVALL; /* see the walls */
                 } else
                     next[zy][zx] = COULD_SEE;
             }
         }
     }
 
-    in_door = levl[u.ux][u.uy].typ == DOOR;
+    in_door = loc(u.ux, u.uy)->typ == DOOR;
 
     /* Can always see adjacent. */
     ylo = max(u.uy - 1, 0);
@@ -638,8 +638,8 @@ vision_recalc(int control)
                         char old_row_val = next_row[col];
 
                         next_row[col] |= IN_SIGHT;
-                        oldseenv = levl[col][row].seenv;
-                        levl[col][row].seenv = SVALL; /* see all! */
+                        oldseenv = loc(col, row)->seenv;
+                        loc(col, row)->seenv = SVALL; /* see all! */
                         /* Update if previously not in sight or new angle. */
                         if (!(old_row_val & IN_SIGHT) || oldseenv != SVALL)
                             newsym(col, row);
@@ -651,7 +651,7 @@ vision_recalc(int control)
 
             } else { /* range is 0 */
                 next_array[u.uy][u.ux] |= IN_SIGHT;
-                levl[u.ux][u.uy].seenv = SVALL;
+                loc(u.ux, u.uy)->seenv = SVALL;
                 next_rmin[u.uy] = min(u.ux, next_rmin[u.uy]);
                 next_rmax[u.uy] = max(u.ux, next_rmax[u.uy]);
             }
@@ -660,7 +660,7 @@ vision_recalc(int control)
         if (has_night_vision && u.xray_range < u.nv_range) {
             if (!u.nv_range) { /* range is 0 */
                 next_array[u.uy][u.ux] |= IN_SIGHT;
-                levl[u.ux][u.uy].seenv = SVALL;
+                loc(u.ux, u.uy)->seenv = SVALL;
                 next_rmin[u.uy] = min(u.ux, next_rmin[u.uy]);
                 next_rmax[u.uy] = max(u.ux, next_rmax[u.uy]);
             } else if (u.nv_range > 0) {
@@ -724,7 +724,7 @@ vision_recalc(int control)
         /* Find the min and max positions on the row. */
         start = min(gv.viz_rmin[row], next_rmin[row]);
         stop = max(gv.viz_rmax[row], next_rmax[row]);
-        lev = &levl[start][row];
+        lev = loc(start, row);
 
         sv = &seenv_matrix[dy + 1][start < u.ux ? 0 : (start > u.ux ? 2 : 1)];
 
@@ -758,7 +758,7 @@ vision_recalc(int control)
                      */
                     dx = u.ux - col;
                     dx = sign(dx);
-                    flev = &(levl[col + dx][row + dy]);
+                    flev = loc(col + dx, row + dy);
                     if (flev->lit
                         || next_array[row + dy][col + dx] & TEMP_LIT) {
                         next_row[col] |= IN_SIGHT; /* we see it */
@@ -850,7 +850,7 @@ block_point(int x, int y)
         gs.seethru = (wizard && explicitdebug("seethru")) ? 1 : -1;
     }
     if (gs.seethru == 1) {
-        if (!does_block(x, y, &levl[x][y]))
+        if (!does_block(x, y, loc(x, y)))
             return;
     }
 #endif


### PR DESCRIPTION
Replace levl macro and direct access to the room locations with a loc(x, y) macro which will direct 
access into a static inline function with type and optionally, if DEBUG is enabled, boundary checking.

This will reveal out of bounds access to the gl.level.locations

I have found multiple callsites that do access rm[] with y >= 21  (ROWNO)  and seen also -1 as index.
Obviously future work could be to extend this kind of hardening to objects and mon array accesses.

I dont know if this kind of large patch causing churn is desirable in this stage of development. In that case this can be used as out of tree debugging aid if someone is interested of hunting the all callsites down. And to handle the varying callsites in 'Issues', one backtrace per issue.

debugfuzzer will usually find out of bound access within a minute or two with this applied.

Thoughts?
