### PR TITLE
Fix: gremlin cry of pain could be heard while deaf

### DIFF
--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -6264,8 +6264,15 @@ flash_hits_mon(
 void
 light_hits_gremlin(struct monst *mon, int dmg)
 {
-    pline_mon(mon, "%s %s!", Monnam(mon),
-          (dmg > mon->mhp / 2) ? "wails in agony" : "cries out in pain");
+    if (!Deaf && mdistu(mon) <= 90) {
+        /* cry of pain can be heard somewhat farther than the waking radius */
+        pline_mon(mon, "%s %s!", Monnam(mon),
+                  (dmg > mon->mhp / 2) ? "wails in agony"
+                                       : "cries out in pain");
+    }
+    else if (canseemon(mon)) {
+        pline_mon(mon, "%s recoils from the light!", Monnam(mon));
+    }
     mon->mhp -= dmg;
     wake_nearto(mon->mx, mon->my, 30);
     if (DEADMONSTER(mon)) {


### PR DESCRIPTION
Main problem was there was no condition applied to this message, so anyone would hear it even if they were deaf. Even assuming a cry of pain is something that could be seen, the message was still printed when the hero couldn't see the gremlin.

This puts both a deafness check and a range check on that cry (if a gremlin somehow takes light damage on the other side of the map behind many walls, it doesn't make much sense to hear its cry), and provides an alternate message if the hero can't hear it, but can see it. The alternate message does rely on the hero being able to /see/, not just spot, the gremlin and the light it's shying away from -- if you can only sense it, there is no special message.