### PR TITLE
Refresh worm segments when (un)taming

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -3766,6 +3766,7 @@ extern boolean worm_cross(int, int, int, int);
 extern int wseg_at(struct monst *, int, int) NO_NNARGS;
 extern void flip_worm_segs_vertical(struct monst *, int, int) NONNULLARG1;
 extern void flip_worm_segs_horizontal(struct monst *, int, int) NONNULLARG1;
+extern void redraw_worm(struct monst *);
 
 /* ### worn.c ### */
 

--- a/src/dog.c
+++ b/src/dog.c
@@ -1180,6 +1180,8 @@ tamedog(struct monst *mtmp, struct obj *obj, boolean givemsg)
               Hallucination ? "approachable" : "friendly");
 
     newsym(mtmp->mx, mtmp->my);
+    if (mtmp->wormno)
+        redraw_worm(mtmp);
     if (attacktype(mtmp->data, AT_WEAP)) {
         mtmp->weapon_check = NEED_HTH_WEAPON;
         (void) mon_wield_item(mtmp);
@@ -1288,8 +1290,12 @@ abuse_dog(struct monst *mtmp)
         else
             growl(mtmp); /* give them a moment's worry */
 
-        if (!mtmp->mtame)
+        if (!mtmp->mtame) {
             newsym(mtmp->mx, mtmp->my);
+            if (mtmp->wormno) {
+                redraw_worm(mtmp);
+            }
+        }
     }
 }
 

--- a/src/worm.c
+++ b/src/worm.c
@@ -988,4 +988,15 @@ flip_worm_segs_horizontal(struct monst *worm, int minx, int maxx)
     }
 }
 
+void
+redraw_worm(struct monst *worm)
+{
+    struct wseg *curr = wtails[worm->wormno];
+
+    while (curr) {
+        newsym(curr->wx, curr->wy);
+        curr = curr->nseg;
+    }
+}
+
 /*worm.c*/


### PR DESCRIPTION
Because newsym() would be called only on the head position of the worm,
if hilite_pet was on, the segments and head of a long worm would have
mismatched highlighting in the immediate aftermath of taming or
untaming.
