### PR TITLE
hints/linux.370: Add support for ubsan (undefined behaviour sanitizer…

### DIFF
--- a/sys/unix/README-hints
+++ b/sys/unix/README-hints
@@ -60,6 +60,9 @@ make WANT_SPEECH=1            If one of the sound libraries was included, also
 make WANT_ASAN=1              Include support for the address sanitizer in the
                               build.
 
+make WANT_UBSAN=1             Include support for the undefined behaviour
+                              sanitizer in the build.
+
 make WANT_SHARE_INSTALL=1     Place the results of the install/update portion
                               of the build into a shared area on a multiuser
                               system.

--- a/sys/unix/hints/include/compiler.370
+++ b/sys/unix/hints/include/compiler.370
@@ -33,6 +33,10 @@ ifeq "$(WANT_ASAN)" "1"
 USE_ASAN=1
 endif
 
+ifeq "$(WANT_UBSAN)" "1"
+USE_UBSAN=1
+endif
+
 # If you want to override the compiler detection just carried out
 # uncomment one of the following pairs. Note, however, that
 # doing this after the detection above will likely result in

--- a/sys/unix/hints/linux.370
+++ b/sys/unix/hints/linux.370
@@ -87,6 +87,11 @@ CFLAGS+=-fsanitize=address
 LFLAGS+=-fsanitize=address
 endif
 
+ifeq "$(USE_UBSAN)" "1"
+CFLAGS+=-fsanitize=undefined
+LFLAGS+=-fsanitize=undefined
+endif
+
 ifeq "$(USE_CURSESLIB)" "1"
 # default
 CURSESLIB = -lncurses -ltinfo


### PR DESCRIPTION
hints/linux.370: Add support for ubsan (undefined behaviour sanitizer for gcc

This will add an option to compile and link nethack executable with ubsan and catch undefined behaviour errors on runtime.