### PR TITLE
Un-defer shimmering dragons.

### DIFF
--- a/include/mondata.h
+++ b/include/mondata.h
@@ -154,6 +154,9 @@
 #define infravision(ptr) (((ptr)->mflags3 & M3_INFRAVISION))
 #define infravisible(ptr) (((ptr)->mflags3 & M3_INFRAVISIBLE))
 #define is_displacer(ptr) (((ptr)->mflags3 & M3_DISPLACES) != 0L)
+#define is_displaced(ptr) ((ptr) == &mons[PM_DISPLACER_BEAST] \
+                            || (ptr) == &mons[PM_SHIMMERING_DRAGON] \
+                            || (ptr) == &mons[PM_BABY_SHIMMERING_DRAGON])
 #define is_mplayer(ptr) \
     (((ptr) >= &mons[PM_ARCHEOLOGIST]) && ((ptr) <= &mons[PM_WIZARD]))
 #define is_watch(ptr) \

--- a/include/monsters.h
+++ b/include/monsters.h
@@ -1360,8 +1360,6 @@
         M1_FLY | M1_THICK_HIDE | M1_NOHANDS | M1_CARNIVORE,
         M2_HOSTILE | M2_STRONG | M2_GREEDY | M2_JEWELS, 0,
         13, DRAGON_SILVER, BABY_SILVER_DRAGON),
-#if 0 /* DEFERRED */
-    /* [see "shimmering dragon" below] */
     MON(NAM("baby shimmering dragon"), S_DRAGON,
         LVL(12, 9, 2, 10, 0), G_GENO,
         A(ATTK(AT_BITE, AD_PHYS, 2, 6),
@@ -1370,7 +1368,6 @@
         M1_FLY | M1_THICK_HIDE | M1_NOHANDS | M1_CARNIVORE,
         M2_HOSTILE | M2_STRONG | M2_GREEDY | M2_JEWELS, 0,
         13, CLR_CYAN, BABY_SHIMMERING_DRAGON),
-#endif
     MON(NAM("baby red dragon"), S_DRAGON,
         LVL(12, 9, 2, 10, 0), G_GENO,
         A(ATTK(AT_BITE, AD_PHYS, 2, 6),
@@ -1461,11 +1458,6 @@
         M2_HOSTILE | M2_STRONG | M2_NASTY | M2_GREEDY | M2_JEWELS | M2_MAGIC,
         0,
         20, DRAGON_SILVER, SILVER_DRAGON),
-#if 0 /* DEFERRED */
-    /* shimmering scales/scale-mail would confer displacement when worn by
-       the hero, so shimmering dragon ought to be displaced (hero who can
-       see one might misjudge its location) but monster displacement hasn't
-       been implemented so we don't include it */
     MON(NAM("shimmering dragon"), S_DRAGON,
         LVL(15, 9, -1, 20, 4), (G_GENO | 1),
         A(ATTK(AT_BREA, AD_MAGM, 4, 6), ATTK(AT_BITE, AD_PHYS, 3, 8),
@@ -1477,7 +1469,6 @@
         M2_HOSTILE | M2_STRONG | M2_NASTY | M2_GREEDY | M2_JEWELS | M2_MAGIC,
         0,
         20, CLR_CYAN, SHIMMERING_DRAGON),
-#endif
     /* red dragon has infravision and can be seen via infravision */
     MON(NAM("red dragon"), S_DRAGON,
         LVL(15, 9, -1, 20, -4), (G_GENO | 1),

--- a/include/objects.h
+++ b/include/objects.h
@@ -498,10 +498,8 @@ DRGN_ARMR("gold dragon scale mail",    1, 0,           900, 1, HI_GOLD,
                                                     GOLD_DRAGON_SCALE_MAIL),
 DRGN_ARMR("silver dragon scale mail",  1, REFLECTING, 1200, 1, DRAGON_SILVER,
                                                     SILVER_DRAGON_SCALE_MAIL),
-#if 0 /* DEFERRED */
 DRGN_ARMR("shimmering dragon scale mail", 1, DISPLACED, 1200, 1, CLR_CYAN,
                                                 SHIMMERING_DRAGON_SCALE_MAIL),
-#endif
 DRGN_ARMR("red dragon scale mail",     1, FIRE_RES,    900, 1, CLR_RED,
                                                     RED_DRAGON_SCALE_MAIL),
 DRGN_ARMR("white dragon scale mail",   1, COLD_RES,    900, 1, CLR_WHITE,
@@ -525,10 +523,8 @@ DRGN_ARMR("gold dragon scales",        0, 0,           500, 7, HI_GOLD,
                                                         GOLD_DRAGON_SCALES),
 DRGN_ARMR("silver dragon scales",      0, REFLECTING,  700, 7, DRAGON_SILVER,
                                                         SILVER_DRAGON_SCALES),
-#if 0 /* DEFERRED */
 DRGN_ARMR("shimmering dragon scales",  0, DISPLACED,   700, 7, CLR_CYAN,
                                                     SHIMMERING_DRAGON_SCALES),
-#endif
 DRGN_ARMR("red dragon scales",         0, FIRE_RES,    500, 7, CLR_RED,
                                                         RED_DRAGON_SCALES),
 DRGN_ARMR("white dragon scales",       0, COLD_RES,    500, 7, CLR_WHITE,

--- a/src/eat.c
+++ b/src/eat.c
@@ -1230,9 +1230,14 @@ cpostfx(int pm)
         }
         break;
     case PM_DISPLACER_BEAST:
+    case PM_SHIMMERING_DRAGON:
+    case PM_BABY_SHIMMERING_DRAGON:
         if (!Displaced) /* give a message (before setting the timeout) */
             toggle_displacement((struct obj *) 0, 0L, TRUE);
-        incr_itimeout(&HDisplaced, d(6, 6));
+        if (pm == PM_SHIMMERING_DRAGON)
+            incr_itimeout(&HDisplaced, rn1(300, 300))
+        else
+            incr_itimeout(&HDisplaced, d(6, 6));
         break;
     case PM_DISENCHANTER:
         /* picks an intrinsic at random and removes it; there's

--- a/src/eat.c
+++ b/src/eat.c
@@ -1235,7 +1235,7 @@ cpostfx(int pm)
         if (!Displaced) /* give a message (before setting the timeout) */
             toggle_displacement((struct obj *) 0, 0L, TRUE);
         if (pm == PM_SHIMMERING_DRAGON)
-            incr_itimeout(&HDisplaced, rn1(300, 300))
+            incr_itimeout(&HDisplaced, rn1(300, 300));
         else
             incr_itimeout(&HDisplaced, d(6, 6));
         break;

--- a/src/hack.c
+++ b/src/hack.c
@@ -1858,7 +1858,7 @@ domove_attackmon_at(
         || ((hides_under(mtmp->data) || mtmp->data->mlet == S_EEL)
             && !is_safemon(mtmp))) {
         /* target monster might decide to switch places with you... */
-        *displaceu = (mtmp->data == &mons[PM_DISPLACER_BEAST] && !rn2(2)
+        *displaceu = (is_displaced(mtmp->data) && !rn2(2)
                       && mtmp->mux == u.ux0 && mtmp->muy == u.uy0
                       && !helpless(mtmp)
                       && !mtmp->meating && !mtmp->mtrapped

--- a/src/mon.c
+++ b/src/mon.c
@@ -546,9 +546,7 @@ make_corpse(struct monst *mtmp, unsigned int corpseflags)
     case PM_GRAY_DRAGON:
     case PM_GOLD_DRAGON:
     case PM_SILVER_DRAGON:
-#if 0 /* DEFERRED */
     case PM_SHIMMERING_DRAGON:
-#endif
     case PM_RED_DRAGON:
     case PM_ORANGE_DRAGON:
     case PM_WHITE_DRAGON:
@@ -751,6 +749,7 @@ make_corpse(struct monst *mtmp, unsigned int corpseflags)
 
     case PM_BABY_GRAY_DRAGON: case PM_BABY_GOLD_DRAGON:
     case PM_BABY_SILVER_DRAGON: case PM_BABY_RED_DRAGON:
+    case PM_BABY_SHIMMERING_DRAGON:
     case PM_BABY_WHITE_DRAGON: case PM_BABY_ORANGE_DRAGON:
     case PM_BABY_BLACK_DRAGON: case PM_BABY_BLUE_DRAGON:
     case PM_BABY_GREEN_DRAGON: case PM_BABY_YELLOW_DRAGON:

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -2107,7 +2107,7 @@ set_apparxy(struct monst *mtmp)
     }
 
     notseen = (!mtmp->mcansee || (Invis && !perceives(mtmp->data)));
-    notthere = (Displaced && mtmp->data != &mons[PM_DISPLACER_BEAST]);
+    notthere = (Displaced && !is_displaced(mtmp->data));
     /* add cases as required.  eg. Displacement ... */
     if (Underwater) {
         displ = 1;

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -2173,11 +2173,9 @@ armor_to_dragon(int atyp)
     case GOLD_DRAGON_SCALE_MAIL:
     case GOLD_DRAGON_SCALES:
         return PM_GOLD_DRAGON;
-#if 0 /* DEFERRED */
     case SHIMMERING_DRAGON_SCALE_MAIL:
     case SHIMMERING_DRAGON_SCALES:
         return PM_SHIMMERING_DRAGON;
-#endif
     case RED_DRAGON_SCALE_MAIL:
     case RED_DRAGON_SCALES:
         return PM_RED_DRAGON;

--- a/win/share/tilemap.c
+++ b/win/share/tilemap.c
@@ -161,8 +161,6 @@ struct conditionals_t {
 #endif
     /* commented out in monst.c at present */
     { MON_GLYPH, PM_SHOCKING_SPHERE, "beholder" },
-    { MON_GLYPH, PM_BABY_SILVER_DRAGON, "baby shimmering dragon" },
-    { MON_GLYPH, PM_SILVER_DRAGON, "shimmering dragon" },
     { MON_GLYPH, PM_JABBERWOCK, "vorpal jabberwock" },
     { MON_GLYPH, PM_VAMPIRE_LEADER, "vampire mage" },
 #ifndef CHARON /* not supported yet */


### PR DESCRIPTION
A comment in the codebase indicates that shimmering dragons are deferred because monster displacement has not yet been implemented. Seeing as that is no longer the case I believe they should be added back in, particularly because shimmering dragon scale mail presents another interesting ascension kit item.

I added a bit of code to ensure that like displacer beasts, shimmering dragon and baby shimmering dragon corpses grant temporary displacement upon consumption. Corpses of full grown dragons grant a large number of turns of displacement in order to reward a player that deals with the additional challenge of one spawning in the castle, and also to present an interesting option for something to wish for before entering the planes.