### PR TITLE
Enable more ways to specify monster inventory in special levels

### DIFF
--- a/doc/lua.adoc
+++ b/doc/lua.adoc
@@ -794,7 +794,8 @@ The hash parameter accepts the following keys:
 | ignorewater    | boolean | ignore water when choosing location for the monster
 | countbirth     | boolean | do we count this monster as generated
 | appear_as      | string | monster can appear as object, monster, or terrain. Add "obj:", "mon:", or "ter:" prefix to the value. |
-| inventory      | function | objects generated in the function are given to the monster
+| inventory      | function | objects generated in the function are given to the monster (any random inventory it gets is discarded unless keep_default_invent is true)
+| keep_default_invent | boolean | if inventory is specified and this is true, those items are in addition to random inventory for this species; if inventory is not specified and this is false, monster gets no starting inventory
 |===
 
 Example:

--- a/include/sp_lev.h
+++ b/include/sp_lev.h
@@ -74,6 +74,11 @@ enum lvlinit_types {
 #define NO_LOC_WARN 0x20 /* no complaints and set x & y to -1, if no loc */
 #define SPACELOC    0x40 /* like DRY, but accepts furniture too */
 
+/* has_invent flags */
+#define NO_INVENT 0         /* monster doesn't get any invent */
+#define CUSTOM_INVENT 0x01  /* monster gets items specified in lua */
+#define DEFAULT_INVENT 0x02 /* monster gets items from makemon() */
+
 #define SP_COORD_X(l) (l & 0xff)
 #define SP_COORD_Y(l) ((l >> 16) & 0xff)
 #define SP_COORD_PACK(x, y) (((x) & 0xff) + (((y) & 0xff) << 16))


### PR DESCRIPTION
This originated with a bug in NerfHack in which the developer specified an inventory for a quest nemesis, but neglected to include the Bell of Opening in it. Since monsters' inventory contents from makemon() were tossed out completely, this caused a situation where the Bell was deleted and the game was unwinnable. The first part of this change is guarding against that by adding mdrop_special_objs before discarding the inventory. This does create a possibility where if the programmer *does* specify a nemesis get the Bell item in their inventory, while neglecting to remove its special case generation in makemon.c, it would generate twice - but two Bells is better than none.

Working on that fix led me to think about a limitation of the current sp_lev.c behavior. You could either have a monster generate with its species-typical inventory by not specifying an inventory for it, or you could have it generate with custom inventory but then have to use that to clumsily reproduce the normal inventory's complex chances and conditionals in mongets(). So the remainder of this commit implements another flag for des.monster(), keep_default_invent, that allows for more flexibility in two ways:

1. When des.monster() contains an inventory function and keep_default_invent is true, the monster will retain everything it gets from makemon() and the objects in the inventory function are in ADDITION to those. This is useful for augmenting a monster's default kit with something to make them more threatening, or just more loot.
2. When des.monster contains no inventory function and keep_default_invent is false, the monster will get NO inventory even if its species is normally supposed to. I'm not sure where exactly this would be used, but it doesn't hurt to have it available.

When keep_default_invent is not specified at all, the behavior remains the same as it is now - if inventory is provided, default items are discarded, and if not, they are kept. This doesn't add the flag to any monsters, so it's currently always unspecified.

Tested all six combinations of inventory (specified or not) and keep_default_invent (true, false, unspecified) with hobbits because they always get at least one item by default, so its absence when it should be suppressed was easy to verify.