### PR TITLE
YANI: Brides of Dracula

### DIFF
--- a/dat/tower1.lua
+++ b/dat/tower1.lua
@@ -30,9 +30,10 @@ des.monster("Vlad the Impaler", 06, 05)
 des.monster("V",niches[1])
 des.monster("V",niches[2])
 des.monster("V",niches[3])
-des.monster("V",niches[4])
-des.monster("V",niches[5])
-des.monster("V",niches[6])
+-- The brides
+des.monster("Vampire Lady",niches[4])
+des.monster("Vampire Lady",niches[5])
+des.monster("Vampire Lady",niches[6])
 -- The doors
 des.door("closed",08,03)
 des.door("closed",10,03)


### PR DESCRIPTION
In the original Bram Stoker novel, Dracula has three brides, colloquially referred to as the [Brides of Dracula](https://en.wikipedia.org/wiki/Brides_of_Dracula). I thought it would be a nice touch for NetHack to quietly reflect this by ensuring three of the vampires of his court are vampire ladies. While this technically increases the difficulty of Vlad's Tower, the vampires in Vlad's court are not necessary to fight, and the experience level of a hero at this point in the game is likely to cause them to spawn as vampire lords or ladies in any case.

No established names exist for these characters, so I have left them unnamed.