### PR TITLE
Add "Murphy" to list of random ghost names

### DIFF
--- a/src/do_name.c
+++ b/src/do_name.c
@@ -762,7 +762,7 @@ static const char *const ghostnames[] = {
     "John",    "Jon",           "Karnov",      "Kay",     "Kenny",  "Kevin",
     "Maud",    "Michiel",       "Mike",        "Peter",   "Robert", "Ron",
     "Tom",     "Wilmar",        "Nick Danger", "Phoenix", "Jiro",   "Mizue",
-    "Stephan", "Lance Braccus", "Shadowhawk"
+    "Stephan", "Lance Braccus", "Shadowhawk",  "Murphy"
 };
 
 /* ghost names formerly set by x_monnam(), now by makemon() instead */


### PR DESCRIPTION
This patch adds "Murphy" to the list of randomly generated ghost names, allowing lucky characters to occasionally encounter "Murphy's ghost" in the dungeon.

"Murphy's Ghost" is a recurring fixture of the long-running "Wizardry" series of classic dungeon crawler video games.  In the first game (1981), he is an early "boss" of the first dungeon level, with a very weak attack but lots of HP and difficult to hit.  Since he granted a lot of XP when killed (and could be killed repeatedly by leaving and re-entering the dungeon), Murphy's Ghost was frequently farmed for levels by new characters making him an extremely memorable encounter.  His popularity with players was so great that he appeared in multiple other games in the series, and other games / media (esp. in Japan) had "Murphy's Ghost" references too.

In fact, this would not be the first Wizardry reference added to Nethack - the randomized scroll description "MAPIRO MAHAMA DIROMAT" is taken directly from an incantation in Wizardry I, which teleports the party back to the starting town.