### PR TITLE
Alloc: Remove in tree heaplogging and avoid adding align to mallocs

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -69,10 +69,6 @@
 
 /* ### alloc.c ### */
 
-#if 0
-/* routines in alloc.c depend on MONITOR_HEAP and are declared in global.h */
-extern long *alloc(unsigned int) NONNULL;
-#endif
 extern char *fmt_ptr(const void *) NONNULL;
 /* moved from hacklib.c to alloc.c so that utility programs have access */
 #define FITSint(x) FITSint_(x, __func__, __LINE__)

--- a/include/global.h
+++ b/include/global.h
@@ -318,8 +318,8 @@ extern char *dupstr_n(const char *string,
                       unsigned *lenout) NONNULL NONNULLPTRS;
 
 /* declare alloc.c's alloc(); allocations made with it use ordinary free() */
-extern long *alloc(unsigned int) NONNULL;  /* alloc.c */
-extern long *re_alloc(long *, unsigned int) NONNULL;
+extern void *alloc(unsigned int) NONNULL;  /* alloc.c */
+extern void *re_alloc(void *, unsigned int) NONNULL;
 
 /* Used for consistency checks of various data files; declare it here so
    that utility programs which include config.h but not hack.h can see it. */

--- a/include/global.h
+++ b/include/global.h
@@ -312,44 +312,14 @@ typedef uchar nhsym;
  *  Null; if memory runs out, it calls panic() and does not return at all.
  */
 
-/* dupstr() is unconditional in alloc.c but not used when MONITOR_HEAP
-   is enabled; some utility programs link with alloc.{o,obj} and need it
-   if nethack is built with MONITOR_HEAP enabled and they aren't; this
-   declaration has been moved out of the '#else' below to avoid getting
-   a complaint from -Wmissing-prototypes when building with MONITOR_HEAP */
 extern char *dupstr(const char *) NONNULL NONNULLARG1;
 /* same, but return strlen(string) in extra argument */
 extern char *dupstr_n(const char *string,
                       unsigned *lenout) NONNULL NONNULLPTRS;
 
-/*
- * MONITOR_HEAP is conditionally used for primitive memory leak debugging.
- * When enabled, NH_HEAPLOG (if defined in the environment) is used as the
- * name of a log file to create for capturing allocations and releases.
- * [The 'heaputil' program to analyze that file isn't included in releases.]
- *
- * See alloc.c.
- */
-#ifdef MONITOR_HEAP
-/* plain alloc() is not declared except in alloc.c */
-extern long *nhalloc(unsigned int, const char *, int) NONNULL NONNULLARG2;
-extern long *nhrealloc(long *, unsigned int, const char *,
-                       int) NONNULL NONNULLARG3;
-extern void nhfree(genericptr_t, const char *, int) NONNULLARG2;
-extern char *nhdupstr(const char *, const char *, int) NONNULL NONNULLPTRS;
-/* this predates C99's __func__; that is trickier to use conditionally
-   because it is not implemented as a preprocessor macro; MONITOR_HEAP
-   wouldn't gain much benefit from it anyway so continue to live without it;
-   if func's caller were accessible, that would be a very different issue */
-#define alloc(a) nhalloc(a, __FILE__, (int) __LINE__)
-#define re_alloc(a,n) nhrealloc(a, n, __FILE__, (int) __LINE__)
-#define free(a) nhfree(a, __FILE__, (int) __LINE__)
-#define dupstr(s) nhdupstr(s, __FILE__, (int) __LINE__)
-#else /* !MONITOR_HEAP */
 /* declare alloc.c's alloc(); allocations made with it use ordinary free() */
 extern long *alloc(unsigned int) NONNULL;  /* alloc.c */
 extern long *re_alloc(long *, unsigned int) NONNULL;
-#endif /* ?MONITOR_HEAP */
 
 /* Used for consistency checks of various data files; declare it here so
    that utility programs which include config.h but not hack.h can see it. */

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -21,55 +21,40 @@ extern unsigned FITSuint_(unsigned long long, const char *, int) NONNULLARG2;
 
 char *fmt_ptr(const genericptr) NONNULL;
 
-/*
- * For historical reasons, nethack's alloc() returns 'long *' rather
- * than 'void *' or 'char *'.
- *
- * Some static analysis complains if it can't deduce that the number
- * of bytes being allocated is a multiple of 'sizeof (long)'.  It
- * recognizes that the following manipulation overcomes that via
- * rounding the requested length up to the next long.  NetHack doesn't
- * make a lot of tiny allocations, so this shouldn't waste much memory
- * regardless of whether malloc() does something similar.  NetHack
- * isn't expected to call alloc(0), but if that happens treat it as
- * alloc(sizeof (long)) instead.
- */
-#define ForceAlignedLength(LTH) \
-    do {                                                        \
-        if (!(LTH) || (LTH) % sizeof (long) != 0)               \
-            (LTH) += sizeof (long) - (LTH) % sizeof (long);     \
-    } while (0)
-
-long *alloc(unsigned int) NONNULL;
-long *re_alloc(long *, unsigned int) NONNULL;
+void *alloc(unsigned int) NONNULL;
+void *re_alloc(void *, unsigned int) NONNULL;
 ATTRNORETURN extern void panic(const char *, ...) PRINTF_F(1, 2) NORETURN;
 
-long *
-alloc(unsigned int lth)
+void *
+alloc(unsigned int bytes)
 {
-    genericptr_t ptr;
+    void *p;
 
-    ForceAlignedLength(lth);
-    ptr = malloc(lth);
-    if (!ptr)
-        panic("Memory allocation failure; cannot get %u bytes", lth);
+    if (!bytes)
+        panic("Zero sized allocs not allowed");
 
-    return (long *) ptr;
+    p = malloc(bytes);
+    if (!p)
+        panic("Memory allocation failure; cannot get %u bytes", bytes);
+
+    return p;
 }
 
 /* realloc() call that might get substituted by nhrealloc(p,n,file,line) */
-long *
-re_alloc(long *oldptr, unsigned int newlth)
+void *
+re_alloc(void *old, unsigned int newlth)
 {
-    long *newptr;
+    void *p;
 
-    ForceAlignedLength(newlth);
-    newptr = (long *) realloc((genericptr_t) oldptr, (size_t) newlth);
+    if (!newlth)
+        panic("Zero sized reallocs not allowed");
+
+    p = realloc(old, (size_t) newlth);
     /* "extend to":  assume it won't ever fail if asked to shrink */
-    if (newlth && !newptr)
+    if (!p)
         panic("Memory allocation failure; cannot extend to %u bytes", newlth);
 
-    return newptr;
+    return p;
 }
 
 #ifdef HAS_PTR_FMT

--- a/src/mdlib.c
+++ b/src/mdlib.c
@@ -503,9 +503,6 @@ static const char *const build_opts[] = {
 #ifdef MAIL
     "mail daemon",
 #endif
-#ifdef MONITOR_HEAP
-    "monitor heap - record memory usage for later analysis",
-#endif
 #if defined(GNUDOS) || defined(__DJGPP__)
     "MSDOS protected mode",
 #endif

--- a/win/X11/winmap.c
+++ b/win/X11/winmap.c
@@ -361,11 +361,6 @@ post_process_tiles(void)
               tile_image, 0, 0, 0, 0, /* src, dest top left */
               width, height);
 
-#ifdef MONITOR_HEAP
-    /* if we let XDestroyImage() handle it, our tracking will be off */
-    if (tile_image->data)
-        free((genericptr_t) tile_image->data), tile_image->data = 0;
-#endif
     XDestroyImage(tile_image); /* data bytes free'd also */
     tile_image = 0;
 

--- a/win/share/gifread.c
+++ b/win/share/gifread.c
@@ -19,9 +19,7 @@
 #include "config.h"
 #include "tile.h"
 
-#ifndef MONITOR_HEAP
 extern long *alloc(unsigned int);
-#endif
 
 #define PPM_ASSIGN(p, red, grn, blu) \
     do {                             \

--- a/win/share/ppmwrite.c
+++ b/win/share/ppmwrite.c
@@ -6,9 +6,7 @@
 #include "config.h"
 #include "tile.h"
 
-#ifndef MONITOR_HEAP
 extern long *alloc(unsigned int);
-#endif
 
 FILE *ppm_file;
 

--- a/win/share/tilemap.c
+++ b/win/share/tilemap.c
@@ -26,13 +26,6 @@
 #define Snprintf(str, size, ...) \
     nh_snprintf(__func__, __LINE__, str, size, __VA_ARGS__)
 
-#ifdef MONITOR_HEAP
-/* with heap monitoring enabled, free(ptr) is a macro which expands to
-   nhfree(ptr,__FILE__,__LINE__); since tilemap doesn't link with
-   src/alloc.o it doesn't have access to nhfree(); use actual free */
-#undef free
-#endif
-
 #define Fprintf (void) fprintf
 
 /*


### PR DESCRIPTION
- Remove MONITOR_HEAP as there is adequate external tooling to cover similar functionality.
- Avoid aligning mallocs to give full control to memory access debug tooling