### PR TITLE
YANI: Add option to start without inventory, skills and spells

### DIFF
--- a/include/optlist.h
+++ b/include/optlist.h
@@ -213,6 +213,9 @@ static int optfn_##a(int, int, boolean, char *, char *);
                 No, Yes, No, No, NoAlias,
                 "deprecated (use S_boulder in sym file instead)")
 #endif
+    NHOPTB(broke, Advanced, 0, opt_in, set_in_config,
+           Off, Yes, No, No, NoAlias, &u.uroleplay.broke, Term_False,
+           "start game with no inventory or spells")
     NHOPTC(catname, Advanced, PL_PSIZ, opt_in, set_gameview,
                 No, Yes, No, No, NoAlias,
                 "name of your starting pet if it is a kitten")

--- a/include/you.h
+++ b/include/you.h
@@ -162,6 +162,7 @@ struct u_roleplay {
     boolean blind;  /* permanently blind */
     boolean nudist; /* has not worn any armor, ever */
     boolean deaf;   /* permanently deaf */
+    boolean broke;  /* start without inventory, skills and spells */
     long numbones;  /* # of bones files loaded  */
 };
 

--- a/src/u_init.c
+++ b/src/u_init.c
@@ -644,6 +644,7 @@ u_init_role(void)
     case PM_CAVE_DWELLER:
         Cave_man[C_AMMO].trquan = rn1(11, 10); /* 10..20 */
         ini_inv(Cave_man);
+        knows_object(FLINT);
         skill_init(Skill_C);
         break;
     case PM_HEALER:
@@ -651,7 +652,12 @@ u_init_role(void)
         ini_inv(Healer);
         if (!rn2(25))
             ini_inv(Lamp);
+        knows_object(POT_HEALING);
+        knows_object(POT_EXTRA_HEALING);
         knows_object(POT_FULL_HEALING);
+        knows_object(SPE_HEALING);
+        knows_object(SPE_EXTRA_HEALING);
+        knows_object(SPE_STONE_TO_FLESH);
         skill_init(Skill_H);
         break;
     case PM_KNIGHT:
@@ -1212,6 +1218,9 @@ ini_inv(struct trobj *trop)
     struct obj *obj;
     int otyp;
     boolean got_sp1 = FALSE; /* got a level 1 spellbook? */
+
+    if (u.uroleplay.broke)
+        return;
 
     while (trop->trclass) {
         otyp = (int) trop->trotyp;

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -1660,13 +1660,15 @@ skill_init(const struct def_skill *class_skill)
     }
 
     /* set skills for magic */
-    if (Role_if(PM_HEALER) || Role_if(PM_MONK)) {
-        P_SKILL(P_HEALING_SPELL) = P_BASIC;
-    } else if (Role_if(PM_CLERIC)) {
-        P_SKILL(P_CLERIC_SPELL) = P_BASIC;
-    } else if (Role_if(PM_WIZARD)) {
-        P_SKILL(P_ATTACK_SPELL) = P_BASIC;
-        P_SKILL(P_ENCHANTMENT_SPELL) = P_BASIC;
+    if (!u.uroleplay.broke) {
+        if (Role_if(PM_HEALER) || Role_if(PM_MONK)) {
+            P_SKILL(P_HEALING_SPELL) = P_BASIC;
+        } else if (Role_if(PM_CLERIC)) {
+            P_SKILL(P_CLERIC_SPELL) = P_BASIC;
+        } else if (Role_if(PM_WIZARD)) {
+            P_SKILL(P_ATTACK_SPELL) = P_BASIC;
+            P_SKILL(P_ENCHANTMENT_SPELL) = P_BASIC;
+        }
     }
 
     /* walk through array to set skill maximums */
@@ -1679,13 +1681,15 @@ skill_init(const struct def_skill *class_skill)
             P_SKILL(skill) = P_UNSKILLED;
     }
 
-    /* High potential fighters already know how to use their hands. */
-    if (P_MAX_SKILL(P_BARE_HANDED_COMBAT) > P_EXPERT)
-        P_SKILL(P_BARE_HANDED_COMBAT) = P_BASIC;
+    if (!u.uroleplay.broke) {
+        /* High potential fighters already know how to use their hands. */
+        if (P_MAX_SKILL(P_BARE_HANDED_COMBAT) > P_EXPERT)
+            P_SKILL(P_BARE_HANDED_COMBAT) = P_BASIC;
 
-    /* Roles that start with a horse know how to ride it */
-    if (gu.urole.petnum == PM_PONY)
-        P_SKILL(P_RIDING) = P_BASIC;
+        /* Roles that start with a horse know how to ride it */
+        if (gu.urole.petnum == PM_PONY)
+            P_SKILL(P_RIDING) = P_BASIC;
+    }
 
     /*
      * Make sure we haven't missed setting the max on a skill


### PR DESCRIPTION
You know how it goes – you have been heralded from birth to be a hero who saves the world and your hour of destiny has come, but you haven't prepared very well. You come from a poor family and could not afford any training or equipment, so the only thing you bring with you into this dungeon is your potential. Empty-handed and with only your underwear on you, go bravely with your god!

The proposed option (tentatively called "broke" here) makes you not only start with no inventory (for which you could just drop everything on turn 1) but also with every skill at Unskilled and no spells. You do, however, start with knowledge of all the objects you would normally be guaranteed to know, which is actually mostly because of the healer: without healing potions at least discovered they would have too little reason to call themselves a healer at all. A rogue still knows what a sack is, a wizard knows all level 1 spellbooks.

You may think that this makes all roles too similar since starting inventory is a big part of what makes each role what they are. However, even with such start every role still has its defining features: archeologist is good with touchstones (admittedly they may never find one) and can become expert in pick-axe, barbarian is strong and gets Cleaver, caveperson can eat cats and is good with spears, and so on.

Best used in conjunction with !bones, lest you find early bones of your own role. I've played several roles like this and found it quite refreshing.

This patch as-is has a problem: starting with no inventory seems to interfere with rendering when using curses, so one has to do something on turn 1 then hit Ctrl+R on turn 2 and then play normally. But because at this point I do not know if the developers or any variant developers are interested in including this, I'll leave it as it is but can fix should the need arise.