### PR TITLE
Fix: ravens specified as hostile on Medusa's Island could be peaceful

### DIFF
--- a/dat/medusa-3.lua
+++ b/dat/medusa-3.lua
@@ -132,7 +132,7 @@ des.monster("water nymph")
 des.monster("water nymph")
 
 for i=1,30 do
-   des.monster({ id = "raven", hostile = 1 })
+   des.monster({ id = "raven", peaceful = 0 })
 end
 
 --#medusa-3.lua


### PR DESCRIPTION
Noticed when testing the recent bec de corbin change which makes ravens generate as peaceful; if you happened to enter medusa-3 while wielding one, all the ravens are peaceful. Even without one, if you entered the level as a neutral character, some of them would randomly be peaceful due to matching alignment. But in the medusa-3.lua file, the ravens are all unconditionally flagged as hostile.

The reason for this behavior is that the lua loading code does not recognize "hostile" (instead peaceful=0 needs to be set), so it does nothing and leaves the ravens to generate as if it had been unspecified. It appeared to affect only these ravens; no other des.monster() uses hostile=1 instead of peaceful=0.

This bug has been around in the 3.7 development branch since the change to Lua, but doesn't happen in 3.6 because the des parser does interpret "hostile" as meaning never peaceful.

I considered augmenting lspo_monster so that it could handle "hostile" and treat it like peaceful=0, but figure it's probably better not to have two different booleans that control the same flag (what if someone specified peaceful = 1 and hostile = 1?)