### PR TITLE
When making an invalid move (stepping diagonally out of doorway) still warned about traps in destination square

### DIFF
--- a/src/hack.c
+++ b/src/hack.c
@@ -2628,6 +2628,7 @@ domove_core(void)
 
     /* warn maybe player before walking into known traps */
     if (ParanoidTrap && (trap = t_at(x, y)) != 0 && trap->tseen
+        && (test_move(u.ux, u.uy, x - u.ux, y - u.uy, TEST_MOVE))
         && (!gc.context.nopick || gc.context.run)
         && !Stunned && !Confusion
         && (immune_to_trap(&gy.youmonst, trap->ttyp) != TRAP_CLEARLY_IMMUNE


### PR DESCRIPTION
Steps to reproduce the issue:
1. Place a trap diagonally from a doorway
2. Stand in the doorway
3. Move toward the trap

Expected results:
You can't move diagonally so nothing will happen.

Actual results:
You get the "Really step onto that fire trap/hole/etc." message
