### PR TITLE
Remove dented pot encyclopedia matching on 'helmet'

### DIFF
--- a/dat/data.base
+++ b/dat/data.base
@@ -2395,7 +2395,6 @@ hell hound*
 ~helm of *
 ~crystal helmet
 helm*
-dented pot
 * helmet
 	A piece of armor designed to protect the head.
 	(What were you expecting?)


### PR DESCRIPTION
Dented pots got their own encyclopedia entry, so they shouldn't still match to "helmet". Even without this change, they match the "dented pot" entry correctly, but only by virtue of it appearing earlier in the encyclopedia.

Inverting the match to "~dented pot" isn't necessary since it isn't something that would otherwise match "helmet", so just remove it.