### PR TITLE
room_discovered was never called for shops

### DIFF
--- a/src/hack.c
+++ b/src/hack.c
@@ -3464,7 +3464,7 @@ check_special_room(boolean newlev)
             intemple(roomno + ROOMOFFSET);
         /*FALLTHRU*/
         default:
-            msg_given = (rt == TEMPLE);
+            msg_given = (rt == TEMPLE || rt >= SHOPBASE);
             rt = 0;
             break;
         }


### PR DESCRIPTION
This may not have been discovered because calling #overview while in a shop will register the shop as seen separately. This made the issue hard to test as the shops would sometimes show up in #overview and sometimes not.

I was going to make it so shops only show up if we enter them when not blind and deaf (or shopkeeper is mute) but it seems the player knows when they enter a shop regardless so I went with the easier fix.
