### PR TITLE
change CHDIR definition conditions

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -463,7 +463,7 @@
  */
 #define INSURANCE /* allow crashed game recovery */
 
-#ifndef MAC
+#if !defined(MAC) && !defined(SHIM_GRAPHICS)
 #define CHDIR /* delete if no chdir() available */
 #endif
 


### PR DESCRIPTION
Compiling to WASM target on non-Mac system will result in a binary that does not work correctly. Since filesystem in WASM environment is different, chdir to HACKDIR cannot be executed properly. 