### PR TITLE
Reset stat abuse / exercise counter on attribute change

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -187,6 +187,9 @@ adjattrib(
         return FALSE;
     }
 
+    /* Any successful change also resets abuse / exercise level */
+    AEXE(ndx) = 0;
+
     disp.botl = TRUE;
     if (msgflg <= 0)
         You_feel("%s%s!", (incr > 1 || incr < -1) ? "very " : "", attrstr);

--- a/src/potion.c
+++ b/src/potion.c
@@ -666,6 +666,9 @@ peffect_restore_ability(struct obj *otmp)
                WEAK or worse, but that's handled via ATEMP(A_STR) now */
             if (ABASE(i) < lim) {
                 ABASE(i) = lim;
+                /* reset stat abuse (but not exercise) to 0 as well */
+                AEXE(i) = max(AEXE(i), 0);
+
                 disp.botl = TRUE;
                 /* only first found if not blessed */
                 if (!otmp->blessed)


### PR DESCRIPTION
* When an attribute changes, reset its corresponding abuse / exercise counter to 0 (i.e. all attribute changes are "whole number" changes)
* Potion / spell of restore ability removes abuse only - exercise level unchanged.  (If negative, `AEXE(i)` is changed to 0 during stat restoration logic.)