### PR TITLE
Fix: map random y-placement used its width instead of height 

### DIFF
--- a/doc/lua.adoc
+++ b/doc/lua.adoc
@@ -1319,6 +1319,8 @@ Example:
 === room
 
 Create a selection of locations inside the (current) room.
+Does not include the edges of the room, such as its walls.
+Does not do any check on terrain type, so if there are non-ROOM locations inside the room, they remain part of the selection.
 
 Example:
 

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -6133,7 +6133,7 @@ TODO: gc.coder->croom needs to be updated
                     if (y < 1)
                         y = 1;
                 } else {
-                    y = rn2(ROWNO - mf->wid);
+                    y = rn2(ROWNO - mf->hei);
                 }
             }
         }


### PR DESCRIPTION
Not sure how long this has existed without triggering any issues, but
when I was testing out a themed room wider than it was tall, I ran into
rn2-of-a-negative-number impossibles. Traced it to here, where it was
trying to subtract the width of the mapfrag from ROWNO to figure out
which y-value it should place the map on. The correct behavior is to
subtract the height of the mapfrag.

This pull request also contains a small unrelated lua.adoc update.