### PR TITLE
Remove useless call to `wakeup` in `bhitm` routine

### DIFF
--- a/src/zap.c
+++ b/src/zap.c
@@ -406,7 +406,6 @@ bhitm(struct monst *mtmp, struct obj *otmp)
                     pline("%s doesn't budge.", Monnam(mtmp));
             }
             if (!DEADMONSTER(mtmp)) {
-                wakeup(mtmp, !mindless(mtmp->data));
                 abuse_dog(mtmp);
             }
         } else if ((obj = which_armor(mtmp, W_SADDLE)) != 0) {


### PR DESCRIPTION
`wakeup(mtmp, TRUE)` is called at the end since `wake` is set.