### PR TITLE
Rephrase "rotten" non-rottable items

### DIFF
--- a/src/eat.c
+++ b/src/eat.c
@@ -1718,7 +1718,7 @@ static int
 rottenfood(struct obj *obj)
 {
     pline("Blecch!  %s %s!",
-          is_metallic(obj) ? "Awful" : "Rotten", foodword(obj));
+          is_rottable(obj) ? "Rotten" : "Awful", foodword(obj));
     if (!rn2(4)) {
         if (Hallucination)
             You_feel("rather trippy.");


### PR DESCRIPTION
A little tweak to #1202 / c134a128acc59f40b2d6cfe9654d77aefae774e0

Also describe rotten plastic (eatable by fire elementals) as "Awful" instead of "Rotten" and do the same if other non-rottable materials become edible in the future.