### PR TITLE
Fix: brides of Dracula not generating in their niches

### DIFF
--- a/dat/tower1.lua
+++ b/dat/tower1.lua
@@ -42,9 +42,9 @@ local Vnames = { nil, nil, nil };
 if (not Vgenod) then
    Vnames = { "Madame", "Marquise", "Countess" };
 end
-des.monster({ id="Vampire Lady", niches[4], name=Vnames[1], waiting=1 })
-des.monster({ id="Vampire Lady", niches[5], name=Vnames[2], waiting=1 })
-des.monster({ id="Vampire Lady", niches[6], name=Vnames[3], waiting=1 })
+des.monster({ id="vampire lady", coord=niches[4], name=Vnames[1], waiting=1 })
+des.monster({ id="vampire lady", coord=niches[5], name=Vnames[2], waiting=1 })
+des.monster({ id="vampire lady", coord=niches[6], name=Vnames[3], waiting=1 })
 -- The doors
 des.door("closed",08,03)
 des.door("closed",10,03)


### PR DESCRIPTION
When the des.monster() statements for the vampire ladies were changed to use the lua-table form, the coordinate argument was not given the coord= name in the table, so the lua loader was ignoring it and the vampire ladies were placed on random spaces on the level. Fix this by supplying the coord=; testing shows that they now appear back in the niches.

Also lowercase the monster species id "Vampire Lady" to "vampire lady". The uppercase didn't affect the species being generated but having the id be the same case as in monsters.h is consistent with how it's done everywhere else.