### PR TITLE
add sanity check on parse_status_hl2()

### DIFF
--- a/src/botl.c
+++ b/src/botl.c
@@ -2830,6 +2830,7 @@ parse_status_hl2(char (*s)[QBUFSZ], boolean from_configfile)
         else
             hilite.behavior = BL_TH_NONE;
 
+        assert(dt >= 0);
         hilite.anytype = dt;
 
         if (hilite.behavior == BL_TH_TEXTMATCH && txt) {


### PR DESCRIPTION
dt is initialized with -1, and it's not so obvious that it will be always overwritten later.