### PR TITLE
Fix a couple of incorrect names in the Terry Pratchett tributes

### DIFF
--- a/dat/tribute
+++ b/dat/tribute
@@ -3665,7 +3665,7 @@ and needs to see in the dark.  Strange but true.
 %e passage
 # p. 218
 %passage 9
-"He's bound to have done /something/," Noddy repeated.
+"He's bound to have done /something/," Nobby repeated.
 
 In this he was echoing the Patrician's view of crime and punishment.  If
 there was a crime, there should be punishment.  If the specific criminal
@@ -6031,7 +6031,7 @@ was mostly unexplored, too.(1)
 %e passage
 # p. 219 (passage begins mid-sentence)
 %passage 12
-[...] Sam Vines had learned a lot from watching Lady Sybil.  She didn't
+[...] Sam Vimes had learned a lot from watching Lady Sybil.  She didn't
 mean to act like that, but she'd been born to it, into a class which had
 always behaved this way:  You went through the world as if there was
 /no possibility/ that anyone would stop you or question you, and most of


### PR DESCRIPTION
Fix a couple of incorrect character names ("Nobby" and "Vimes") in the Discworld tribute quotes.