### PR TITLE
Make the curses windowport able to interpret glyph color adjustment

### DIFF
--- a/win/curses/cursmain.c
+++ b/win/curses/cursmain.c
@@ -913,6 +913,16 @@ curses_print_glyph(
     special = glyphinfo->gm.glyphflags;
     ch = glyphinfo->ttychar;
     color = glyphinfo->gm.sym.color;
+
+#ifdef ENHANCED_SYMBOLS
+    /* The curses library does not support truecolor, only the more limited 256
+       color mode. On top of this, the windowport only supports 16 color mode.
+       Thus, we only allow users to customize glyph colors to the basic NetHack
+       colors. */
+    if (glyphinfo->gm.u && glyphinfo->gm.u->ucolor & NH_BASIC_COLOR) {
+        color = (glyphinfo->gm.u->ucolor & ~NH_BASIC_COLOR);
+    }
+#endif
     if ((special & MG_PET) && iflags.hilite_pet) {
         attr = curses_convert_attr(iflags.wc2_petattr);
     }


### PR DESCRIPTION
The ncurses library only has 256 color support, but the curses windowport is limited even beyond this, to 16 colors. This commit allows curses to do a limited interpretation of the glyph user color adjustment to the basic NetHack colors. Two examples:

This works:

    OPTIONS=glyph:G_pet_female_kitten:U+0066/red

This does not since it tries to invoke a 24bit color:

    OPTIONS=glyph:G_pet_female_kitten:U+0066/255-0-0

Something I was also contemplating, unrelated to implementation of this support in curses, would be the ability for the following:

* allow defining colors if other symbol handling modes are used (possibly limited to the standard 16 colors)
* allow defining attributes (for example: glyph:G_pet_female_kitten:U+0066/red/underline)
* allow specifying glyphs as wildcards for defining global color/attribute changes