### PR TITLE
Clean up hardcoded material constant in water vault themerm

### DIFF
--- a/dat/themerms.lua
+++ b/dat/themerms.lua
@@ -686,12 +686,12 @@ xx|.....|xx
      local itm = obj.new(escape_items[math.random(#escape_items)]);
      local itmcls = itm:class()
      local box
-     if itmcls[ "material" ] == 19 then                         -- GLASS==19
-         -- item is made of glass so explicitly force chest to be unlocked
+     if itmcls[ "material" ] == "glass" then
+         -- explicitly force chest to be unlocked
 	 box = des.object({ id = "chest", coord = chest_spots[1],
                             olocked = "no" });
      else
-         -- item isn't made of glass; accept random locked/unlocked state
+         -- accept random locked/unlocked state
 	 box = des.object({ id = "chest", coord = chest_spots[1] });
      end;
      box:addcontent(itm);

--- a/src/nhlobj.c
+++ b/src/nhlobj.c
@@ -219,7 +219,7 @@ l_obj_objects_to_table(lua_State *L)
     /* TODO: oc_bimanual, oc_bulky */
     nhl_add_table_entry_int(L, "tough", o->oc_tough);
     nhl_add_table_entry_int(L, "dir", o->oc_dir); /* TODO: convert to text */
-    nhl_add_table_entry_int(L, "material", o->oc_material); /* TODO: convert to text */
+    nhl_add_table_entry_str(L, "material", materialnm[o->oc_material]);
     /* TODO: oc_subtyp, oc_skill, oc_armcat */
     nhl_add_table_entry_int(L, "oprop", o->oc_oprop);
     nhl_add_table_entry_char(L, "class",


### PR DESCRIPTION
This implements a TODO to return an object's material as text rather than as an int when a Lua file requests all the details about an object's objclass. That is as simple as looking it up in materialnm[].

With that done, it's possible to clean up the one use where a Lua file looks up the material of an object it generated, in the "water-surrounded vault" themed room, previously an inflexible 19 but which can now be compared directly to "glass". It also enables shortening the comments that follow since the branches of the if statement are now obvious.