### PR TITLE
Add swallow and explosion glyphs to glyph_to_cmap

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -725,30 +725,7 @@ enum glyph_offsets {
      && (glyph) < (GLYPH_CMAP_C_OFF + ((S_goodpos - S_digbeam) + 1)))
 
 /* final MAXPCHARS is legal array index because of trailing fencepost entry */
-#define glyph_to_cmap(glyph) \
-    (((glyph) == GLYPH_CMAP_STONE_OFF)                                  \
-      ? S_stone                                                         \
-      : glyph_is_cmap_main(glyph)                                       \
-        ? (((glyph) - GLYPH_CMAP_MAIN_OFF) + S_vwall)                   \
-        : glyph_is_cmap_mines(glyph)                                    \
-          ? (((glyph) - GLYPH_CMAP_MINES_OFF) + S_vwall)                \
-          : glyph_is_cmap_gehennom(glyph)                               \
-            ? (((glyph) - GLYPH_CMAP_GEH_OFF) + S_vwall)                \
-            : glyph_is_cmap_knox(glyph)                                 \
-              ? (((glyph) - GLYPH_CMAP_KNOX_OFF) + S_vwall)             \
-              : glyph_is_cmap_sokoban(glyph)                            \
-                ? (((glyph) - GLYPH_CMAP_SOKO_OFF) + S_vwall)           \
-                : glyph_is_cmap_a(glyph)                                \
-                  ? (((glyph) - GLYPH_CMAP_A_OFF) + S_ndoor)            \
-                  : glyph_is_cmap_altar(glyph)                          \
-                    ? (S_altar)                                         \
-                    : glyph_is_cmap_b(glyph)                            \
-                      ? (((glyph) - GLYPH_CMAP_B_OFF) + S_grave)        \
-                      : glyph_is_cmap_c(glyph)                          \
-                        ? (((glyph) - GLYPH_CMAP_C_OFF) + S_digbeam)    \
-                        : glyph_is_cmap_zap(glyph)                      \
-                          ? ((((glyph) - GLYPH_ZAP_OFF) % 4) + S_vbeam) \
-                          : MAXPCHARS)
+int glyph_to_cmap(int glpyh);
 
 #define glyph_to_swallow(glyph) \
     (glyph_is_swallow(glyph) ? (((glyph) - GLYPH_SWALLOW_OFF) & 0x7) : 0)

--- a/include/display.h
+++ b/include/display.h
@@ -729,6 +729,8 @@ int glyph_to_cmap(int glpyh);
 
 #define glyph_to_swallow(glyph) \
     (glyph_is_swallow(glyph) ? (((glyph) - GLYPH_SWALLOW_OFF) & 0x7) : 0)
+#define glyph_to_explosion(glyph) \
+    (glyph_is_explosion(glyph) ? (((glyph) - GLYPH_EXPLODE_OFF) % (S_expl_br - S_expl_tl + 1)) : 0)
 #define glyph_to_warning(glyph) \
     (glyph_is_warning(glyph) ? ((glyph) - GLYPH_WARNING_OFF) : NO_GLYPH)
 

--- a/src/glyphs.c
+++ b/src/glyphs.c
@@ -189,6 +189,35 @@ fix_glyphname(char *str)
     return str;
 }
 
+int
+glyph_to_cmap(int glyph)
+{
+    if (glyph == GLYPH_CMAP_STONE_OFF)
+        return S_stone;
+    else if (glyph_is_cmap_main(glyph))
+        return (glyph - GLYPH_CMAP_MAIN_OFF) + S_vwall;
+    else if (glyph_is_cmap_mines(glyph))
+        return (glyph - GLYPH_CMAP_MINES_OFF) + S_vwall;
+    else if (glyph_is_cmap_gehennom(glyph))
+        return (glyph - GLYPH_CMAP_GEH_OFF) + S_vwall;
+    else if (glyph_is_cmap_knox(glyph))
+        return (glyph - GLYPH_CMAP_KNOX_OFF) + S_vwall;
+    else if (glyph_is_cmap_sokoban(glyph))
+        return (glyph - GLYPH_CMAP_SOKO_OFF) + S_vwall;
+    else if (glyph_is_cmap_a(glyph))
+        return (glyph - GLYPH_CMAP_A_OFF) + S_ndoor;
+    else if (glyph_is_cmap_altar(glyph))
+        return S_altar;
+    else if (glyph_is_cmap_b(glyph))
+        return (glyph - GLYPH_CMAP_B_OFF) + S_grave;
+    else if (glyph_is_cmap_c(glyph))
+        return (glyph - GLYPH_CMAP_C_OFF) + S_digbeam;
+    else if (glyph_is_cmap_zap(glyph))
+        return ((glyph - GLYPH_ZAP_OFF) % 4) + S_vbeam;
+    else
+        return MAXPCHARS;
+}
+
 staticfn int
 glyph_find_core(const char *id, struct find_struct *findwhat)
 {

--- a/src/glyphs.c
+++ b/src/glyphs.c
@@ -214,6 +214,10 @@ glyph_to_cmap(int glyph)
         return (glyph - GLYPH_CMAP_C_OFF) + S_digbeam;
     else if (glyph_is_cmap_zap(glyph))
         return ((glyph - GLYPH_ZAP_OFF) % 4) + S_vbeam;
+    else if (glyph_is_swallow(glyph))
+        return glyph_to_swallow(glyph) + S_sw_tl;
+    else if (glyph_is_explosion(glyph))
+        return glyph_to_explosion(glyph) + S_expl_tl;
     else
         return MAXPCHARS;
 }
@@ -1051,8 +1055,7 @@ parse_id(const char *id, struct find_struct *findwhat)
 
                         j = glyph - GLYPH_EXPLODE_OFF;
                         expl = j / ((S_expl_br - S_expl_tl) + 1);
-                        cmap = (j % ((S_expl_br - S_expl_tl) + 1))
-                               + S_expl_tl;
+                        cmap = glyph_to_explosion(glyph) + S_expl_tl;
                         i = cmap - S_expl_tl;
                         Snprintf(buf[2], sizeof buf[2], "%s ",
                                  expl_type_texts[expl]);


### PR DESCRIPTION
This makes custom S_sw_tc etc. from Enhanced1 symset actually work,
yielding nice smooth outlines for swallowers and explosions.

While looking at where else glyph_to_swallow was used, I noticed that
parse_id subtracted S_sw_tl from glyph_to_swallow, even though it
returns 0 to 7. This looks like it would cause out-of-bounds access and
perhaps a segfault when trying to customise glyphs for individual
monster swallow glyphs (or whatever it is parse_id is used for), but
I haven't tried to confirm nor change this because who would ever do
such thing?

Convert glyph_to_cmap from macro to function. 
Even if nethack is meant to support compilers that do not know about
inline functions, this one was frankly too long to be a macro already,
and I'm about to make it longer still.
