### PR TITLE
Add winter wolf cub to cannibal check for werewolves

### DIFF
--- a/src/were.c
+++ b/src/were.c
@@ -83,6 +83,7 @@ were_beastie(int pm)
     case PM_WEREWOLF:
     case PM_WOLF:
     case PM_WARG:
+    case PM_WINTER_WOLF_CUB:   
     case PM_WINTER_WOLF:
         return PM_WEREWOLF;
     default:


### PR DESCRIPTION
Noticed the incongruity while doing the wiki documentation rounds for canines.