### PR TITLE
Remove magic members from instance globals

### DIFF
--- a/include/decl.h
+++ b/include/decl.h
@@ -181,7 +181,6 @@ struct instance_globals_a {
     struct h2o_ctx acid_ctx;
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_b {
@@ -219,7 +218,6 @@ struct instance_globals_b {
     boolean bot_disabled;
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_c {
@@ -299,7 +297,6 @@ struct instance_globals_c {
 
     /* zap.c */
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_d {
@@ -341,7 +338,6 @@ struct instance_globals_d {
     boolean decor_levitate_override;
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_e {
@@ -362,7 +358,6 @@ struct instance_globals_e {
                                  to gb.beyond_savefile_load */
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_f {
@@ -387,7 +382,6 @@ struct instance_globals_f {
     long int followmsg; /* last time of follow message */
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_g {
@@ -435,7 +429,6 @@ struct instance_globals_g {
     long glyphmap_perlevel_flags;
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_h {
@@ -456,7 +449,6 @@ struct instance_globals_h {
     struct attack *hitmsg_prev;
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_i {
@@ -490,7 +482,6 @@ struct instance_globals_i {
     /* new */
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_j {
@@ -499,7 +490,6 @@ struct instance_globals_j {
     int jumping_is_magic; /* current jump result of magic */
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_k {
@@ -513,7 +503,6 @@ struct instance_globals_k {
     boolean known;
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_l {
@@ -579,7 +568,6 @@ struct instance_globals_l {
     char lua_copyright[LUA_COPYRIGHT_BUFSIZ];
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_m {
@@ -646,7 +634,6 @@ struct instance_globals_m {
                               * POT_WATER should become discovered */
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_n {
@@ -696,7 +683,6 @@ struct instance_globals_n {
     short nocreate4;
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_o {
@@ -755,7 +741,6 @@ struct instance_globals_o {
     boolean obj_zapped;
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_p {
@@ -806,13 +791,11 @@ struct instance_globals_p {
 
     /* new stuff */
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_q {
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_r {
@@ -841,7 +824,6 @@ struct instance_globals_r {
     struct repo repo;
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_s {
@@ -923,7 +905,6 @@ struct instance_globals_s {
     int seethru; /* 'bubble' debugging: clouds and water don't block light */
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_t {
@@ -974,7 +955,6 @@ struct instance_globals_t {
     int twohits; /* 0: single hit; 1: first of 2; 2: second of 2 */
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_u {
@@ -994,7 +974,6 @@ struct instance_globals_u {
 
     /* new stuff */
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_v {
@@ -1031,7 +1010,6 @@ struct instance_globals_v {
     struct sound_voice voice;
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_w {
@@ -1056,7 +1034,6 @@ struct instance_globals_w {
     struct win_settings wsettings;      /* wintype.h */
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_x {
@@ -1077,7 +1054,6 @@ struct instance_globals_x {
     coordxy xstart, xsize;
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_y {
@@ -1095,7 +1071,6 @@ struct instance_globals_y {
     coordxy ystart, ysize;
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_z {
@@ -1112,7 +1087,6 @@ struct instance_globals_z {
                         * remember who zapped the wand. */
 
     boolean havestate;
-    unsigned long magic; /* validate that structure layout is preserved */
 };
 
 struct instance_globals_saved_b {

--- a/src/decl.c
+++ b/src/decl.c
@@ -146,8 +146,6 @@ NEARDATA long yn_number = 0L;
 const char *ARGV0;
 #endif
 
-#define IVMAGIC 0xdeadbeef
-
 static const struct Role urole_init_data = {
     { "Undefined", 0 },
     { { 0, 0 }, { 0, 0 }, { 0, 0 }, { 0, 0 }, { 0, 0 },
@@ -228,7 +226,6 @@ static const struct instance_globals_a g_init_a = {
     /* trap.c */
     { 0, 0, FALSE }, /* acid_ctx */
     TRUE, /* havestate*/
-    IVMAGIC  /* a_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_b g_init_b = {
@@ -261,7 +258,6 @@ static const struct instance_globals_b g_init_b = {
     FALSE, /* bot_disabled */
 
     TRUE, /* havestate*/
-    IVMAGIC  /* b_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_c g_init_c = {
@@ -312,7 +308,6 @@ static const struct instance_globals_c g_init_c = {
     /* uhitm.c */
     NON_PM, /* corpsenm_digested */
     TRUE, /* havestate*/
-    IVMAGIC  /* c_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_d g_init_d = {
@@ -340,7 +335,6 @@ static const struct instance_globals_d g_init_d = {
     FALSE, /* decor_fumble_override */
     FALSE, /* decor_levitate_override */
     TRUE, /* havestate*/
-    IVMAGIC  /* d_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_e g_init_e = {
@@ -355,7 +349,6 @@ static const struct instance_globals_e g_init_e = {
     /* new */
     0,      /* early_raw_messages */
     TRUE, /* havestate*/
-    IVMAGIC  /* e_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_f g_init_f = {
@@ -374,7 +367,6 @@ static const struct instance_globals_f g_init_f = {
     /* shk.c */
     0L, /* followmsg */
     TRUE, /* havestate*/
-    IVMAGIC  /* f_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_g g_init_g = {
@@ -411,7 +403,6 @@ static const struct instance_globals_g g_init_g = {
     /* per-level glyph mapping flags */
     0L,     /* glyphmap_perlevel_flags */
     TRUE, /* havestate*/
-    IVMAGIC  /* g_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_h g_init_h = {
@@ -430,7 +421,6 @@ static const struct instance_globals_h g_init_h = {
     NULL, /* hitmsg_prev */
     /* save.c */
     TRUE, /* havestate*/
-    IVMAGIC  /* h_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_i g_init_i = {
@@ -453,14 +443,12 @@ static const struct instance_globals_i g_init_i = {
     FALSE, /* in_mk_themerooms */
 
     TRUE, /* havestate*/
-    IVMAGIC  /* i_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_j g_init_j = {
     /* apply.c */
     0,  /* jumping_is_magic */
     TRUE, /* havestate*/
-    IVMAGIC  /* j_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_k g_init_k = {
@@ -470,7 +458,6 @@ static const struct instance_globals_k g_init_k = {
     /* read.c */
     UNDEFINED_VALUE, /* known */
     TRUE, /* havestate*/
-    IVMAGIC  /* k_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_l g_init_l = {
@@ -520,7 +507,6 @@ static const struct instance_globals_l g_init_l = {
     DUMMY,   /* lua_ver[LUA_VER_BUFSIZ] */
     DUMMY,   /* lua_copyright[LUA_COPYRIGHT_BUFSIZ] */
     TRUE, /* havestate*/
-    IVMAGIC  /* l_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_m g_init_m = {
@@ -569,7 +555,6 @@ static const struct instance_globals_m g_init_m = {
     /* trap.c */
     FALSE, /* mentioned_water */
     TRUE, /* havestate*/
-    IVMAGIC  /* m_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_n g_init_n = {
@@ -604,7 +589,6 @@ static const struct instance_globals_n g_init_n = {
     STRANGE_OBJECT, /* nocreate3 */
     STRANGE_OBJECT, /* nocreate4 */
     TRUE, /* havestate*/
-    IVMAGIC  /* n_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_o g_init_o = {
@@ -648,7 +632,6 @@ static const struct instance_globals_o g_init_o = {
     /* zap.c */
     FALSE,  /* obj_zapped */
     TRUE, /* havestate*/
-    IVMAGIC  /* o_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_p g_init_p = {
@@ -684,12 +667,10 @@ static const struct instance_globals_p g_init_p = {
     /* zap.c */
     UNDEFINED_VALUE, /* poly_zap */
     TRUE, /* havestate*/
-    IVMAGIC  /* p_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_q g_init_q = {
     TRUE, /* havestate*/
-    IVMAGIC  /* q_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_r g_init_r = {
@@ -710,7 +691,6 @@ static const struct instance_globals_r g_init_r = {
     /* shk.c */
     UNDEFINED_VALUES, /* repo */
     TRUE, /* havestate*/
-    IVMAGIC  /* r_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_s g_init_s = {
@@ -767,7 +747,6 @@ static const struct instance_globals_s g_init_s = {
     /* vision.c */
     0, /* seethru */
     TRUE, /* havestate*/
-    IVMAGIC  /* s_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_t g_init_t = {
@@ -802,7 +781,6 @@ static const struct instance_globals_t g_init_t = {
     0, /* twohits */
     /**/
     TRUE, /* havestate*/
-    IVMAGIC  /* t_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_u g_init_u = {
@@ -816,7 +794,6 @@ static const struct instance_globals_u g_init_u = {
     /* save.c */
     { 0, 0 }, /* uz_save */
     TRUE, /* havestate*/
-    IVMAGIC  /* u_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_v g_init_v = {
@@ -842,7 +819,6 @@ static const struct instance_globals_v g_init_v = {
     FALSE, /* vision_full_recalc */
     UNDEFINED_VALUES,  /* voice */
     TRUE, /* havestate*/
-    IVMAGIC  /* v_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_w g_init_w = {
@@ -860,7 +836,6 @@ static const struct instance_globals_w g_init_w = {
     /* new */
     { wdmode_traditional, NO_COLOR },       /* wsettings */
     TRUE, /* havestate*/
-    IVMAGIC  /* w_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_x g_init_x = {
@@ -874,7 +849,6 @@ static const struct instance_globals_x g_init_x = {
     UNDEFINED_VALUE, /* xstart */
     UNDEFINED_VALUE, /* xsize */
     TRUE, /* havestate*/
-    IVMAGIC  /* x_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_y g_init_y = {
@@ -888,7 +862,6 @@ static const struct instance_globals_y g_init_y = {
     UNDEFINED_VALUE, /* ystart */
     UNDEFINED_VALUE, /* ysize */
     TRUE, /* havestate*/
-    IVMAGIC  /* y_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_z g_init_z = {
@@ -897,7 +870,6 @@ static const struct instance_globals_z g_init_z = {
     /* muse.c */
     FALSE, /* zap_oseen */
     TRUE, /* havestate*/
-    IVMAGIC  /* z_magic to validate that structure layout has been preserved */
 };
 
 static const struct instance_globals_saved_b init_svb = {
@@ -1092,12 +1064,6 @@ const struct const_globals cg = {
 
 #define MAGICCHECK(xx) \
     do {                                                                   \
-        if ((xx).magic != IVMAGIC) {                                       \
-            raw_printf(                                                    \
-                 "decl_globals_init: %s.magic in unexpected state (%lx).", \
-                       #xx, (xx).magic);                                   \
-            exit(1);                                                       \
-        }                                                                  \
         if ((xx).havestate != TRUE) {                                      \
             raw_printf(                                                    \
                  "decl_globals_init: %s.havestate not True.", #xx);        \


### PR DESCRIPTION
We ought to trust compiler and we have other
tools to check oob access.