### PR TITLE
Qt: Fix QTCXXFLAGS and WINLIB when compiling with WANT_WINT_QT6

### DIFF
--- a/sys/unix/hints/include/multiw-2.370
+++ b/sys/unix/hints/include/multiw-2.370
@@ -15,7 +15,7 @@
 #     - WINOBJ0
 #---
 # User selections could be specified as combinations of any of the following:
-# WIN_WANT_TTY=1, WIN_WANT_CURSES=1, WIN_WANT_QT=1, WIN_WANT_X11=1
+# WANT_WIN_TTY=1, WANT_WIN_CURSES=1, WANT_WIN_QT=1, WANT_WIN_X11=1
 # The selections will all be linked into the same binary.
 #
 # Assuming you have the prerequisite packages mentioned above, you can

--- a/sys/unix/hints/macOS.370
+++ b/sys/unix/hints/macOS.370
@@ -281,12 +281,12 @@ WINLIB += $(shell PKG_CONFIG_PATH=$(QTDIR)/lib/pkgconfig \
 		pkg-config Qt5Gui Qt5Widgets Qt5Multimedia --libs)
 endif    # WANT_WIN_QT5
 ifdef WANT_WIN_QT6
-QTCXXFLAGS += -std=c++17 -I $(QTDIR)/include -I $(QTDIR)/include/QtCore \
-		-I $(QTDIR)/include/QtMultimedia
+QTCXXFLAGS += $(sort $(shell PKG_CONFIG_PATH=$(QTDIR)/lib/pkgconfig \
+		pkg-config Qt6Gui Qt6Widgets Qt6Multimedia --cflags))
 MOC = moc
 MOCPATH = $(QTDIR)/share/qt/libexec/moc
-WINLIB += -F $(QTDIR)/Frameworks -framework QtCore -framework QtGui \
-		-framework QtWidgets -framework QtMultimedia
+WINLIB += $(shell PKG_CONFIG_PATH=$(QTDIR)/lib/pkgconfig \
+		pkg-config Qt6Gui Qt6Widgets Qt6Multimedia --libs)
 endif    # WANT_WIN_QT6
 VARDATND0 += nhtiles.bmp rip.xpm nhsplash.xpm
 # XXX if /Developer/qt exists and QTDIR not set, use that


### PR DESCRIPTION
The previous code made incorrect assumptions about Qt6's file hierarchy.
Reuse automatic configuration (with pkg-config) for Qt5, and replace '5' by '6'.

Works on macOS Tahoe 26.1 (25B78), when following instructions from `sys/unix/NewInstall.unx`.
This is especially important, as Qt6 is now the default for Homebrew (`brew`).

Also fix a typo in multiw-2.370.