### PR TITLE
Various fixes and additions for cross compilation to WebAssembly

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -482,6 +482,9 @@ extern struct nomakedefs_s nomakedefs;
 #if !defined(CROSS_TO_WASM) /* no popen in WASM */
 #define PANICTRACE_GDB
 #endif
+#ifdef CROSS_TO_WASM
+#undef COMPRESS
+#endif
 #endif
 
 /* Supply nethack_enter macro if not supplied by port */

--- a/src/role.c
+++ b/src/role.c
@@ -2175,7 +2175,7 @@ genl_player_selection(void)
     /*NOTREACHED*/
 }
 
-#if defined(TTY_GRAPHICS) || defined(CURSES_GRAPHICS)
+#if defined(TTY_GRAPHICS) || defined(CURSES_GRAPHICS) || defined(SHIM_GRAPHICS)
 /* ['#else' far below] */
 
 staticfn boolean reset_role_filtering(void);

--- a/sys/unix/hints/include/cross-pre2.370
+++ b/sys/unix/hints/include/cross-pre2.370
@@ -216,7 +216,7 @@ ifdef CROSS_TO_WASM
 # originally from https://github.com/NetHack/NetHack/pull/385
 #===============-=================================================
 #
-WASM_DEBUG = 1
+#WASM_DEBUG = 1
 WASM_DATA_DIR = $(TARGETPFX)wasm-data
 WASM_TARGET = $(TARGETPFX)nethack.js
 EMCC_LFLAGS =
@@ -227,10 +227,13 @@ EMCC_LFLAGS += -s ALLOW_TABLE_GROWTH
 EMCC_LFLAGS += -s ASYNCIFY -s ASYNCIFY_IMPORTS='["local_callback"]'
 EMCC_LFLAGS += -O3
 EMCC_LFLAGS += -s MODULARIZE
-EMCC_LFLAGS += -s EXPORTED_FUNCTIONS='["_main", "_shim_graphics_set_callback", "_display_inventory"]'
+EMCC_LFLAGS += -s EXPORTED_FUNCTIONS='["_main", "_shim_graphics_set_callback", "_display_inventory", "_malloc"]'
 EMCC_LFLAGS += -s EXPORTED_RUNTIME_METHODS='["cwrap", "ccall", "addFunction", \
-			"removeFunction", "UTF8ToString", "getValue", "setValue"]'
+			"removeFunction", "UTF8ToString", "stringToUTF8", "getValue", \
+			"setValue", "ENV", "FS", "IDBFS"]'
 EMCC_LFLAGS += -s ERROR_ON_UNDEFINED_SYMBOLS=0
+EMCC_LFLAGS += -s EXPORT_ES6=1
+EMCC_LFLAGS += -lidbfs.js
 # XXX: the "@/" at the end of "--embed-file" tells emscripten to embed the files
 # in the root directory, otherwise they will end up in the $(WASM_DATA_DIR) path
 EMCC_LFLAGS += --embed-file $(WASM_DATA_DIR)@/

--- a/win/shim/winshim.c
+++ b/win/shim/winshim.c
@@ -115,7 +115,7 @@ void name fn_args { \
 #endif /* __EMSCRIPTEN__ */
 
 VDECLCB(shim_init_nhwindows,(int *argcp, char **argv), "vpp", P2V argcp, P2V argv)
-VDECLCB(shim_player_selection,(void), "v")
+DECLCB(boolean, shim_player_selection_or_tty,(void), "b")
 VDECLCB(shim_askname,(void), "v")
 VDECLCB(shim_get_nh_event,(void), "v")
 VDECLCB(shim_exit_nhwindows,(const char *str), "vs", P2V str)
@@ -123,33 +123,33 @@ VDECLCB(shim_suspend_nhwindows,(const char *str), "vs", P2V str)
 VDECLCB(shim_resume_nhwindows,(void), "v")
 DECLCB(winid, shim_create_nhwindow, (int type), "ii", A2P type)
 VDECLCB(shim_clear_nhwindow,(winid window), "vi", A2P window)
-VDECLCB(shim_display_nhwindow,(winid window, boolean blocking), "vii", A2P window, A2P blocking)
+VDECLCB(shim_display_nhwindow,(winid window, boolean blocking), "vib", A2P window, A2P blocking)
 VDECLCB(shim_destroy_nhwindow,(winid window), "vi", A2P window)
 VDECLCB(shim_curs,(winid a, int x, int y), "viii", A2P a, A2P x, A2P y)
 VDECLCB(shim_putstr,(winid w, int attr, const char *str), "viis", A2P w, A2P attr, P2V str)
-VDECLCB(shim_display_file,(const char *name, boolean complain), "vsi", P2V name, A2P complain)
+VDECLCB(shim_display_file,(const char *name, boolean complain), "vsb", P2V name, A2P complain)
 VDECLCB(shim_start_menu,(winid window, unsigned long mbehavior), "vii", A2P window, A2P mbehavior)
 VDECLCB(shim_add_menu,
     (winid window, const glyph_info *glyphinfo, const ANY_P *identifier, char ch, char gch, int attr, int clr, const char *str, unsigned int itemflags),
-    "vippiiiisi",
+    "vipi00iisi",
     A2P window, P2V glyphinfo, P2V identifier, A2P ch, A2P gch, A2P attr, A2P clr, P2V str, A2P itemflags)
 VDECLCB(shim_end_menu,(winid window, const char *prompt), "vis", A2P window, P2V prompt)
 /* XXX: shim_select_menu menu_list is an output */
-DECLCB(int, shim_select_menu,(winid window, int how, MENU_ITEM_P **menu_list), "iiio", A2P window, A2P how, P2V menu_list)
+DECLCB(int, shim_select_menu,(winid window, int how, MENU_ITEM_P **menu_list), "iiip", A2P window, A2P how, P2V menu_list)
 DECLCB(char, shim_message_menu,(char let, int how, const char *mesg), "ciis", A2P let, A2P how, P2V mesg)
 VDECLCB(shim_mark_synch,(void), "v")
 VDECLCB(shim_wait_synch,(void), "v")
 VDECLCB(shim_cliparound,(int x, int y), "vii", A2P x, A2P y)
-VDECLCB(shim_update_positionbar,(char *posbar), "vp", P2V posbar)
-VDECLCB(shim_print_glyph,(winid w, coordxy x, coordxy y, const glyph_info *glyphinfo, const glyph_info *bkglyphinfo), "viiipp", A2P w, A2P x, A2P y, P2V glyphinfo, P2V bkglyphinfo)
+VDECLCB(shim_update_positionbar,(char *posbar), "vs", P2V posbar)
+VDECLCB(shim_print_glyph,(winid w, coordxy x, coordxy y, const glyph_info *glyphinfo, const glyph_info *bkglyphinfo), "vi11pp", A2P w, A2P x, A2P y, P2V glyphinfo, P2V bkglyphinfo)
 VDECLCB(shim_raw_print,(const char *str), "vs", P2V str)
 VDECLCB(shim_raw_print_bold,(const char *str), "vs", P2V str)
 DECLCB(int, shim_nhgetch,(void), "i")
-DECLCB(int, shim_nh_poskey,(coordxy *x, coordxy *y, int *mod), "iooo", P2V x, P2V y, P2V mod)
+DECLCB(int, shim_nh_poskey,(coordxy *x, coordxy *y, int *mod), "ippp", P2V x, P2V y, P2V mod)
 VDECLCB(shim_nhbell,(void), "v")
 DECLCB(int, shim_doprev_message,(void),"iv")
-DECLCB(char, shim_yn_function,(const char *query, const char *resp, char def), "cssi", P2V query, P2V resp, A2P def)
-VDECLCB(shim_getlin,(const char *query, char *bufp), "vso", P2V query, P2V bufp)
+DECLCB(char, shim_yn_function,(const char *query, const char *resp, char def), "css0", P2V query, P2V resp, A2P def)
+VDECLCB(shim_getlin,(const char *query, char *bufp), "vsp", P2V query, P2V bufp)
 DECLCB(int,shim_get_ext_cmd,(void),"iv")
 VDECLCB(shim_number_pad,(int state), "vi", A2P state)
 VDECLCB(shim_delay_output,(void), "v")
@@ -162,17 +162,17 @@ DECLCB(char *,shim_get_color_string,(void),"sv")
 VDECLCB(shim_start_screen, (void), "v")
 VDECLCB(shim_end_screen, (void), "v")
 VDECLCB(shim_preference_update, (const char *pref), "vp", P2V pref)
-DECLCB(char *,shim_getmsghistory, (boolean init), "si", A2P init)
-VDECLCB(shim_putmsghistory, (const char *msg, boolean restoring_msghist), "vsi", P2V msg, A2P restoring_msghist)
+DECLCB(char *,shim_getmsghistory, (boolean init), "sb", A2P init)
+VDECLCB(shim_putmsghistory, (const char *msg, boolean restoring_msghist), "vsb", P2V msg, A2P restoring_msghist)
 VDECLCB(shim_status_init, (void), "v")
 VDECLCB(shim_status_enablefield,
     (int fieldidx, const char *nm, const char *fmt, boolean enable),
-    "vippi",
+    "vippb",
     A2P fieldidx, P2V nm, P2V fmt, A2P enable)
 /* XXX: the second argument to shim_status_update is sometimes an integer and sometimes a pointer */
 VDECLCB(shim_status_update,
     (int fldidx, genericptr_t ptr, int chg, int percent, int color, unsigned long *colormasks),
-    "vioiiip",
+    "vipiiip",
     A2P fldidx, P2V ptr, A2P chg, A2P percent, A2P color, P2V colormasks)
 
 #ifdef __EMSCRIPTEN__
@@ -183,6 +183,14 @@ void shim_update_inventory(int a1 UNUSED) {
         display_inventory(NULL, FALSE);
     }
 }
+
+void shim_player_selection() {
+    boolean do_genl_player_setup = shim_player_selection_or_tty();
+    if (do_genl_player_setup) {
+        genl_player_setup(80);
+    }
+}
+
 win_request_info *
 shim_ctrl_nhwindow(
     winid window UNUSED,
@@ -203,6 +211,7 @@ struct window_procs shim_procs = {
     WPID(shim),
     (0
      | WC_ASCII_MAP
+     | WC_MOUSE_SUPPORT
      | WC_COLOR | WC_HILITE_PET | WC_INVERSE | WC_EIGHT_BIT_IN),
     (0
 #if defined(SELECTSAVED)
@@ -262,7 +271,7 @@ EM_JS(void, local_callback, (const char *cb_name, const char *shim_name, void *r
     // unrolling and it crashes. Thus we use Asyncify.handleSleep() and wakeUp() to make sure that async doesn't break
     // Asyncify. For details, see: https://emscripten.org/docs/porting/asyncify.html#optimizing
     Asyncify.handleSleep(wakeUp => {
-        // convert callback arguments to proper JavaScript varaidic arguments
+        // convert callback arguments to proper JavaScript variadic arguments
         let name = UTF8ToString(shim_name);
         let fmt = UTF8ToString(fmt_str);
         let cbName = UTF8ToString(cb_name);
@@ -287,40 +296,25 @@ EM_JS(void, local_callback, (const char *cb_name, const char *shim_name, void *r
 
         // do the callback
         let userCallback = globalThis[cbName];
-        runJsEventLoop(() => userCallback.call(this, name, ... jsArgs)).then((retVal) => {
+        userCallback.call(this, name, ... jsArgs).then((retVal) => {
             // save the return value
             setPointerValue(name, ret_ptr, retType, retVal);
-            // return
-            setTimeout(() => {
-                reentryMutexUnlock();
+            reentryMutexUnlock();
+            try {
                 wakeUp();
-            }, 0);
+            } catch (e) {
+                
+            }
         });
 
         function getArg(name, ptr, type) {
-            return (type === "o")?ptr:getPointerValue(name, getValue(ptr, "*"), type);
-        }
-
-        // setTimeout() with value of '0' is similar to setImmediate() (but setImmediate isn't standard)
-        // this lets the JS loop run for a tick so that other events can occur
-        // XXX: I also tried replacing the for(;;) in allmain.c:moveloop() with emscripten_set_main_loop()
-        // unfortunately that won't work -- if the simulate_infinite_loop arg is false, it falls through
-        // and the program ends;
-        // if is true, it throws an exception to break out of main(), but doesn't get caught because
-        // the stack isn't running under main() anymore...
-        // I think this is suboptimal, but we will have to live with it (for now?)
-        async function runJsEventLoop(cb) {
-            return new Promise((resolve) => {
-                setTimeout(() => {
-                    resolve(cb());
-                }, 0);
-            });
+            return (type === "p") ? getValue(ptr, "*") : getPointerValue(name, getValue(ptr, "*"), type);
         }
 
         function reentryMutexLock(name) {
             globalThis.nethackGlobal = globalThis.nethackGlobal || {};
             if(globalThis.nethackGlobal.shimFunctionRunning) {
-                throw new Error(`'${name}' attempting second call to 'local_callback' before '${globalThis.nethackGlobal.shimFunctionRunning}' has finished, will crash emscripten Asyncify. For details see: emscripten.org/docs/porting/asyncify.html#reentrancy`);
+                console.error(`'${name}' attempting second call to 'local_callback' before '${globalThis.nethackGlobal.shimFunctionRunning}' has finished, will crash emscripten Asyncify. For details see: emscripten.org/docs/porting/asyncify.html#reentrancy`);
             }
             globalThis.nethackGlobal.shimFunctionRunning = name;
         }


### PR DESCRIPTION
Hello,

I have been working on a browser/mobile port of NetHack 3.7 using cross-compilation to WebAssembly (it is very playable already, you can try it at https://guillaumebrunerie.github.io/nethack/).

![Screenshot_20241130-183417](https://github.com/user-attachments/assets/7ccd8fe6-03c2-4c5d-9f5d-64094bda63e6)


The existing code for compiling to WebAssembly was a great help, although it wasn’t fully up to date and was missing a number of things in order to be able to create a proper window port (for instance there was no way to set `iflags.window_inited` to true, `print_glyph` was not working properly as its signature changed, and various other things).

This pull request contains various fixes and additions that I found were needed/helpful.

Changes:
- export more constants/pointers/globals,
- fix various types that are incorrect,
- disable compression of save files, as it uses fork which isn’t supported in WebAssembly,
- include `genl_player_setup` when `SHIM_GRAPHICS` is defined, in order to make it possible to reuse the existing player selection code,
- move initialization of JavaScript global constants up, as I was running in some issue when `raw_print` was being called before initialization,
- change various compilation options for Emscripten, in particular it now generates an ES6 module (easier to use in a modern Javascript project) and exports more methods from Emscripten (for instance to be able to use the virtual file system when saving).
- simplify the implementation of the main loop to avoid `setTimeout` which can be pretty slow in the browser when called many times,
- change the way pointer arguments are being sent to JavaScript in `getArg` (they were being sent as a pointer to the pointer itself on the stack, which doesn’t really make sense, now the pointer itself is sent)

Ping @apowers313 who first implemented cross compilation to WebAssembly (#385), and @Anhijkt who I see recently fixed an issue that I ran into as well (#1328).