### PR TITLE
Add missing hardware shop string

### DIFF
--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -3438,6 +3438,9 @@ shop_string(int rtype)
     case WANDSHOP:
         str = "wand shop";
         break;
+    case TOOLSHOP:
+        str = "hardware store";
+        break;
     case BOOKSHOP:
         str = "bookstore";
         break;


### PR DESCRIPTION
I noticed, when testing shops in the overview menu, that hardware store was just listed as "shop".

The TOOLSHOP case was missed in the switch statement in the shop_string function.