### PR TITLE
win/wintty: Limit how many digits count can hold

### DIFF
--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -1567,6 +1567,16 @@ process_menu_window(winid window, struct WinDesc *cw)
                 goto group_accel;
 
             count = (count * 10L) + (long) (morc - '0');
+
+	    /* debugfuzzer can easily push the input to overflow
+	       long and cause ubsan to be upset. There is no practical
+	       need to have such a big counts. Limit max for what int
+	       could hold. That is 8 digits so should be enough. */
+	    if (count >= (1L << 30)) {
+	        finished = TRUE;
+	        break;
+	    }
+
             /*
              * It is debatable whether we should allow 0 to
              * start a count.  There is no difference if the


### PR DESCRIPTION
Debugfuzzer will end up pushing such amount of characters into the count gatherer that we eventually overflow long type.

Limit the count to what signed int could hold. This still allows 8 digits and that should be enough
for practical purposes.

This will prevent long overflow and spurious ubsan reports.