### PR TITLE
Fix: quantum mechanics' tele attack had inverted negation check

### DIFF
--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -2813,7 +2813,7 @@ mhitm_ad_tlpt(
         int tmphp;
 
         hitmsg(magr, mattk);
-        if (!mhitm_mgc_atk_negated(magr, mdef, FALSE)) {
+        if (mhitm_mgc_atk_negated(magr, mdef, FALSE)) {
             You("are not affected.");
         } else {
             if (flags.verbose)


### PR DESCRIPTION
Noticed when I summoned a quantum mechanic in wizard mode with a starting character who should have no armor protection against their teleport attack, but every touch resulted in "You are not affected". It turns out the if statement checking for armor protection is backwards, so you were never affected when you have no protection and were almost always affected when you had good protection.

This appears to date back to when the all-purpose 'negated' variable was removed and "You are not affected" moved to after the negation check; the new conditional kept the ! by mistake.