### PR TITLE
Make pline_mon work if youmonst is passed to it

### DIFF
--- a/src/pline.c
+++ b/src/pline.c
@@ -136,7 +136,10 @@ pline_mon(struct monst *mtmp, const char *line, ...)
 {
     va_list the_args;
 
-    set_msg_xy(mtmp->mx, mtmp->my);
+    if (mtmp == &gy.youmonst)
+        set_msg_xy(0, 0);
+    else
+        set_msg_xy(mtmp->mx, mtmp->my);
 
     va_start(the_args, line);
     vpline(line, the_args);


### PR DESCRIPTION
I was working on another patch involving a message that could be printed for either a monster or the player (using a struct monst * variable that either holds the monster or &gy.youmonst), but wasn't able to easily use pline_mon for the message since the mx and my of youmonst aren't kept updated as the hero moves. (In my testing, they were always 0, but it's not clear if they will remain 0 throughout the game, or if that's a bad assumption to make.)

Allow this in the future by checking for youmonst in pline_mon and setting the coordinates to 0,0 explicitly so no relative coordinate message gets printed when it's about the hero.

I'm not sure if it's a reasonable assumption that no messages that could ever be passed to pline_mon for a player would ever need to note "(here)" when accessiblemsg is turned on. If that's the case, the correct thing would be to set the coordinates to u.ux, u.uy instead of 0,0.