### PR TITLE
Add gender preference (same or opposite) and check it in could_seduce()

### DIFF
--- a/include/monst.h
+++ b/include/monst.h
@@ -160,8 +160,10 @@ struct monst {
     Bitfield(wormno, 5);    /* at most 31 worms on any level */
     Bitfield(mtemplit, 1);  /* temporarily seen; only valid during bhit() */
     Bitfield(meverseen, 1); /* mon has been seen at some point */
-
     Bitfield(mspotted, 1);  /* mon is currently seen by hero */
+
+    Bitfield(mprefopp, 1);  /* mon has preference for opposite sex */
+    Bitfield(mprefsame, 1); /* mon has preference for same sex */
 
     unsigned long mstrategy; /* for monsters with mflag3: current strategy */
 #ifdef NHSTDC

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -1279,6 +1279,11 @@ makemon(
     else
         mtmp->female = femaleok ? rn2(2) : 0;
 
+    /* 90% chance of preferring opposite sex
+       and 10% chance of preferring same */
+    mtmp->mprefopp = (rn2(10) < 9);
+    mtmp->mprefsame = (rn2(10) < 1);
+
     if (In_sokoban(&u.uz) && !mindless(ptr)) { /* know about traps here */
         mon_learns_traps(mtmp, PIT);
         mon_learns_traps(mtmp, HOLE);

--- a/src/mhitu.c
+++ b/src/mhitu.c
@@ -24,7 +24,7 @@ staticfn int passiveum(struct permonst *, struct monst *, struct attack *);
 
 #define ld() ((yyyymmdd((time_t) 0) - (getyear() * 10000L)) == 0xe5)
 
-/* monster hits hero (most callers have been moved to uthim.c) */
+/* monster hits hero (most callers have been moved to uhitm.c) */
 void
 hitmsg(struct monst *mtmp, struct attack *mattk)
 {
@@ -1895,7 +1895,7 @@ could_seduce(
     struct attack *mattk) /* non-Null: current atk; Null: genrl capability */
 {
     struct permonst *pagr;
-    boolean agrinvis, defperc;
+    boolean agrinvis, defperc, agrpref;
     xint16 genagr, gendef;
     int adtyp;
 
@@ -1936,7 +1936,11 @@ could_seduce(
         || (adtyp != AD_SEDU && adtyp != AD_SSEX && adtyp != AD_SITM))
         return 0;
 
-    return (genagr == 1 - gendef) ? 1 : (pagr->mlet == S_NYMPH) ? 2 : 0;
+    /* check for attacker preference of defender gender */
+    agrpref = ((genagr == gendef && magr->mprefsame)
+        || (genagr != gendef && magr->mprefopp));
+
+    return agrpref ? 1 : (pagr->mlet == S_NYMPH) ? 2 : 0;
 }
 
 /* returns 1 if monster teleported (or hero leaves monster's vicinity) */


### PR DESCRIPTION
This PR adds two bits to monsters that track gender preferences - a 90% chance for "opposite" and a separate 10% for "same" - and these preference bits are checked in `could_seduce()` during a "seduction attack" against the defender's gender to determine whether the monster will seduce or not.

From the player's perspective, this simply means that 9/10 opposite gender foocubus will make a pass and 1/10 of the same will - same overall odds, just not 10/10 to 0/10.

**Gay incubus?**
Yes.  It makes any foocubus (or nymph) 81% hetero, 9% homo, 9% bi and 1% asexual.  Happy Pride!

**But I'm not into men?**
Grow up.