### PR TITLE
Some fixes to make NetHack compile and run on MacOS Sequoia (15.0) using Xcode 16 (beta 3)

### DIFF
--- a/sys/unix/NetHack.xcodeproj/project.pbxproj
+++ b/sys/unix/NetHack.xcodeproj/project.pbxproj
@@ -7,6 +7,19 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		056E43C62C810EE800FD1F52 /* coloratt.c in Sources */ = {isa = PBXBuildFile; fileRef = 056E43BC2C810EE800FD1F52 /* coloratt.c */; };
+		056E43C72C810EE800FD1F52 /* nhmd4.c in Sources */ = {isa = PBXBuildFile; fileRef = 056E43C02C810EE800FD1F52 /* nhmd4.c */; };
+		056E43C82C810EE800FD1F52 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = 056E43BF2C810EE800FD1F52 /* Makefile */; };
+		056E43C92C810EE800FD1F52 /* report.c in Sources */ = {isa = PBXBuildFile; fileRef = 056E43C12C810EE800FD1F52 /* report.c */; };
+		056E43CA2C810EE800FD1F52 /* selvar.c in Sources */ = {isa = PBXBuildFile; fileRef = 056E43C22C810EE800FD1F52 /* selvar.c */; };
+		056E43CB2C810EE800FD1F52 /* calendar.c in Sources */ = {isa = PBXBuildFile; fileRef = 056E43BB2C810EE800FD1F52 /* calendar.c */; };
+		056E43CC2C810EE800FD1F52 /* stairs.c in Sources */ = {isa = PBXBuildFile; fileRef = 056E43C32C810EE800FD1F52 /* stairs.c */; };
+		056E43CD2C810EE800FD1F52 /* glyphs.c in Sources */ = {isa = PBXBuildFile; fileRef = 056E43BE2C810EE800FD1F52 /* glyphs.c */; };
+		056E43CE2C810EE800FD1F52 /* strutil.c in Sources */ = {isa = PBXBuildFile; fileRef = 056E43C42C810EE800FD1F52 /* strutil.c */; };
+		056E43CF2C810EE800FD1F52 /* getpos.c in Sources */ = {isa = PBXBuildFile; fileRef = 056E43BD2C810EE800FD1F52 /* getpos.c */; };
+		056E43D02C810EE800FD1F52 /* wizcmds.c in Sources */ = {isa = PBXBuildFile; fileRef = 056E43C52C810EE800FD1F52 /* wizcmds.c */; };
+		059660BE2C80B00400398EDE /* hacklib.c in Sources */ = {isa = PBXBuildFile; fileRef = 31B8A36421A238040055BD01 /* hacklib.c */; };
+		059660C12C80B0C700398EDE /* hacklib.c in Sources */ = {isa = PBXBuildFile; fileRef = 31B8A36421A238040055BD01 /* hacklib.c */; };
 		31B8A30C21A20D8B0055BD01 /* makedefs.c in Sources */ = {isa = PBXBuildFile; fileRef = 31B8A30B21A20D8B0055BD01 /* makedefs.c */; };
 		31B8A30F21A20DC10055BD01 /* objects.c in Sources */ = {isa = PBXBuildFile; fileRef = 31B8A30D21A20DC10055BD01 /* objects.c */; };
 		31B8A31021A20DC10055BD01 /* monst.c in Sources */ = {isa = PBXBuildFile; fileRef = 31B8A30E21A20DC10055BD01 /* monst.c */; };
@@ -244,6 +257,15 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		059660C42C80B15300398EDE /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 8;
+			dstPath = usr/share/man/man1;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
 		3189576F21A1FCC100FB2ABE /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -271,18 +293,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 		};
-		31B8A45521A26A970055BD01 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = /usr/share/man/man1/;
-			dstSubfolderSpec = 0;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 1;
-		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		056E43BB2C810EE800FD1F52 /* calendar.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = calendar.c; path = ../../src/calendar.c; sourceTree = "<group>"; };
+		056E43BC2C810EE800FD1F52 /* coloratt.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = coloratt.c; path = ../../src/coloratt.c; sourceTree = "<group>"; };
+		056E43BD2C810EE800FD1F52 /* getpos.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = getpos.c; path = ../../src/getpos.c; sourceTree = "<group>"; };
+		056E43BE2C810EE800FD1F52 /* glyphs.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = glyphs.c; path = ../../src/glyphs.c; sourceTree = "<group>"; };
+		056E43BF2C810EE800FD1F52 /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; name = Makefile; path = ../../src/Makefile; sourceTree = "<group>"; };
+		056E43C02C810EE800FD1F52 /* nhmd4.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = nhmd4.c; path = ../../src/nhmd4.c; sourceTree = "<group>"; };
+		056E43C12C810EE800FD1F52 /* report.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = report.c; path = ../../src/report.c; sourceTree = "<group>"; };
+		056E43C22C810EE800FD1F52 /* selvar.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = selvar.c; path = ../../src/selvar.c; sourceTree = "<group>"; };
+		056E43C32C810EE800FD1F52 /* stairs.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = stairs.c; path = ../../src/stairs.c; sourceTree = "<group>"; };
+		056E43C42C810EE800FD1F52 /* strutil.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = strutil.c; path = ../../src/strutil.c; sourceTree = "<group>"; };
+		056E43C52C810EE800FD1F52 /* wizcmds.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wizcmds.c; path = ../../src/wizcmds.c; sourceTree = "<group>"; };
 		2A953FB221A3F404007906E5 /* XCode.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = XCode.xcconfig; sourceTree = "<group>"; };
 		3186A36D21A4B0F90052BF02 /* xwindowp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = xwindowp.h; path = ../../include/xwindowp.h; sourceTree = "<group>"; };
 		3186A36E21A4B0FA0052BF02 /* botl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = botl.h; path = ../../include/botl.h; sourceTree = "<group>"; };
@@ -628,6 +652,17 @@
 		3189578C21A1FF8200FB2ABE /* src */ = {
 			isa = PBXGroup;
 			children = (
+				056E43BB2C810EE800FD1F52 /* calendar.c */,
+				056E43BC2C810EE800FD1F52 /* coloratt.c */,
+				056E43BD2C810EE800FD1F52 /* getpos.c */,
+				056E43BE2C810EE800FD1F52 /* glyphs.c */,
+				056E43BF2C810EE800FD1F52 /* Makefile */,
+				056E43C02C810EE800FD1F52 /* nhmd4.c */,
+				056E43C12C810EE800FD1F52 /* report.c */,
+				056E43C22C810EE800FD1F52 /* selvar.c */,
+				056E43C32C810EE800FD1F52 /* stairs.c */,
+				056E43C42C810EE800FD1F52 /* strutil.c */,
+				056E43C52C810EE800FD1F52 /* wizcmds.c */,
 				54A3D3EB282C55A900143F8C /* utf8map.c */,
 				54435B51247999CB00804CB3 /* nhlobj.c */,
 				54FB2B4A246310A600397C0E /* symbols.c */,
@@ -1022,6 +1057,7 @@
 				3189577C21A1FDA400FB2ABE /* Frameworks */,
 				3189577D21A1FDA400FB2ABE /* CopyFiles */,
 				317E7C4B21A35F0500F6E4E5 /* Copy makedefs */,
+				059660C02C80B07100398EDE /* Codesign makedefs */,
 				319CBA3821A3458100150830 /* Build data */,
 				317E7C4521A3548F00F6E4E5 /* Build rumors */,
 				317E7C4E21A3697300F6E4E5 /* Build options */,
@@ -1045,6 +1081,8 @@
 				31B8A44621A26A4B0055BD01 /* Sources */,
 				31B8A44721A26A4B0055BD01 /* Frameworks */,
 				31B8A44821A26A4B0055BD01 /* CopyFiles */,
+				059660C32C80B12300398EDE /* Copy recover */,
+				059660C52C80B1A000398EDE /* Codesign recover */,
 			);
 			buildRules = (
 			);
@@ -1062,8 +1100,9 @@
 			buildPhases = (
 				31B8A45321A26A970055BD01 /* Sources */,
 				31B8A45421A26A970055BD01 /* Frameworks */,
-				31B8A45521A26A970055BD01 /* CopyFiles */,
-				3192867221A3AA5700325BEB /* copy dlb */,
+				059660C42C80B15300398EDE /* CopyFiles */,
+				3192867221A3AA5700325BEB /* Copy dlb */,
+				059660C22C80B0FD00398EDE /* Codesign dlb */,
 			);
 			buildRules = (
 			);
@@ -1084,6 +1123,7 @@
 				BAE8010727B97760002B3786 /* Sources */,
 				BAE8010827B97760002B3786 /* Frameworks */,
 				BAE8010F27B9825E002B3786 /* Build nhlua.h */,
+				056E43A42C81094100FD1F52 /* Copy libnhlua.a */,
 			);
 			buildRules = (
 			);
@@ -1143,6 +1183,97 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		056E43A42C81094100FD1F52 /* Copy libnhlua.a */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Copy libnhlua.a";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "echo \"Copying ${BUILT_PRODUCTS_DIR}/libnhlua.a to ${NH_LIB_DIR}/libnhlua.a\"\ncp \"${BUILT_PRODUCTS_DIR}\"/libnhlua.a \"${NH_LIB_DIR}\"/libnhlua.a\necho \"Copying ${BUILT_PRODUCTS_DIR}/libnhlua.a to ${NH_LIB_DIR}/libnhlua.a\"\ncp \"${BUILT_PRODUCTS_DIR}\"/libnhlua.a \"${NH_LIB_DIR}\"/libnhlua.a\n";
+		};
+		059660C02C80B07100398EDE /* Codesign makedefs */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Codesign makedefs";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "codesign --force --deep -s - \"${NH_UTIL_DIR}\"/makedefs\n";
+		};
+		059660C22C80B0FD00398EDE /* Codesign dlb */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Codesign dlb";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "codesign --force --deep -s - \"${NH_UTIL_DIR}\"/dlb\n";
+		};
+		059660C32C80B12300398EDE /* Copy recover */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Copy recover";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cp \"${BUILT_PRODUCTS_DIR}\"/recover \"${NH_UTIL_DIR}\"/recover\n";
+		};
+		059660C52C80B1A000398EDE /* Codesign recover */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Codesign recover";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "codesign --force --deep -s - \"${NH_UTIL_DIR}\"/recover\n";
+		};
 		317E7C4521A3548F00F6E4E5 /* Build rumors */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1466,7 +1597,7 @@
 			shellPath = /bin/sh;
 			shellScript = "cp \"${BUILT_PRODUCTS_DIR}\"/nethack \"${NH_SRC_DIR}\"/nethack\n";
 		};
-		3192867221A3AA5700325BEB /* copy dlb */ = {
+		3192867221A3AA5700325BEB /* Copy dlb */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1476,7 +1607,7 @@
 			inputPaths = (
 				"${BUILT_PRODUCTS_DIR}/dlb",
 			);
-			name = "copy dlb";
+			name = "Copy dlb";
 			outputFileListPaths = (
 			);
 			outputPaths = (
@@ -1545,7 +1676,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd $NH_ROOT_DIR\necho LUA VERSION: $LUA_VERSION\nif test ! -d lib/lua-$LUA_VERSION ; then ( echo \"Fetching $LUA_VERSION\" && \\\n          mkdir -p lib && cd lib && \\\n          curl -s -S -R -O http://www.lua.org/ftp/lua-$LUA_VERSION.tar.gz && \\\n          tar zxf lua-$LUA_VERSION.tar.gz && \\\n          rm -f lua-$LUA_VERSION.tar.gz ) ; fi\n";
+			shellScript = "cd $NH_ROOT_DIR\necho LUA VERSION: $LUA_VERSION\nif test ! -d lib/lua-$LUA_VERSION ; then ( echo \"Fetching $LUA_VERSION\" && \\\n          mkdir -p lib && cd lib && \\\n          curl -s -S -R -O https://www.lua.org/ftp/lua-$LUA_VERSION.tar.gz && \\\n          tar zxf lua-$LUA_VERSION.tar.gz && \\\n          rm -f lua-$LUA_VERSION.tar.gz ) ; fi\n";
 		};
 		BAE8010F27B9825E002B3786 /* Build nhlua.h */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1616,6 +1747,17 @@
 				31B8A3CB21A238060055BD01 /* alloc.c in Sources */,
 				31B8A39821A238060055BD01 /* mail.c in Sources */,
 				31B8A3C821A238060055BD01 /* options.c in Sources */,
+				056E43C62C810EE800FD1F52 /* coloratt.c in Sources */,
+				056E43C72C810EE800FD1F52 /* nhmd4.c in Sources */,
+				056E43C82C810EE800FD1F52 /* Makefile in Sources */,
+				056E43C92C810EE800FD1F52 /* report.c in Sources */,
+				056E43CA2C810EE800FD1F52 /* selvar.c in Sources */,
+				056E43CB2C810EE800FD1F52 /* calendar.c in Sources */,
+				056E43CC2C810EE800FD1F52 /* stairs.c in Sources */,
+				056E43CD2C810EE800FD1F52 /* glyphs.c in Sources */,
+				056E43CE2C810EE800FD1F52 /* strutil.c in Sources */,
+				056E43CF2C810EE800FD1F52 /* getpos.c in Sources */,
+				056E43D02C810EE800FD1F52 /* wizcmds.c in Sources */,
 				31B8A3CD21A238060055BD01 /* write.c in Sources */,
 				31B8A40F21A23EEC0055BD01 /* cursmesg.c in Sources */,
 				31B8A3DF21A238060055BD01 /* end.c in Sources */,
@@ -1716,6 +1858,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				059660BE2C80B00400398EDE /* hacklib.c in Sources */,
 				544A5CF0277B40CF00734B53 /* panic.c in Sources */,
 				5493735A277AAE830031FE02 /* alloc.c in Sources */,
 				5439B3BC275AADC600B8FB2F /* date.c in Sources */,
@@ -1737,6 +1880,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				059660C12C80B0C700398EDE /* hacklib.c in Sources */,
 				31B8A46121A26AF60055BD01 /* panic.c in Sources */,
 				31B8A45E21A26ACF0055BD01 /* dlb.c in Sources */,
 				31B8A46021A26AE70055BD01 /* dlb_main.c in Sources */,
@@ -2003,6 +2147,23 @@
 				GCC_C_LANGUAGE_STANDARD = c99;
 				INSTALL_PATH = "$(NH_INSTALL_DIR)";
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
+				OTHER_CFLAGS = (
+					"-DNOMAIL",
+					"-DNOTPARMDECL",
+					"-DDEFAULT_WINDOW_SYS=\\\"tty\\\"",
+					"-DDLB",
+					"-DGREPPATH=\\\"/usr/bin/grep\\\"",
+					"-DSYSCF",
+					"-DSYSCF_FILE=\\\"$(NH_INSTALL_DIR)/sysconf\\\"",
+					"-DHACKDIR=\\\"$(NH_INSTALL_DIR)\\\"",
+					"-DSECURE",
+					"-DCURSES_GRAPHICS",
+					"-DSND_LIB_MACSOUND",
+					"-DSND_SOUNDEFFECTS_AUTOMAP",
+					"-DUSER_SOUNDS",
+					"-DCURSES_UNICODE",
+					"-D_XOPEN_SOURCE_EXTENDED",
+				);
 				"OTHER_LDFLAGS[arch=*]" = "-L${NH_LIB_DIR}/lua";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -2017,6 +2178,20 @@
 				GCC_C_LANGUAGE_STANDARD = c99;
 				INSTALL_PATH = "$(NH_INSTALL_DIR)";
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
+				OTHER_CFLAGS = (
+					"-DNOMAIL",
+					"-DNOTPARMDECL",
+					"-DDEFAULT_WINDOW_SYS=\\\"tty\\\"",
+					"-DDLB",
+					"-DGREPPATH=\\\"/usr/bin/grep\\\"",
+					"-DSYSCF",
+					"-DSYSCF_FILE=\\\"$(NH_INSTALL_DIR)/sysconf\\\"",
+					"-DHACKDIR=\\\"$(NH_INSTALL_DIR)\\\"",
+					"-DSECURE",
+					"-DCURSES_GRAPHICS",
+					"-DCURSES_UNICODE",
+					"-D_XOPEN_SOURCE_EXTENDED",
+				);
 				"OTHER_LDFLAGS[arch=*]" = "-L${NH_LIB_DIR}/lua";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};


### PR DESCRIPTION
For NetHack 3.7.0-106 Work-in-progress

Some fixes to make NetHack compile and run on MacOS Sequoia (15.0) using Xcode 16 (beta 3):

1) The project file was missing a few links to source files.
2) There were a few missing 'Copy' build phases.
3) 'makedefs' needed (ad-hoc) codesigning to be able to run, so added a build phase. Did the same for 'dlb' and 'recover', although I think they are not being used.
4) Lua needs to be downloaded through 'https:', not 'http:'.
5) Added defines "-DCURSES_UNICODE" and "-D_XOPEN_SOURCE_EXTENDED" to make NetHack properly compile with curses.