### PR TITLE
config.nh: fix example MENUCOLOR regex

### DIFF
--- a/doc/config.nh
+++ b/doc/config.nh
@@ -498,7 +498,7 @@
 #  Show all unholy water in red
 #MENUCOLOR=" unholy " = red
 #  Show all cursed worn items in orange and underlined
-#MENUCOLOR=" cursed .* (being worn)" = orange&underline
+#MENUCOLOR=" cursed .* \(being worn\)" = orange&underline
 
 
 # Use the IBM character set rather than just plain ascii characters


### PR DESCRIPTION
The parsing of `MENUCOLOR`s uses POSIX extended regular expressions through C++'s `std::regex`, which will interpret parentheses as a capture group instead of literal parentheses. It's unclear to me whether the docs for this have always had this minor inconsistency or if it was correct before the change in regex engine (it doesn't matter either way I suppose).