### PR TITLE
Implement iflags.use_menu_glyphs for curses and tty.

### DIFF
--- a/dat/opthelp
+++ b/dat/opthelp
@@ -80,6 +80,7 @@ travel         enables travelling via mouse click if supported;    [True]
                attempting to move the hero; does not affect travel via '_'
 use_darkgray   use bold black instead of blue for black glyphs.    [True]
 use_inverse    display detected monsters in highlighted manner    [False]
+use_menu_glyphs show object glyphs in menu items (tty, curses)     [True]
 verbose        print more commentary during the game               [True]
 whatis_menu    show menu when getting a map location              [False]
 whatis_moveskip skip same glyphs when getting a map location      [False]

--- a/doc/Guidebook.mn
+++ b/doc/Guidebook.mn
@@ -4980,6 +4980,9 @@ to be \fIFalse\fP.
 Use bold black instead of blue for black glyphs (TTY only).
 .lp use_inverse
 If NetHack can, it should display inverse when the game specifies it.
+.lp use_menu_glyphs
+If NetHack can, it should display glyphs next to objects in the
+inventory.
 .lp vary_msgcount
 If NetHack can, it should display this number of messages at a time in
 the message window.

--- a/doc/Guidebook.tex
+++ b/doc/Guidebook.tex
@@ -5503,6 +5503,10 @@ Use bold black instead of blue for black glyphs (TTY only).
 \item[\ib{use\verb+_+inverse}]
 If {\it NetHack\/} can, it should display inverse when the game specifies it.
 %.lp
+\item[\ib{use\verb+_+inverse}]
+If {\it NetHack\/} can, it should display glyphs next to objects in the
+inventory.
+%.lp
 \item[\ib{vary\verb+_+msgcount}]
 If {\it NetHack\/} can, it should display this number of messages at a time
 in the message window.

--- a/doc/Guidebook.tex
+++ b/doc/Guidebook.tex
@@ -5503,7 +5503,7 @@ Use bold black instead of blue for black glyphs (TTY only).
 \item[\ib{use\verb+_+inverse}]
 If {\it NetHack\/} can, it should display inverse when the game specifies it.
 %.lp
-\item[\ib{use\verb+_+inverse}]
+\item[\ib{use\verb+_+menu\verb+_+glyphs}]
 If {\it NetHack\/} can, it should display glyphs next to objects in the
 inventory.
 %.lp

--- a/doc/config.nh
+++ b/doc/config.nh
@@ -181,6 +181,9 @@
 # acts as an accelerator key to select items of that class.
 #OPTIONS=menu_objsyms
 
+# Show object glyphs in menus if supported by the windowport (tty, curses)
+#OPTIONS=use_menu_glyphs
+
 # Do not clear the screen before drawing menus, and align menus to right
 #OPTIONS=menu_overlay
 

--- a/include/flag.h
+++ b/include/flag.h
@@ -330,6 +330,7 @@ struct instance_flags {
     boolean tux_penalty;      /* True iff hero is a monk and wearing a suit */
     boolean use_background_glyph; /* use background glyph when appropriate */
     boolean use_menu_color;   /* use color in menus; only if wc_color */
+    boolean use_menu_glyphs;  /* use object glyphs in menus, if the port supports it */
 #ifdef STATUS_HILITES
     long hilite_delta;        /* number of moves to leave a temp hilite lit */
     long unhilite_deadline; /* time when oldest temp hilite should be unlit */

--- a/include/optlist.h
+++ b/include/optlist.h
@@ -789,6 +789,9 @@ static int optfn_##a(int, int, boolean, char *, char *);
     NHOPTB(use_inverse, Advanced, 0, opt_out, set_in_game,
            On, Yes, No, No, NoAlias, &iflags.wc_inverse, Term_False,
            "display detected monsters in inverse")
+    NHOPTB(use_menu_glyphs, Advanced, 0, opt_out, set_in_game,
+           On, Yes, No, No, NoAlias, &iflags.use_menu_glyphs,
+           Term_False, "show object glyphs in menu items")
     NHOPTB(use_truecolor, Advanced, 0, opt_in, set_in_config,
                 Off, Yes, No, No, "use_truecolour",
            &iflags.use_truecolor, Term_False,

--- a/include/wintty.h
+++ b/include/wintty.h
@@ -34,6 +34,7 @@ typedef struct tty_mi {
     anything identifier; /* user identifier */
     long count;          /* user count */
     char *str;           /* description string (including accelerator) */
+    glyph_info glyphinfo;    /* glyph */
     int attr;            /* string attribute */
     int color;           /* string color */
     boolean selected;    /* TRUE if selected by user */

--- a/win/curses/cursdial.c
+++ b/win/curses/cursdial.c
@@ -1060,11 +1060,9 @@ menu_win_size(nhmenu *menu)
         } else {
             /* Add space for accelerator (selector letter) */
             curentrywidth += 4;
-#if 0 /* FIXME: menu glyphs */
             if (menu_item_ptr->glyphinfo.glyph != NO_GLYPH
                 && iflags.use_menu_glyphs)
                 curentrywidth += 2;
-#endif
         }
         if (curentrywidth > maxentrywidth) {
             maxentrywidth = curentrywidth;
@@ -1283,19 +1281,16 @@ menu_display_page(
             entry_cols -= 4;
             start_col += 4;
         }
-#if 0
-        /* FIXME: menuglyphs not implemented yet */
         if (menu_item_ptr->glyphinfo.glyph != NO_GLYPH
             && iflags.use_menu_glyphs) {
-            color = (int) menu_item_ptr->glyphinfo.color;
+            color = menu_item_ptr->glyphinfo.gm.sym.color;
             curses_toggle_color_attr(win, color, NONE, ON);
-            mvwaddch(win, menu_item_ptr->line_num + 1, start_col, curletter);
+            mvwaddch(win, menu_item_ptr->line_num + 1, start_col, menu_item_ptr->glyphinfo.ttychar);
             curses_toggle_color_attr(win, color, NONE, OFF);
             mvwaddch(win, menu_item_ptr->line_num + 1, start_col + 1, ' ');
             entry_cols -= 2;
             start_col += 2;
         }
-#endif
 	color = menu_item_ptr->color;
         if (color == NO_COLOR)
             color = NONE;

--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -1461,6 +1461,13 @@ process_menu_window(winid window, struct WinDesc *cw)
                                 (void) putchar('+'); /* all selected */
                             else
                                 (void) putchar('#'); /* count selected */
+                        } else if (iflags.use_menu_glyphs && n == 2 
+                                    && curr->identifier.a_void != 0 
+                                    && curr->glyphinfo.glyph != NO_GLYPH) {
+                            /* tty_print_glyph could be used, but is overkill and requires referencing the cursor location */
+                            toggle_menu_attr(TRUE, curr->glyphinfo.gm.sym.color, ATR_NONE);
+                            (void) putchar(curr->glyphinfo.ttychar);
+                            toggle_menu_attr(FALSE, curr->glyphinfo.gm.sym.color, ATR_NONE);
                         } else
                             (void) putchar(*cp);
                     } /* for *cp */
@@ -2537,8 +2544,8 @@ tty_start_menu(winid window, unsigned long mbehavior)
 void
 tty_add_menu(
     winid window,  /* window to use, must be of type NHW_MENU */
-    const glyph_info *glyphinfo UNUSED, /* glyph info with glyph to
-                                         * display with item */
+    const glyph_info *glyphinfo, /* glyph info with glyph to
+                                  * display with item */
     const anything *identifier, /* what to return if selected */
     char ch,                /* selector letter (0 = pick our own) */
     char gch,               /* group accelerator (0 = no group) */
@@ -2595,6 +2602,7 @@ tty_add_menu(
     item->attr = attr;
     item->color = clr;
     item->str = dupstr(newstr);
+    item->glyphinfo = *glyphinfo;
 
     item->next = cw->mlist;
     cw->mlist = item;


### PR DESCRIPTION
Implements iflags.use_menu_glyphs in both the curses and tty window ports. Results are identical to those of 3.4.3-based implementations of this feature. 

![Screenshot from 2025-04-03 19-54-48](https://github.com/user-attachments/assets/94379379-ba05-43cd-913e-9422a1005623)
