### PR TITLE
util: match fopen_datafile function prototype

### DIFF
--- a/util/dlb_main.c
+++ b/util/dlb_main.c
@@ -18,7 +18,7 @@
 
 ATTRNORETURN static void xexit(int) NORETURN;
 ATTRNORETURN extern void panic(const char *, ...) NORETURN;
-FILE *fopen_datafile(const char *, const char *);
+FILE *fopen_datafile(const char *, const char *, int);
 
 #ifdef DLB
 #ifdef DLBLIB
@@ -134,8 +134,10 @@ Write(int out, char *buf, long len)
 
 /* open_library(dlb.c) needs this (which normally comes from src/files.c) */
 FILE *
-fopen_datafile(const char *filename, const char *mode)
+fopen_datafile(const char *filename, const char *mode, int prefix)
 {
+    prefix = !prefix; /* not needed, silence compiler */
+
     return fopen(filename, mode);
 }
 


### PR DESCRIPTION
The prototype for fopen_datafile() is different if it is used for util/dlb. Add the missing integer parameter and assert that it is only used for dataprefixes.