### PR TITLE
followup fix for github issue #1157.

### DIFF
--- a/src/muse.c
+++ b/src/muse.c
@@ -1562,7 +1562,7 @@ mbhitm(struct monst *mtmp, struct obj *otmp)
         } else {
             miss("wand", mtmp);
         }
-        if (learnit && cansee(mtmp->mx, mtmp->my) && gz.zap_oseen)
+        if (learnit && gz.zap_oseen)
             makeknown(WAN_STRIKING);
         break;
     case WAN_TELEPORTATION:


### PR DESCRIPTION
For some reason the cansee check wasn't working to see the monster zapping the wand. Changed it to canseemon and tested getting zapped and it auto-identifies now.