### PR TITLE
win/curses: Check input range in menu selection fallthrough

### DIFF
--- a/win/curses/cursdial.c
+++ b/win/curses/cursdial.c
@@ -1555,7 +1555,8 @@ menu_get_selections(WINDOW *win, nhmenu *menu, int how)
             }
             /*FALLTHRU*/
         default:
-            if (isdigit(curletter) && !selectors[curletter]
+            if (curletter > 0 && curletter < 256
+                && isdigit(curletter) && !selectors[curletter]
                 && !groupaccels[curletter]) {
                 count = curses_get_count(curletter);
                 /* after count, we know some non-digit is already pending */


### PR DESCRIPTION
curletter is screened to be in valid range in all
other switch/case branches except in the default case, which is fallthrough.

Add check for valid range in here also, otherwise
array might be addressed with invalid offset.

This should fix the following, found
with UBSAN and #debugfuzzer:

../win/curses/cursdial.c:1558:49: runtime error: index -154 out of bounds for type 'char [256]' 0x5f3857eff140 in menu_get_selections ../win/curses/cursdial.c:1558 0x5f3857ef78c8 in curses_display_nhmenu ../win/curses/cursdial.c:801 0x5f3857edd390 in curses_select_menu ../win/curses/cursmain.c:768