### PR TITLE
Fix: zapping a wand of fire down while water walking on a pool

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -3217,6 +3217,7 @@ extern const char * trapname(int, boolean);
 extern void ignite_items(struct obj *) NO_NNARGS;
 extern void trap_ice_effects(coordxy x, coordxy y, boolean ice_is_melting);
 extern void trap_sanity_check(void);
+extern int trapeffect_pit(struct monst *, struct trap *, unsigned);
 
 /* ### u_init.c ### */
 

--- a/src/trap.c
+++ b/src/trap.c
@@ -24,7 +24,6 @@ staticfn int trapeffect_bear_trap(struct monst *, struct trap *, unsigned);
 staticfn int trapeffect_slp_gas_trap(struct monst *, struct trap *, unsigned);
 staticfn int trapeffect_rust_trap(struct monst *, struct trap *, unsigned);
 staticfn int trapeffect_fire_trap(struct monst *, struct trap *, unsigned);
-staticfn int trapeffect_pit(struct monst *, struct trap *, unsigned);
 staticfn int trapeffect_hole(struct monst *, struct trap *, unsigned);
 staticfn int trapeffect_telep_trap(struct monst *, struct trap *, unsigned);
 staticfn int trapeffect_level_telep(struct monst *, struct trap *, unsigned);
@@ -1746,7 +1745,7 @@ trapeffect_fire_trap(
     return Trap_Effect_Finished;
 }
 
-staticfn int
+int
 trapeffect_pit(
     struct monst *mtmp,
     struct trap *trap,

--- a/src/zap.c
+++ b/src/zap.c
@@ -5,6 +5,7 @@
 
 #include "hack.h"
 
+extern int trapeffect_pit(struct monst *, struct trap *, unsigned); /* from trap.c */
 /* Disintegration rays have special treatment; corpses are never left.
  * But the routine which calculates the damage is separate from the routine
  * which kills the monster.  The damage routine returns this cookie to
@@ -5064,6 +5065,10 @@ zap_over_floor(
                 rangemod -= 3;
                 lev->typ = ROOM, lev->flags = 0;
                 t = maketrap(x, y, PIT);
+                /* If you're walking on water and zap a wand of fire down
+                   to evaporate a pool, you should fall in the pit. */
+                if (u.ux == x && u.uy == y)
+                    trapeffect_pit(&gy.youmonst, t, 0);
                 /*if (t) -- this was before the vapor cloud was added --
                       t->tseen = 1;*/
                 if (see_it)


### PR DESCRIPTION
This is my first PR for NetHack so feedback and constructive criticism is greatly appreciated!

Test case: You're wearing water walking boots and standing on a pool of water and zap a wand of fire down (hopefully with fire resistance).

Current behavior: The water evaporates and a pit is created but not revealed, if you look down it looks like a normal floor until you search or step off and back on the space.

Fix: I put trapeffect_pit into extern.h so it could be called from zap.c. This allows all the edge cases to be handled (zapping down while flying, falling in a pit while polymorphed into a pit fiend, etc.).