### PR TITLE
Modernize code of LaTeX Guidebook

### DIFF
--- a/doc/Guidebook.tex
+++ b/doc/Guidebook.tex
@@ -7,12 +7,6 @@
 
 \setlist[description]{leftmargin=30mm, topsep=2mm, partopsep=0mm, parsep=0mm, itemsep=1mm, labelwidth=28mm, labelsep=2mm}
 
-\newcommand{\nd}{\noindent}
-
-\newcommand{\tb}[1]{\tt #1 \hfill}
-\newcommand{\bb}[1]{\bf #1 \hfill}
-\newcommand{\ib}[1]{\it #1 \hfill}
-
 \hyphenation{CRASHREPORTURL}
 
 \begin{document}
@@ -77,7 +71,7 @@ at the local inn, becoming more and more depressed as you watch the odds
 of your success being posted on the inn's walls getting lower and lower.
 
 %.pg
-\nd In the morning you awake, collect your belongings, and
+\noindent In the morning you awake, collect your belongings, and
 set off for the dungeon.  After several days of uneventful
 travel, you see the ancient ruins that mark the entrance to the
 Mazes of Menace.  It is late at night, so you make camp at the entrance
@@ -2034,7 +2028,7 @@ Help menu:  get the list of available extended commands.
 \end{description}
 
 %.pg
-\nd If your keyboard has a meta key (which, when pressed in combination
+\noindent If your keyboard has a meta key (which, when pressed in combination
 with another key, modifies it by setting the `meta' [8th, or `high']
 bit), you can invoke many extended commands by meta-ing the first
 letter of the command.
@@ -2146,7 +2140,7 @@ equivalent is used for another command, so the three key combination
 \end{description}
 
 %.pg
-\nd If the {\it number\textunderscore pad\/} option is on, some additional letter commands
+\noindent If the {\it number\textunderscore pad\/} option is on, some additional letter commands
 are available:
 \begin{description}[font=\ttfamily]
 %.lp
@@ -3056,7 +3050,7 @@ leather jacket         & 9 &                   & no armor              & 10\\
 \end{center}
 
 %.pg
-\nd You can also wear other pieces of armor (cloak over suit, shirt under
+\noindent You can also wear other pieces of armor (cloak over suit, shirt under
 suit, helmet, gloves, boots, shield) to lower your armor class even
 further.
 %--too obvious to mention unless we include polymorph into ettin or maralith
@@ -4069,7 +4063,7 @@ you would enter the command
 \end{verbatim}
 %.ED
 
-\nd in {\it csh}
+\noindent in {\it csh}
 (note the need to escape the `!' since it's special
 to that shell), or the pair of commands
 %.SD i
@@ -4079,7 +4073,7 @@ to that shell), or the pair of commands
 \end{verbatim}
 %.ED
 
-\nd in {\it sh}, {\it ksh}, or {\it bash}.
+\noindent in {\it sh}, {\it ksh}, or {\it bash}.
 
 %.pg
 The NETHACKOPTIONS value is effectively the same as a single OPTIONS
@@ -5847,14 +5841,14 @@ can only be bound to a single key.
 %.pg
 \begin{description}[itemindent=10mm, labelwidth=15mm, rightmargin=15mm]
 %.lp
-\item[{\bb{count}}]
+\item[count]
 Prefix key to start a count, to repeat a command this many times.
 With {\it number\textunderscore pad\/} only. Default is~`{\tt n}'.
 %.lp
-\item[{\bb{getdir.help}}]
+\item[getdir.help]
 When asked for a direction, the key to show the help. Default is~`{\tt ?}'.
 %.lp
-\item[{\bb{getdir.mouse}}]
+\item[getdir.mouse]
 When asked for a direction, the key to initiate a simulated mouse click.
 You will be asked to pick a location.
 Use movement keystrokes to move the cursor around the map, then type
@@ -5864,110 +5858,110 @@ to finish as if performing a left or right click.
 Only useful when using the {\tt \#therecmdmenu} command.
 Default is~`{\tt \textunderscore }'.
 %.lp
-\item[{\bb{getdir.self}}]
+\item[getdir.self]
 When asked for a direction, the key to target yourself. Default is~`{\tt .}'.
 %.lp
-\item[{\bb{getdir.self2}}]
+\item[getdir.self2]
 When asked for a direction, an alternate key to target yourself.
 Default is~`{\tt s}'.
 %.lp
-\item[{\bb{getpos.autodescribe}}]
+\item[getpos.autodescribe]
 When asked for a location, the key to toggle {\it autodescribe\/}.
 Default is~`{\tt \#}'.
 %.lp
-\item[{\bb{getpos.all.next}}]
+\item[getpos.all.next]
 When asked for a location, the key to go to next closest interesting thing.
 Default is~`{\tt a}'.
 %.lp
-\item[{\bb{getpos.all.prev}}]
+\item[getpos.all.prev]
 When asked for a location, the key to go to previous closest interesting thing.
 Default is~`{\tt A}'.
 %.lp
-\item[{\bb{getpos.door.next}}]
+\item[getpos.door.next]
 When asked for a location, the key to go to next closest door or doorway.
 Default is~`{\tt d}'.
 %.lp
-\item[{\bb{getpos.door.prev}}]
+\item[getpos.door.prev]
 When asked for a location, the key to go to previous closest door or doorway.
 Default is~`{\tt D}'.
 %.lp
-\item[{\bb{getpos.help}}]
+\item[getpos.help]
 When asked for a location, the key to show help. Default is~`{\tt ?}'.
 %.lp
-\item[{\bb{getpos.mon.next}}]
+\item[getpos.mon.next]
 When asked for a location, the key to go to next closest monster.
 Default is~`{\tt m}'.
 %.lp
-\item[{\bb{getpos.mon.prev}}]
+\item[getpos.mon.prev]
 When asked for a location, the key to go to previous closest monster.
 Default is~`{\tt M}'.
 %.lp
-\item[{\bb{getpos.obj.next}}]
+\item[getpos.obj.next]
 When asked for a location, the key to go to next closest object.
 Default is~`{\tt o}'.
 %.lp
-\item[{\bb{getpos.obj.prev}}]
+\item[getpos.obj.prev]
 When asked for a location, the key to go to previous closest object.
 Default is~`{\tt O}'.
 %.lp
-\item[{\bb{getpos.menu}}]
+\item[getpos.menu]
 When asked for a location, and using one of the next or previous keys to
 cycle through targets, toggle showing a menu instead. Default is~`{\tt !}'.
 %.lp
-\item[{\bb{getpos.moveskip}}]
+\item[getpos.moveskip]
 When asked for a location, and using the shifted movement keys or
 meta-digit keys to fast-move around, move by skipping the same glyphs
 instead of by 8 units.
 Default is~`{\tt *}'.
 %.lp
-\item[{\bb{getpos.filter}}]
+\item[getpos.filter]
 When asked for a location, change the filtering mode when using one of
 the next or previous keys to cycle through targets. Toggles between no
 filtering, in view only, and in the same area only. Default is~`{\tt "}'.
 %.lp
-\item[{\bb{getpos.pick}}]
+\item[getpos.pick]
 When asked for a location, the key to choose the location, and possibly
 ask for more info.
 When simulating a mouse click after being asked for a direction (see
 getdir.mouse above), the key to use to respond as right click.
 Default is~`{\tt .}'.
 %.lp
-\item[{\bb{getpos.pick.once}}]
+\item[getpos.pick.once]
 When asked for a location, the key to choose the location, and skip
 asking for more info.
 When simulating a mouse click after being asked for a direction,
 the key to respond as left click.
 Default is~`{\tt ,}'.
 %.lp
-\item[{\bb{getpos.pick.quick}}]
+\item[getpos.pick.quick]
 When asked for a location, the key to choose the location, skip asking
 for more info, and exit the location asking loop. Default is~`{\tt ;}'.
 %.lp
-\item[{\bb{getpos.pick.verbose}}]
+\item[getpos.pick.verbose]
 When asked for a location, the key to choose the location, and show more
 info without asking. Default is~`{\tt :}'.
 %.lp
-\item[{\bb{getpos.self}}]
+\item[getpos.self]
 When asked for a location, the key to go to your location.
 Default is~`{\tt @}'.
 %.lp
-\item[{\bb{getpos.unexplored.next}}]
+\item[getpos.unexplored.next]
 When asked for a location, the key to go to next closest unexplored location.
 Default is~`{\tt x}'.
 %.lp
-\item[{\bb{getpos.unexplored.prev}}]
+\item[getpos.unexplored.prev]
 When asked for a location, the key to go to previous closest unexplored
 location. Default is~`{\tt X}'.
 %.lp
-\item[{\bb{getpos.valid}}]
+\item[getpos.valid]
 When asked for a location, the key to go to show valid target locations.
 Default is~`{\tt \$}'.
 %.lp
-\item[{\bb{getpos.valid.next}}]
+\item[getpos.valid.next]
 When asked for a location, the key to go to next closest valid location.
 Default is~`{\tt z}'.
 %.lp
-\item[{\bb{getpos.valid.prev}}]
+\item[getpos.valid.prev]
 When asked for a location, the key to go to previous closest valid location.
 Default is~`{\tt Z}'.
 \end{description}
@@ -6943,12 +6937,12 @@ Main events in the course of the game development are described below:
 
 %.pg
 \bigskip
-\nd {\it Jay Fenlason\/} wrote the original {\it Hack}, with help from {\it
+\noindent {\it Jay Fenlason\/} wrote the original {\it Hack}, with help from {\it
 Kenny Woodland}, {\it Mike Thome}, and {\it Jon Payne}.
 
 %.pg
 \medskip
-\nd {\it Andries Brouwer\/} did a major re-write while at
+\noindent {\it Andries Brouwer\/} did a major re-write while at
 Stichting Mathematisch Centrum (now Centrum Wiskunde \& Informatica),
 transforming Hack into a very different game.
 He published the Hack source code for use on UNIX
@@ -6963,7 +6957,7 @@ was created for discussing it.
 
 %.pg
 \medskip
-\nd {\it Don G. Kneller\/} ported {\it Hack\/} 1.0.3 to Microsoft C and MS-DOS,
+\noindent {\it Don G. Kneller\/} ported {\it Hack\/} 1.0.3 to Microsoft C and MS-DOS,
 producing {\it PC Hack\/} 1.01e, added support for DEC Rainbow graphics in
 version 1.03g, and went on to produce at least four more versions (3.0, 3.2,
 3.51, and 3.6;
@@ -6972,12 +6966,12 @@ note that these are old {\it Hack\/} version numbers, not contemporary
 
 %.pg
 \medskip
-\nd {\it R. Black\/} ported {\it PC Hack\/} 3.51 to Lattice C and the Atari
+\noindent {\it R. Black\/} ported {\it PC Hack\/} 3.51 to Lattice C and the Atari
 520/1040ST, producing {\it ST Hack\/} 1.03.
 
 %.pg
 \medskip
-\nd {\it Mike Stephenson\/} merged these various versions back together,
+\noindent {\it Mike Stephenson\/} merged these various versions back together,
 incorporating many of the added features, and produced {\it NetHack\/} version
 1.4 in 1987.
 He then coordinated a cast of thousands in enhancing and debugging
@@ -6988,7 +6982,7 @@ via {\it ftp\/} and {\it uucp\/} after expiring from the newsgroup.
 
 %.pg
 \medskip
-\nd Later, Mike coordinated a major re-write of the game, heading a team which
+\noindent Later, Mike coordinated a major re-write of the game, heading a team which
 included {\it Ken Arromdee}, {\it Jean-Christophe Collet}, {\it Steve Creps},
 {\it Eric Hendrickson}, {\it Izchak Miller}, {\it Eric S. Raymond}, {\it John
 Rupley}, {\it Mike Threepoint}, and {\it Janet Walz}, to produce
@@ -6996,14 +6990,14 @@ Rupley}, {\it Mike Threepoint}, and {\it Janet Walz}, to produce
 
 %.pg
 \medskip
-\nd {\it NetHack\/} 3.0 was ported to the Atari by {\it Eric R. Smith}, to OS/2 by
+\noindent {\it NetHack\/} 3.0 was ported to the Atari by {\it Eric R. Smith}, to OS/2 by
 {\it Timo Hakulinen}, and to VMS by {\it David Gentzel}.  The three of them
 and {\it Kevin Darcy\/} later joined the main {\it NetHack Development Team} to produce
 subsequent revisions of 3.0.
 
 %.pg
 \medskip
-\nd {\it Olaf Seibert\/} ported {\it NetHack\/} 2.3 and 3.0 to the Amiga.  {\it
+\noindent {\it Olaf Seibert\/} ported {\it NetHack\/} 2.3 and 3.0 to the Amiga.  {\it
 Norm Meluch}, {\it Stephen Spackman\/} and {\it Pierre Martineau\/} designed
 overlay code for {\it PC NetHack\/} 3.0.  {\it Johnny Lee\/} ported {\it
 NetHack\/} 3.0 to the Macintosh.  Along with various other Dungeoneers, they
@@ -7022,7 +7016,7 @@ the three component numbering scheme began to be used with 3.1.0.
 
 %.pg
 \medskip
-\nd Headed by {\it Mike Stephenson\/} and coordinated by {\it Izchak Miller\/}
+\noindent Headed by {\it Mike Stephenson\/} and coordinated by {\it Izchak Miller\/}
 and {\it Janet Walz}, the {\it NetHack Development Team} which now included
 {\it Ken Arromdee},
 {\it David Cohrs}, {\it Jean-Christophe Collet}, {\it Kevin Darcy},
@@ -7038,19 +7032,19 @@ Version 3.1.0 was released in January of 1993.
 
 %.pg
 \medskip
-\nd {\it Ken Lorber}, {\it Gregg Wonderly\/} and {\it Greg Olson}, with help
+\noindent {\it Ken Lorber}, {\it Gregg Wonderly\/} and {\it Greg Olson}, with help
 from {\it Richard Addison}, {\it Mike Passaretti}, and {\it Olaf Seibert},
 developed {\it NetHack\/} 3.1 for the Amiga.
 
 %.pg
 \medskip
-\nd {\it Norm Meluch\/} and {\it Kevin Smolkowski}, with help from
+\noindent {\it Norm Meluch\/} and {\it Kevin Smolkowski}, with help from
 {\it Carl Schelin}, {\it Stephen Spackman}, {\it Steve VanDevender},
 and {\it Paul Winner}, ported {\it NetHack\/} 3.1 to the PC.
 
 %.pg
 \medskip
-\nd {\it Jon W\{tte} and {\it Hao-yang Wang},
+\noindent {\it Jon W\{tte} and {\it Hao-yang Wang},
 with help from {\it Ross Brown}, {\it Mike Engber}, {\it David Hairston},
 {\it Michael Hamel}, {\it Jonathan Handler}, {\it Johnny Lee},
 {\it Tim Lennan}, {\it Rob Menke}, and {\it Andy Swanson},
@@ -7059,7 +7053,7 @@ Building on their development, {\it Bart House} added a Think C port.
 
 %.pg
 \medskip
-\nd {\it Timo Hakulinen\/} ported {\it NetHack\/} 3.1 to OS/2.
+\noindent {\it Timo Hakulinen\/} ported {\it NetHack\/} 3.1 to OS/2.
 {\it Eric Smith\/} ported {\it NetHack\/} 3.1 to the Atari.
 {\it Pat Rankin}, with help from {\it Joshua Delahunty},
 was responsible for the VMS version of {\it NetHack\/} 3.1.
@@ -7067,7 +7061,7 @@ was responsible for the VMS version of {\it NetHack\/} 3.1.
 
 %.pg
 \medskip
-\nd {\it Dean Luick}, with help from {\it David Cohrs}, developed
+\noindent {\it Dean Luick}, with help from {\it David Cohrs}, developed
 {\it NetHack\/} 3.1 for X11.
 It drew the map as text rather than graphically but
 included {\tt nh10.bdf}, an optionally used custom X11 font which has
@@ -7079,7 +7073,7 @@ forth, not separate images for beetles and ants or for cloaks and boots).
 
 %.pg
 \medskip
-\nd {\it Warwick Allison\/} wrote a graphically displayed version
+\noindent {\it Warwick Allison\/} wrote a graphically displayed version
 of {\it NetHack\/}
 for the Atari where the tiny pictures were described as ``icons'' and
 were distinct for specific types of monsters and objects rather than just
@@ -7092,7 +7086,7 @@ picked up by various other games.
 
 %.pg
 \medskip
-\nd The 3.2 {\it NetHack Development Team}, comprised of {\it Michael Allison}, {\it Ken
+\noindent The 3.2 {\it NetHack Development Team}, comprised of {\it Michael Allison}, {\it Ken
 Arromdee}, {\it David Cohrs}, {\it Jessie Collet}, {\it Steve Creps}, {\it
 Kevin Darcy}, {\it Timo Hakulinen}, {\it Steve Linhart}, {\it Dean Luick},
 {\it Pat Rankin}, {\it Eric Smith}, {\it Mike Stephenson}, {\it Janet Walz},
@@ -7100,7 +7094,7 @@ and {\it Paul Winner}, released version 3.2.0 in April of 1996.
 
 %.pg
 \medskip
-\nd Version 3.2 marked the tenth anniversary of the formation of the
+\noindent Version 3.2 marked the tenth anniversary of the formation of the
 development team.
 In a testament to their dedication to the game, all thirteen members
 of the original {\it NetHack Development Team} remained on the team at the
@@ -7202,22 +7196,22 @@ runs on:
 
 %.pg
 \medskip
-\nd{\it Pat Rankin} maintained 3.4 for VMS.
+\noindent{\it Pat Rankin} maintained 3.4 for VMS.
 
 %.pg
 \medskip
-\nd {\it Michael Allison} maintained {\it NetHack\/} 3.4 for the MS-DOS
+\noindent {\it Michael Allison} maintained {\it NetHack\/} 3.4 for the MS-DOS
 platform.
 {\it Paul Winner} and {\it Yitzhak Sapir} provided encouragement.
 
 %.pg
 \medskip
-\nd {\it Dean Luick}, {\it Mark Modrall}, and {\it Kevin Hugo} maintained and
+\noindent {\it Dean Luick}, {\it Mark Modrall}, and {\it Kevin Hugo} maintained and
 enhanced the Macintosh port of 3.4.
 
 %.pg
 \medskip
-\nd {\it Michael Allison}, {\it David Cohrs}, {\it Alex Kompel},
+\noindent {\it Michael Allison}, {\it David Cohrs}, {\it Alex Kompel},
 {\it Dion Nicolaas}, and
 {\it Yitzhak Sapir} maintained and enhanced 3.4 for the Microsoft Windows
 platform.
@@ -7226,7 +7220,7 @@ platform.
 
 %.pg
 \medskip
-\nd {\it Ron Van Iwaarden} was the sole maintainer of {\it NetHack\/} for
+\noindent {\it Ron Van Iwaarden} was the sole maintainer of {\it NetHack\/} for
 OS/2 the past
 several releases. Unfortunately Ron's last OS/2 machine stopped working in
 early 2006. A great many thanks to Ron for keeping {\it NetHack\/} alive on
@@ -7234,13 +7228,13 @@ OS/2 all these years.
 
 %.pg
 \medskip
-\nd {\it Janne Salmij\"{a}rvi} and {\it Teemu Suikki} maintained
+\noindent {\it Janne Salmij\"{a}rvi} and {\it Teemu Suikki} maintained
 and enhanced the Amiga port of 3.4 after {\it Janne Salmij\"{a}rvi} resurrected
 it for 3.3.1.
 
 %.pg
 \medskip
-\nd {\it Christian ``Marvin'' Bressler} maintained 3.4 for the Atari after he
+\noindent {\it Christian ``Marvin'' Bressler} maintained 3.4 for the Atari after he
 resurrected it for 3.3.1.
 
 %.pg
@@ -7379,7 +7373,7 @@ some bug fixes.
 
 %.pg
 \medskip
-\nd The official {\it NetHack\/} web site is maintained by {\it Ken Lorber} at
+\noindent The official {\it NetHack\/} web site is maintained by {\it Ken Lorber} at
 {\catcode`\#=11
 \special{html:<a href="https://www.nethack.org/">}}
 https:{\tt /}{\tt /}www.nethack.org{\tt /}.
@@ -7390,7 +7384,7 @@ https:{\tt /}{\tt /}www.nethack.org{\tt /}.
 %.hn 2
 
 \subsection*{Special Thanks}
-\nd On behalf of the {\it NetHack\/} community, thank you very much once
+\noindent On behalf of the {\it NetHack\/} community, thank you very much once
 again to {\it M. Drew Streib} and {\it Pasi Kallinen} for providing a
 public NetHack server at nethack.alt.org. Thanks to {\it Keith Simpson}
 and {\it Andy Thomson} for hardfought.org. Thanks to all those
@@ -7403,7 +7397,7 @@ unnamed dungeoneers who invest their time and effort into annual
 %.hn 2
 \subsection*{Dungeoneers}
 %.pg
-\nd From time to time, some depraved individual out there in netland sends a
+\noindent From time to time, some depraved individual out there in netland sends a
 particularly intriguing modification to help out with the game.  The
 {\it NetHack Development Team} sometimes makes note of the names of the worst
 of these miscreants in this, the list of Dungeoneers:

--- a/doc/Guidebook.tex
+++ b/doc/Guidebook.tex
@@ -25,10 +25,6 @@
 
 \hyphenation{CRASHREPORTURL}
 
-% this will make \tt underscores look better, but requires that
-% math subscripts will never be used in this document
-\catcode`\_=12
-
 \begin{document}
 %
 % input file: guidebook.mn
@@ -3936,8 +3932,8 @@ Example:
 %.ed
 
 %.lp
-\item[\bb{AUTOPICKUP\_EXCEPTION}]
-Set exceptions to the {{\it pickup\_types\/}}
+\item[\bb{AUTOPICKUP\textunderscore EXCEPTION}]
+Set exceptions to the {{\it pickup\textunderscore types\/}}
 option. See the ``Configuring Autopickup Exceptions'' section.
 %.lp
 \item[\bb{BINDINGS}]
@@ -4377,7 +4373,7 @@ An object's inventory letter sticks to it when it's dropped (default on).
 If this is off, dropping an object shifts all the remaining inventory letters.
 Persistent.
 %.lp
-\item[\ib{force\_invmenu}]
+\item[\ib{force\textunderscore invmenu}]
 Commands asking for an inventory item show a menu instead of
 a text query with possible menu letters. Default is off.
 %.lp
@@ -5583,7 +5579,7 @@ Acceptable values are
 (The 26x82 size threshold for `2' refers to number of rows and
 columns of the display.
 A width of at least 110 columns (\verb&80+2+26+2&) is needed for
-{\it align_status\/}
+{\it align\textunderscore status\/}
 set to {\tt left} or {\tt right}.)
 
 %.lp ""
@@ -5633,9 +5629,9 @@ computer unless you manually click submit on a form.
 %.si
 \blist{}
 %.lp
-\item[OPTION=crash_email:{\it email_address}]
+\item[OPTION=crash\textunderscore email:{\it email\textunderscore address}]
 %.lp
-\item[OPTION=crash_name:{\it your_name}]
+\item[OPTION=crash\textunderscore name:{\it your\textunderscore name}]
 %.ei
 \elist
 These options are used only to save you some typing on the crash
@@ -5643,7 +5639,7 @@ report and \#bugreport forms.
 %.si
 \blist{}
 %.lp
-\item[OPTION=crash_urlmax:{\it bytes}]
+\item[OPTION=crash\textunderscore urlmax:{\it bytes}]
 %.ei
 \elist
 This option is used to limit the length of the URLs generated and is only
@@ -6244,8 +6240,8 @@ Instead of a behavior, `condition' takes the following condition flags:
 {\it stone}, {\it slime}, {\it strngl}, {\it foodpois}, {\it termill},
 {\it blind}, {\it deaf}, {\it stun}, {\it conf}, {\it hallu},
 {\it lev}, {\it fly}, and {\it ride}.
-You can use `major\_troubles' as an alias
-for stone through termill, `minor\_troubles' for blind through hallu,
+You can use `major\textunderscore troubles' as an alias
+for stone through termill, `minor\textunderscore troubles' for blind through hallu,
 `movement' for lev, fly, and ride, and `all' for every condition.
 
 %.lp ""
@@ -6387,7 +6383,7 @@ Default                      & Symbol Name                & Description\\
 \hline \hline
 \endhead
 \verb@ @ & S\textunderscore air                     &	(air)\\
-\_ & S\textunderscore altar                   &	(altar)\\
+\textunderscore  & S\textunderscore altar                   &	(altar)\\
 \verb@"@ & S\textunderscore amulet                  &	(amulet)\\
 \verb@A@ & S\textunderscore angel                   &	(angelic being)\\
 \verb@a@ & S\textunderscore ant                     &	(ant or other insect)\\
@@ -6660,7 +6656,7 @@ has been compiled with the capability. When compiling {\it NetHack\/}
 from source
 on Linux and other POSIX systems, define {\tt MSGHANDLER\/} to enable it.
 To use
-the capability, set the environment variable {\tt NETHACK\_MSGHANDLER\/} to
+the capability, set the environment variable {\tt NETHACK\textunderscore MSGHANDLER\/} to
 an executable, which will be executed with the game message as the program's
 only parameter.
 %.pg

--- a/doc/Guidebook.tex
+++ b/doc/Guidebook.tex
@@ -1,11 +1,8 @@
-\documentstyle[titlepage,longtable]{article}
 % NetHack 3.7  Guidebook.tex $NHDT-Date: 1745139202 2025/04/20 00:53:22 $  $NHDT-Branch: NetHack-3.7 $:$NHDT-Revision: 1.579 $ */
-%+% we're still limping along in LaTeX 2.09 compatibility mode
-%-%\documentclass{article}
-%-%\usepackage{hyperref} % before longtable
-%-%% if hyperref isn't available, we can get by with this instead
-%-%%\RequirePackage[errorshow]{tracefnt} \DeclareSymbolFont{typewriter}{OT1}{cmtt}{m}{n}
-%-%\usepackage{longtable}
+\documentclass[titlepage, a4paper]{article}
+\usepackage{hyperref}
+\usepackage{longtable}
+
 \textheight 220mm
 \textwidth 160mm
 \oddsidemargin 0mm
@@ -566,7 +563,7 @@ Note: statues are displayed as if they were the monsters they depict
 so won't appear as a {\it grave accent\/} (aka {\it back-tick}).
 \item[\tb{0}]
 An iron ball.
-\item[\tb{\verb+_+}]
+\item[\tb{\textunderscore}]
 An altar, or an iron chain.
 \item[\tb{\{}]
 A fountain or a sink.
@@ -577,8 +574,8 @@ or a pool of lava or a wall of lava.
 An opulent throne.
 \item[\tb{a-z}] {\normalfont and}]
 \item[\tb{A-HJ-Z}] {\normalfont and}]
-%should probably change \item[\tb{@\&\verb+'+:;}] to \item[\tb{\verb+@&':;+}]
-\item[\tb{@\&\verb+'+:;}]
+%should probably change \item[\tb{@\&\textquotesingle:;}] to \item[\tb{\verb+@&':;+}]
+\item[\tb{@\&\textquotesingle:;}]
 Letters and certain other symbols represent the various inhabitants
 of the Mazes of Menace.
 Watch out, they can be nasty and vicious.
@@ -632,7 +629,7 @@ command.
 %.pg
 You can put a number before some commands to repeat them that many
 times; for example, ``{\tt 10s}'' will search ten times.  If you have the
-{\it number\verb+_+pad\/}
+{\it number\textunderscore pad\/}
 option set, you must type `{\tt n}' to prefix a count, so the example above
 would be typed ``{\tt n10s}'' instead.  Commands for which counts make no
 sense ignore them.  In addition, movement commands can be prefixed for
@@ -674,7 +671,7 @@ option is on, a short description of what you see at each location is
 shown as you move the cursor.  Typing `{\tt \#}' while picking a location will
 toggle that option on or off.
 The
-{\it whatis\verb+_+coord\/}
+{\it whatis\textunderscore coord\/}
 option controls whether the short description includes map coordinates.
 
 %.lp ""
@@ -685,7 +682,7 @@ always gives any additional information available about that name.
 You may also request a description of nearby monsters,
 all monsters currently displayed, nearby objects, or all objects.
 The
-{\it whatis\verb+_+coord\/}
+{\it whatis\textunderscore coord\/}
 option controls which format of map coordinate is included with their
 descriptions.
 %.lp
@@ -712,7 +709,7 @@ one-step movement commands cause you to fight monsters; the others
 \verb+   h- . -l   + & \verb+   4- . -6   +\\
 \verb+    / | \    + & \verb+    / | \    +\\
 \verb+   b  j  n   + & \verb+   1  2  3   +\\
-                     & (if {\it number\verb+_+pad\/} set)
+                     & (if {\it number\textunderscore pad\/} set)
 \end{tabular}
 \end{center}
 %.ed
@@ -782,7 +779,7 @@ by using {\tt m} and {\tt G<direction>} in combination.
 {\tt m} can also be used in combination with {\tt g<direction>},
 {\tt <Control>+<direction>}, or {\tt <Shift>+<direction>}.
 %.lp
-\item[\tb{\tt \verb+_+}]
+\item[\tb{\tt \textunderscore }]
 Travel to a map location via a shortest-path algorithm.\\
 %.lp ""
 The shortest path
@@ -799,7 +796,7 @@ location other than the current position.
 \item[\tb{.}]
 Wait or rest, do nothing for one turn.
 Precede with the `{\tt m}' prefix
-to wait for a turn even next to a hostile monster, if {\it safe\verb+_+wait\/}
+to wait for a turn even next to a hostile monster, if {\it safe\textunderscore wait\/}
 is on.
 %.lp
 \item[\tb{a}]
@@ -893,7 +890,7 @@ If you attempt to eat while already satiated, you might choke to death.
 If you risk it, you will be asked whether
 to ``continue eating?'' {\it if you survive the first bite\/}.
 You can set the
-{\it paranoid\verb+_+confirmation:eating\/}
+{\it paranoid\textunderscore confirmation:eating\/}
 option to require a response of ``{\tt yes}'' instead of just `{\tt y}'.
 %.lp
 % Make sure Elbereth is not hyphenated below, the exact spelling matters.
@@ -993,7 +990,7 @@ Repeat previous message.\\
 %.lp ""
 Subsequent {\tt \^{}P}'s repeat earlier messages.
 For some interfaces, the behavior can be varied via the
-{\it msg\verb+_+window\/} option.
+{\it msg\textunderscore window\/} option.
 %.lp
 \item[\tb{q}]
 Quaff (drink) something (potion, water, etc).\\
@@ -1019,7 +1016,7 @@ Remove a worn accessory (ring, amulet, or blindfold).\\
 If you're wearing more than one, you'll be prompted for which one to
 remove.  When you're only wearing one, then by default it will be removed
 without asking, but you can set the
-{\it paranoid\verb+_+confirmation:Remove\/}
+{\it paranoid\textunderscore confirmation:Remove\/}
 option to require a prompt.\\
 %.lp ""
 This command may also be used to take off armor.  The prompt for which
@@ -1035,7 +1032,7 @@ Redraw the screen.
 Search for secret doors and traps around you.
 It usually takes several tries to find something.
 Precede with the `{\tt m}' prefix to wait for a turn
-even next to a hostile monster, if {\it safe\verb+_+wait\/}
+even next to a hostile monster, if {\it safe\textunderscore wait\/}
 is on.\\
 %.lp ""
 Can also be used to figure out whether there is still a monster at
@@ -1077,7 +1074,7 @@ and/or a shirt, or a suit covering a shirt, as if the underlying items
 weren't there.)
 When you're only wearing one, then by default it will
 be taken off without asking, but you can set the
-{\it paranoid\verb+_+confirmation:Remove\/}
+{\it paranoid\textunderscore confirmation:Remove\/}
 option to require a prompt.\\
 %.lp ""
 This command may also be used to remove accessories.  The prompt
@@ -1233,15 +1230,15 @@ May be preceded by `{\tt m}' to select preferred display order.
 %.lp
 \item[\tb{|}]
 If persistent inventory display is supported and enabled (with the
-{\it perm\verb+_+invent\/}
+{\it perm\textunderscore invent\/}
 option), interact with it instead of with the map.
 \\
 %.lp ""
 Allows scrolling with the
-menu\verb+_+first\verb+_+page, menu\verb+_+previous\verb+_+page,
-menu\verb+_+next\verb+_+page, and menu\verb+_+last\verb+_+page
+menu\textunderscore first\textunderscore page, menu\textunderscore previous\textunderscore page,
+menu\textunderscore next\textunderscore page, and menu\textunderscore last\textunderscore page
 keys (`{\tt \^{}}', `{\tt <}', `{\tt >}', `{\tt \verb+|+}' by default).
-Some interfaces also support menu\verb+_+shift\verb+_+left and menu\verb+_+shift\verb+_+right
+Some interfaces also support menu\textunderscore shift\textunderscore left and menu\textunderscore shift\textunderscore right
 keys (`{\tt \verb+{+}' and `{\tt \verb+}+}' by default).
 Use the {\it Return\/} (aka {\it Enter\/}) or {\it Escape\/} key to
 resume play.
@@ -1309,7 +1306,7 @@ Allows you to specify one line of text to associate with the current
 dungeon level.  All levels with annotations are displayed by the
 ``{\tt \#overview}'' command. Autocompletes.
 Default key is `{\tt M-A}',
-and also `{\tt \^{}N}' if {\it number\verb+_+pad\/} is on.
+and also `{\tt \^{}N}' if {\it number\textunderscore pad\/} is on.
 %.lp
 \item[\tb{\#apply}]
 Apply (use) a tool such as a pick-axe, a key, or a lamp.
@@ -1393,14 +1390,14 @@ Default key is `{\tt M-X}'.\\
 Requires confirmation; default response is `{\tt n}' (no).
 To really switch to explore mode, respond with `{\tt y}'.
 You can set the
-{\it paranoid\verb+_+confirmation:quit\/}
+{\it paranoid\textunderscore confirmation:quit\/}
 option to require a response of ``{\tt yes}'' instead.
 %.lp
 \item[\tb{\#fight}]
 Prefix key to force fight a direction, even if you see nothing
 to fight there.
 Default key is `{\tt F}', or `{\tt -}' with
-{\it number\verb+_+pad\/}
+{\it number\textunderscore pad\/}
 %.lp
 \item[\tb{\#fire}]
 Fire ammunition from quiver, possibly autowielding a launcher,
@@ -1436,7 +1433,7 @@ Show what type of thing a map symbol corresponds to. Default key is `{\tt ;}'.
 \item[\tb{\#help}]
 Show the help menu.
 Default key is `{\tt ?}',
-and also `{\tt h}' if {\it number\verb+_+pad\/} is on.
+and also `{\tt h}' if {\it number\textunderscore pad\/} is on.
 %.lp
 \item[\tb{\#herecmdmenu}]
 Show a menu of possible actions directed at your current location.
@@ -1444,7 +1441,7 @@ The menu is limited to a subset of the likeliest actions, not an
 exhaustive set of all possibilities.
 Autocompletes.\\
 %.lp ""
-If mouse support is enabled and the {\it herecmd\verb+_+menu\/}
+If mouse support is enabled and the {\it herecmd\textunderscore menu\/}
 option is On, clicking on the hero (or steed when mounted) will
 execute this command.
 %.lp
@@ -1463,12 +1460,12 @@ Invoke an object's special powers. Autocompletes. Default key is `{\tt M-i}'.
 \item[\tb{\#jump}]
 Jump to another location. Autocompletes.
 Default key is `{\tt M-j}',
-and also `{\tt j}' if {\it number\verb+_+pad\/} is on.
+and also `{\tt j}' if {\it number\textunderscore pad\/} is on.
 %.lp
 \item[\tb{\#kick}]
 Kick something.
 Default key is `{\tt \^{}D}',
-and also `{\tt k}' if {\it number\verb+_+pad\/} is on.
+and also `{\tt k}' if {\it number\textunderscore pad\/} is on.
 %.lp
 \item[\tb{\#known}]
 Show what object types have been discovered.
@@ -1508,7 +1505,7 @@ from a steed standing next to you. Autocompletes.
 Precede with the `{\tt m}' prefix to skip containers at your location
 and go directly to removing a saddle.
 Default key is `{\tt M-l}',
-and also `{\tt l}' if {\it number\verb+_+pad\/} is on.
+and also `{\tt l}' if {\it number\textunderscore pad\/} is on.
 %.lp
 \item[\tb{\#monster}]
 Use a monster's special ability (when polymorphed into monster form).
@@ -1574,7 +1571,7 @@ Debug mode only.\\
 Asks for confirmation; default is `{\tt n}' (no); continue playing.
 To really panic, respond with `{\tt y}'.
 You can set the
-{\it paranoid\verb+_+confirmation:quit\/}
+{\it paranoid\textunderscore confirmation:quit\/}
 option to require a response of ``{\tt yes}'' instead.
 %.lp
 \item[\tb{\#pay}]
@@ -1582,7 +1579,7 @@ Pay your shopping bill. Default key is `{\tt p}'.
 %.lp
 \item[\tb{\#perminv}]
 If persistent inventory display is supported and enabled (with the
-{\it perm\verb+_+invent\/} option), interact with it instead of with the map.
+{\it perm\textunderscore invent\/} option), interact with it instead of with the map.
 You'll be prompted for menu scrolling keystrokes such
 as `{\tt \verb+>+}' and `{\tt \verb+<+}'.
 Press {\tt Return} or {\tt Escape} to resume normal play.
@@ -1606,7 +1603,7 @@ You probably shouldn't start off a new game by praying right away.)
 Since using this command by accident can cause trouble, there is an
 option to make you confirm your intent before praying.  It is enabled
 by default, and you can reset the
-{\it paranoid\verb+_+confirmation\/}
+{\it paranoid\textunderscore confirmation\/}
 option to disable it.
 %.lp
 \item[\tb{\#prevmsg}]
@@ -1629,7 +1626,7 @@ you are asked to confirm your intent before quitting.
 Default response is `{\tt n}' (no); continue playing.
 To really quit, respond with `{\tt y}'.
 You can set the
-{\it paranoid\verb+_+confirmation:quit\/}
+{\it paranoid\textunderscore confirmation:quit\/}
 option to require a response of ``{\tt yes}'' instead.
 %.lp
 \item[\tb{\#quiver}]
@@ -1641,7 +1638,7 @@ Read a scroll, a spellbook, or something else. Default key is `{\tt r}'.
 \item[\tb{\#redraw}]
 Redraw the screen.
 Default key is `{\tt \^{}R}',
-and also `{\tt \^{}L}' if {\it number\verb+_+pad\/} is on.
+and also `{\tt \^{}L}' if {\it number\textunderscore pad\/} is on.
 %.lp
 \item[\tb{\#remove}]
 Remove an accessory (ring, amulet, etc). Default key is `{\tt R}'.
@@ -1657,7 +1654,7 @@ Default key is `{\tt m}'.
 %.lp
 \item[\tb{\#retravel}]
 Travel to a previously selected travel destination.
-Default key is `{\tt C-\verb+_+}'.
+Default key is `{\tt C-\textunderscore }'.
 See also {\tt \#travel}.
 %.lp
 \item[\tb{\#ride}]
@@ -1670,20 +1667,20 @@ Rub a lamp or a stone. Autocompletes. Default key is `{\tt M-r}'.
 \item[\tb{\#run}]
 Prefix key to run towards a direction.
 Default key is `{\tt G}' when
-{\it number\verb+_+pad\/}
+{\it number\textunderscore pad\/}
 is off,
 `{\tt 5}' when
-{\it number\verb+_+pad\/}
+{\it number\textunderscore pad\/}
 is set to 1~or~3,
 otherwise `{\tt M-5}' when it is set to 2~or~4.
 %.lp
 \item[\tb{\#rush}]
 Prefix key to rush towards a direction.
 Default key is `{\tt g}' when
-{\it number\verb+_+pad\/}
+{\it number\textunderscore pad\/}
 is off,
 `{\tt M-5}' when
-{\it number\verb+_+pad\/}
+{\it number\textunderscore pad\/}
 is set to 1~or~3,
 otherwise `{\tt 5}' when it is set to 2~or~4.
 %.lp
@@ -1823,7 +1820,7 @@ Autocompletes.
 %%--invoking it by mouse seems to be broken
 %% \\
 %% .lp ""
-%% If mouse support is enabled and the {\it herecmd\verb+_+menu\/}
+%% If mouse support is enabled and the {\it herecmd\textunderscore menu\/}
 %% option is On, clicking on an adjacent location will execute this command.
 %.lp
 \item[\tb{\#throw}]
@@ -1853,7 +1850,7 @@ Autocompletes. Default key is `{\tt M-T}'.
 %.lp
 \item[\tb{\#travel}]
 Travel to a specific location on the map.
-Default key is `{\tt \verb+_+}'.
+Default key is `{\tt \textunderscore }'.
 Using the ``request menu'' prefix shows a menu of interesting targets in sight
 without asking to move the cursor.
 When picking a target with cursor and the {\it autodescribe\/}
@@ -1867,7 +1864,7 @@ Turn undead away. Autocompletes. Default key is `{\tt M-t}'.
 \item[\tb{\#twoweapon}]
 Toggle two-weapon combat on or off. Autocompletes.
 Default key is `{\tt X}',
-and also `{\tt M-2}' if {\it number\verb+_+pad\/} is off.\\
+and also `{\tt M-2}' if {\it number\textunderscore pad\/} is off.\\
 %.lp ""
 Note that you must
 use suitable weapons for this type of combat, or it will
@@ -1875,7 +1872,7 @@ be automatically turned off.
 %.lp
 \item[\tb{\#untrap}]
 Untrap something (trap, door, or chest).
-Default key is `{\tt M-u}', and `{\tt u}' if {\it number\verb+_+pad\/} is on.\\
+Default key is `{\tt M-u}', and `{\tt u}' if {\it number\textunderscore pad\/} is on.\\
 %.lp ""
 In some circumstances it can also be used to rescue trapped monsters.
 %.lp
@@ -1932,7 +1929,7 @@ Debug mode only.
 \item[\tb{\#wait}]
 Rest one move while doing nothing.
 Default key is `{\tt .}', and also `{\tt{ }}' if
-{\it rest\verb+_+on\verb+_+space\/} is on.
+{\it rest\textunderscore on\textunderscore space\/} is on.
 %.lp
 \item[\tb{\#wear}]
 Wear a piece of armor. Default key is `{\tt W}'.
@@ -2081,7 +2078,7 @@ equivalent is used for another command, so the three key combination
 {\tt\#?} (not supported by all platforms)
 %.lp
 \item[\tb{M-2}]
-{\tt\#twoweapon} (unless the {\it number\verb+_+pad\/} option is enabled)
+{\tt\#twoweapon} (unless the {\it number\textunderscore pad\/} option is enabled)
 %.lp
 \item[\tb{M-a}]
 {\tt\#adjust}
@@ -2163,7 +2160,7 @@ equivalent is used for another command, so the three key combination
 \elist
 
 %.pg
-\nd If the {\it number\verb+_+pad\/} option is on, some additional letter commands
+\nd If the {\it number\textunderscore pad\/} option is on, some additional letter commands
 are available:
 \blist{}
 %.lp
@@ -2471,7 +2468,7 @@ There are several options which can be used to augment the normal feedback.
 
 %.pg
 The
-{\it pile\verb+_+limit\/}
+{\it pile\textunderscore limit\/}
 option controls how many objects can be in a
 pile---sharing the same map location---for
 the game to state ``there are objects here'' instead of listing them.
@@ -2493,7 +2490,7 @@ auto-pickup and without giving feedback about them.
 
 %.pg
 The
-{\it mention\verb+_+walls\/}
+{\it mention\textunderscore walls\/}
 option controls whether you get feedback if you try to walk into a wall
 or solid stone or off the edge of the map.
 Normally nothing happens (unless the hero is blind and no wall is shown,
@@ -2503,7 +2500,7 @@ some non-obvious reason.
 
 %.pg
 The
-{\it mention\verb+_+decor\/}
+{\it mention\textunderscore decor\/}
 option controls whether you get feedback when walking on ``furniture.''
 Normally stepping onto stairs or a fountain or an altar or various other
 things doesn't elicit anything unless it is covered by one or more objects
@@ -2524,7 +2521,7 @@ case the back on land circumstance is implied.
 The
 {\it confirm\/}
 and
-{\it safe\verb+_+pet\/}
+{\it safe\textunderscore pet\/}
 options control what happens when you try to move onto a peaceful monster's
 spot or a tame one's spot.
 
@@ -2536,13 +2533,13 @@ onto a visible monster's spot without the move being considered an attack
 (see the {\it Fighting\/} subsection of {\it Monsters\/} below).
 The `{\tt fight}' command prefix (default `{\tt F}';
 also `{\tt -}' if
-{\it number\verb+_+pad\/}
+{\it number\textunderscore pad\/}
 is on) can be used to force an attack, when guessing where an unseen
 monster is or when deliberately attacking a peaceful or tame creature.
 
 %.pg
 The
-{\it run\verb+_+mode}
+{\it run\textunderscore mode}
 option controls how frequently the map gets redrawn when moving more
 than one step in a single command (so when rushing, running, or traveling).
 
@@ -2605,7 +2602,7 @@ In most circumstances, if you attempt to attack a peaceful monster by
 moving into its location, you'll be asked to confirm your intent.  By
 default an answer of `{\tt y}' acknowledges that intent,
 which can be error prone if you're using `{\tt y}' to move.  You can set the
-{\it paranoid\verb+_+confirmation:attack\/}
+{\it paranoid\textunderscore confirmation:attack\/}
 option to require a response of ``{\tt yes}'' instead.
 %.pg
 
@@ -2804,7 +2801,7 @@ by the presence of the word {\tt cursed}, {\tt uncursed} or
 In some cases {\tt uncursed} will be omitted as being redundant when
 enough other information is displayed.
 The
-{\it implicit\verb+_+uncursed\/}
+{\it implicit\textunderscore uncursed\/}
 option can be used to control this; toggle it off to have {\tt uncursed}
 be displayed even when that can be deduced from other attributes.
 
@@ -2941,7 +2938,7 @@ The number of items that the character has a chance to fire varies from
 turn to turn.  You can explicitly limit the number of shots by using a
 numeric prefix before the `{\tt t}' or `{\tt f}' command.
 For example, ``{\tt 2f}'' (or ``{\tt n2f}'' if using
-{\it number\verb+_+pad\/}
+{\it number\textunderscore pad\/}
 mode) would ensure that at most 2 arrows are shot
 even if you could have fired 3.  If you specify
 a larger number than would have been shot (``{\tt 4f}'' in this example),
@@ -3490,7 +3487,7 @@ you are carrying (shopkeepers aside).
 Gold pieces are the only type of object where bless/curse state does not
 apply.
 They're always uncursed but never described as uncursed even if you turn
-off the ``{\it implicit\verb+_+uncursed\/}'' option.
+off the ``{\it implicit\textunderscore uncursed\/}'' option.
 You can set the ``{\it goldX\/}''
 option if you prefer to have gold pieces be treated as bless/curse state
 {\it unknown\/} rather than as known to be uncursed.
@@ -3520,7 +3517,7 @@ again you will re-discover the object and resume remembering it.
 The situation is the same for a pile of objects, except that only the
 top item of the pile is displayed.
 The
-{\it hilite\verb+_+pile\/}
+{\it hilite\textunderscore pile\/}
 option can be enabled in order to show an item differently when it is
 the top one of a pile.
 
@@ -4153,7 +4150,7 @@ Cannot be set with the `{\tt O}' command.  Persistent.
 \item[\ib{autodescribe}]
 Automatically describe the terrain under cursor when asked to get a location
 on the map (default true).
-The {\it whatis\verb+_+coord\/}
+The {\it whatis\textunderscore coord\/}
 option controls whether the description includes map coordinates.
 %.lp
 \item[\ib{autodig}]
@@ -4169,8 +4166,8 @@ Automatically pick up things onto which you move (default off).
 Persistent.
 \\
 %.lp ""
-See ``{\it pickup\verb+_+types\/}'' and also
-``{\it autopickup\verb+_+exception\/}'' for ways to refine the behavior.
+See ``{\it pickup\textunderscore types\/}'' and also
+``{\it autopickup\textunderscore exception\/}'' for ways to refine the behavior.
 \\
 %.lp ""
 Note: prior to version 3.7.0, the default for {\it autopickup\/} was {\it on}.
@@ -4269,16 +4266,16 @@ players if it detects some anticipated mistakes (default on).
 Have user confirm attacks on pets, shopkeepers, and other
 peaceable creatures (default on).  Persistent.
 %.lp
-\item[\ib{dark\verb+_+room}]
+\item[\ib{dark\textunderscore room}]
 Show out-of-sight areas of lit rooms (default on).  Persistent.
 %.lp
 \item[\ib{deaf}]
 Start the character permanently deaf (default false).  Persistent.
 %.lp
-\item[\ib{dropped\verb+_+nopick}]
+\item[\ib{dropped\textunderscore nopick}]
 If this option is on, items you dropped will not be automatically picked up,
 even if ``{\it autopickup\/}'' is also on and they are in
-``{\it pickup\verb+_+types\/}'' or match a positive autopickup exception
+``{\it pickup\textunderscore types\/}'' or match a positive autopickup exception
 (default on).  Persistent.
 %.lp
 \item[\ib{disclose}]
@@ -4411,7 +4408,7 @@ When filtering objects based on bless/curse state (BUCX), whether to
 treat gold pieces as {\tt X} (unknown bless/curse state, when `on')
 or {\tt U} (known to be uncursed, when `off', the default).
 Gold is never blessed or cursed, but it is not described as ``uncursed''
-even when the {\it implicit\verb+_+uncursed\/} option is `off'.
+even when the {\it implicit\textunderscore uncursed\/} option is `off'.
 %.lp
 \item[\ib{help}]
 If more information is available for an object looked at
@@ -4420,12 +4417,12 @@ Turning help off makes just looking at things faster, since you aren't
 interrupted with the ``{\tt More info?}'' prompt, but it also means that you
 might miss some interesting and/or important information.  Persistent.
 %.lp
-\item[\ib{herecmd\verb+_+menu}]
+\item[\ib{herecmd\textunderscore menu}]
 When using a windowport that supports mouse and clicking on yourself or
 next to you, show a menu of possible actions for the location.
 Same as ``{\tt \#herecmdmenu}'' and ``{\tt \#therecmdmenu}'' commands.
 %.lp
-\item[\ib{hilite\verb+_+pet}]
+\item[\ib{hilite\textunderscore pet}]
 Visually distinguish pets from similar animals (default off).
 The behavior of this option depends on the type of windowing you use.
 In text windowing, text highlighting or inverse video is often used;
@@ -4434,9 +4431,9 @@ with tiles, generally displays a heart symbol near pets.
 %.lp ""
 With the tty or curses interface, the {\it petattr\/}
 option controls how to highlight pets and setting it will turn the
-{\it hilite\verb+_+pet\/} option on or off as warranted.
+{\it hilite\textunderscore pet\/} option on or off as warranted.
 %.lp
-\item[\ib{hilite\verb+_+pile}]
+\item[\ib{hilite\textunderscore pile}]
 Visually distinguish piles of objects from individual objects (default off).
 The behavior of this option depends on the type of windowing you use.
 In text windowing, text highlighting or inverse video is often used;
@@ -4477,7 +4474,7 @@ Cannot be set with the `{\tt O}' command.
 \item[\ib{ignintr}]
 Ignore interrupt signals, including breaks (default off).  Persistent.
 %.lp
-\item[\ib{implicit\verb+_+uncursed}]
+\item[\ib{implicit\textunderscore uncursed}]
 Omit ``uncursed'' from object descriptions when it can be deduced from
 other aspects of the description (default on).
 Persistent.
@@ -4489,7 +4486,7 @@ If you use menu coloring, you may want to turn this off.
 Display an introductory message when starting the game (default on).
 Persistent.
 %.lp
-\item[\ib{lit\verb+_+corridor}]
+\item[\ib{lit\textunderscore corridor}]
 Show corridor squares seen by night vision or a light source held by your
 character as lit (default off).  Persistent.
 %.lp
@@ -4506,15 +4503,15 @@ Enable mail delivery during the game (default on).  Persistent.
 An obsolete synonym for ``{\tt gender:male}''.  Cannot be set with the
 `{\tt O}' command.
 %.lp
-\item[\ib{mention\verb+_+decor}]
+\item[\ib{mention\textunderscore decor}]
 Give feedback when walking onto various dungeon features such as stairs,
 fountains, or altars which are ordinarily only described when covered
 by one or more objects (default off).  Persistent.
 %.lp
-\item[\ib{mention\verb+_+map}]
+\item[\ib{mention\textunderscore map}]
 Give feedback when interesting map locations change (default off).
 %.lp
-\item[\ib{mention\verb+_+walls}]
+\item[\ib{mention\textunderscore walls}]
 Give feedback when walking against a wall (default off).  Persistent.
 %.lp
 \item[\ib{menucolors}]
@@ -4542,43 +4539,43 @@ object classes rather than a character prompt, and then a menu of matching
 objects for selection.
 (Choosing its `A' (Autoselect-All) choice skips the second menu.
 To avoid choosing that by accident,
-set {\it paranoid\verb+_+confirm:AutoAll\/} to require confirmation.)
+set {\it paranoid\textunderscore confirm:AutoAll\/} to require confirmation.)
 Partial skips the object class filtering and
 immediately displays a menu of all objects.
-\item[\ib{menu\verb+_+deselect\verb+_+all}]
+\item[\ib{menu\textunderscore deselect\textunderscore all}]
 Key to deselect all items in a menu.
 Implemented by the Amiga, Gem, X11 and tty ports.
 Default `-'.
-\item[\ib{menu\verb+_+deselect\verb+_+page}]
+\item[\ib{menu\textunderscore deselect\textunderscore page}]
 Key to deselect all items on this page of a menu.
 Implemented by the Amiga, Gem and tty ports.
 Default `\verb+\+'.
-\item[\ib{menu\verb+_+first\verb+_+page}]
+\item[\ib{menu\textunderscore first\textunderscore page}]
 Key to jump to the first page in a menu.
 Implemented by the Amiga, Gem and tty ports.
 Default `\verb+^+'.
-\item[\ib{menu\verb+_+headings}]
+\item[\ib{menu\textunderscore headings}]
 Controls how the headings in a menu are highlighted.
 Takes a text attribute, or text color and attribute separated by ampersand.
 For allowed attributes and colors, see ``{\it Configuring Menu Colors\/}``.
 Not all ports can actually display all types.
-\item[\ib{menu\verb+_+invert\verb+_+all}]
+\item[\ib{menu\textunderscore invert\textunderscore all}]
 Key to invert all items in a menu.
 Implemented by the Amiga, Gem, X11 and tty ports.
 Default `@'.
-\item[\ib{menu\verb+_+invert\verb+_+page}]
+\item[\ib{menu\textunderscore invert\textunderscore page}]
 Key to invert all items on this page of a menu.
 Implemented by the Amiga, Gem and tty ports.
 Default `\verb+~+'.
-\item[\ib{menu\verb+_+last\verb+_+page}]
+\item[\ib{menu\textunderscore last\textunderscore page}]
 Key to jump to the last page in a menu.
 Implemented by the Amiga, Gem and tty ports.
 Default `\verb+|+'.
-\item[\ib{menu\verb+_+next\verb+_+page}]
+\item[\ib{menu\textunderscore next\textunderscore page}]
 Key to go to the next menu page.
 Implemented by the Amiga, Gem and tty ports.
 Default `\verb+>+'.
-\item[\ib{menu\verb+_+objsyms}]
+\item[\ib{menu\textunderscore objsyms}]
 % [originally menu_objsyms was a boolean]
 % Show object symbols in menu headings in menus where
 % the object symbols act as menu accelerators (default off).
@@ -4613,46 +4610,46 @@ objects among classes.
 Supported by tty and curses.
 When setting the value, it can be specified by digit or keyword.
 The default value is {\tt Conditional} (4).
-\item[\ib{menu\verb+_+overlay}]
+\item[\ib{menu\textunderscore overlay}]
 Do not clear the screen before drawing menus, and align
 menus to the right edge of the screen. Only for the tty port.
 (default on)
-\item[\ib{menu\verb+_+previous\verb+_+page}]
+\item[\ib{menu\textunderscore previous\textunderscore page}]
 Key to go to the previous menu page.
 Implemented by the Amiga, Gem and tty ports.
 Default `\verb+<+'.
-\item[\ib{menu\verb+_+search}]
+\item[\ib{menu\textunderscore search}]
 Key to search for some text and toggle selection state of matching menu items.
 Default `:'.
-\item[\ib{menu\verb+_+select\verb+_+all}]
+\item[\ib{menu\textunderscore select\textunderscore all}]
 Key to select all items in a menu.
 Implemented by the Amiga, Gem, X11 and tty ports.
 Default `.'.
-\item[\ib{menu\verb+_+select\verb+_+page}]
+\item[\ib{menu\textunderscore select\textunderscore page}]
 Key to select all items on this page of a menu.
 Implemented by the Amiga, Gem and tty ports.
 Default `,'.
 
 %.lp
-\item[\ib{menu\verb+_+shift\verb+_+left}]
+\item[\ib{menu\textunderscore shift\textunderscore left}]
 Key to scroll a menu---one which has been
 scrolled right---back to the left.
-Implemented for {\it perm\verb+_+invent\/} only by curses and X11.
+Implemented for {\it perm\textunderscore invent\/} only by curses and X11.
 Default `{\tt \verb+{+}'.
 
 %.lp
-\item[\ib{menu\verb+_+shift\verb+_+right}]
+\item[\ib{menu\textunderscore shift\textunderscore right}]
 Key to scroll a menu which has text beyond the
 right edge to the right.
-Implemented for {\it perm\verb+_+invent\/} only by curses by X11.
+Implemented for {\it perm\textunderscore invent\/} only by curses by X11.
 Default `{\tt \verb+}+}'.
 % %.lp
-% \item[\ib{menu\verb+_+tab\verb+_+sep}]
+% \item[\ib{menu\textunderscore tab\textunderscore sep}]
 % Format menu entries using TAB to separate columns (default off).
 % Only applicable to some menus, and only useful to some interfaces.
 % Debug mode only.
 %.lp
-\item[\ib{mon\verb+_+movement}]
+\item[\ib{mon\textunderscore movement}]
 Show a message when hero notices a monster movement (default is off).
 %.lp
 \item[\ib{monpolycontrol}]
@@ -4663,7 +4660,7 @@ Debug mode only.
 Prompt for destination whenever any monster gets teleported (default off).
 Debug mode only.
 %.lp
-\item[\ib{mouse\verb+_+support}]
+\item[\ib{mouse\textunderscore support}]
 Allow use of the mouse for input and travel.
 Valid settings are:
 
@@ -4677,7 +4674,7 @@ Valid settings are:
 
 Omitting a value is the same as specifying {\tt 1}
 and negating
-{\it mouse\verb+_+support\/}
+{\it mouse\textunderscore support\/}
 is the same as specifying {\tt 0}.
 %.lp
 \item[\ib{msghistory}]
@@ -4685,7 +4682,7 @@ The number of top line messages to save (and be able to recall
 with `{\tt \^{}P}') (default 20).
 Cannot be set with the `{\tt O}' command.
 %.lp
-\item[\ib{msg\verb+_+window}]
+\item[\ib{msg\textunderscore window}]
 Allows you to change the way recalled messages are displayed.
 Currently it is only supported for tty (all four choices) and for curses
 (`{\tt f}' and `{\tt r}' choices, default `{\tt r}').
@@ -4730,7 +4727,7 @@ Start the character with no armor (default false).  Persistent.
 \item[\ib{null}]
 Send padding nulls to the terminal (default on).  Persistent.
 %.lp
-\item[\ib{number\verb+_+pad}]
+\item[\ib{number\textunderscore pad}]
 Use digit keys instead of letters to move (default 0 or off).\\
 Valid settings are:
 
@@ -4750,7 +4747,7 @@ Valid settings are:
 
 For backward compatibility, omitting a value is the same as specifying {\tt 1}
 and negating
-{\it number\verb+_+pad\/}
+{\it number\textunderscore pad\/}
 is the same as specifying {\tt 0}.
 (Settings {\tt 2} and {\tt 4} are for compatibility with MS-DOS or old PC Hack;
 in addition to the different behavior for `{\tt 5}', `{\tt Alt-5}' acts as `{\tt G}'
@@ -4767,10 +4764,10 @@ Specify the order to list object types in (default
 containing the symbols for the various object types.  Any omitted types
 are filled in at the end from the previous order.
 %.lp
-\item[\ib{paranoid\verb+_+confirmation}]
+\item[\ib{paranoid\textunderscore confirmation}]
 A space separated list of specific situations where alternate
 prompting is desired.
-The default is ``{\it paranoid\verb+_+confirmation:pray swim trap}''.
+The default is ``{\it paranoid\textunderscore confirmation:pray swim trap}''.
 %.sd
 %.si
 \newlength{\pcwidth}
@@ -4831,17 +4828,17 @@ turn on all of the above.
 %.ed
 By default, the pray, swim, and trap choices are enabled, the others disabled.
 To disable them without setting
-any of the other choices, use ``{\it paranoid\verb+_+confirmation:none}''.
+any of the other choices, use ``{\it paranoid\textunderscore confirmation:none}''.
 To keep them enabled while setting any of the others, you can
 include them in the list, such as
-``{\it par\-a\-noid\verb+_+con\-fir\-ma\-tion:attack~pray~swim~Remove\/}''
+``{\it par\-a\-noid\textunderscore con\-fir\-ma\-tion:attack~pray~swim~Remove\/}''
 or you can precede the first entry in the list with a plus sign,
-``{\it paranoid\verb+_+confirmation:\verb|+|attack~Remove\/}''.
+``{\it paranoid\textunderscore confirmation:\verb|+|attack~Remove\/}''.
 To remove an entry that has been previously set without removing others,
 precede the first entry in the list with a minus sign,
-``{\it paranoid\verb+_+confirmation:-swim\/}.
+``{\it paranoid\textunderscore confirmation:-swim\/}.
 To both add some new entries and remove some old ones, you can use
-multiple {\it paranoid\verb+_+confirmation\/} option settings, or you can
+multiple {\it paranoid\textunderscore confirmation\/} option settings, or you can
 use the `{\tt \verb|+|}' form and list entries to be added by their name
 and entries to be removed by `{\tt !}' and name.
 The positive (no `!') and negative (with `!') entries
@@ -4850,22 +4847,22 @@ can be intermixed.
 \item[\ib{pauper}]
 Start the character with no possessions (default false).  Persistent.
 %.lp
-\item[\ib{perm\verb+_+invent}]
+\item[\ib{perm\textunderscore invent}]
 If true, always display your current inventory in a window (default is false).
 %.lp ""
 \\
 This only
 makes sense for windowing system interfaces that implement this feature.
 For those that do, the
-{\tt perminv\verb+_+mode}
+{\tt perminv\textunderscore mode}
 option can be used to refine what gets displayed
-for {\it perm\verb+_+invent\/}.
+for {\it perm\textunderscore invent\/}.
 Setting that to a value other than {\it none\/}
-while {\it perm\verb+_+invent\/} is false will change it to true.
+while {\it perm\textunderscore invent\/} is false will change it to true.
 %.lp
-\item[\ib{perminv\verb+_+mode}]
+\item[\ib{perminv\textunderscore mode}]
 Augments the
-{\tt perm\verb+_+invent}
+{\tt perm\textunderscore invent}
 option.
 Value is one of
 %.PS "\f(CRin-use\fP"
@@ -4874,7 +4871,7 @@ Value is one of
 \blist{\leftmargin \pcwidth \topsep 1mm \itemsep 0mm}
 %.PL
 \item[{\tt none}]
-behave as if {\it perm\verb+_+invent\/} is false;
+behave as if {\it perm\textunderscore invent\/} is false;
 \item[{all}]
 show all inventory except for gold;
 \item[{full}]
@@ -4883,7 +4880,7 @@ show full inventory including gold;
 only show items which are in use (worn, wielded, lit lamp).
 %.PE
 \elist
-Default is {\it none\/} but if {\it perm\verb+_+invent\/} gets set to true
+Default is {\it none\/} but if {\it perm\textunderscore invent\/} gets set to true
 while it is {\it none\/} it will be changed to {\it all\/}.
 %.lp ""
 \\
@@ -4894,7 +4891,7 @@ included for {\it all\/} despite that mode normally omitting gold.
 \item[\ib{petattr}]
 Specifies one or more text highlighting attributes to use when showing
 pets on the map.
-Effectively a superset of the {\it hilite\verb+_+pet\/} boolean option.
+Effectively a superset of the {\it hilite\textunderscore pet\/} boolean option.
 Curses or tty interface only; value is one of
 none, bold, dim, underline, italic, blink, and inverse.
 Some of those choices might not work,
@@ -4911,29 +4908,29 @@ it will be silently ignored.  For example, ``{\tt horse}'' will only be
 honored when playing a knight.
 Cannot be set with the `{\tt O}' command.
 %.lp
-\item[\ib{pickup\verb+_+burden}]
+\item[\ib{pickup\textunderscore burden}]
 When you pick up an item that would exceed this encumbrance
 level (Unencumbered, Burdened, streSsed, straiNed, overTaxed,
 or overLoaded), you will be asked if you want to continue.
 (Default `S').  Persistent.
 %.lp
-\item[\ib{pickup\verb+_+stolen}]
+\item[\ib{pickup\textunderscore stolen}]
 If this option is on and ``{\it autopickup\/}'' is also on, try to pick up
 things that a monster stole from you, even if they aren't in
-``{\it pickup\verb+_+types\/}'' or
+``{\it pickup\textunderscore types\/}'' or
 match an autopickup exception.
 Default is on.
 Persistent.
 %.lp
-\item[\ib{pickup\verb+_+thrown}]
+\item[\ib{pickup\textunderscore thrown}]
 If this option is on and ``{\it autopickup\/}'' is also on, try to pick up
 things that you threw, even if they aren't in
-``{\it pickup\verb+_+types\/}'' or
+``{\it pickup\textunderscore types\/}'' or
 match an autopickup exception.
 Default is on.
 Persistent.
 %.lp
-\item[\ib{pickup\verb+_+types}]
+\item[\ib{pickup\textunderscore types}]
 Specify the object types to be picked up when ``{\it autopickup\/}''
 is on.
 Default is all types.
@@ -4943,20 +4940,20 @@ Persistent.
 The value is a list of object symbols, such as
 {\tt \verb&pickup_types:$?!&} to pick up gold, scrolls, and potions.
 You can use
-``{\it autopickup\verb+_+exception\/}''
+``{\it autopickup\textunderscore exception\/}''
 configuration file lines to further refine ``{\it autopickup\/}'' behavior.
 \\
 %.lp ""
-There is no way to set {\it pickup\verb+_+types\/} to ``{\it none}''.
+There is no way to set {\it pickup\textunderscore types\/} to ``{\it none}''.
 (Setting it to an empty value reverts to ``{\it all}''.)
 If you want to avoid automatically picking up any types of items but do
 want to have {\it autopickup\/} on in order to have
-{\it autopickup\verb+_+exceptions\/} control what you do and don't pick
-up, you can set {\it pickup\verb+_+types\/} to `{\tt .}'.
+{\it autopickup\textunderscore exceptions\/} control what you do and don't pick
+up, you can set {\it pickup\textunderscore types\/} to `{\tt .}'.
 That is the type symbol for {\it venom\/} and you won't come across
 any venom items so won't unintentionally pick such up.
 %.lp
-\item[\ib{pile\verb+_+limit}]
+\item[\ib{pile\textunderscore limit}]
 When walking across a pile of objects on the floor, threshold at which
 the message ``there are few/several/many objects here'' is given instead
 of showing a popup list of those objects.  A value of 0 means ``no limit''
@@ -4980,10 +4977,10 @@ something pushes the old item into your alternate weapon slot (default off).
 Likewise for the `{\tt a}' (apply) command if it causes the applied item to
 become wielded.  Persistent.
 %.lp
-\item[\ib{query\verb+_+menu}]
+\item[\ib{query\textunderscore menu}]
 Use a menu when asked specific yes/no queries, instead of a prompt.
 %.lp
-\item[\ib{quick\verb+_+farsight}]
+\item[\ib{quick\textunderscore farsight}]
 When set, usually prevents the ``you sense your surroundings'' message
 where play pauses to allow you to browse the map whenever clairvoyance
 randomly activates.
@@ -5004,7 +5001,7 @@ player will be prompted unless role forces a choice for race.
 unless role forces a choice for race.
 Cannot be set with the `{\tt O}' command.  Persistent.
 %.lp
-\item[\ib{rest\verb+_+on\verb+_+space}]
+\item[\ib{rest\textunderscore on\textunderscore space}]
 Make the space bar a synonym for the `{\tt .}' (\#wait) command (default off).
 Persistent.
 %.lp
@@ -5071,14 +5068,14 @@ results of moving.  The default is {\it run\/}; versions prior to 3.4.1
 used {\it teleport\/} only.  Whether or not the effect is noticeable will
 depend upon the window port used or on the type of terminal.  Persistent.
 %.lp
-\item[\ib{safe\verb+_+pet}]
+\item[\ib{safe\textunderscore pet}]
 Prevent you from (knowingly) attacking your pets (default on).  Persistent.
 %.lp
-\item[\ib{safe\verb+_+wait}]
+\item[\ib{safe\textunderscore wait}]
 Prevents you from waiting or searching when next to a hostile monster
 (default on).  Persistent.
 %.lp
-\item[\ib{sanity\verb+_+check}]
+\item[\ib{sanity\textunderscore check}]
 Evaluate monsters, objects, and map prior to each turn (default off).
 Debug mode only.
 %.lp
@@ -5213,7 +5210,7 @@ Allow sounds to be emitted from an integrated sound library (default on).
 Display a sparkly effect when a monster (including yourself) is hit by an
 attack to which it is resistant (default on).  Persistent.
 %.lp
-\item[\ib{spot\verb+_+monsters}]
+\item[\ib{spot\textunderscore monsters}]
 Show a message when hero notices a monster (default is off).
 %.lp
 \item[\ib{standout}]
@@ -5224,13 +5221,13 @@ Controls how many turns status hilite behaviors highlight
 the field. If negated or set to zero, disables status hiliting.
 See ``{\it Configuring Status Hilites\/}'' for further information.
 %.lp
-\item[\ib{status\verb+_+updates}]
+\item[\ib{status\textunderscore updates}]
 Allow updates to the status lines at the bottom of the screen (default true).
 %.lp
-\item[\ib{suppress\verb+_+alert}]
+\item[\ib{suppress\textunderscore alert}]
 This option may be set to a {\it NetHack\/} version level to suppress
 alert notification messages about feature changes for that
-and prior versions (for example, ``{\tt suppress\verb+_+alert:3.3.1}'')
+and prior versions (for example, ``{\tt suppress\textunderscore alert:3.3.1}'')
 %.lp
 \item[\ib{symset}]
 This option may be used to select one of the named symbol sets found within
@@ -5240,7 +5237,7 @@ Use ``{\tt symset:default}'' to explicitly select the default symbols.
 \item[\ib{time}]
 Show the elapsed game time in turns on bottom line (default off).  Persistent.
 %.lp
-\item[\ib{timed\verb+_+delay}]
+\item[\ib{timed\textunderscore delay}]
 When pausing momentarily for display effect, such as with explosions and
 moving objects, use a timer rather than sending extra characters to the
 screen.  (Applies to ``tty'' and ``curses'' interfaces only; ``X11'' interface always
@@ -5263,10 +5260,10 @@ the score list around after game end on a terminal or emulating window.
 Allow the travel command via mouse click (default on).
 Turning this option off will prevent the game from attempting unintended
 moves if you make inadvertent mouse clicks on the map window.
-Does not affect traveling via the `{\tt \verb+_+}' (``{\tt \#travel}'')
+Does not affect traveling via the `{\tt \textunderscore }' (``{\tt \#travel}'')
 command.  Persistent.
 % %.lp
-% \item[ib{travel\verb+_+debug}]
+% \item[ib{travel\textunderscore debug}]
 % Display intended path during each step of travel (default off).
 % Debug mode only.
 %.lp
@@ -5277,7 +5274,7 @@ Setting this option on or off in the config file will skip the query.
 \item[\ib{verbose}]
 Provide more commentary during the game (default on).  Persistent.
 %.lp
-\item[\ib{whatis\verb+_+coord}]
+\item[\ib{whatis\textunderscore coord}]
 When using the `{\tt /}' or `{\tt ;}' commands to look around on the map with
 ``{\tt autodescribe}''
 on, display coordinates after the description.
@@ -5298,13 +5295,13 @@ The possible settings are:
 
 %.lp ""
 The
-{\it whatis\verb+_+coord\/}
+{\it whatis\textunderscore coord\/}
 option is also used with
 the `{\tt /m}', `{\tt /M}', `{\tt /o}', and `{\tt /O}' sub-commands
 of `{\tt /}',
 where the `{\it none\/}' setting is overridden with `{\it map}'.
 %.lp
-\item[\ib{whatis\verb+_+filter}]
+\item[\ib{whatis\textunderscore filter}]
 When getting a location on the map, and using the keys to cycle through
 next and previous targets, allows filtering the possible targets.
 (default none)\\
@@ -5327,12 +5324,12 @@ the door you were last moving towards.\\
 Filtering can also be changed when getting a location with
 the ``getpos.filter'' key.
 %.lp
-\item[\ib{whatis\verb+_+menu}]
+\item[\ib{whatis\textunderscore menu}]
 When getting a location on the map, and using a key to cycle through
 next and previous targets, use a menu instead to pick a target.
 (default off)
 %.lp
-\item[\ib{whatis\verb+_+moveskip}]
+\item[\ib{whatis\textunderscore moveskip}]
 When getting a location on the map, and using shifted movement keys or
 meta-digit keys to fast-move, instead of moving 8 units at a time,
 move by skipping the same glyphs.
@@ -5382,13 +5379,13 @@ with the `{\tt O}' command.
 
 \blist{}
 %.lp
-\item[\ib{align\verb+_+message}]
+\item[\ib{align\textunderscore message}]
  Where to align or place the message window (top, bottom, left, or right)
 %.lp
-\item[\ib{align\verb+_+status}]
+\item[\ib{align\textunderscore status}]
  Where to align or place the status window (top, bottom, left, or right).
 %.lp
-\item[\ib{ascii\verb+_+map}]
+\item[\ib{ascii\textunderscore map}]
 %.hw DECgraphics IBMgraphics \% don't hyphenate these
 \hyphenation{DECgraphics IBMgraphics}
 If {\it NetHack\/} can, it should display the map using simple
@@ -5397,47 +5394,47 @@ In some cases, characters can be augmented with line-drawing symbols;
 use the {\tt symset}
 option to select a symbol set such as {\it DECgraphics\/}
 or {\it IBMgraphics\/} if your display supports them.
-Setting {\tt ascii\verb+_+map} to {\it True\/} forces
-{\tt tiled\verb+_+map} to be {\it False}.
+Setting {\tt ascii\textunderscore map} to {\it True\/} forces
+{\tt tiled\textunderscore map} to be {\it False}.
 %.lp
 \item[\ib{color}]
 If {\it NetHack\/} can, it should display color for different monsters,
 objects, and dungeon features (default on).
 %.lp
-\item[\ib{eight\verb+_+bit\verb+_+tty}]
+\item[\ib{eight\textunderscore bit\textunderscore tty}]
 If {\it NetHack\/} can, it should pass eight-bit character values (for example, specified with the
 {\it traps \/} option) straight through to your terminal (default off).
 %.lp
-\item[\ib{font\verb+_+map}]
+\item[\ib{font\textunderscore map}]
 If {\it NetHack\/} can, it should use a font by the chosen name for the
 map window.
 %.lp
-\item[\ib{font\verb+_+menu}]
+\item[\ib{font\textunderscore menu}]
 If {\it NetHack\/} can, it should use a font by the chosen name for menu
 windows.
 %.lp
-\item[\ib{font\verb+_+message}]
+\item[\ib{font\textunderscore message}]
 If {\it NetHack\/} can, it should use a font by the chosen name for the message window.
 %.lp
-\item[\ib{font\verb+_+status}]
+\item[\ib{font\textunderscore status}]
 If {\it NetHack\/} can, it should use a font by the chosen name for the status window.
 %.lp
-\item[\ib{font\verb+_+text}]
+\item[\ib{font\textunderscore text}]
 If {\it NetHack\/} can, it should use a font by the chosen name for text windows.
 %.lp
-\item[\ib{font\verb+_+size\verb+_+map}]
+\item[\ib{font\textunderscore size\textunderscore map}]
 If {\it NetHack\/} can, it should use this size font for the map window.
 %.lp
-\item[\ib{font\verb+_+size\verb+_+menu}]
+\item[\ib{font\textunderscore size\textunderscore menu}]
 If {\it NetHack\/} can, it  should use this size font for menu windows.
 %.lp
-\item[\ib{font\verb+_+size\verb+_+message}]
+\item[\ib{font\textunderscore size\textunderscore message}]
 If {\it NetHack\/} can, it should use this size font for the message window.
 %.lp
-\item[\ib{font\verb+_+size\verb+_+status}]
+\item[\ib{font\textunderscore size\textunderscore status}]
 If {\it NetHack\/} can, it should use this size font for the status window.
 %.lp
-\item[\ib{font\verb+_+size\verb+_+text}]
+\item[\ib{font\textunderscore size\textunderscore text}]
 If {\it NetHack\/} can, it should use this size font for text windows.
 %.lp
 \item[\ib{fullscreen}]
@@ -5448,30 +5445,30 @@ Use color text and/or highlighting attributes when displaying some
 non-map data (such as menu selector letters).
 Curses interface only; default is on.
 %.lp
-\item[\ib{large\verb+_+font}]
+\item[\ib{large\textunderscore font}]
 If {\it NetHack\/} can, it should use a large font.
 %.lp
-\item[\ib{map\verb+_+mode}]
+\item[\ib{map\textunderscore mode}]
 If {\it NetHack\/} can, it should display the map in the manner specified.
 %.lp
-\item[\ib{player\verb+_+selection}]
+\item[\ib{player\textunderscore selection}]
 If {\it NetHack\/} can, it should pop up dialog boxes or use prompts for character selection.
 %.lp
-\item[\ib{popup\verb+_+dialog}]
+\item[\ib{popup\textunderscore dialog}]
 If {\it NetHack\/} can, it should pop up dialog boxes for input.
 %.lp
-\item[\ib{preload\verb+_+tiles}]
+\item[\ib{preload\textunderscore tiles}]
 If {\it NetHack\/} can, it should preload tiles into memory.
 For example, in the protected mode MS-DOS version, control whether tiles
 get pre-loaded into RAM at the start of the game.  Doing so
 enhances performance of the tile graphics, but uses more memory. (default on).
 Cannot be set with the `{\tt O}' command.
 %.lp
-\item[\ib{scroll\verb+_+amount}]
+\item[\ib{scroll\textunderscore amount}]
 If {\it NetHack\/} can, it should scroll the display by this number of cells
-when the hero reaches the scroll\verb+_+margin.
+when the hero reaches the scroll\textunderscore margin.
 %.lp
-\item[\ib{scroll\verb+_+margin}]
+\item[\ib{scroll\textunderscore margin}]
 If {\it NetHack\/} can, it should scroll the display when the hero or cursor
 is this number of cells away from the edge of the window.
 %.lp
@@ -5483,7 +5480,7 @@ choose from at game startup, if it can. Not all ports support this option.
 If {\it NetHack\/} can, it should display an onscreen keyboard.
 Handhelds are most likely to support this option.
 %.lp
-\item[\ib{splash\verb+_+screen}]
+\item[\ib{splash\textunderscore screen}]
 If {\it NetHack\/} can, it should display an opening splash screen when
 it starts up (default yes).
 %.lp
@@ -5500,7 +5497,7 @@ command.
 
 %.lp ""
 The {\tt curses} interface does likewise if the
-{\it align\verb+_+status\/}
+{\it align\textunderscore status\/}
 option is set to {\it top\/} or {\it bottom\/} but ignores
 {\it statuslines\/}
 when set to {\it left\/} or {\it right}.
@@ -5521,16 +5518,16 @@ older than {\tt qt-5.9},
 can only be set in the run-time configuration file or via NETHACKOPTIONS,
 not during play with the `{\tt O}' command.)
 %.lp
-\item[\ib{term\verb+_+cols} {\normalfont and}]
+\item[\ib{term\textunderscore cols} {\normalfont and}]
 %.lp
-\item[\ib{term\verb+_+rows}]
+\item[\ib{term\textunderscore rows}]
 Curses interface only.
 Number of columns and rows to use for the display.
 Curses will attempt to resize to the values specified but will settle
 for smaller sizes if they are too big.
 Default is the current window size.
 %.lp
-\item[\ib{tile\verb+_+file}]
+\item[\ib{tile\textunderscore file}]
 Specify the name of an alternative tile file to override the default.
 \\
 %.lp ""
@@ -5538,30 +5535,30 @@ Note: the X11 interface uses X resources rather than NetHack's options
 to select an alternate tile file.
 See {\tt NetHack.ad}, the sample X ``application defaults'' file.
 %.lp
-\item[\ib{tile\verb+_+height}]
+\item[\ib{tile\textunderscore height}]
 Specify the preferred height of each tile in a tile capable port.
 %.lp
-\item[\ib{tile\verb+_+width}]
+\item[\ib{tile\textunderscore width}]
 Specify the preferred width of each tile in a tile capable port
 %.lp
-\item[\ib{tiled\verb+_+map}]
+\item[\ib{tiled\textunderscore map}]
 If {\it NetHack\/} can, it should display the map using {\it tiles} graphics
 rather than simple characters (letters and punctuation, possibly
 augmented by line-drawing symbols).
-Setting {\tt tiled\verb+_+map} to {\it True\/} forces
-{\tt ascii\verb+_+map} to be {\it False}.
+Setting {\tt tiled\textunderscore map} to {\it True\/} forces
+{\tt ascii\textunderscore map} to be {\it False}.
 %.lp
-\item[\ib{use\verb+_+darkgray}]
+\item[\ib{use\textunderscore darkgray}]
 Use bold black instead of blue for black glyphs (TTY only).
 %.lp
-\item[\ib{use\verb+_+inverse}]
+\item[\ib{use\textunderscore inverse}]
 If {\it NetHack\/} can, it should display inverse when the game specifies it.
 %.lp
-\item[\ib{use\verb+_+menu\verb+_+glyphs}]
+\item[\ib{use\textunderscore menu\textunderscore glyphs}]
 If {\it NetHack\/} can, it should display glyphs next to objects in the
 inventory.
 %.lp
-\item[\ib{vary\verb+_+msgcount}]
+\item[\ib{vary\textunderscore msgcount}]
 If {\it NetHack\/} can, it should display this number of messages at a time
 in the message window.
 %.lp
@@ -5577,8 +5574,8 @@ Acceptable values are
 {\tt 1} --- on, always show borders\\
 {\tt 2} --- auto, on display is at least
 (\verb&24+2&)x(\verb&80+2&) [default]\\
-{\tt 3} --- on, except forced off for perm\verb+_+invent\\
-{\tt 4} --- auto, except forced off for perm\verb+_+invent\\
+{\tt 3} --- on, except forced off for perm\textunderscore invent\\
+{\tt 4} --- auto, except forced off for perm\textunderscore invent\\
 %.ei
 %.ed
 
@@ -5677,7 +5674,7 @@ ESC into a meta-shifted version of the second character (default off).
 %.lp ""
 This conversion is only done for commands, not for other input prompts.
 Note that typing one or more digits as a count prefix prior to a
-command---preceded by {\tt n} if the {\it number\verb+_+pad\/}
+command---preceded by {\tt n} if the {\it number\textunderscore pad\/}
 option is set---is
 also subject to this conversion, so attempting to
 abort the count by typing ESC will leave {\it NetHack\/} waiting for another
@@ -5720,15 +5717,15 @@ Setting {\it autodetect\/} attempts {\it vesa\/}, then {\it vga\/}, and
 finally sets {\it default\/} if neither of those modes works.
 Cannot be set with the `{\tt O}' command.
 %.lp
-\item[\ib{video\verb+_+height}]
+\item[\ib{video\textunderscore height}]
 Set the VGA mode resolution height (MS-DOS only, with video:vesa)
 %.lp
-\item[\ib{video\verb+_+width}]
+\item[\ib{video\textunderscore width}]
 Set the VGA mode resolution width (MS-DOS only, with video:vesa)
 %.lp
 \item[\ib{videocolors}]
 \begin{sloppypar}
-Set the color palette for PC systems using NO\verb+_+TERMS
+Set the color palette for PC systems using NO\textunderscore TERMS
 (default 4-2-6-1-5-3-15-12-10-14-9-13-11, {\it PC\/ NetHack\/} only).
 The order of colors is red, green, brown, blue, magenta, cyan,
 bright.white, bright.red, bright.green, yellow, bright.blue,
@@ -5762,18 +5759,18 @@ and User sounds.
 
 %.pg
 You can further refine the behavior of the ``{\tt autopickup}'' option
-beyond what is available through the ``{\tt pickup\verb+_+types}'' option.
+beyond what is available through the ``{\tt pickup\textunderscore types}'' option.
 
 %.pg
-By placing ``{\tt autopickup\verb+_+exception}'' lines in your configuration
+By placing ``{\tt autopickup\textunderscore exception}'' lines in your configuration
 file, you can define patterns to be checked when the game is about to
 autopickup something.
 
 \blist{}
 %.lp
-\item[\ib{autopickup\verb+_+exception}]
-Sets an exception to the ``{\it pickup\verb+_+types}'' option.
-The {\it autopickup\verb+_+exception\/} option should be followed by a regular
+\item[\ib{autopickup\textunderscore exception}]
+Sets an exception to the ``{\it pickup\textunderscore types}'' option.
+The {\it autopickup\textunderscore exception\/} option should be followed by a regular
 expression to be used as a pattern to match against the singular form of the
 description of an object at your location.
 
@@ -5787,7 +5784,7 @@ character in the pattern, specifically:
 %.ei
 %.ed
 
-The {\it autopickup\verb+_+exception\/} rules are processed in the order
+The {\it autopickup\textunderscore exception\/} rules are processed in the order
 in which they appear in your configuration file, thus allowing a
 later rule to override an earlier rule.
 
@@ -5795,7 +5792,7 @@ later rule to override an earlier rule.
 Exceptions can be set with the `{\tt O}' command, but because they are not
 included in your configuration file, they won't be in effect if you save
 and then restore your game.
-{\it autopickup\verb+_+exception\/} rules are not saved with the game.
+{\it autopickup\textunderscore exception\/} rules are not saved with the game.
 \elist
 
 %.lp "Here are some examples:"
@@ -5866,7 +5863,7 @@ can only be bound to a single key.
 %.lp
 \item[{\bb{count}}]
 Prefix key to start a count, to repeat a command this many times.
-With {\it number\verb+_+pad\/} only. Default is~`{\tt n}'.
+With {\it number\textunderscore pad\/} only. Default is~`{\tt n}'.
 %.lp
 \item[{\bb{getdir.help}}]
 When asked for a direction, the key to show the help. Default is~`{\tt ?}'.
@@ -5879,7 +5876,7 @@ the getpos.pick.once key (default `{\tt ,}')
 or the getpos.pick key (default `{\tt .}')
 to finish as if performing a left or right click.
 Only useful when using the {\tt \#therecmdmenu} command.
-Default is~`{\tt \verb+_+}'.
+Default is~`{\tt \textunderscore }'.
 %.lp
 \item[{\bb{getdir.self}}]
 When asked for a direction, the key to target yourself. Default is~`{\tt .}'.
@@ -6111,7 +6108,7 @@ a menu line will be used for the line.
 %.pg
 Note that if you intend to have one or more color specifications match
 ``~uncursed~'', you will probably want to turn the
-{\it implicit\verb+_+uncursed\/}
+{\it implicit\textunderscore uncursed\/}
 option off so that all items known to be uncursed are actually
 displayed with the ``uncursed'' description.
 
@@ -6389,190 +6386,190 @@ character.
 Default                      & Symbol Name                & Description\\
 \hline \hline
 \endhead
-\verb@ @ & S\verb+_+air                     &	(air)\\
-\_ & S\verb+_+altar                   &	(altar)\\
-\verb@"@ & S\verb+_+amulet                  &	(amulet)\\
-\verb@A@ & S\verb+_+angel                   &	(angelic being)\\
-\verb@a@ & S\verb+_+ant                     &	(ant or other insect)\\
-\verb@^@ & S\verb+_+anti\verb+_+magic\verb+_+trap       &	(anti-magic field)\\
-\verb@[@ & S\verb+_+armor                   &	(suit or piece of armor)\\
-\verb@[@ & S\verb+_+armour                  &	(suit or piece of armor)\\
-\verb@^@ & S\verb+_+arrow\verb+_+trap             &	(arrow trap)\\
-\verb@0@ & S\verb+_+ball                    &	(iron ball)\\
-\# & S\verb+_+bars                    &	(iron bars)\\
-\verb@B@ & S\verb+_+bat                     &	(bat or bird)\\
-\verb@^@ & S\verb+_+bear\verb+_+trap              &	(bear trap)\\
-\verb@-@ & S\verb+_+blcorn                  &	(bottom left corner)\\
-\verb@b@ & S\verb+_+blob                    &	(blob)\\
-\verb@+@ & S\verb+_+book                    &	(spellbook)\\
-\verb@)@ & S\verb+_+boomleft                &	(boomerang open left)\\
-\verb@(@ & S\verb+_+boomright               &	(boomerang open right)\\
-\verb@`@ & S\verb+_+boulder                 &	(boulder)\\
-\verb@-@ & S\verb+_+brcorn                  &	(bottom right corner)\\
-\verb@>@ & S\verb+_+brdnladder              &	(branch ladder down)\\
-\verb@>@ & S\verb+_+brdnstair               &	(branch staircase down)\\
-\verb@<@ & S\verb+_+brupladder              &	(branch ladder up)\\
-\verb@<@ & S\verb+_+brupstair               &	(branch staircase up)\\
-\verb@C@ & S\verb+_+centaur                 &	(centaur)\\
-\verb@_@ & S\verb+_+chain                   &	(iron chain)\\
-\# & S\verb+_+cloud                   &	(cloud)\\
-\verb@c@ & S\verb+_+cockatrice              &	(cockatrice)\\
-\$ & S\verb+_+coin                    &	(pile of coins)\\
-\# & S\verb+_+corr                    &	(corridor)\\
-\verb@-@ & S\verb+_+crwall                  &	(wall)\\
-\verb@-@ & S\verb+_+darkroom                &	(dark room)\\
-\verb@^@ & S\verb+_+dart\verb+_+trap              &	(dart trap)\\
-\verb@&@ & S\verb+_+demon                   &	(major demon)\\
-\verb@*@ & S\verb+_+digbeam                 &	(dig beam)\\
-\verb@>@ & S\verb+_+dnladder                &	(ladder down)\\
-\verb@>@ & S\verb+_+dnstair                 &	(staircase down)\\
-\verb@d@ & S\verb+_+dog                     &	(dog or other canine)\\
-\verb@D@ & S\verb+_+dragon                  &	(dragon)\\
-\verb@;@ & S\verb+_+eel                     &	(sea monster)\\
-\verb@E@ & S\verb+_+elemental               &	(elemental)\\
-\# & S\verb+_+engrcorr                      &	(engraving in a corridor)\\
-\verb@`@ & S\verb+_+engroom                 &	(engraving in a room)\\
-\verb@/@ & S\verb+_+expl\verb+_+tl          &	(explosion top left)\\
-\verb@-@ & S\verb+_+expl\verb+_+tc          &	(explosion top center)\\
-\verb@\@ & S\verb+_+expl\verb+_+tr          &	(explosion top right)\\
-\verb@|@ & S\verb+_+expl\verb+_+ml          &	(explosion middle left)\\
-\verb@ @ & S\verb+_+expl\verb+_+mc          &	(explosion middle center)\\
-\verb@|@ & S\verb+_+expl\verb+_+mr          &	(explosion middle right)\\
-\verb@\@ & S\verb+_+expl\verb+_+bl          &	(explosion bottom left)\\
-\verb@-@ & S\verb+_+expl\verb+_+bc          &	(explosion bottom center)\\
-\verb@/@ & S\verb+_+expl\verb+_+br          &	(explosion bottom right)\\
-\verb@e@ & S\verb+_+eye                     &	(eye or sphere)\\
-\verb@^@ & S\verb+_+falling\verb+_+rock\verb+_+trap     &	(falling rock trap)\\
-\verb@f@ & S\verb+_+feline                  &	(cat or other feline)\\
-\verb@^@ & S\verb+_+fire\verb+_+trap              &	(fire trap)\\
-\verb@!@ & S\verb+_+flashbeam               &	(flash beam)\\
-\% & S\verb+_+food                    &	(piece of food)\\
-\{ & S\verb+_+fountain                &	(fountain)\\
-\verb@F@ & S\verb+_+fungus                  &	(fungus or mold)\\
-\verb@*@ & S\verb+_+gem                     &	(gem or rock)\\
-\verb@ @ & S\verb+_+ghost                   &	(ghost)\\
-\verb@H@ & S\verb+_+giant                   &	(giant humanoid)\\
-\verb@G@ & S\verb+_+gnome                   &	(gnome)\\
-\verb@'@ & S\verb+_+golem                   &	(golem)\\
-\verb@|@ & S\verb+_+grave                   &	(grave)\\
-\verb@g@ & S\verb+_+gremlin                 &	(gremlin)\\
-\verb@-@ & S\verb+_+hbeam                   &	(wall)\\
-\# & S\verb+_+hcdbridge               &	(horizontal raised drawbridge)\\
-\verb@+@ & S\verb+_+hcdoor                  &	(closed door)\\
-\verb@.@ & S\verb+_+hodbridge               &	(horizontal lowered drawbridge)\\
-\verb@|@ & S\verb+_+hodoor                  &	(open door)\\
-\verb\^\ & S\verb+_+hole                    &	(hole)\\
-\verb~@~ & S\verb+_+human                   &	(human or elf)\\
-\verb@h@ & S\verb+_+humanoid                &	(humanoid)\\
-\verb@-@ & S\verb+_+hwall                   &	(horizontal wall)\\
-\verb@.@ & S\verb+_+ice                     &	(ice)\\
-\verb@i@ & S\verb+_+imp                     &	(imp or minor demon)\\
-\verb@I@ & S\verb+_+invisible               &	(invisible monster)\\
-\verb@J@ & S\verb+_+jabberwock              &	(jabberwock)\\
-\verb@j@ & S\verb+_+jelly                   &	(jelly)\\
-\verb@k@ & S\verb+_+kobold                  &	(kobold)\\
-\verb@K@ & S\verb+_+kop                     &	(Keystone Kop)\\
-\verb@^@ & S\verb+_+land\verb+_+mine              &	(land mine)\\
-\verb@}@ & S\verb+_+lava                    &	(molten lava)\\
-\verb@}@ & S\verb+_+lavawall                &	(wall of lava)\\
-\verb@l@ & S\verb+_+leprechaun              &	(leprechaun)\\
-\verb@^@ & S\verb+_+level\verb+_+teleporter       &	(level teleporter)\\
-\verb@L@ & S\verb+_+lich                    &	(lich)\\
-\verb@y@ & S\verb+_+light                   &	(light)\\
-\# & S\verb+_+litcorr                 &	(lit corridor)\\
-\verb@:@ & S\verb+_+lizard                  &	(lizard)\\
-\verb@\@ & S\verb+_+lslant                  &	(wall)\\
-\verb@^@ & S\verb+_+magic\verb+_+portal           &	(magic portal)\\
-\verb@^@ & S\verb+_+magic\verb+_+trap             &	(magic trap)\\
-\verb@m@ & S\verb+_+mimic                   &	(mimic)\\
-\verb@]@ & S\verb+_+mimic\verb+_+def              &	(mimic)\\
-\verb@M@ & S\verb+_+mummy                   &	(mummy)\\
-\verb@N@ & S\verb+_+naga                    &	(naga)\\
-\verb@.@ & S\verb+_+ndoor                   &	(doorway)\\
-\verb@n@ & S\verb+_+nymph                   &	(nymph)\\
-\verb@O@ & S\verb+_+ogre                    &	(ogre)\\
-\verb@o@ & S\verb+_+orc                     &	(orc)\\
-\verb@p@ & S\verb+_+piercer                 &	(piercer)\\
-\verb@^@ & S\verb+_+pit                     &	(pit)\\
-\# & S\verb+_+poisoncloud             &	(poison cloud)\\
-\verb@^@ & S\verb+_+polymorph\verb+_+trap         &	(polymorph trap)\\
-\verb@}@ & S\verb+_+pool                    &	(water)\\
-\verb@!@ & S\verb+_+potion                  &	(potion)\\
-\verb@P@ & S\verb+_+pudding                 &	(pudding or ooze)\\
-\verb@q@ & S\verb+_+quadruped               &	(quadruped)\\
-\verb@Q@ & S\verb+_+quantmech               &	(quantum mechanic)\\
-\verb@=@ & S\verb+_+ring                    &	(ring)\\
-\verb@`@ & S\verb+_+rock                    &	(boulder or statue)\\
-\verb@r@ & S\verb+_+rodent                  &	(rodent)\\
-\verb@^@ & S\verb+_+rolling\verb+_+boulder\verb+_+trap  &	(rolling boulder trap)\\
-\verb@.@ & S\verb+_+room                    &	(floor of a room)\\
-\verb@/@ & S\verb+_+rslant                  &	(wall)\\
-\verb@^@ & S\verb+_+rust\verb+_+trap              &	(rust trap)\\
-\verb@R@ & S\verb+_+rustmonst               &	(rust monster or disenchanter)\\
-\verb@?@ & S\verb+_+scroll                  &	(scroll)\\
-\# & S\verb+_+sink                    &	(sink)\\
-\verb@^@ & S\verb+_+sleeping\verb+_+gas\verb+_+trap     &	(sleeping gas trap)\\
-\verb@S@ & S\verb+_+snake                   &	(snake)\\
-\verb@s@ & S\verb+_+spider                  &	(arachnid or centipede)\\
-\verb@^@ & S\verb+_+spiked\verb+_+pit             &	(spiked pit)\\
-\verb@^@ & S\verb+_+squeaky\verb+_+board          &	(squeaky board)\\
-\verb@0@ & S\verb+_+ss1                     &	(magic shield 1 of 4)\\
-\# & S\verb+_+ss2                     &	(magic shield 2 of 4)\\
-\verb+@+ & S\verb+_+ss3                     &	(magic shield 3 of 4)\\
-\verb@*@ & S\verb+_+ss4                     &	(magic shield 4 of 4)\\
-\verb@^@ & S\verb+_+statue\verb+_+trap            &	(statue trap)\\
-\verb@ @ & S\verb+_+stone                   &	(solid rock)\\
-\verb@]@ & S\verb+_+strange\verb+_+obj      &	(strange object)\\
-\verb@-@ & S\verb+_+sw\verb+_+bc                  &	(swallow bottom center)\\
-\verb@\@ & S\verb+_+sw\verb+_+bl                  &	(swallow bottom left)\\
-\verb@/@ & S\verb+_+sw\verb+_+br                  &	(swallow bottom right	)\\
-\verb@|@ & S\verb+_+sw\verb+_+ml                  &	(swallow middle left)\\
-\verb@|@ & S\verb+_+sw\verb+_+mr                  &	(swallow middle right)\\
-\verb@-@ & S\verb+_+sw\verb+_+tc                  &	(swallow top center)\\
-\verb@/@ & S\verb+_+sw\verb+_+tl                  &	(swallow top left)\\
-\verb@\@ & S\verb+_+sw\verb+_+tr                  &	(swallow top right)\\
-\verb@-@ & S\verb+_+tdwall                  &	(wall)\\
-\verb@^@ & S\verb+_+teleportation\verb+_+trap     &	(teleportation trap)\\
-\verb@\@ & S\verb+_+throne                  &	(opulent throne)\\
-\verb@-@ & S\verb+_+tlcorn                  &	(top left corner)\\
-\verb@|@ & S\verb+_+tlwall                  &	(wall)\\
-\verb@(@ & S\verb+_+tool                    &	(useful item (pick-axe, key, lamp...))\\
-\verb@^@ & S\verb+_+trap\verb+_+door              &	(trap door)\\
-\verb@t@ & S\verb+_+trapper                 &	(trapper or lurker above)\\
-\verb@-@ & S\verb+_+trcorn                  &	(top right corner)\\
-\# & S\verb+_+tree                    &	(tree)\\
-\verb@T@ & S\verb+_+troll                   &	(troll)\\
-\verb@|@ & S\verb+_+trwall                  &	(wall)\\
-\verb@-@ & S\verb+_+tuwall                  &	(wall)\\
-\verb@U@ & S\verb+_+umber                   &	(umber hulk)\\
-\verb@ @ & S\verb+_+unexplored              &	(unexplored terrain)\\
-\verb@u@ & S\verb+_+unicorn                 &	(unicorn or horse)\\
-\verb@<@ & S\verb+_+upladder                &	(ladder up)\\
-\verb@<@ & S\verb+_+upstair                 &	(staircase up)\\
-\verb@V@ & S\verb+_+vampire                 &	(vampire)\\
-\verb@|@ & S\verb+_+vbeam                   &	(wall)\\
-\# & S\verb+_+vcdbridge               &	(vertical raised drawbridge)\\
-\verb@+@ & S\verb+_+vcdoor                  &	(closed door)\\
-\verb@.@ & S\verb+_+venom                   &	(splash of venom)\\
-\verb@^@ & S\verb+_+vibrating\verb+_+square       &	(vibrating square)\\
-\verb@.@ & S\verb+_+vodbridge               &	(vertical lowered drawbridge)\\
-\verb@-@ & S\verb+_+vodoor                  &	(open door)\\
-\verb@v@ & S\verb+_+vortex                  &	(vortex)\\
-\verb@|@ & S\verb+_+vwall                   &	(vertical wall)\\
-\verb@/@ & S\verb+_+wand                    &	(wand)\\
-\verb@}@ & S\verb+_+water                   &	(water)\\
-\verb@)@ & S\verb+_+weapon                  &	(weapon)\\
-\verb@"@ & S\verb+_+web                     &	(web)\\
-\verb@w@ & S\verb+_+worm                    &	(worm)\\
-\verb@~@ & S\verb+_+worm\verb+_+tail              &	(long worm tail)\\
-\verb@W@ & S\verb+_+wraith                  &	(wraith)\\
-\verb@x@ & S\verb+_+xan                     &	(xan or other extraordinary insect)\\
-\verb@X@ & S\verb+_+xorn                    &	(xorn)\\
-\verb@Y@ & S\verb+_+yeti                    &	(apelike creature)\\
-\verb@Z@ & S\verb+_+zombie                  &	(zombie)\\
-\verb@z@ & S\verb+_+zruty                   &	(zruty)\\
-\verb@ @ & S\verb+_+pet\verb+_+override     &	(any pet if ACCESSIBILITY=1 is set)\\
-\verb@ @ & S\verb+_+hero\verb+_+override    &	(hero if ACCESSIBILITY=1 is set)
+\verb@ @ & S\textunderscore air                     &	(air)\\
+\_ & S\textunderscore altar                   &	(altar)\\
+\verb@"@ & S\textunderscore amulet                  &	(amulet)\\
+\verb@A@ & S\textunderscore angel                   &	(angelic being)\\
+\verb@a@ & S\textunderscore ant                     &	(ant or other insect)\\
+\verb@^@ & S\textunderscore anti\textunderscore magic\textunderscore trap       &	(anti-magic field)\\
+\verb@[@ & S\textunderscore armor                   &	(suit or piece of armor)\\
+\verb@[@ & S\textunderscore armour                  &	(suit or piece of armor)\\
+\verb@^@ & S\textunderscore arrow\textunderscore trap             &	(arrow trap)\\
+\verb@0@ & S\textunderscore ball                    &	(iron ball)\\
+\# & S\textunderscore bars                    &	(iron bars)\\
+\verb@B@ & S\textunderscore bat                     &	(bat or bird)\\
+\verb@^@ & S\textunderscore bear\textunderscore trap              &	(bear trap)\\
+\verb@-@ & S\textunderscore blcorn                  &	(bottom left corner)\\
+\verb@b@ & S\textunderscore blob                    &	(blob)\\
+\verb@+@ & S\textunderscore book                    &	(spellbook)\\
+\verb@)@ & S\textunderscore boomleft                &	(boomerang open left)\\
+\verb@(@ & S\textunderscore boomright               &	(boomerang open right)\\
+\verb@`@ & S\textunderscore boulder                 &	(boulder)\\
+\verb@-@ & S\textunderscore brcorn                  &	(bottom right corner)\\
+\verb@>@ & S\textunderscore brdnladder              &	(branch ladder down)\\
+\verb@>@ & S\textunderscore brdnstair               &	(branch staircase down)\\
+\verb@<@ & S\textunderscore brupladder              &	(branch ladder up)\\
+\verb@<@ & S\textunderscore brupstair               &	(branch staircase up)\\
+\verb@C@ & S\textunderscore centaur                 &	(centaur)\\
+\verb@_@ & S\textunderscore chain                   &	(iron chain)\\
+\# & S\textunderscore cloud                   &	(cloud)\\
+\verb@c@ & S\textunderscore cockatrice              &	(cockatrice)\\
+\$ & S\textunderscore coin                    &	(pile of coins)\\
+\# & S\textunderscore corr                    &	(corridor)\\
+\verb@-@ & S\textunderscore crwall                  &	(wall)\\
+\verb@-@ & S\textunderscore darkroom                &	(dark room)\\
+\verb@^@ & S\textunderscore dart\textunderscore trap              &	(dart trap)\\
+\verb@&@ & S\textunderscore demon                   &	(major demon)\\
+\verb@*@ & S\textunderscore digbeam                 &	(dig beam)\\
+\verb@>@ & S\textunderscore dnladder                &	(ladder down)\\
+\verb@>@ & S\textunderscore dnstair                 &	(staircase down)\\
+\verb@d@ & S\textunderscore dog                     &	(dog or other canine)\\
+\verb@D@ & S\textunderscore dragon                  &	(dragon)\\
+\verb@;@ & S\textunderscore eel                     &	(sea monster)\\
+\verb@E@ & S\textunderscore elemental               &	(elemental)\\
+\# & S\textunderscore engrcorr                      &	(engraving in a corridor)\\
+\verb@`@ & S\textunderscore engroom                 &	(engraving in a room)\\
+\verb@/@ & S\textunderscore expl\textunderscore tl          &	(explosion top left)\\
+\verb@-@ & S\textunderscore expl\textunderscore tc          &	(explosion top center)\\
+\verb@\@ & S\textunderscore expl\textunderscore tr          &	(explosion top right)\\
+\verb@|@ & S\textunderscore expl\textunderscore ml          &	(explosion middle left)\\
+\verb@ @ & S\textunderscore expl\textunderscore mc          &	(explosion middle center)\\
+\verb@|@ & S\textunderscore expl\textunderscore mr          &	(explosion middle right)\\
+\verb@\@ & S\textunderscore expl\textunderscore bl          &	(explosion bottom left)\\
+\verb@-@ & S\textunderscore expl\textunderscore bc          &	(explosion bottom center)\\
+\verb@/@ & S\textunderscore expl\textunderscore br          &	(explosion bottom right)\\
+\verb@e@ & S\textunderscore eye                     &	(eye or sphere)\\
+\verb@^@ & S\textunderscore falling\textunderscore rock\textunderscore trap     &	(falling rock trap)\\
+\verb@f@ & S\textunderscore feline                  &	(cat or other feline)\\
+\verb@^@ & S\textunderscore fire\textunderscore trap              &	(fire trap)\\
+\verb@!@ & S\textunderscore flashbeam               &	(flash beam)\\
+\% & S\textunderscore food                    &	(piece of food)\\
+\{ & S\textunderscore fountain                &	(fountain)\\
+\verb@F@ & S\textunderscore fungus                  &	(fungus or mold)\\
+\verb@*@ & S\textunderscore gem                     &	(gem or rock)\\
+\verb@ @ & S\textunderscore ghost                   &	(ghost)\\
+\verb@H@ & S\textunderscore giant                   &	(giant humanoid)\\
+\verb@G@ & S\textunderscore gnome                   &	(gnome)\\
+\verb@'@ & S\textunderscore golem                   &	(golem)\\
+\verb@|@ & S\textunderscore grave                   &	(grave)\\
+\verb@g@ & S\textunderscore gremlin                 &	(gremlin)\\
+\verb@-@ & S\textunderscore hbeam                   &	(wall)\\
+\# & S\textunderscore hcdbridge               &	(horizontal raised drawbridge)\\
+\verb@+@ & S\textunderscore hcdoor                  &	(closed door)\\
+\verb@.@ & S\textunderscore hodbridge               &	(horizontal lowered drawbridge)\\
+\verb@|@ & S\textunderscore hodoor                  &	(open door)\\
+\verb\^\ & S\textunderscore hole                    &	(hole)\\
+\verb~@~ & S\textunderscore human                   &	(human or elf)\\
+\verb@h@ & S\textunderscore humanoid                &	(humanoid)\\
+\verb@-@ & S\textunderscore hwall                   &	(horizontal wall)\\
+\verb@.@ & S\textunderscore ice                     &	(ice)\\
+\verb@i@ & S\textunderscore imp                     &	(imp or minor demon)\\
+\verb@I@ & S\textunderscore invisible               &	(invisible monster)\\
+\verb@J@ & S\textunderscore jabberwock              &	(jabberwock)\\
+\verb@j@ & S\textunderscore jelly                   &	(jelly)\\
+\verb@k@ & S\textunderscore kobold                  &	(kobold)\\
+\verb@K@ & S\textunderscore kop                     &	(Keystone Kop)\\
+\verb@^@ & S\textunderscore land\textunderscore mine              &	(land mine)\\
+\verb@}@ & S\textunderscore lava                    &	(molten lava)\\
+\verb@}@ & S\textunderscore lavawall                &	(wall of lava)\\
+\verb@l@ & S\textunderscore leprechaun              &	(leprechaun)\\
+\verb@^@ & S\textunderscore level\textunderscore teleporter       &	(level teleporter)\\
+\verb@L@ & S\textunderscore lich                    &	(lich)\\
+\verb@y@ & S\textunderscore light                   &	(light)\\
+\# & S\textunderscore litcorr                 &	(lit corridor)\\
+\verb@:@ & S\textunderscore lizard                  &	(lizard)\\
+\verb@\@ & S\textunderscore lslant                  &	(wall)\\
+\verb@^@ & S\textunderscore magic\textunderscore portal           &	(magic portal)\\
+\verb@^@ & S\textunderscore magic\textunderscore trap             &	(magic trap)\\
+\verb@m@ & S\textunderscore mimic                   &	(mimic)\\
+\verb@]@ & S\textunderscore mimic\textunderscore def              &	(mimic)\\
+\verb@M@ & S\textunderscore mummy                   &	(mummy)\\
+\verb@N@ & S\textunderscore naga                    &	(naga)\\
+\verb@.@ & S\textunderscore ndoor                   &	(doorway)\\
+\verb@n@ & S\textunderscore nymph                   &	(nymph)\\
+\verb@O@ & S\textunderscore ogre                    &	(ogre)\\
+\verb@o@ & S\textunderscore orc                     &	(orc)\\
+\verb@p@ & S\textunderscore piercer                 &	(piercer)\\
+\verb@^@ & S\textunderscore pit                     &	(pit)\\
+\# & S\textunderscore poisoncloud             &	(poison cloud)\\
+\verb@^@ & S\textunderscore polymorph\textunderscore trap         &	(polymorph trap)\\
+\verb@}@ & S\textunderscore pool                    &	(water)\\
+\verb@!@ & S\textunderscore potion                  &	(potion)\\
+\verb@P@ & S\textunderscore pudding                 &	(pudding or ooze)\\
+\verb@q@ & S\textunderscore quadruped               &	(quadruped)\\
+\verb@Q@ & S\textunderscore quantmech               &	(quantum mechanic)\\
+\verb@=@ & S\textunderscore ring                    &	(ring)\\
+\verb@`@ & S\textunderscore rock                    &	(boulder or statue)\\
+\verb@r@ & S\textunderscore rodent                  &	(rodent)\\
+\verb@^@ & S\textunderscore rolling\textunderscore boulder\textunderscore trap  &	(rolling boulder trap)\\
+\verb@.@ & S\textunderscore room                    &	(floor of a room)\\
+\verb@/@ & S\textunderscore rslant                  &	(wall)\\
+\verb@^@ & S\textunderscore rust\textunderscore trap              &	(rust trap)\\
+\verb@R@ & S\textunderscore rustmonst               &	(rust monster or disenchanter)\\
+\verb@?@ & S\textunderscore scroll                  &	(scroll)\\
+\# & S\textunderscore sink                    &	(sink)\\
+\verb@^@ & S\textunderscore sleeping\textunderscore gas\textunderscore trap     &	(sleeping gas trap)\\
+\verb@S@ & S\textunderscore snake                   &	(snake)\\
+\verb@s@ & S\textunderscore spider                  &	(arachnid or centipede)\\
+\verb@^@ & S\textunderscore spiked\textunderscore pit             &	(spiked pit)\\
+\verb@^@ & S\textunderscore squeaky\textunderscore board          &	(squeaky board)\\
+\verb@0@ & S\textunderscore ss1                     &	(magic shield 1 of 4)\\
+\# & S\textunderscore ss2                     &	(magic shield 2 of 4)\\
+\verb+@+ & S\textunderscore ss3                     &	(magic shield 3 of 4)\\
+\verb@*@ & S\textunderscore ss4                     &	(magic shield 4 of 4)\\
+\verb@^@ & S\textunderscore statue\textunderscore trap            &	(statue trap)\\
+\verb@ @ & S\textunderscore stone                   &	(solid rock)\\
+\verb@]@ & S\textunderscore strange\textunderscore obj      &	(strange object)\\
+\verb@-@ & S\textunderscore sw\textunderscore bc                  &	(swallow bottom center)\\
+\verb@\@ & S\textunderscore sw\textunderscore bl                  &	(swallow bottom left)\\
+\verb@/@ & S\textunderscore sw\textunderscore br                  &	(swallow bottom right	)\\
+\verb@|@ & S\textunderscore sw\textunderscore ml                  &	(swallow middle left)\\
+\verb@|@ & S\textunderscore sw\textunderscore mr                  &	(swallow middle right)\\
+\verb@-@ & S\textunderscore sw\textunderscore tc                  &	(swallow top center)\\
+\verb@/@ & S\textunderscore sw\textunderscore tl                  &	(swallow top left)\\
+\verb@\@ & S\textunderscore sw\textunderscore tr                  &	(swallow top right)\\
+\verb@-@ & S\textunderscore tdwall                  &	(wall)\\
+\verb@^@ & S\textunderscore teleportation\textunderscore trap     &	(teleportation trap)\\
+\verb@\@ & S\textunderscore throne                  &	(opulent throne)\\
+\verb@-@ & S\textunderscore tlcorn                  &	(top left corner)\\
+\verb@|@ & S\textunderscore tlwall                  &	(wall)\\
+\verb@(@ & S\textunderscore tool                    &	(useful item (pick-axe, key, lamp...))\\
+\verb@^@ & S\textunderscore trap\textunderscore door              &	(trap door)\\
+\verb@t@ & S\textunderscore trapper                 &	(trapper or lurker above)\\
+\verb@-@ & S\textunderscore trcorn                  &	(top right corner)\\
+\# & S\textunderscore tree                    &	(tree)\\
+\verb@T@ & S\textunderscore troll                   &	(troll)\\
+\verb@|@ & S\textunderscore trwall                  &	(wall)\\
+\verb@-@ & S\textunderscore tuwall                  &	(wall)\\
+\verb@U@ & S\textunderscore umber                   &	(umber hulk)\\
+\verb@ @ & S\textunderscore unexplored              &	(unexplored terrain)\\
+\verb@u@ & S\textunderscore unicorn                 &	(unicorn or horse)\\
+\verb@<@ & S\textunderscore upladder                &	(ladder up)\\
+\verb@<@ & S\textunderscore upstair                 &	(staircase up)\\
+\verb@V@ & S\textunderscore vampire                 &	(vampire)\\
+\verb@|@ & S\textunderscore vbeam                   &	(wall)\\
+\# & S\textunderscore vcdbridge               &	(vertical raised drawbridge)\\
+\verb@+@ & S\textunderscore vcdoor                  &	(closed door)\\
+\verb@.@ & S\textunderscore venom                   &	(splash of venom)\\
+\verb@^@ & S\textunderscore vibrating\textunderscore square       &	(vibrating square)\\
+\verb@.@ & S\textunderscore vodbridge               &	(vertical lowered drawbridge)\\
+\verb@-@ & S\textunderscore vodoor                  &	(open door)\\
+\verb@v@ & S\textunderscore vortex                  &	(vortex)\\
+\verb@|@ & S\textunderscore vwall                   &	(vertical wall)\\
+\verb@/@ & S\textunderscore wand                    &	(wand)\\
+\verb@}@ & S\textunderscore water                   &	(water)\\
+\verb@)@ & S\textunderscore weapon                  &	(weapon)\\
+\verb@"@ & S\textunderscore web                     &	(web)\\
+\verb@w@ & S\textunderscore worm                    &	(worm)\\
+\verb@~@ & S\textunderscore worm\textunderscore tail              &	(long worm tail)\\
+\verb@W@ & S\textunderscore wraith                  &	(wraith)\\
+\verb@x@ & S\textunderscore xan                     &	(xan or other extraordinary insect)\\
+\verb@X@ & S\textunderscore xorn                    &	(xorn)\\
+\verb@Y@ & S\textunderscore yeti                    &	(apelike creature)\\
+\verb@Z@ & S\textunderscore zombie                  &	(zombie)\\
+\verb@z@ & S\textunderscore zruty                   &	(zruty)\\
+\verb@ @ & S\textunderscore pet\textunderscore override     &	(any pet if ACCESSIBILITY=1 is set)\\
+\verb@ @ & S\textunderscore hero\textunderscore override    &	(hero if ACCESSIBILITY=1 is set)
 \end{longtable}%
 }
 
@@ -6582,16 +6579,16 @@ Notes:
 
 %.lp "*"
 Several symbols in this table appear to be blank.
-They are the space character, except for S\verb+_+pet\verb+_+override
-and S\verb+_+hero\verb+_+override which don't have any default value
+They are the space character, except for S\textunderscore pet\textunderscore override
+and S\textunderscore hero\textunderscore override which don't have any default value
 and can only be used if enabled in the ``sysconf'' file.
 
 %.lp "*"
-S\verb+_+rock is misleadingly named; rocks and stones use S\verb+_+gem.
+S\textunderscore rock is misleadingly named; rocks and stones use S\textunderscore gem.
 Statues and boulders are the rock being referred to, but since
 version 3.6.0, statues are displayed as the monster they depict.
-So S\verb+_+rock is only used for boulders and not used at all if
-overridden by the more specific S\verb+_+boulder.
+So S\textunderscore rock is only used for boulders and not used at all if
+overridden by the more specific S\textunderscore boulder.
 
 %.lp
 %.hn 2
@@ -6615,7 +6612,7 @@ character sequences and explicit 24-bit red-green-blue colors in order for the g
 representation to be visible as specified.
 
 For example, the following line in your configuration file will cause
-the glyph representation for glyphid G\verb+_+pool to use Unicode codepoint
+the glyph representation for glyphid G\textunderscore pool to use Unicode codepoint
 U+224B and the color represented by R-G-B value 0-0-160:\\
 \begin{verbatim}
 OPTIONS=glyph:G_pool/U+224B/0-0-160
@@ -6625,8 +6622,8 @@ The list of acceptable glyphid's can be produced by
 \begin{verbatim}
     nethack --glyphids
 \end{verbatim}
-Individual NetHack glyphs can be specified using the G\verb+_+ prefix,
-or you can use an S\verb+_+ symbol for a glyphid and store the custom
+Individual NetHack glyphs can be specified using the G\textunderscore prefix,
+or you can use an S\textunderscore symbol for a glyphid and store the custom
 representation for all NetHack glyphs that would map to that
 particular symbol.
 
@@ -6678,50 +6675,50 @@ Load a symbol set appropriate for use by blind players.
 \item[\ib{menustyle:traditional}]
 This will assist in the interface to speech synthesizers.
 %.lp
-\item[\ib{nomenu\verb+_+overlay}]
+\item[\ib{nomenu\textunderscore overlay}]
 Show menus on a cleared screen and aligned to the left edge.
 %.lp
-\item[\ib{number\verb+_+pad}]
+\item[\ib{number\textunderscore pad}]
 A lot of speech access programs use the number-pad to review the screen.
-If this is the case, disable the number\verb+_+pad option and use the
+If this is the case, disable the number\textunderscore pad option and use the
 traditional Rogue-like commands.
 %.lp
-\item[\ib{paranoid\verb+_+confirmation:swim}]
+\item[\ib{paranoid\textunderscore confirmation:swim}]
 Prevent walking into water or lava.
 %.lp
 \item[\ib{accessiblemsg}]
 Adds direction or location information to messages.
 %.lp
-\item[\ib{spot\verb+_+monsters}]
+\item[\ib{spot\textunderscore monsters}]
 Shows a message when hero notices a monster; combine with accessiblemsg.
 %.lp
-\item[\ib{mon\verb+_+movement}]
+\item[\ib{mon\textunderscore movement}]
 Shows a message when hero notices a monster movement;
-combine with spot\verb+_+monsters and accessiblemsg.
+combine with spot\textunderscore monsters and accessiblemsg.
 %.lp
 \item[\ib{autodescribe}]
 Automatically describe the terrain under the cursor when targeting.
 %.lp
-\item[\ib{mention\verb+_+map}]
+\item[\ib{mention\textunderscore map}]
 Give feedback messages when interesting map locations change.
 %.lp
-\item[\ib{mention\verb+_+walls}]
+\item[\ib{mention\textunderscore walls}]
 Give feedback messages when walking towards a wall or when travel command
 was interrupted.
 %.lp
-\item[\ib{whatis\verb+_+coord:compass}]
+\item[\ib{whatis\textunderscore coord:compass}]
 When targeting with cursor, describe the cursor position with coordinates
 relative to your character.
 %.lp
-\item[\ib{whatis\verb+_+filter:area}]
+\item[\ib{whatis\textunderscore filter:area}]
 When targeting with cursor, filter possible locations so only those in
 the same area (eg. same room, or same corridor) are considered.
 %.lp
-\item[\ib{whatis\verb+_+moveskip}]
+\item[\ib{whatis\textunderscore moveskip}]
 When targeting with cursor and using fast-move, skip the same glyphs instead
 of moving 8 units at a time.
 %.lp
-\item[\ib{nostatus\verb+_+updates}]
+\item[\ib{nostatus\textunderscore updates}]
 Prevent updates to the status lines at the bottom of the screen, if
 your screen-reader reads those lines. The same information can be
 seen via the {\tt \#attributes} command.
@@ -6779,11 +6776,11 @@ A string explaining how to recover a game on this system (no default value).
 0 or 1 to disable or enable, respectively, the SEDUCE option.
 When disabled, incubi and succubi behave like nymphs.
 %.lp
-\item[\ib{CHECK\verb+_+PLNAME}]
+\item[\ib{CHECK\textunderscore PLNAME}]
 Setting this to 1 will make the EXPLORERS, WIZARDS, and SHELLERS check
 for the player name instead of the user's login name.
 %.lp
-\item[\ib{CHECK\verb+_+SAVE\verb+_+UID}]
+\item[\ib{CHECK\textunderscore SAVE\textunderscore UID}]
 0 or 1 to disable or enable, respectively, the UID
 (used identification number) checking for save files (to verify that the
 user who is restoring is the same one who saved).
@@ -6803,7 +6800,7 @@ Maximum number of entries in the score file.
 \item[\ib{POINTSMIN}]
 Minimum number of points to get an entry in the score file.
 %.lp
-\item[\ib{PERS\verb+_+IS\verb+_+UID}]
+\item[\ib{PERS\textunderscore IS\textunderscore UID}]
 0 or 1 to use user names or numeric userids, respectively, to identify
 unique people for the score file.
 %.lp
@@ -6811,16 +6808,16 @@ unique people for the score file.
 0 or 1 to control whether the help menu entry for command
 line usage is shown or suppressed.
 %.lp
-\item[\ib{MAX\verb+_+STATUENAME\verb+_+RANK}]
+\item[\ib{MAX\textunderscore STATUENAME\textunderscore RANK}]
 Maximum number of score file entries to use for
 random statue names (default is 10).
 %.lp
 \item[\ib{ACCESSIBILITY}]
 0 or 1 to disable or enable, respectively, the ability for players
-to set S\verb+_+pet\verb+_+override and S\verb+_+hero\verb+_+override 
+to set S\textunderscore pet\textunderscore override and S\textunderscore hero\textunderscore override 
 symbols in their configuration file.
 %.lp
-\item[\ib{PORTABLE\verb+_+DEVICE\verb+_+PATHS}]
+\item[\ib{PORTABLE\textunderscore DEVICE\textunderscore PATHS}]
 0 or 1 Windows OS only, the game will look for all of its external
 files, and write to all of its output files in one place 
 rather than at the standard locations.

--- a/doc/Guidebook.tex
+++ b/doc/Guidebook.tex
@@ -1,13 +1,8 @@
 % NetHack 3.7  Guidebook.tex $NHDT-Date: 1745139202 2025/04/20 00:53:22 $  $NHDT-Branch: NetHack-3.7 $:$NHDT-Revision: 1.579 $ */
-\documentclass[titlepage, a4paper]{article}
+\documentclass[titlepage]{article}
 \usepackage{hyperref}
 \usepackage{longtable}
-
-\textheight 220mm
-\textwidth 160mm
-\oddsidemargin 0mm
-\evensidemargin 0mm
-\topmargin 0mm
+\usepackage[a4paper, text={160mm, 220mm}, centering]{geometry}
 
 \newcommand{\nd}{\noindent}
 

--- a/doc/Guidebook.tex
+++ b/doc/Guidebook.tex
@@ -2,21 +2,16 @@
 \documentclass[titlepage]{article}
 \usepackage{hyperref}
 \usepackage{longtable}
+\usepackage{enumitem}
 \usepackage[a4paper, text={160mm, 220mm}, centering]{geometry}
+
+\setlist[description]{leftmargin=30mm, topsep=2mm, partopsep=0mm, parsep=0mm, itemsep=1mm, labelwidth=28mm, labelsep=2mm}
 
 \newcommand{\nd}{\noindent}
 
 \newcommand{\tb}[1]{\tt #1 \hfill}
 \newcommand{\bb}[1]{\bf #1 \hfill}
 \newcommand{\ib}[1]{\it #1 \hfill}
-
-\newcommand{\blist}[1]
-{\begin{list}{$\bullet$}
-    {\leftmargin 30mm \topsep 2mm \partopsep 0mm \parsep 0mm \itemsep 1mm
-     \labelwidth 28mm \labelsep 2mm
-     #1}}
-
-\newcommand{\elist}{\end{list}}
 
 \hyphenation{CRASHREPORTURL}
 
@@ -104,24 +99,24 @@ will vary with your background and training:
 
 %.pg
 %
-\blist{}
-\item[\bb{Archeologists}]%
+\begin{description}
+\item[Archeologists]
 understand dungeons pretty well; this enables them
 to move quickly and sneak up on the local nasties.  They start equipped
 with the tools for a proper scientific expedition.
 %.pg
 %
-\item[\bb{Barbarians}]%
+\item[Barbarians]
 are warriors out of the hinterland, hardened to battle.
 They begin their quests with naught but uncommon strength, a trusty hauberk,
 and a great two-handed sword.
 %.pg
 %
-\item[\bb{Cavemen {\rm and} Cavewomen}]
+\item[Cavemen \textrm{and} Cavewomen]
 start with exceptional strength, but unfortunately, neolithic weapons.
 %.pg
 %
-\item[\bb{Healers}]%
+\item[Healers]
 are wise in medicine and apothecary.  They know the
 herbs and simples that can restore vitality, ease pain, anesthetize,
 and neutralize
@@ -130,61 +125,61 @@ of health or sickness.  Their medical practice earns them quite reasonable
 amounts of money, with which they enter the dungeon.
 %.pg
 %
-\item[\bb{Knights}]%
+\item[Knights]
 are distinguished from the common skirmisher by their
 devotion to the ideals of chivalry and by the surpassing excellence of
 their armor.
 %.pg
 %
-\item[\bb{Monks}]%
+\item[Monks]
 are ascetics, who by rigorous practice of physical and mental
 disciplines have become capable of fighting as effectively without weapons
 as with.  They wear no armor but make up for it with increased mobility.
 %.pg
 %
-\item[\bb{Priests {\rm and} Priestesses}]%
+\item[Priests \textrm{and} Priestesses]
 are clerics militant, crusaders
 advancing the cause of righteousness with arms, armor, and arts
 thaumaturgic.  Their ability to commune with deities via prayer
 occasionally extricates them from peril, but can also put them in it.
 %.pg
 %
-\item[\bb{Rangers}]%
+\item[Rangers]
 are most at home in the woods, and some say slightly out
 of place in a dungeon.  They are, however, experts in archery as well
 as tracking and stealthy movement.
 %.pg
 %
-\item[\bb{Rogues}]%
+\item[Rogues]
 are agile and stealthy thieves, with knowledge of locks,
 traps, and poisons.  Their advantage lies in surprise, which they employ
 to great advantage.
 %.pg
 %
-\item[\bb{Samurai}]%
+\item[Samurai]
 are the elite warriors of feudal Nippon.  They are lightly
 armored and quick, and wear the %
 {\it dai-sho}, two swords of the deadliest
 keenness.
 %.pg
 %
-\item[\bb{Tourists}]%
+\item[Tourists]
 start out with lots of gold (suitable for shopping with),
 a credit card, lots of food, some maps, and an expensive camera.  Most
 monsters don't like being photographed.
 %.pg
 %
-\item[\bb{Valkyries}]%
+\item[Valkyries]
 are hardy warrior women.  Their upbringing in the harsh
 Northlands makes them strong, inures them to extremes of cold, and instills
 in them stealth and cunning.
 %.pg
 %
-\item[\bb{Wizards}]%
+\item[Wizards]
 start out with a knowledge of magic, a selection of magical
 items, and a particular affinity for dweomercraft.  Although seemingly weak
 and easy to overcome at first sight, an experienced Wizard is a deadly foe.
-\elist
+\end{description}
 
 %.pg
 You may also choose the race of your character (within limits; most
@@ -192,39 +187,39 @@ roles have restrictions on which races are eligible for them):
 
 %.pg
 %
-\blist{}
-\item[\bb{Dwarves}]%
+\begin{description}
+\item[Dwarves]
 are smaller than humans or elves, but are stocky and solid
 individuals.  Dwarves' most notable trait is their great expertise in mining
 and metalwork.  Dwarvish armor is said to be second in quality not even to the
 mithril armor of the Elves.
 %.pg
 %
-\item[\bb{Elves}]%
+\item[Elves]
 are agile, quick, and perceptive; very little of what goes
 on will escape an Elf.  The quality of Elven craftsmanship often gives
 them an advantage in arms and armor.
 %.pg
 %
-\item[\bb{Gnomes}]%
+\item[Gnomes]
 are smaller than but generally similar to dwarves.  Gnomes are
 known to be expert miners, and it is known that a secret underground mine
 complex built by this race exists within the Mazes of Menace, filled with
 both riches and danger.
 %.pg
 %
-\item[\bb{Humans}]%
+\item[Humans]
 are by far the most common race of the surface world, and
 are thus the norm to which other races are often compared.  Although
 they have no special abilities, they can succeed in any role.
 %.pg
 %
-\item[\bb{Orcs}]%
+\item[Orcs]
 are a cruel and barbaric race that hate every living thing
 (including other orcs).  Above all others, Orcs hate Elves with a passion
 unequalled, and will go out of their way to kill one at any opportunity.
 The armor and weapons fashioned by the Orcs are typically of inferior quality.
-\elist
+\end{description}
 
 %.hn 1
 \section{What do all those things on the screen mean?}
@@ -339,12 +334,12 @@ the third line.
 Here are explanations of what the various status items mean:
 
 %.lp
-\blist{}
-\item[\bb{Title}]
+\begin{description}
+\item[Title]
 Your character's name and professional ranking (based on role and
 {\it experience level\/}, see below).
 %.lp
-\item[\bb{Strength}]
+\item[Strength]
 A measure of your character's strength; one of your six basic
 attributes.  A human character's attributes can range from 3 to 18 inclusive;
 non-humans may exceed these limits
@@ -354,29 +349,29 @@ higher your strength, the stronger you are.  Strength affects how
 successfully you perform physical tasks, how much damage you do in
 combat, and how much loot you can carry.
 %.lp
-\item[\bb{Dexterity}]
+\item[Dexterity]
 Dexterity affects your chances to hit in combat, to avoid traps, and
 do other tasks requiring agility or manipulation of objects.
 %.lp
-\item[\bb{Constitution}]
+\item[Constitution]
 Constitution affects your ability to recover from injuries and other
 strains on your stamina.
 When strength is low or modest, constitution also affects how much you
 can carry.  With sufficiently high strength, the contribution to
 carrying capacity from your constitution no longer matters.
 %.lp
-\item[\bb{Intelligence}]
+\item[Intelligence]
 Intelligence affects your ability to cast spells and read spellbooks.
 %.lp
-\item[\bb{Wisdom}]
+\item[Wisdom]
 Wisdom comes from your practical experience (especially when dealing with
 magic).  It affects your magical energy.
 %.lp
-\item[\bb{Charisma}]
+\item[Charisma]
 Charisma affects how certain creatures react toward you.  In
 particular, it can affect the prices shopkeepers offer you.
 %.lp
-\item[\bb{Alignment}]
+\item[Alignment]
 %
 {\it Lawful}, {\it Neutral\/} or {\it Chaotic}.  Often, Lawful is
 taken as good and Chaotic as evil, but legal and ethical do not always
@@ -385,35 +380,35 @@ monsters react toward you.  Monsters of a like alignment are more likely
 to be non-aggressive, while those of an opposing alignment are more likely
 to be seriously offended at your presence.
 %.lp
-\item[\bb{Dungeon Level}]
+\item[Dungeon Level]
 How deep you are in the dungeon.  You start at level one and the number
 increases as you go deeper into the dungeon.  Some levels are special,
 and are identified by a name and not a number.  The Amulet of Yendor is
 reputed to be somewhere beneath the twentieth level.
 %.lp
-\item[\bb{Gold}]
+\item[Gold]
 The number of gold pieces you are openly carrying.  Gold which you have
 concealed in containers is not counted.
 %.lp
-\item[\bb{Hit Points}]
+\item[Hit Points]
 Your current and maximum hit points.  Hit points indicate how much
 damage you can take before you die.  The more you get hit in a fight,
 the lower they get.  You can regain hit points by resting, or by using
 certain magical items or spells.  The number in parentheses is the maximum
 number your hit points can reach.
 %.lp
-\item[\bb{Power}]
+\item[Power]
 Spell points.  This tells you how much mystic energy ({\it mana\/})
 you have available for spell casting.  Again, resting will regenerate the
 amount available.
 %.lp
-\item[\bb{Armor Class}]
+\item[Armor Class]
 A measure of how effectively your armor stops blows from unfriendly
 creatures.  The lower this number is, the more effective the armor; it
 is quite possible to have negative armor class.
 See the {\it Armor\/} subsection of {\it Objects\/} for more information.
 %.lp
-\item[\bb{Experience}]
+\item[Experience]
 Your current experience level.
 If the {\it showexp\/}
 option is set, it will be followed by a slash and experience points.
@@ -426,11 +421,11 @@ the points with it has dropped significantly.
 You can use the `{\tt O}' command to turn {\it showexp\/}
 off to avoid using up the limited status line space.)
 %.lp
-\item[\bb{Time}]
+\item[Time]
 The number of turns elapsed so far, displayed if you have the
 {\it time\/} option set.
 %.lp
-\item[\bb{Status}]
+\item[Status]
 Hunger:
 your current hunger status.
 Values are {\it Satiated}, {\it Not~Hungry\/} (or {\it Normal\/}),
@@ -472,7 +467,7 @@ all current status information in unabbreviated format.
 It also shows other information which might be included on the status
 lines if those had more room.
 
-\elist
+\end{description}
 
 %.hn 2
 \subsection*{The message line (top)}
@@ -501,88 +496,88 @@ options to change some of the symbols the game uses; otherwise, the
 game will use default symbols.  Here is a list of what the default
 symbols mean:
 
-\blist{}
-\item[\tb{-}]
+\begin{description}[font=\ttfamily]
+\item[-]
 The horizontal or corner walls of a room, or an open east/west door.
-\item[\tb{|}]
+\item[|]
 The vertical walls of a room, or an open north/south door, or a grave.
-\item[\tb{.}]
+\item[.]
 The floor of a room, or ice, or a doorless doorway, or the span of an
 open drawbridge.
-\item[\tb{\#}]
+\item[\#]
 A corridor, or iron bars, or a tree, or the portcullis of a closed
 drawbridge.\\
 %.lp ""
 Note: engravings in corridors also appear as \# but are shown in
 a different color from normal corridor locations.
-\item[\tb{>}]
+\item[>]
 Stairs down: a way to the next level.
-\item[\tb{<}]
+\item[<]
 Stairs up: a way to the previous level.
-\item[\tb{+}]
+\item[+]
 A closed door, or a spellbook containing a spell you may be able to learn.
-\item[\tb{@}]
+\item[@]
 Your character or a human or an elf.
-\item[\tb{\$}]
+\item[\textdollar]
 A pile of gold.
-\item[\tb{\^}]
+\item[\textasciicircum]
 A trap (once you have detected it).
-\item[\tb{)}]
+\item[)]
 A weapon.
-\item[\tb{[}]
+\item[{[}]
 A suit or piece of armor.
-\item[\tb{\%}]
+\item[\%]
 Something edible (not necessarily healthy).
-\item[\tb{?}]
+\item[?]
 A scroll.
-\item[\tb{/}]
+\item[/]
 A wand.
-\item[\tb{=}]
+\item[=]
 A ring.
-\item[\tb{!}]
+\item[!]
 A potion.
-\item[\tb{(}]
+\item[(]
 A useful item (pick-axe, key, lamp \ldots).
-\item[\tb{"}]
+\item["]
 An amulet or a spider web.
-\item[\tb{*}]
+\item[*]
 A gem or rock (possibly valuable, possibly worthless).
-\item[\tb{\`}]
+\item[\textasciigrave]
 A boulder or statue or an engraving on the floor of a room.\\
 %.lp ""
 Note: statues are displayed as if they were the monsters they depict
 so won't appear as a {\it grave accent\/} (aka {\it back-tick}).
-\item[\tb{0}]
+\item[0]
 An iron ball.
-\item[\tb{\textunderscore}]
+\item[\textunderscore]
 An altar, or an iron chain.
-\item[\tb{\{}]
+\item[\textbraceleft]
 A fountain or a sink.
-\item[\tb{\}}]
+\item[\textbraceright]
 A pool of water or moat or a wall of water
 or a pool of lava or a wall of lava.
-\item[\tb{$\backslash$}]
+\item[\textbackslash]
 An opulent throne.
-\item[\tb{a-z}] {\normalfont and}]
-\item[\tb{A-HJ-Z}] {\normalfont and}]
-%should probably change \item[\tb{@\&\textquotesingle:;}] to \item[\tb{\verb+@&':;+}]
-\item[\tb{@\&\textquotesingle:;}]
+\item[a-z \textrm{\textmd{and}}]
+\item[A-HJ-Z \textrm{\textmd{and}}]
+%should probably change \item[@\&\textquotesingle:;] to \item[\verb+@&':;+]
+\item[@\&\textquotesingle :;]
 Letters and certain other symbols represent the various inhabitants
 of the Mazes of Menace.
 Watch out, they can be nasty and vicious.
 Sometimes, however, they can be helpful.
-\item[\tb{I}]
+\item[I]
 Rather than a specific type of monster, this marks the last known
 location of an invisible or otherwise unseen monster.
 Note that the monster could have moved.
 The `{\tt s}', `{\tt F}', and `{\tt m}' commands may be useful here.
-\item[\tb{1-5}]
+\item[1-5]
 The digits 1 through 5 may be displayed, marking unseen monsters sensed
 via the {\it Warning\/} attribute.
 Less dangerous monsters are indicated by lower values, more dangerous by
 higher values.
 
-\elist
+\end{description}
 %.pg
 You need not memorize all these symbols; you can ask the game what any
 symbol represents with the `{\tt /}' command (see the next section for
@@ -632,12 +627,12 @@ The list of commands is rather long, but it can be read at any time
 during the game through the `{\tt ?}' command, which accesses a menu of
 helpful texts.  Here are the default key bindings for your reference:
 
-\blist{}
+\begin{description}[font=\ttfamily]
 %.lp
-\item[\tb{?}]
+\item[?]
 Help menu:  display one of several help texts available.
 %.lp
-\item[\tb{/}]
+\item[/]
 The {\tt whatis} command, to
 tell what a symbol represents.  You may choose to specify a location
 or type a symbol (or even a whole word) to explain.
@@ -677,16 +672,16 @@ The
 option controls which format of map coordinate is included with their
 descriptions.
 %.lp
-\item[\tb{\&}]
+\item[\&]
 Tell what a command does.
 %.lp
-\item[\tb{<}]
+\item[<]
 Go up to the previous level (if you are on a staircase or ladder).
 %.lp
-\item[\tb{>}]
+\item[>]
 Go down to the next level (if you are on a staircase or ladder).
 %.lp
-\item[\tb{[yuhjklbn]}]
+\item[{[yuhjklbn]}]
 Go one step in the direction indicated (see Figure 3).  If you sense
 or remember
 a monster there, you will fight the monster instead.  Only these
@@ -708,10 +703,10 @@ one-step movement commands cause you to fight monsters; the others
 Figure 3
 \end{center}
 %.lp
-\item[\tb{[YUHJKLBN]}]
+\item[{[YUHJKLBN]}]
 Go in that direction until you hit a wall or run into something.
 %.lp
-\item[\tb{m[yuhjklbn]}]
+\item[m{[yuhjklbn]}]
 Prefix:  move without picking up objects or fighting (even if you remember
 a monster there).\\
 %.lp ""
@@ -746,13 +741,13 @@ skip containers and go straight to adjacent monsters.
 In debug mode (aka ``wizard mode''), the `{\tt m}' prefix may also be
 used with the ``{\tt \#teleport}'' and ``{\tt \#wizlevelport}'' commands.
 %.lp
-\item[\tb{F[yuhjklbn]}]
+\item[F{[yuhjklbn]}]
 Prefix:  fight a monster (even if you only guess one is there).
 %.lp
-\item[\tb{g[yuhjklbn]}]
+\item[g{[yuhjklbn]}]
 Prefix:  Move until something interesting is found.
 %.lp
-\item[\tb{G[yuhjklbn] {\rm or} <Control>+[yuhjklbn]}]
+\item[G{[yuhjklbn]} \textrm{\textmd{or}} <Control>+{[yuhjklbn]}]
 Prefix:  Similar to `{\tt g}', but forking of corridors is not considered
 interesting.
 \\
@@ -762,7 +757,7 @@ Note:  {\tt <Control>+<key>} means holding the {\tt <Control>} or
 shorthand elsewhere in the Guidebook to mean the same thing.  Control
 characters are case-insensitive so {\tt \^{}x} and {\tt \^{}X} are the same.
 %.lp
-\item[\tb{M[yuhjklbn]}]
+\item[M{[yuhjklbn]}]
 Old versions supported `{\tt M}' as a movement prefix which
 combined the effect of `{\tt m}' with {\tt <Control>+<direction>}.
 That is no longer supported as a prefix but similar effect can be achieved
@@ -770,7 +765,7 @@ by using {\tt m} and {\tt G<direction>} in combination.
 {\tt m} can also be used in combination with {\tt g<direction>},
 {\tt <Control>+<direction>}, or {\tt <Shift>+<direction>}.
 %.lp
-\item[\tb{\tt \textunderscore }]
+\item[\textunderscore]
 Travel to a map location via a shortest-path algorithm.\\
 %.lp ""
 The shortest path
@@ -784,45 +779,45 @@ For ports with mouse
 support, the command is also invoked when a mouse-click takes place on a
 location other than the current position.
 %.lp
-\item[\tb{.}]
+\item[.]
 Wait or rest, do nothing for one turn.
 Precede with the `{\tt m}' prefix
 to wait for a turn even next to a hostile monster, if {\it safe\textunderscore wait\/}
 is on.
 %.lp
-\item[\tb{a}]
+\item[a]
 Apply (use) a tool (pick-axe, key, lamp \ldots).\\
 %.lp ""
 If used on a wand, that wand will be broken, releasing its magic in the
 process.
 Confirmation is required.
 %.lp
-\item[\tb{A}]
+\item[A]
 Remove one or more worn items, such as armor.\\
 %.lp ""
 Use `{\tt T}' (take off) to take off only one piece of armor
 or `{\tt R}' (remove) to take off only one accessory.
 %.lp
-\item[\tb{\^{}A}]
+\item[\textasciicircum A]
 Repeat the previous command.
 %.lp
-\item[\tb{c}]
+\item[c]
 Close a door.
 %.lp
-\item[\tb{C}]
+\item[C]
 Call (name) a monster, an individual object, or a type of object.\\
 %.lp ""
 Same as extended command ``{\tt \#name}''.
 %.lp
-\item[\tb{\^{}C}]
+\item[\textasciicircum C]
 Panic button.  Quit the game.
 %.lp
-\item[\tb{d}]
+\item[d]
 Drop something.\\
 For example {\tt d7a} --- drop seven items of object
 {\it a}.
 %.lp
-\item[\tb{D}]
+\item[D]
 Drop several things.\\
 %.lp ""
 In answer to the question\\
@@ -866,10 +861,10 @@ Lastly, you may specify multiple values within multiple categories:
 blessed or uncursed.
 (In versions prior to 3.6, filter combinations behaved differently.)
 %.lp
-\item[\tb{\^{}D}]
+\item[\textasciicircum D]
 Kick something (usually a door).
 %.lp
-\item[\tb{e}]
+\item[e]
 Eat food.\\
 %.lp ""
 Normally checks for edible item(s) on the floor, then if none are found
@@ -888,7 +883,7 @@ option to require a response of ``{\tt yes}'' instead of just `{\tt y}'.
 % (Only specified here to parallel Guidebook.mn; use of \tt font implicitly
 % prevents automatic hyphenation in TeX and LaTeX.)
 \hyphenation{Elbereth}		%override the deduced syllable breaks
-\item[\tb{E}]
+\item[E]
 Engrave a message on the floor.\\
 %.sd
 %.si
@@ -900,7 +895,7 @@ Engraving the word ``{\tt Elbereth}'' will cause most monsters to not attack
 you hand-to-hand (but if you attack, you will rub it out); this is
 often useful to give yourself a breather.
 %.lp
-\item[\tb{f}]
+\item[f]
 Fire (shoot or throw) one of the objects placed in your quiver (or
 quiver sack, or that you have at the ready).
 You may select ammunition with a previous `{\tt Q}' command, or let the
@@ -917,10 +912,10 @@ Remember to swap back to your main melee weapon afterwards.
 \\
 See also `{\tt t}' (throw) for more general throwing and shooting.
 %.lp
-\item[\tb{i}]
+\item[i]
 List your inventory (everything you're carrying).
 %.lp
-\item[\tb{I}]
+\item[I]
 List selected parts of your inventory, usually be specifying the character
 for a particular set of objects, like `{\tt [}' for armor or `{\tt !}'
 for potions.\\
@@ -938,10 +933,10 @@ for potions.\\
 %.ei
 %.ed
 %.lp
-\item[\tb{o}]
+\item[o]
 Open a door.
 %.lp
-\item[\tb{O}]
+\item[O]
 Set options.\\
 %.lp ""
 A menu showing the current option values will be
@@ -954,7 +949,7 @@ are listed later in this Guidebook.  Options are usually set before the
 game rather than with the `{\tt O}' command; see the section on options below.
 Precede {\tt O} with the {\tt m} prefix to show advanced options.
 %.lp
-\item[\tb{\^{}O}]
+\item[\textasciicircum O]
 Show overview.\\
 %.lp ""
 Shortcut for ``{\tt \#overview}'':
@@ -964,10 +959,10 @@ list interesting dungeon levels visited.\\
 the placement of all special levels.
 Use ``{\tt \#wizwhere}'' to run that command.)
 %.lp
-\item[\tb{p}]
+\item[p]
 Pay your shopping bill.
 %.lp
-\item[\tb{P}]
+\item[P]
 Put on an accessory (ring, amulet, or blindfold).\\
 %.lp ""
 This command may also be used to wear armor.  The prompt for
@@ -976,14 +971,14 @@ an unlisted item of armor will attempt to wear it.
 (See the `{\tt W}' command below.  It lists armor as the inventory
 choices but will accept an accessory and attempt to put that on.)
 %.lp
-\item[\tb{\^{}P}]
+\item[\textasciicircum P]
 Repeat previous message.\\
 %.lp ""
 Subsequent {\tt \^{}P}'s repeat earlier messages.
 For some interfaces, the behavior can be varied via the
 {\it msg\textunderscore window\/} option.
 %.lp
-\item[\tb{q}]
+\item[q]
 Quaff (drink) something (potion, water, etc).\\
 %.lp ""
 When there is a fountain or sink present, it asks whether to drink
@@ -993,15 +988,15 @@ inventory.
 Precede {\tt q} with the {\tt m} prefix to skip asking about
 drinking from a fountain or sink.
 %.lp
-\item[\tb{Q}]
+\item[Q]
 Select an object for your quiver, quiver sack, or just generally at
 the ready (only one of these is available at a time).  You can then throw
 this (or one of these) using the `{\tt f}' command.
 %.lp
-\item[\tb{r}]
+\item[r]
 Read a scroll or spellbook.
 %.lp
-\item[\tb{R}]
+\item[R]
 Remove a worn accessory (ring, amulet, or blindfold).\\
 %.lp ""
 If you're wearing more than one, you'll be prompted for which one to
@@ -1016,10 +1011,10 @@ worn armor can be chosen.
 (See the `{\tt T}' command below.  It lists armor as the inventory
 choices but will accept an accessory and attempt to remove it.)
 %.lp
-\item[\tb{\^{}R}]
+\item[\textasciicircum R]
 Redraw the screen.
 %.lp
-\item[\tb{s}]
+\item[s]
 Search for secret doors and traps around you.
 It usually takes several tries to find something.
 Precede with the `{\tt m}' prefix to wait for a turn
@@ -1029,7 +1024,7 @@ is on.\\
 Can also be used to figure out whether there is still a monster at
 an adjacent ``remembered, unseen monster'' marker.
 %.lp
-\item[\tb{S}]
+\item[S]
 Save the game (which suspends play and exits the program).
 The saved game will be restored automatically the next time you play
 using the same character name.\\
@@ -1044,7 +1039,7 @@ without saving and later restore again.\\
 There is no ``save current game state and keep playing'' command, not
 even in explore mode where saved game files can be kept and re-used.
 %.lp
-\item[\tb{t}]
+\item[t]
 Throw an object or shoot a projectile.\\
 %.lp ""
 There's no separate ``shoot'' command.
@@ -1056,7 +1051,7 @@ it by hand and it will generally be less effective than when shot.\\
 See also `{\tt f}' (fire) for throwing or shooting an item pre-selected
 via the `{\tt Q}' (quiver) command, with some extra assistance.
 %.lp
-\item[\tb{T}]
+\item[T]
 Take off armor.\\
 %.lp ""
 If you're wearing more than one piece, you'll be prompted for which
@@ -1074,16 +1069,16 @@ accessory can be chosen.
 (See the `{\tt R}' command above.  It lists accessories as the inventory
 choices but will accept an item of armor and attempt to take it off.)
 %.lp
-\item[\tb{\^{}T}]
+\item[\textasciicircum T]
 Teleport, if you have the ability.
 %.lp
-\item[\tb{v}]
+\item[v]
 Display version number.
 %.lp
-\item[\tb{V}]
+\item[V]
 Display the game history.
 %.lp
-\item[\tb{w}]
+\item[w]
 Wield weapon.\\
 %.sd
 %.si
@@ -1093,7 +1088,7 @@ Wield weapon.\\
 Some characters can wield two weapons at once; use the `{\tt X}' command
 (or the ``{\tt \#twoweapon}'' extended command) to do so.
 %.lp
-\item[\tb{W}]
+\item[W]
 Wear armor.\\
 %.lp ""
 This command may also be used to put on an accessory (ring, amulet, or
@@ -1102,14 +1097,14 @@ armor, but choosing an unlisted accessory will attempt to put it on.
 (See the `{\tt P}' command above.  It lists accessories as the inventory
 choices but will accept an item of armor and attempt to wear it.)
 %.lp
-\item[\tb{x}]
+\item[x]
 Exchange your wielded weapon with the item in your alternate weapon slot.\\
 %.lp ""
 The latter is used as your secondary weapon when engaging in
 two-weapon combat.  Note that if one of these slots is empty,
 the exchange still takes place.
 %.lp
-\item[\tb{X}]
+\item[X]
 Toggle two-weapon combat, if your character can do it.  Also available
 via the ``{\tt \#twoweapon}'' extended command.\\
 %.lp ""
@@ -1117,7 +1112,7 @@ via the ``{\tt \#twoweapon}'' extended command.\\
 play to ``explore mode'', also known as ``discovery mode'', which has now
 been moved to ``{\tt \#exploremode}'' and {\tt M-X}.)
 %.lp
-\item[\tb{\^{}X}]
+\item[\textasciicircum X]
 Display basic information about your character.\\
 %.lp ""
 Displays name, role, race, gender (unless role name makes that
@@ -1131,7 +1126,7 @@ In normal play, that's all that `{\tt \^{}X}' displays.
 In explore mode, the role and status feedback is augmented by the
 information provided by {\it enlightenment\/} magic.
 %.lp
-\item[\tb{z}]
+\item[z]
 Zap a wand.\\
 %.sd
 %.si
@@ -1139,7 +1134,7 @@ Zap a wand.\\
 %.ei
 %.ed
 %.lp
-\item[\tb{Z}]
+\item[Z]
 Zap (cast) a spell.\\
 %.sd
 %.si
@@ -1147,52 +1142,52 @@ Zap (cast) a spell.\\
 %.ei
 %.ed
 %.lp
-\item[\tb{\^{}Z}]
+\item[\textasciicircum Z]
 Suspend the game (UNIX versions with job control only).
 See ``\#suspend'' below for more details.
 %.lp
-\item[\tb{:}]
+\item[:]
 Look at what is here.
 %.lp
-\item[\tb{;}]
+\item[;]
 Show what type of thing a visible symbol corresponds to.
 %.lp
-\item[\tb{,}]
+\item[,]
 Pick up some things from the floor beneath you.\\
 %.lp ""
 May be preceded by `{\tt m}' to force a selection menu.
 %.lp
-\item[\tb{@}]
+\item[@]
 Toggle the {\it autopickup\/} option on and off.
 %.lp
-\item[\tb{\^{}}]
+\item[\textasciicircum]
 Ask for the type of an adjacent trap you found earlier.
 %.lp
-\item[\tb{)}]
+\item[)]
 Tell what weapon you are wielding.
 %.lp
-\item[\tb{[}]
+\item[{]}]
 Tell what armor you are wearing.
 %.lp
-\item[\tb{=}]
+\item[=]
 Tell what rings you are wearing.
 %.lp
-\item[\tb{"}]
+\item["]
 Tell what amulet you are wearing.
 %.lp
-\item[\tb{(}]
+\item[(]
 Tell what tools you are using.
 %.lp
-\item[\tb{*}]
+\item[*]
 Tell what equipment you are using.\\
 %.lp ""
 Combines the preceding five type-specific
 commands into one.
 %.lp
-\item[\tb{\$}]
+\item[\$]
 Report the gold you're carrying, possibly shop credit and/or debt too.
 %.lp
-\item[\tb{+}]
+\item[+]
 List the spells you know.\\
 %.lp ""
 Using this command, you can also rearrange
@@ -1206,20 +1201,20 @@ pick ``reassign casting letters''.  (Any spells learned after that will
 be added to the end of the list rather than be inserted into the sorted
 ordering.)
 %.lp
-\item[\tb{$\backslash$}]
+\item[\textbackslash]
 Show what types of objects have been discovered.
 \\
 %.lp ""
 May be preceded by `{\tt m}' to select preferred display order.
 %.lp
-\item[\tb{\`}]
+\item[\textasciigrave]
 Show discovered types for one class of objects.
 \\
-.lp ""
+%.lp ""
 May be preceded by `{\tt m}' to select preferred display order.
 
 %.lp
-\item[\tb{|}]
+\item[|]
 If persistent inventory display is supported and enabled (with the
 {\it perm\textunderscore invent\/}
 option), interact with it instead of with the map.
@@ -1235,11 +1230,11 @@ Use the {\it Return\/} (aka {\it Enter\/}) or {\it Escape\/} key to
 resume play.
 
 %.lp
-\item[\tb{!}]
+\item[!]
 Escape to a shell.
 See ``\#shell'' below for more details.
 %.lp
-\item[\tb{Del}]
+\item[Del]
 Show map without obstructions.
 You can view the explored portion of the current level's map without
 monsters; without monsters and objects; or without monsters, objects,
@@ -1254,7 +1249,7 @@ Many terminals have an option to swap the {\tt <delete>} and {\tt <backspace>}
 keys, so typing the {\tt <del>} key might not execute this command.
 If that happens, you can use the extended command ``{\tt \#terrain}'' instead.
 %.lp
-\item[\tb{\#}]
+\item[\#]
 Perform an extended command.\\
 %.lp ""
 As you can see, the authors of {\it NetHack\/}
@@ -1263,7 +1258,7 @@ used commands.
 What extended commands are available depends on what features
 the game was compiled with.
 %.lp
-\item[\tb{\#adjust}]
+\item[\#adjust]
 Adjust inventory letters (most useful when the
 {\it fixinv\/}
 option is ``on''). Autocompletes. Default key is `{\tt M-a}'.\\
@@ -1292,14 +1287,14 @@ name when the other doesn't and give that name to the result, while
 splitting (count given) will ignore the source stack's name when
 deciding whether to merge with the destination stack.
 %.lp
-\item[\tb{\#annotate}]
+\item[\#annotate]
 Allows you to specify one line of text to associate with the current
 dungeon level.  All levels with annotations are displayed by the
 ``{\tt \#overview}'' command. Autocompletes.
 Default key is `{\tt M-A}',
 and also `{\tt \^{}N}' if {\it number\textunderscore pad\/} is on.
 %.lp
-\item[\tb{\#apply}]
+\item[\#apply]
 Apply (use) a tool such as a pick-axe, a key, or a lamp.
 Default key is `{\tt a}'.\\
 %.lp ""
@@ -1309,72 +1304,72 @@ skips those items.\\
 If used on a wand, that wand will be broken, releasing its magic in the
 process.  Confirmation is required.
 %.lp
-\item[\tb{\#attributes}]
+\item[\#attributes]
 Show your attributes. Default key is `{\tt \^{}X}'.
 %.lp
-\item[\tb{\#autopickup}]
+\item[\#autopickup]
 Toggle the {\it autopickup\/} option. Default key is `{\tt @}'.
 %.lp
-\item[\tb{\#bugreport}]
+\item[\#bugreport]
 Bring up a browser window to submit a report to the {\it NetHack Development
 Team}.
 Can be disabled at the time the program is built; when enabled,
 CRASHREPORTURL must be set in the system configuration file.
 %.lp
-\item[\tb{\#call}]
+\item[\#call]
 Call (name) a monster, or an object in inventory, on the floor,
 or in the discoveries list, or add an annotation for the
 current level (same as ``{\tt \#annotate}''). Default key is `{\tt C}'.
 %.lp
-\item[\tb{\#cast}]
+\item[\#cast]
 Cast a spell. Default key is `{\tt Z}'.
 %.lp
-\item[\tb{\#chat}]
+\item[\#chat]
 Talk to someone. Default key is `{\tt M-c}'.
 %.lp
-\item[\tb{\#chronicle}]
+\item[\#chronicle]
 Show a list of important game events.
 %.lp
-\item[\tb{\#close}]
+\item[\#close]
 Close a door. Default key is `{\tt c}'.
 %.lp
-\item[\tb{\#conduct}]
+\item[\#conduct]
 List voluntary challenges you have maintained. Autocompletes.
 Default key is `{\tt M-C}'.\\
 %.lp ""
 See the section below entitled ``Conduct'' for details.
 %.lp
-\item[\tb{\#debugfuzzer}]
+\item[\#debugfuzzer]
 Start the fuzz tester.
 Debug mode only.
 %.lp
-\item[\tb{\#dip}]
+\item[\#dip]
 Dip an object into something. Autocompletes. Default key is `{\tt M-d}'.\\
 %.lp ""
 The {\tt m} prefix skips dipping into a fountain or pool if there
 is one at your location.
 %.lp
-\item[\tb{\#down}]
+\item[\#down]
 Go down a staircase. Default key is `{\tt >}'.
 %.lp
-\item[\tb{\#drop}]
+\item[\#drop]
 Drop an item. Default key is `{\tt d}'.
 %.lp
-\item[\tb{\#droptype}]
+\item[\#droptype]
 Drop specific item types. Default key is `{\tt D}'.
 %.lp
-\item[\tb{\#eat}]
+\item[\#eat]
 Eat something. Default key is `{\tt e}'.
 The `{\tt m}' prefix skips eating items on the floor.
 %.lp
-\item[\tb{\#engrave}]
+\item[\#engrave]
 Engrave writing on the floor. Default key is `{\tt E}'.
 %.lp
-\item[\tb{\#enhance}]
+\item[\#enhance]
 Advance or check weapon and spell skills. Autocompletes.
 Default key is `{\tt M-e}'.
 %.lp
-\item[\tb{\#exploremode}]
+\item[\#exploremode]
 Switch from normal play to non-scoring explore mode.
 Default key is `{\tt M-X}'.\\
 %.lp ""
@@ -1384,21 +1379,21 @@ You can set the
 {\it paranoid\textunderscore confirmation:quit\/}
 option to require a response of ``{\tt yes}'' instead.
 %.lp
-\item[\tb{\#fight}]
+\item[\#fight]
 Prefix key to force fight a direction, even if you see nothing
 to fight there.
 Default key is `{\tt F}', or `{\tt -}' with
 {\it number\textunderscore pad\/}
 %.lp
-\item[\tb{\#fire}]
+\item[\#fire]
 Fire ammunition from quiver, possibly autowielding a launcher,
 or hit with a wielded polearm.
 Default key is `{\tt f}'.
 %.lp
-\item[\tb{\#force}]
+\item[\#force]
 Force a lock. Autocompletes. Default key is `{\tt M-f}'.
 %.lp
-\item[\tb{\#genocided}]
+\item[\#genocided]
 List any monster types which have been genocided.
 In explore mode and debug mode it also shows types which have become
 extinct.
@@ -1418,15 +1413,15 @@ The menu omits those two choices when used for {\tt \#genocide}.
 Autocompletes.
 Default key is `{\tt M-g}'.
 %.lp
-\item[\tb{\#glance}]
+\item[\#glance]
 Show what type of thing a map symbol corresponds to. Default key is `{\tt ;}'.
 %.lp
-\item[\tb{\#help}]
+\item[\#help]
 Show the help menu.
 Default key is `{\tt ?}',
 and also `{\tt h}' if {\it number\textunderscore pad\/} is on.
 %.lp
-\item[\tb{\#herecmdmenu}]
+\item[\#herecmdmenu]
 Show a menu of possible actions directed at your current location.
 The menu is limited to a subset of the likeliest actions, not an
 exhaustive set of all possibilities.
@@ -1436,29 +1431,29 @@ If mouse support is enabled and the {\it herecmd\textunderscore menu\/}
 option is On, clicking on the hero (or steed when mounted) will
 execute this command.
 %.lp
-\item[\tb{\#history}]
+\item[\#history]
 Show long version and game history. Default key is `{\tt V}'.
 %.lp
-\item[\tb{\#inventory}]
+\item[\#inventory]
 Show your inventory. Default key is `{\tt i}'.
 %.lp
-\item[\tb{\#inventtype}]
+\item[\#inventtype]
 Inventory specific item types. Default key is `{\tt I}'.
 %.lp
-\item[\tb{\#invoke}]
+\item[\#invoke]
 Invoke an object's special powers. Autocompletes. Default key is `{\tt M-i}'.
 %.lp
-\item[\tb{\#jump}]
+\item[\#jump]
 Jump to another location. Autocompletes.
 Default key is `{\tt M-j}',
 and also `{\tt j}' if {\it number\textunderscore pad\/} is on.
 %.lp
-\item[\tb{\#kick}]
+\item[\#kick]
 Kick something.
 Default key is `{\tt \^{}D}',
 and also `{\tt k}' if {\it number\textunderscore pad\/} is on.
 %.lp
-\item[\tb{\#known}]
+\item[\#known]
 Show what object types have been discovered.
 Default key is `{\tt $\backslash$}'.
 \\
@@ -1467,30 +1462,30 @@ The `{\tt m}' prefix allows assigning a new value to the
 {\it sortdiscoveries\/}
 option to control the order in which the discoveries are displayed.
 %.lp
-\item[\tb{\#knownclass}]
+\item[\#knownclass]
 Show discovered types for one class of objects.
 Default key is `{\tt `}'.
 \\
 %.lp ""
 The `{\tt m}' prefix operates the same as for {\tt \#known}.
 %.lp
-\item[\tb{\#levelchange}]
+\item[\#levelchange]
 Change your experience level.
 Autocompletes.
 Debug mode only.
 %.lp
-\item[\tb{\#lightsources}]
+\item[\#lightsources]
 Show mobile light sources.
 Autocompletes.
 Debug mode only.
 %.lp
-\item[\tb{\#look}]
+\item[\#look]
 Look at what is here, under you. Default key is `{\tt :}'.
 %.lp
-\item[\tb{\#lookaround}]
+\item[\#lookaround]
 Describe what you can see, or remember, of your surroundings.
 %.lp
-\item[\tb{\#loot}]
+\item[\#loot]
 Loot a box or bag on the floor beneath you, or the saddle
 from a steed standing next to you. Autocompletes.
 Precede with the `{\tt m}' prefix to skip containers at your location
@@ -1498,17 +1493,17 @@ and go directly to removing a saddle.
 Default key is `{\tt M-l}',
 and also `{\tt l}' if {\it number\textunderscore pad\/} is on.
 %.lp
-\item[\tb{\#monster}]
+\item[\#monster]
 Use a monster's special ability (when polymorphed into monster form).
 Autocompletes. Default key is `{\tt M-m}'.
 %.lp
-\item[\tb{\#name}]
+\item[\#name]
 Name a monster, an individual object, or a type of object.
 Same as ``{\tt \#call}''.
 Autocompletes.
 Default keys are `{\tt N}', `{\tt M-n}', and `{\tt M-N}'.
 %.lp
-\item[\tb{\#offer}]
+\item[\#offer]
 Offer a sacrifice to the gods. Autocompletes. Default key is `{\tt M-o}'.\\
 %.lp ""
 You'll need to find an altar to have any chance at success.
@@ -1516,21 +1511,21 @@ Corpses of recently killed monsters are the fodder of choice.
 %.lp ""
 The `{\tt m}' prefix skips offering any items which are on the altar.\\
 %.lp
-\item[\tb{\#open}]
+\item[\#open]
 Open a door. Default key is `{\tt o}'.
 %.lp
-\item[\tb{\#options}]
+\item[\#options]
 Show and change option settings. Default key is `{\tt O}'.
 Precede with the {\tt m} prefix to show advanced options.
 %.lp
-\item[\tb{\#optionsfull}]
+\item[\#optionsfull]
 Show advanced game option settings.
 No default key.
 Precede with the `{\tt m}' prefix to execute the simpler options command.
 (Mainly useful if you use {\tt BINDING=O:optionsfull} to switch
 `{\tt O}' from simple options back to traditional advanced options.)
 %.lp
-\item[\tb{\#overview}]
+\item[\#overview]
 Display information you've discovered about the dungeon.
 Any visited level
 % [note: amnesia no longer causes levels to be forgotten so exclude this]
@@ -1553,7 +1548,7 @@ Autocompletes.
 Default keys are `{\tt \^{}O}', and `{\tt M-O}'.
 % DON'T PANIC!
 %.lp
-\item[\tb{\#panic}]
+\item[\#panic]
 Test the panic routine.
 Terminates the current game.
 Autocompletes.
@@ -1565,10 +1560,10 @@ You can set the
 {\it paranoid\textunderscore confirmation:quit\/}
 option to require a response of ``{\tt yes}'' instead.
 %.lp
-\item[\tb{\#pay}]
+\item[\#pay]
 Pay your shopping bill. Default key is `{\tt p}'.
 %.lp
-\item[\tb{\#perminv}]
+\item[\#perminv]
 If persistent inventory display is supported and enabled (with the
 {\it perm\textunderscore invent\/} option), interact with it instead of with the map.
 You'll be prompted for menu scrolling keystrokes such
@@ -1576,16 +1571,16 @@ as `{\tt \verb+>+}' and `{\tt \verb+<+}'.
 Press {\tt Return} or {\tt Escape} to resume normal play.
 Default key is {\tt \verb+|+}.
 %.lp
-\item[\tb{\#pickup}]
+\item[\#pickup]
 Pick up things at the current location. Default key is `{\tt ,}'.
 The `{\tt m}' prefix forces use of a menu.
 %.lp
-\item[\tb{\#polyself}]
+\item[\#polyself]
 Polymorph self.
 Autocompletes.
 Debug mode only.
 %.lp
-\item[\tb{\#pray}]
+\item[\#pray]
 Pray to the gods for help. Autocompletes. Default key is `{\tt M-p}'.\\
 %.lp ""
 Praying too soon after receiving prior help is a bad idea.
@@ -1597,19 +1592,19 @@ by default, and you can reset the
 {\it paranoid\textunderscore confirmation\/}
 option to disable it.
 %.lp
-\item[\tb{\#prevmsg}]
+\item[\#prevmsg]
 Show previously displayed game messages. Default key is `{\tt \^{}P}'.
 %.lp
-\item[\tb{\#puton}]
+\item[\#puton]
 Put on an accessory (ring, amulet, etc). Default key is `{\tt P}'.
 %.lp
-\item[\tb{\#quaff}]
+\item[\#quaff]
 Quaff (drink) something. Default key is `{\tt q}'.\\
 %.lp ""
 The {\tt m} prefix skips drinking from a fountain or sink if there
 is one at your location.
 %.lp
-\item[\tb{\#quit}]
+\item[\#quit]
 Quit the program without saving your game. Autocompletes.\\
 %.lp ""
 Since using this command by accident would throw away the current game,
@@ -1620,42 +1615,42 @@ You can set the
 {\it paranoid\textunderscore confirmation:quit\/}
 option to require a response of ``{\tt yes}'' instead.
 %.lp
-\item[\tb{\#quiver}]
+\item[\#quiver]
 Select ammunition for quiver. Default key is `{\tt Q}'.
 %.lp
-\item[\tb{\#read}]
+\item[\#read]
 Read a scroll, a spellbook, or something else. Default key is `{\tt r}'.
 %.lp
-\item[\tb{\#redraw}]
+\item[\#redraw]
 Redraw the screen.
 Default key is `{\tt \^{}R}',
 and also `{\tt \^{}L}' if {\it number\textunderscore pad\/} is on.
 %.lp
-\item[\tb{\#remove}]
+\item[\#remove]
 Remove an accessory (ring, amulet, etc). Default key is `{\tt R}'.
 %.lp
-\item[{\tb{\#repeat}}]
+\item[\#repeat]
 Repeat the previous command.
 Default key is~`{\tt \^{}A}'.
 %.lp
-\item[\tb{\#reqmenu}]
+\item[\#reqmenu]
 Prefix key to modify the behavior or request menu from some commands.
 Prevents autopickup when used with movement commands.
 Default key is `{\tt m}'.
 %.lp
-\item[\tb{\#retravel}]
+\item[\#retravel]
 Travel to a previously selected travel destination.
 Default key is `{\tt C-\textunderscore }'.
 See also {\tt \#travel}.
 %.lp
-\item[\tb{\#ride}]
+\item[\#ride]
 Ride (or stop riding) a saddled creature. Autocompletes.
 Default key is `{\tt M-R}'.
 %.lp
-\item[\tb{\#rub}]
+\item[\#rub]
 Rub a lamp or a stone. Autocompletes. Default key is `{\tt M-r}'.
 %.lp
-\item[\tb{\#run}]
+\item[\#run]
 Prefix key to run towards a direction.
 Default key is `{\tt G}' when
 {\it number\textunderscore pad\/}
@@ -1665,7 +1660,7 @@ is off,
 is set to 1~or~3,
 otherwise `{\tt M-5}' when it is set to 2~or~4.
 %.lp
-\item[\tb{\#rush}]
+\item[\#rush]
 Prefix key to rush towards a direction.
 Default key is `{\tt g}' when
 {\it number\textunderscore pad\/}
@@ -1675,45 +1670,45 @@ is off,
 is set to 1~or~3,
 otherwise `{\tt 5}' when it is set to 2~or~4.
 %.lp
-\item[\tb{\#save}]
+\item[\#save]
 Save the game and exit the program.
 Default key is `{\tt S}'.
 %.lp
-\item[\tb{\#saveoptions}]
+\item[\#saveoptions]
 Save configuration options to the config file.
 This will overwrite the file, removing all comments, so if you have
 manually edited the config file, don't use this.
 %.lp
-\item[\tb{\#search}]
+\item[\#search]
 Search for traps and secret doors around you. Default key is `{\tt s}'.
 %.lp
-\item[\tb{\#seeall}]
+\item[\#seeall]
 Show all equipment in use. Default key is `{\tt *}'.
 %.lp ""
 \\
 Will display in-use items in a menu even when there is only one.
 %.lp
-\item[\tb{\#seeamulet}]
+\item[\#seeamulet]
 Show the amulet currently worn. Default key is `{\tt "}'.
 %.lp ""
 \\
 Using the `{\tt m}' prefix will force the display of a worn
 amulet in a menu rather than with just a message.
 %.lp
-\item[\tb{\#seearmor}]
+\item[\#seearmor]
 Show the armor currently worn. Default key is `{\tt [}'.
 %.lp ""
 \\
 Will display worn armor in a menu even when there is only thing worn.
 %.lp
-\item[\tb{\#seerings}]
+\item[\#seerings]
 Show the ring(s) currently worn. Default key is `{\tt =}'.
 %.lp ""
 Will display worn rings in a menu if there are two (or there is
 just one and is a meat ring rather than a ``real'' ring).
 Use the `{\tt m}' prefix to force a menu for one ring.
 %.lp
-\item[\tb{\#seetools}]
+\item[\#seetools]
 Show the tools currently in use. Default key is `{\tt (}'.
 %.lp ""
 Will display the result in a message if there is one tool in use (worn
@@ -1722,7 +1717,7 @@ attached to pets).
 Will display a menu if there are more than one or if the command is
 preceded by the `{\tt m}' prefix.
 %.lp
-\item[\tb{\#seeweapon}]
+\item[\#seeweapon]
 Show the weapon currently wielded. Default key is `{\tt )}'.
 %.lp ""
 If dual-wielding, a separate message about the secondary weapon will be
@@ -1731,7 +1726,7 @@ Using the `{\tt m}' prefix will force a menu and it will include
 primary weapon, alternate weapon even when not dual-wielding, and also
 whatever is currently assigned to the quiver slot.
 %.lp
-\item[\tb{\#shell}]
+\item[\#shell]
 Do a shell escape, switching from NetHack to a subprocess.
 Can be disabled at the time the program is built.
 When enabled, access for specific users can be controlled by the system
@@ -1739,17 +1734,17 @@ configuration file.
 Use the shell command `{\tt exit}' to return to the game.
 Default key is `{\tt !}'.
 %.lp
-\item[\tb{\#showgold}]
+\item[\#showgold]
 Report the gold in your inventory, including gold you know about in
 containers you're carrying.  If you are inside a shop, report any credit
 or debt you have in that shop.
 Default key is `{\tt \$}'.
 %.lp
-\item[\tb{\#showspells}]
+\item[\#showspells]
 List and reorder known spells.
 Default key is `{\tt +}'.
 %.lp
-\item[\tb{\#showtrap}]
+\item[\#showtrap]
 Describe an adjacent trap, possibly covered by objects or a monster.
 To be eligible, the trap must already be discovered.
 (The ``{\tt \#terrain}'' command can display your map with all objects and
@@ -1757,15 +1752,15 @@ monsters temporarily removed, making it possible to see all discovered
 traps.)
 Default key is `{\tt \^{}}'.
 %.lp
-\item[\tb{\#sit}]
+\item[\#sit]
 Sit down. Autocompletes. Default key is `{\tt M-s}'.
 %.lp
-\item[\tb{\#stats}]
+\item[\#stats]
 Show memory usage statistics.
 Autocompletes.
 Debug mode only.
 %.lp
-\item[\tb{\#suspend}]
+\item[\#suspend]
 Suspend the game, switching from NetHack to the terminal it was started
 from without performing save-and-exit.
 Can be disabled at the time the program is built.
@@ -1775,19 +1770,19 @@ UNIX.
 Use the shell command `{\tt fg}' to return to the game.
 Default key is `{\tt \^{}Z}'.
 %.lp
-\item[\tb{\#swap}]
+\item[\#swap]
 Swap wielded and secondary weapons. Default key is `{\tt x}'.
 %.lp
-\item[\tb{\#takeoff}]
+\item[\#takeoff]
 Take off one piece of armor. Default key is `{\tt T}'.
 %.lp
-\item[\tb{\#takeoffall}]
+\item[\#takeoffall]
 Remove all armor. Default key is `{\tt A}'.
 %.lp
-\item[\tb{\#teleport}]
+\item[\#teleport]
 Teleport around the level. Default key is `{\tt \^{}T}'.
 %.lp
-\item[\tb{\#terrain}]
+\item[\#terrain]
 Show map without obstructions.
 In normal play you can view the explored portion of the current level's
 map without monsters; without monsters and objects; or without monsters,
@@ -1803,7 +1798,7 @@ In debug mode there are additional choices.\\
 Autocompletes.
 Default key is `{\tt <del>}' or `{\tt <delete>}' (see {\it Del\/} above).
 %.lp
-\item[\tb{\#therecmdmenu}]
+\item[\#therecmdmenu]
 Show a menu of possible actions directed at a location next to you.
 The menu is limited to a subset of the likeliest actions, not an
 exhaustive set of all possibilities.
@@ -1814,15 +1809,15 @@ Autocompletes.
 %% If mouse support is enabled and the {\it herecmd\textunderscore menu\/}
 %% option is On, clicking on an adjacent location will execute this command.
 %.lp
-\item[\tb{\#throw}]
+\item[\#throw]
 Throw something. Default key is `{\tt t}'.
 %.lp
-\item[\tb{\#timeout}]
+\item[\#timeout]
 Look at the timeout queue.
 Autocompletes.
 Debug mode only.
 %.lp
-\item[\tb{\#tip}]
+\item[\#tip]
 Tip over a container (bag or box) to pour out its contents.
 When there are containers on the floor, the game will prompt to pick one
 of them or ``tip something being carried''.
@@ -1839,7 +1834,7 @@ floor container menu.
 %.lp ""
 Autocompletes. Default key is `{\tt M-T}'.
 %.lp
-\item[\tb{\#travel}]
+\item[\#travel]
 Travel to a specific location on the map.
 Default key is `{\tt \textunderscore }'.
 Using the ``request menu'' prefix shows a menu of interesting targets in sight
@@ -1849,10 +1844,10 @@ option is on, the top line will show ``(no travel path)'' if
 your character does not know of a path to that location.
 See also {\tt \#retravel}.
 %.lp
-\item[\tb{\#turn}]
+\item[\#turn]
 Turn undead away. Autocompletes. Default key is `{\tt M-t}'.
 %.lp
-\item[\tb{\#twoweapon}]
+\item[\#twoweapon]
 Toggle two-weapon combat on or off. Autocompletes.
 Default key is `{\tt X}',
 and also `{\tt M-2}' if {\it number\textunderscore pad\/} is off.\\
@@ -1861,16 +1856,16 @@ Note that you must
 use suitable weapons for this type of combat, or it will
 be automatically turned off.
 %.lp
-\item[\tb{\#untrap}]
+\item[\#untrap]
 Untrap something (trap, door, or chest).
 Default key is `{\tt M-u}', and `{\tt u}' if {\it number\textunderscore pad\/} is on.\\
 %.lp ""
 In some circumstances it can also be used to rescue trapped monsters.
 %.lp
-\item[\tb{\#up}]
+\item[\#up]
 Go up a staircase. Default key is `{\tt <}'.
 %.lp
-\item[\tb{\#vanquished}]
+\item[\#vanquished]
 List vanquished monsters by type and count.
 \\
 %.lp ""
@@ -1896,7 +1891,7 @@ monsters answering `{\tt a}' will let you choose from the sort menu.
 Autocompletes.
 Default key is `{\tt M-V}'.
 %.lp
-\item[\tb{\#version}]
+\item[\#version]
 Print compile time options for this version of {\it NetHack\/}.
 
 %.lp
@@ -1907,50 +1902,50 @@ option in your run-time configuration file to select the one you want.
 %.lp
 Autocompletes. Default key is `{\tt M-v}'.
 %.lp
-\item[\tb{\#versionshort}]
+\item[\#versionshort]
 Show the program's version number, plus the date and time that the
 running copy was built from sources (not the version's release date).
 Default key is `{\tt v}'.
 %.lp
-\item[\tb{\#vision}]
+\item[\#vision]
 Show vision array.
 Autocompletes.
 Debug mode only.
 %.lp
-\item[\tb{\#wait}]
+\item[\#wait]
 Rest one move while doing nothing.
 Default key is `{\tt .}', and also `{\tt{ }}' if
 {\it rest\textunderscore on\textunderscore space\/} is on.
 %.lp
-\item[\tb{\#wear}]
+\item[\#wear]
 Wear a piece of armor. Default key is `{\tt W}'.
 %.lp
-\item[\tb{\#whatdoes}]
+\item[\#whatdoes]
 Tell what a key does. Default key is `{\tt \&}'.
 %.lp
-\item[\tb{\#whatis}]
+\item[\#whatis]
 Show what type of thing a symbol corresponds to. Default key is `{\tt /}'.
 %.lp
-\item[\tb{\#wield}]
+\item[\#wield]
 Wield a weapon. Default key is `{\tt w}'.
 %.lp
-\item[\tb{\#wipe}]
+\item[\#wipe]
 Wipe off your face. Autocompletes. Default key is `{\tt M-w}'.
 %.lp
-\item[\tb{\#wizborn}]
+\item[\#wizborn]
 Show monster birth, death, genocide, and extinct statistics.
 Debug mode only.
 %.lp
-\item[\tb{\#wizbury}]
+\item[\#wizbury]
 Bury objects under and around you.
 Autocompletes.
 Debug mode only.
 %.lp
-\item[\tb{\#wizcast}]
+\item[\#wizcast]
 Cast any spell.
 Debug mode only.
 %.lp
-\item[\tb{\#wizdetect}]
+\item[\#wizdetect]
 Reveal hidden things (secret doors or traps or unseen monsters)
 within a modest radius.
 No time elapses.
@@ -1958,44 +1953,44 @@ Autocompletes.
 Debug mode only.
 Default key is `{\tt \^{}E}'.
 %.lp
-\item[\tb{\#wizgenesis}]
+\item[\#wizgenesis]
 Create a monster.
 May be prefixed by a count to create more than one.
 Autocompletes.
 Debug mode only.
 Default key is `{\tt \^{}G}'.
 %.lp
-\item[\tb{\#wizidentify}]
+\item[\#wizidentify]
 Identify all items in inventory.
 Autocompletes.
 Debug mode only.
 Default key is `{\tt \^{}I}'.
 %.lp
-\item[\tb{\#wizintrinsic}]
+\item[\#wizintrinsic]
 Set one or more intrinsic attributes.
 Autocompletes.
 Debug mode only.
 %.lp
-\item[\tb{\#wizkill}]
+\item[\#wizkill]
 Remove monsters from play by just pointing at them.
 By default the hero gets credit or blame for killing the targets.
 Precede this command with the `{\tt m}' prefix to override that.
 Autocompletes.
 Debug mode only.
 %.lp
-\item[\tb{\#wizlevelport}]
+\item[\#wizlevelport]
 Teleport to another level.
 Autocompletes.
 Debug mode only.
 Default key is `{\tt \^{}V}'.
 %.lp
-\item[\tb{\#wizmap}]
+\item[\#wizmap]
 Map the level.
 Autocompletes.
 Debug mode only.
 Default key is `{\tt \^{}F}'.
 %.lp
-\item[\tb{\#wizrumorcheck}]
+\item[\#wizrumorcheck]
 Verify rumor boundaries by displaying first and last true rumors and
 first and last false rumors.\\
 %.lp ""
@@ -2005,38 +2000,38 @@ and hallucinatory monsters.\\
 Autocompletes.
 Debug mode only.
 %.lp
-\item[\tb{\#wizseenv}]
+\item[\#wizseenv]
 Show map locations' seen vectors.
 Autocompletes.
 Debug mode only.
 %.lp
-\item[\tb{\#wizsmell}]
+\item[\#wizsmell]
 Smell monster.
 Autocompletes.
 Debug mode only.
 %.lp
-\item[\tb{\#wizwhere}]
+\item[\#wizwhere]
 Show locations of special levels.
 Autocompletes.
 Debug mode only.
 %.lp
-\item[\tb{\#wizwish}]
+\item[\#wizwish]
 Wish for something.
 Autocompletes.
 Debug mode only.
 Default key is `{\tt \^{}W}'.
 %.lp
-\item[\tb{\#wmode}]
+\item[\#wmode]
 Show wall modes.
 Autocompletes.
 Debug mode only.
 %.lp
-\item[\tb{\#zap}]
+\item[\#zap]
 Zap a wand. Default key is `{\tt z}'.
 %.lp
-\item[\tb{\#?}]
+\item[\#?]
 Help menu:  get the list of available extended commands.
-\elist
+\end{description}
 
 %.pg
 \nd If your keyboard has a meta key (which, when pressed in combination
@@ -2063,116 +2058,116 @@ equivalent is used for another command, so the three key combination
 {\tt meta+Shift+letter} is needed.
 
 %.BR 1
-\blist{}
+\begin{description}[font=\ttfamily]
 %.lp
-\item[\tb{M-?}]
+\item[M-?]
 {\tt\#?} (not supported by all platforms)
 %.lp
-\item[\tb{M-2}]
+\item[M-2]
 {\tt\#twoweapon} (unless the {\it number\textunderscore pad\/} option is enabled)
 %.lp
-\item[\tb{M-a}]
+\item[M-a]
 {\tt\#adjust}
 %.lp
-\item[\tb{M-A}]
+\item[M-A]
 {\tt\#annotate}
 %.lp
-\item[\tb{M-c}]
+\item[M-c]
 {\tt\#chat}
 %.lp
-\item[\tb{M-C}]
+\item[M-C]
 {\tt\#conduct}
 %.lp
-\item[\tb{M-d}]
+\item[M-d]
 {\tt\#dip}
 %.lp
-\item[\tb{M-e}]
+\item[M-e]
 {\tt\#enhance}
 %.lp
-\item[\tb{M-f}]
+\item[M-f]
 {\tt\#force}
 %.lp
-\item[\tb{M-g}]
+\item[M-g]
 {\tt\#genocided}
 %.lp
-\item[\tb{M-i}]
+\item[M-i]
 {\tt\#invoke}
 %.lp
-\item[\tb{M-j}]
+\item[M-j]
 {\tt\#jump}
 %.lp
-\item[\tb{M-l}]
+\item[M-l]
 {\tt\#loot}
 %.lp
-\item[\tb{M-m}]
+\item[M-m]
 {\tt\#monster}
 %.lp
-\item[\tb{M-n}]
+\item[M-n]
 {\tt\#name}
 %.lp
-\item[\tb{M-o}]
+\item[M-o]
 {\tt\#offer}
 %.lp
-\item[\tb{M-O}]
+\item[M-O]
 {\tt\#overview}
 %.lp
-\item[\tb{M-p}]
+\item[M-p]
 {\tt\#pray}
 %.Ip
-\item[\tb{M-r}]
+\item[M-r]
 {\tt\#rub}
 %.lp
-\item[\tb{M-R}]
+\item[M-R]
 {\tt\#ride}
 %.lp
-\item[\tb{M-s}]
+\item[M-s]
 {\tt\#sit}
 %.lp
-\item[\tb{M-t}]
+\item[M-t]
 {\tt\#turn}
 %.lp
-\item[\tb{M-T}]
+\item[M-T]
 {\tt\#tip}
 %.lp
-\item[\tb{M-u}]
+\item[M-u]
 {\tt\#untrap}
 %.lp
-\item[\tb{M-v}]
+\item[M-v]
 {\tt\#version}
 %.lp
-\item[\tb{M-V}]
+\item[M-V]
 {\tt\#vanquished}
 %.lp
-\item[\tb{M-w}]
+\item[M-w]
 {\tt\#wipe}
 %.lp
-\item[\tb{M-X}]
+\item[M-X]
 {\tt\#exploremode}
-\elist
+\end{description}
 
 %.pg
 \nd If the {\it number\textunderscore pad\/} option is on, some additional letter commands
 are available:
-\blist{}
+\begin{description}[font=\ttfamily]
 %.lp
-\item[\tb{h}]
+\item[h]
 {\tt\#help}
 %.lp
-\item[\tb{j}]
+\item[j]
 {\tt\#jump}
 %.lp
-\item[\tb{k}]
+\item[k]
 {\tt\#kick}
 %.lp
-\item[\tb{l}]
+\item[l]
 {\tt\#loot}
 %.lp
-\item[\tb{N}]
+\item[N]
 {\tt\#name}
 %.lp
-\item[\tb{u}]
+\item[u]
 {\tt\#untrap}
-\elist
+\end{description}
 
 %.BR 1 \"blank line for extra separation; plain text output looks better
 
@@ -2429,21 +2424,21 @@ Several aspects of shop behavior might be unexpected.
 \begin{itemize}
 % note: a bullet is the default item label so we could omit [$\bullet$] here
 %.lp \(bu 2
-\item[$\bullet$]
+\item
 The price of a given item can vary due to a variety of factors.
 %.lp \(bu 2
-\item[$\bullet$]
+\item
 A shopkeeper treats the spot immediately inside the door as if it were
 outside the shop.
 %.lp \(bu 2
-\item[$\bullet$]
+\item
 While the shopkeeper watches you like a hawk, he or she will generally ignore
 any other customers.
 %.lp \(bu 2
-\item[$\bullet$]
+\item
 If a shop is ``closed for inventory,'' it will not open of its own accord.
 %.lp \(bu 2
-\item[$\bullet$]
+\item
 Shops do not get restocked with new items, regardless of inventory depletion.
 \end{itemize}
 
@@ -3678,62 +3673,62 @@ in which you might accomplish them.
 %.PS "Mines'\~End\~"
 \settowidth{\achwidth}{\tt Mines'~End~}
 \addtolength{\achwidth}{\labelsep}
-\blist{\leftmargin \achwidth \topsep 1mm \itemsep 0mm}
+\begin{description}[leftmargin=\achwidth, topsep=1mm, itemsep=0mm, labelwidth=*, font=\ttfamily, align=right]
 %.PL Shop
-\item[{\tt <Rank>}]
+\item[<Rank>]
 Attained rank title {\it Rank}.
-\item[{\tt Shop}]
+\item[Shop]
 Entered a shop.
-\item[{\tt Temple}]
+\item[Temple]
 Entered a temple.
-\item[{\tt Mines}]
+\item[Mines]
 Entered the Gnomish Mines.
-\item[{\tt Town}]
+\item[Town]
 Entered Mine Town.
-\item[{\tt Oracle}]
+\item[Oracle]
 Consulted the Oracle of Delphi.
-\item[{\tt Novel}]
+\item[Novel]
 Read a passage from a Discworld Novel.
-\item[{\tt Sokoban}]
+\item[Sokoban]
 Entered Sokoban.
-\item[{\tt "Big~Room"}]
+\item["Big~Room"]
 Entered the Big Room.
-\item[{\tt "Soko-Prize"}]
+\item["Soko-Prize"]
 Explored to the top of Sokoban and found a special item there.
-\item[{\tt Mines'~End}]
+\item[Mines'~End]
 Explored to the bottom of the Gnomish Mines and found a special item there.
-\item[{\tt Medusa}]
+\item[Medusa]
 Defeated Medusa.
-\item[{\tt Tune}]
+\item[Tune]
 Discovered the tune that can be used to open and close the drawbridge on
 the Castle level.
-\item[{\tt Bell}]
+\item[Bell]
 Acquired the Bell of Opening.
-\item[{\tt Gehennom}]
+\item[Gehennom]
 Entered Gehennom.
-\item[{\tt Candle}]
+\item[Candle]
 Acquired the Candelabrum of Invocation.
-\item[{\tt Book}]
+\item[Book]
 Acquired the Book of the Dead.
-\item[{\tt Invocation}]
+\item[Invocation]
 Gained access to the bottommost level of Gehennom.
-\item[{\tt Amulet}]
+\item[Amulet]
 Acquired the fabled Amulet of Yendor.
-\item[{\tt Endgame}]
+\item[Endgame]
 Reached the Elemental Planes.
-\item[{\tt Astral}]
+\item[Astral]
 Reached the Astral Plane level.
-\item[{\tt Blind}]
+\item[Blind]
 Blind from birth.
-\item[{\tt Deaf}]
+\item[Deaf]
 Deaf from birth.
-\item[{\tt Nudist}]
+\item[Nudist]
 Never wore any armor.
-\item[{\tt Pauper}]
+\item[Pauper]
 Started out with no possessions.
-\item[{\tt Ascended}]
+\item[Ascended]
 Delivered the Amulet to its final destination.
-\elist
+\end{description}
 %.PE
 %.ED
 
@@ -3860,8 +3855,8 @@ settings particular to that directive.
 Here is a list of allowed directives:
 
 %.lp
-\blist{}
-\item[\bb{OPTIONS}]
+\begin{description}
+\item[OPTIONS]
 There are two types of options, boolean and compound options.
 Boolean options toggle a setting on or off, while compound options
 take more diverse values.
@@ -3882,35 +3877,35 @@ Example:
 %.ed
 
 %.lp
-\item[\bb{HACKDIR}]
+\item[HACKDIR]
 Default location of files {\it NetHack\/} needs. On Windows HACKDIR
 defaults to the location of the {\it NetHack.exe\/} or {\it NetHackw.exe\/} file
 so setting HACKDIR to override that is not usually necessary or recommended.
 %.lp
-\item[\bb{LEVELDIR}]
+\item[LEVELDIR]
 The location that in-progress level files are stored. Defaults to HACKDIR,
 must be writable.
 %.lp
-\item[\bb{SAVEDIR}]
+\item[SAVEDIR]
 The location where saved games are kept. Defaults to HACKDIR, must be
 writable.
 %.lp
-\item[\bb{BONESDIR}]
+\item[BONESDIR]
 The location that bones files are kept. Defaults to HACKDIR, must be
 writable.
 %.lp
-\item[\bb{LOCKDIR}]
+\item[LOCKDIR]
 The location that file synchronization locks are stored. Defaults to
 HACKDIR, must be writable.
 %.lp
-\item[\bb{TROUBLEDIR}]
+\item[TROUBLEDIR]
 The location that a record of game aborts and self-diagnosed game problems
 is kept. Defaults to HACKDIR, must be writable.
 %
 % config file entries beyond this point are shown alphabetically
 %
 %.lp
-\item[\bb{AUTOCOMPLETE}]
+\item[AUTOCOMPLETE]
 Enable or disable an extended command autocompletion.
 Autocompletion has no effect for the X11 windowport.
 You can specify multiple autocompletions. To enable
@@ -3927,11 +3922,11 @@ Example:
 %.ed
 
 %.lp
-\item[\bb{AUTOPICKUP\textunderscore EXCEPTION}]
+\item[AUTOPICKUP\textunderscore EXCEPTION]
 Set exceptions to the {{\it pickup\textunderscore types\/}}
 option. See the ``Configuring Autopickup Exceptions'' section.
 %.lp
-\item[\bb{BINDINGS}]
+\item[BINDINGS]
 Change the key bindings of some special keys, menu accelerators,
 extended commands, or mouse buttons. You can specify multiple bindings.
 Format is key followed by the command, separated by a colon.
@@ -3946,7 +3941,7 @@ Example:
 %.ed
 
 %.lp
-\item[\bb{CHOOSE}]
+\item[CHOOSE]
 Chooses at random one of the comma-separated parameters as an active
 section name.
 Lines in other sections are ignored.
@@ -3972,27 +3967,27 @@ section begins; whatever follows will be common to all sections.
 Otherwise the last section extends to the end of the options file.
 
 %.lp
-\item[\bb{MENUCOLOR}]
+\item[MENUCOLOR]
 Highlight menu lines with different colors.
 See the ``Configuring Menu Colors`` section.
 %.lp
-\item[\bb{MSGTYPE}]
+\item[MSGTYPE]
 Change the way messages are shown in the top status line.
 See the ``Configuring Message Types`` section.
 %.lp
-\item[\bb{ROGUESYMBOLS}]
+\item[ROGUESYMBOLS]
 Custom symbols for the rogue level's symbol set.
 See {\it SYMBOLS} below.
 %.lp
-\item[\bb{SOUND}]
+\item[SOUND]
 Define a sound mapping.
 See the ``Configuring User Sounds'' section.
 %.lp
-\item[\bb{SOUNDDIR}]
+\item[SOUNDDIR]
 Define the directory that contains the sound files.
 See the ``Configuring User Sounds'' section.
 %.lp
-\item[\bb{SYMBOLS}]
+\item[SYMBOLS]
 Override one or more symbols in the symbol set used for all dungeon
 levels except for the special rogue level.
 See the ``Modifying {\it NetHack\/} Symbols'' section.
@@ -4008,7 +4003,7 @@ Example:
 %.ed
 
 %.lp
-\item[\bb{WIZKIT}]
+\item[WIZKIT]
 Debug mode only:  extra items to add to initial inventory.
 Value is the name of a text file containing a list of item names,
 one per line, up to a maximum of 128 lines.
@@ -4021,7 +4016,7 @@ Example:
    WIZKIT=~/wizkit.txt
 \end{verbatim}
 %.ed
-\elist
+\end{description}
 
 %.lp ""
 %.pg
@@ -4115,17 +4110,17 @@ Some options are persistent, and are saved and reloaded along with
 the game.  Changing a persistent option in the configuration file
 applies only to new games.
 
-\blist{}
+\begin{description}[font=\itshape]
 %.lp
-\item[\ib{accessiblemsg}]
+\item[accessiblemsg]
 Add location or direction information to messages (default is off).
 %.lp
-\item[\ib{acoustics}]
+\item[acoustics]
 Enable messages about what your character hears (default on).
 Note that this has nothing to do with your computer's audio capabilities.
 Persistent.
 %.lp
-\item[\ib{alignment}]
+\item[alignment]
 Your starting alignment ({\tt align:lawful}, {\tt align:neutral},
 or {\tt align:chaotic}).
 You may specify just the first letter.
@@ -4138,21 +4133,21 @@ If {\tt align} is not specified, there is no default value;
 player will be prompted unless role and/or race forces a choice for alignment.
 Cannot be set with the `{\tt O}' command.  Persistent.
 %.lp
-\item[\ib{autodescribe}]
+\item[autodescribe]
 Automatically describe the terrain under cursor when asked to get a location
 on the map (default true).
 The {\it whatis\textunderscore coord\/}
 option controls whether the description includes map coordinates.
 %.lp
-\item[\ib{autodig}]
+\item[autodig]
 Automatically dig if you are wielding a digging tool and moving into a place
 that can be dug (default false).  Persistent.
 %.lp
-\item[\ib{autoopen}]
+\item[autoopen]
 Walking into a closed door attempts to open it (default true).
 Persistent.
 %.lp
-\item[\ib{autopickup}]
+\item[autopickup]
 Automatically pick up things onto which you move (default off).
 Persistent.
 \\
@@ -4163,7 +4158,7 @@ See ``{\it pickup\textunderscore types\/}'' and also
 %.lp ""
 Note: prior to version 3.7.0, the default for {\it autopickup\/} was {\it on}.
 %.lp
-\item[\ib{autoquiver}]
+\item[autoquiver]
 This option controls what happens when you attempt the `{\tt f}' (fire)
 command when nothing is quivered or readied (default false).
 When true, the computer will fill
@@ -4176,7 +4171,7 @@ with the `{\tt Q}' command instead.
 If no weapon is found or the option is
 false, the `{\tt t}' (throw) command is executed instead.  Persistent.
 %.lp
-\item[\ib{autounlock}]
+\item[autounlock]
 %\hyphenation{apply\-key}%this needs to be tested...
 Controls what action to take when attempting to walk into a locked door
 or to loot a locked container.
@@ -4187,32 +4182,32 @@ Takes a plus-sign separated list of values:
 %.PS Apply-Key
 \settowidth{\auwidth}{\tt Apply-Key}
 \addtolength{\auwidth}{\labelsep}
-\blist{\leftmargin \auwidth \topsep 1mm \itemsep 0mm}
+\begin{description}[leftmargin=\auwidth, topsep=1mm, itemsep=0mm, labelwidth=*, font=\ttfamily, align=right]
 %.PL Untrap
-\item[{\tt Untrap}]
+\item[Untrap]
 prompt about whether to attempt to find a trap;
 it might fail to find one even when present; if it does find one, it
 will ask whether you want to try to disarm the trap; if you decline,
 your character will forget that the door or box is trapped;
 %.PL Apply-Key
-\item[{\tt Apply-Key}]
+\item[Apply-Key]
 if carrying a key or other unlocking tool, prompt about using it;
 %.PL Kick
-\item[{\tt Kick}]
+\item[Kick]
 kick the door (if you omit untrap or decline to attempt untrap and
 you omit apply-key or you lack a key or you decline to use the key;
 has no effect on containers);
 %.PL Force
-\item[{\tt Force}]
+\item[Force]
 try to force a container's lid with your currently
 wielded weapon (if you omit untrap or decline to attempt untrap and
 you omit apply-key or you lack a key or you decline to use the key;
 has no effect on doors);
 %.PL None
-\item[{\tt None}]
+\item[None]
 none of the above; can't be combined with the other choices.
 %.PE
-\elist
+\end{description}
 Omitting the value is treated as if {\tt autounlock:apply-key}.
 Preceding {\tt autounlock} with `{\tt !}' or ``{\tt no}'' is treated as
 {\tt autounlock:none}.
@@ -4227,49 +4222,49 @@ destroy some of its contents or damage your weapon or both.
 The default is Apply-Key.
 Persistent.
 %.lp
-\item[\ib{blind}]
+\item[blind]
 Start the character permanently blind (default false).  Persistent.
 %.lp
-\item[\ib{bones}]
+\item[bones]
 Allow saving and loading bones files (default true).  Persistent.
 %.lp
-\item[\ib{boulder}]
+\item[boulder]
 Set the character used to display boulders (default is the ``large rock''
 class symbol, `{\tt `}').
 %.lp
-\item[\ib{catname}]
+\item[catname]
 Name your starting cat (for example, ``{\tt catname:Morris}'').
 Cannot be set with the `{\tt O}' command.
 %.lp character
-\item[\ib{character}]
+\item[character]
 Synonym for ``{\tt role}'' to pick the type of your character
 (for example ``{\tt character:Monk}'').  See {\it role\/} for more details.
 %.lp
-\item[\ib{checkpoint}]
+\item[checkpoint]
 Save game state after each level change, for possible recovery after
 program crash (default on).  Persistent.
 %.lp
-\item[\ib{cmdassist}]
+\item[cmdassist]
 Have the game provide some additional command assistance for new
 players if it detects some anticipated mistakes (default on).
 %.lp
-\item[\ib{confirm}]
+\item[confirm]
 Have user confirm attacks on pets, shopkeepers, and other
 peaceable creatures (default on).  Persistent.
 %.lp
-\item[\ib{dark\textunderscore room}]
+\item[dark\textunderscore room]
 Show out-of-sight areas of lit rooms (default on).  Persistent.
 %.lp
-\item[\ib{deaf}]
+\item[deaf]
 Start the character permanently deaf (default false).  Persistent.
 %.lp
-\item[\ib{dropped\textunderscore nopick}]
+\item[dropped\textunderscore nopick]
 If this option is on, items you dropped will not be automatically picked up,
 even if ``{\it autopickup\/}'' is also on and they are in
 ``{\it pickup\textunderscore types\/}'' or match a positive autopickup exception
 (default on).  Persistent.
 %.lp
-\item[\ib{disclose}]
+\item[disclose]
 Controls what information the program reveals when the game ends.
 Value is a space separated list of prompting/category pairs
 (default is `{\tt ni na nv ng nc no}',
@@ -4339,11 +4334,11 @@ traps and each other as well as by you.
 And the dungeon overview shows all levels you had visited but does not
 reveal things about them that you hadn't discovered.
 %.lp
-\item[\ib{dogname}]
+\item[dogname]
 Name your starting dog (for example, ``{\tt dogname:Fang}'').
 Cannot be set with the `{\tt O}' command.
 %.lp
-\item[\ib{extmenu}]
+\item[extmenu]
 Changes the extended commands interface to pop-up a menu of available commands.
 It is keystroke compatible with the traditional interface except that it does
 not require that you hit Enter.
@@ -4354,32 +4349,32 @@ command, it controls whether the menu shows all available commands (on)
 or just the subset of commands which have traditionally been considered
 extended ones (off).
 %.lp
-\item[\ib{female}]
+\item[female]
 An obsolete synonym for ``{\tt gender:female}''.  Cannot be set with the
 `{\tt O}' command.
 %.lp
-\item[\ib{fireassist}]
+\item[fireassist]
 This option controls what happens when you attempt the `{\tt f}' (fire)
 and don't have an appropriate launcher, such as a bow or a sling, wielded.
 If on, you will automatically wield the launcher. Default is on.
 %.lp
-\item[\ib{fixinv}]
+\item[fixinv]
 An object's inventory letter sticks to it when it's dropped (default on).
 If this is off, dropping an object shifts all the remaining inventory letters.
 Persistent.
 %.lp
-\item[\ib{force\textunderscore invmenu}]
+\item[force\textunderscore invmenu]
 Commands asking for an inventory item show a menu instead of
 a text query with possible menu letters. Default is off.
 %.lp
-\item[\ib{fruit}]
+\item[fruit]
 Name a fruit after something you enjoy eating (for example, ``{\tt fruit:mango}'')
 (default ``{\tt slime mold}''). Basically a nostalgic whimsy that
 {\it NetHack\/} uses from time to time.  You should set this to something you
 find more appetizing than slime mold.  Apples, oranges, pears, bananas, and
 melons already exist in {\it NetHack\/}, so don't use those.
 %.lp
-\item[\ib{gender}]
+\item[gender]
 Your starting gender ({\tt gender:male} or {\tt gender:female}).
 You may specify just the first letter.
 Although you can
@@ -4394,26 +4389,26 @@ If {\tt gender} is not specified, there is no default value;
 player will be prompted unless role and/or race forces a choice for gender.
 Cannot be set with the `{\tt O}' command.  Persistent.
 %.lp
-\item[\ib{goldX}]
+\item[goldX]
 When filtering objects based on bless/curse state (BUCX), whether to
 treat gold pieces as {\tt X} (unknown bless/curse state, when `on')
 or {\tt U} (known to be uncursed, when `off', the default).
 Gold is never blessed or cursed, but it is not described as ``uncursed''
 even when the {\it implicit\textunderscore uncursed\/} option is `off'.
 %.lp
-\item[\ib{help}]
+\item[help]
 If more information is available for an object looked at
 with the `{\tt /}' command, ask if you want to see it (default on).
 Turning help off makes just looking at things faster, since you aren't
 interrupted with the ``{\tt More info?}'' prompt, but it also means that you
 might miss some interesting and/or important information.  Persistent.
 %.lp
-\item[\ib{herecmd\textunderscore menu}]
+\item[herecmd\textunderscore menu]
 When using a windowport that supports mouse and clicking on yourself or
 next to you, show a menu of possible actions for the location.
 Same as ``{\tt \#herecmdmenu}'' and ``{\tt \#therecmdmenu}'' commands.
 %.lp
-\item[\ib{hilite\textunderscore pet}]
+\item[hilite\textunderscore pet]
 Visually distinguish pets from similar animals (default off).
 The behavior of this option depends on the type of windowing you use.
 In text windowing, text highlighting or inverse video is often used;
@@ -4424,14 +4419,14 @@ With the tty or curses interface, the {\it petattr\/}
 option controls how to highlight pets and setting it will turn the
 {\it hilite\textunderscore pet\/} option on or off as warranted.
 %.lp
-\item[\ib{hilite\textunderscore pile}]
+\item[hilite\textunderscore pile]
 Visually distinguish piles of objects from individual objects (default off).
 The behavior of this option depends on the type of windowing you use.
 In text windowing, text highlighting or inverse video is often used;
 with tiles, generally displays a small plus-symbol beside the object
 on the top of the pile.
 %.lp
-\item[\ib{hitpointbar}]
+\item[hitpointbar]
 Show a hit point bar graph behind your name and title in the status
 display (default off).
 \\
@@ -4458,14 +4453,14 @@ To resize that, use the {\tt \#optionsfull} command to toggle the
 {\it hitpointbar\/} option off, perform the resize while it's off, then
 use the same command to toggle it back on.)
 %.lp
-\item[\ib{horsename}]
+\item[horsename]
 Name your starting horse (for example, ``{\tt horsename:Trigger}'').
 Cannot be set with the `{\tt O}' command.
 %.lp
-\item[\ib{ignintr}]
+\item[ignintr]
 Ignore interrupt signals, including breaks (default off).  Persistent.
 %.lp
-\item[\ib{implicit\textunderscore uncursed}]
+\item[implicit\textunderscore uncursed]
 Omit ``uncursed'' from object descriptions when it can be deduced from
 other aspects of the description (default on).
 Persistent.
@@ -4473,43 +4468,43 @@ Persistent.
 %.lp ""
 If you use menu coloring, you may want to turn this off.
 %.lp
-\item[\ib{legacy}]
+\item[legacy]
 Display an introductory message when starting the game (default on).
 Persistent.
 %.lp
-\item[\ib{lit\textunderscore corridor}]
+\item[lit\textunderscore corridor]
 Show corridor squares seen by night vision or a light source held by your
 character as lit (default off).  Persistent.
 %.lp
-\item[\ib{lootabc}]
+\item[lootabc]
 When using a menu to interact with a container,
 use the old `{\tt a}', `{\tt b}', and `{\tt c}' keyboard shortcuts
 rather than the mnemonics `{\tt o}', `{\tt i}', and `{\tt b}' (default off).
 Persistent.
 %.lp
-\item[\ib{mail}]
+\item[mail]
 Enable mail delivery during the game (default on).  Persistent.
 %.lp
-\item[\ib{male}]
+\item[male]
 An obsolete synonym for ``{\tt gender:male}''.  Cannot be set with the
 `{\tt O}' command.
 %.lp
-\item[\ib{mention\textunderscore decor}]
+\item[mention\textunderscore decor]
 Give feedback when walking onto various dungeon features such as stairs,
 fountains, or altars which are ordinarily only described when covered
 by one or more objects (default off).  Persistent.
 %.lp
-\item[\ib{mention\textunderscore map}]
+\item[mention\textunderscore map]
 Give feedback when interesting map locations change (default off).
 %.lp
-\item[\ib{mention\textunderscore walls}]
+\item[mention\textunderscore walls]
 Give feedback when walking against a wall (default off).  Persistent.
 %.lp
-\item[\ib{menucolors}]
+\item[menucolors]
 Enable coloring menu lines (default off).
 See ``{\it Configuring Menu Colors\/}'' on how to configure the colors.
 %.lp
-\item[\ib{menustyle}]
+\item[menustyle]
 Controls the method used when you need to choose various objects (in
 response to the {\tt Drop} (aka {\tt droptype}) command, for instance).
 The value specified should be the first letter of one of the following:
@@ -4533,40 +4528,40 @@ To avoid choosing that by accident,
 set {\it paranoid\textunderscore confirm:AutoAll\/} to require confirmation.)
 Partial skips the object class filtering and
 immediately displays a menu of all objects.
-\item[\ib{menu\textunderscore deselect\textunderscore all}]
+\item[menu\textunderscore deselect\textunderscore all]
 Key to deselect all items in a menu.
 Implemented by the Amiga, Gem, X11 and tty ports.
 Default `-'.
-\item[\ib{menu\textunderscore deselect\textunderscore page}]
+\item[menu\textunderscore deselect\textunderscore page]
 Key to deselect all items on this page of a menu.
 Implemented by the Amiga, Gem and tty ports.
 Default `\verb+\+'.
-\item[\ib{menu\textunderscore first\textunderscore page}]
+\item[menu\textunderscore first\textunderscore page]
 Key to jump to the first page in a menu.
 Implemented by the Amiga, Gem and tty ports.
 Default `\verb+^+'.
-\item[\ib{menu\textunderscore headings}]
+\item[menu\textunderscore headings]
 Controls how the headings in a menu are highlighted.
 Takes a text attribute, or text color and attribute separated by ampersand.
 For allowed attributes and colors, see ``{\it Configuring Menu Colors\/}``.
 Not all ports can actually display all types.
-\item[\ib{menu\textunderscore invert\textunderscore all}]
+\item[menu\textunderscore invert\textunderscore all]
 Key to invert all items in a menu.
 Implemented by the Amiga, Gem, X11 and tty ports.
 Default `@'.
-\item[\ib{menu\textunderscore invert\textunderscore page}]
+\item[menu\textunderscore invert\textunderscore page]
 Key to invert all items on this page of a menu.
 Implemented by the Amiga, Gem and tty ports.
 Default `\verb+~+'.
-\item[\ib{menu\textunderscore last\textunderscore page}]
+\item[menu\textunderscore last\textunderscore page]
 Key to jump to the last page in a menu.
 Implemented by the Amiga, Gem and tty ports.
 Default `\verb+|+'.
-\item[\ib{menu\textunderscore next\textunderscore page}]
+\item[menu\textunderscore next\textunderscore page]
 Key to go to the next menu page.
 Implemented by the Amiga, Gem and tty ports.
 Default `\verb+>+'.
-\item[\ib{menu\textunderscore objsyms}]
+\item[menu\textunderscore objsyms]
 % [originally menu_objsyms was a boolean]
 % Show object symbols in menu headings in menus where
 % the object symbols act as menu accelerators (default off).
@@ -4601,57 +4596,57 @@ objects among classes.
 Supported by tty and curses.
 When setting the value, it can be specified by digit or keyword.
 The default value is {\tt Conditional} (4).
-\item[\ib{menu\textunderscore overlay}]
+\item[menu\textunderscore overlay]
 Do not clear the screen before drawing menus, and align
 menus to the right edge of the screen. Only for the tty port.
 (default on)
-\item[\ib{menu\textunderscore previous\textunderscore page}]
+\item[menu\textunderscore previous\textunderscore page]
 Key to go to the previous menu page.
 Implemented by the Amiga, Gem and tty ports.
 Default `\verb+<+'.
-\item[\ib{menu\textunderscore search}]
+\item[menu\textunderscore search]
 Key to search for some text and toggle selection state of matching menu items.
 Default `:'.
-\item[\ib{menu\textunderscore select\textunderscore all}]
+\item[menu\textunderscore select\textunderscore all]
 Key to select all items in a menu.
 Implemented by the Amiga, Gem, X11 and tty ports.
 Default `.'.
-\item[\ib{menu\textunderscore select\textunderscore page}]
+\item[menu\textunderscore select\textunderscore page]
 Key to select all items on this page of a menu.
 Implemented by the Amiga, Gem and tty ports.
 Default `,'.
 
 %.lp
-\item[\ib{menu\textunderscore shift\textunderscore left}]
+\item[menu\textunderscore shift\textunderscore left]
 Key to scroll a menu---one which has been
 scrolled right---back to the left.
 Implemented for {\it perm\textunderscore invent\/} only by curses and X11.
 Default `{\tt \verb+{+}'.
 
 %.lp
-\item[\ib{menu\textunderscore shift\textunderscore right}]
+\item[menu\textunderscore shift\textunderscore right]
 Key to scroll a menu which has text beyond the
 right edge to the right.
 Implemented for {\it perm\textunderscore invent\/} only by curses by X11.
 Default `{\tt \verb+}+}'.
 % %.lp
-% \item[\ib{menu\textunderscore tab\textunderscore sep}]
+% \item[menu\textunderscore tab\textunderscore sep]
 % Format menu entries using TAB to separate columns (default off).
 % Only applicable to some menus, and only useful to some interfaces.
 % Debug mode only.
 %.lp
-\item[\ib{mon\textunderscore movement}]
+\item[mon\textunderscore movement]
 Show a message when hero notices a monster movement (default is off).
 %.lp
-\item[\ib{monpolycontrol}]
+\item[monpolycontrol]
 Prompt for new form whenever any monster changes shape (default off).
 Debug mode only.
 %.lp
-\item[\ib{montelecontrol}]
+\item[montelecontrol]
 Prompt for destination whenever any monster gets teleported (default off).
 Debug mode only.
 %.lp
-\item[\ib{mouse\textunderscore support}]
+\item[mouse\textunderscore support]
 Allow use of the mouse for input and travel.
 Valid settings are:
 
@@ -4668,12 +4663,12 @@ and negating
 {\it mouse\textunderscore support\/}
 is the same as specifying {\tt 0}.
 %.lp
-\item[\ib{msghistory}]
+\item[msghistory]
 The number of top line messages to save (and be able to recall
 with `{\tt \^{}P}') (default 20).
 Cannot be set with the `{\tt O}' command.
 %.lp
-\item[\ib{msg\textunderscore window}]
+\item[msg\textunderscore window]
 Allows you to change the way recalled messages are displayed.
 Currently it is only supported for tty (all four choices) and for curses
 (`{\tt f}' and `{\tt r}' choices, default `{\tt r}').
@@ -4692,7 +4687,7 @@ For backward compatibility, no value needs to be specified (which
 defaults to {\it full\/}), or it can be negated (which defaults
 to {\it single\/}).
 %.lp
-\item[\ib{name}]
+\item[name]
 Set your character's name (defaults to your user name).  You can also
 set your character's role by appending a dash and one or more letters of
 the role (that is, by suffixing one of
@@ -4707,18 +4702,18 @@ The former can made to behave like the latter by specifying a generic name
 such as ``player''.
 Cannot be set with the `{\tt O}' command.
 %.lp
-\item[\ib{news}]
+\item[news]
 Read the {\it NetHack\/} news file, if present (default on).
 Since the news is shown at the beginning of the game, there's no point
 in setting this with the `{\tt O}' command.
 %.lp
-\item[\ib{nudist}]
+\item[nudist]
 Start the character with no armor (default false).  Persistent.
 %.lp
-\item[\ib{null}]
+\item[null]
 Send padding nulls to the terminal (default on).  Persistent.
 %.lp
-\item[\ib{number\textunderscore pad}]
+\item[number\textunderscore pad]
 Use digit keys instead of letters to move (default 0 or off).\\
 Valid settings are:
 
@@ -4749,13 +4744,13 @@ When moving by numbers, to enter a count prefix for those commands
 which accept one (such as ``{\tt 12s}'' to search twelve times), precede it
 with the letter `{\tt n}' (``{\tt n12s}'').
 %.lp
-\item[\ib{packorder}]
+\item[packorder]
 Specify the order to list object types in (default
 ``\verb&")[%?+!=/(*`0_&''). The value of this option should be a string
 containing the symbols for the various object types.  Any omitted types
 are filled in at the end from the previous order.
 %.lp
-\item[\ib{paranoid\textunderscore confirmation}]
+\item[paranoid\textunderscore confirmation]
 A space separated list of specific situations where alternate
 prompting is desired.
 The default is ``{\it paranoid\textunderscore confirmation:pray swim trap}''.
@@ -4764,57 +4759,57 @@ The default is ``{\it paranoid\textunderscore confirmation:pray swim trap}''.
 \newlength{\pcwidth}
 \settowidth{\pcwidth}{\tt Were-change}
 \addtolength{\pcwidth}{\labelsep}
-\blist{\leftmargin \pcwidth \topsep 1mm \itemsep 0mm}
-\item[{\tt Confirm}]
+\begin{description}[leftmargin=\pcwidth, topsep=1mm, itemsep=0mm, labelwidth=*, font=\ttfamily, align=right]
+\item[Confirm]
 for any prompts which are set to require ``yes'' rather than `y',
 also require ``no'' to reject instead of accepting any non-yes response
 as no; changes pray and AutoAll to require ``yes'' or ``no'' too;
-\item[{\tt quit~~~}]
+\item[quit]
 require ``{\tt yes}'' rather than `{\tt y}' to confirm quitting
 the game or switching into non-scoring explore mode;
-\item[{\tt die~~~~}]
+\item[die]
 require ``{\tt yes}'' rather than `{\tt y}' to confirm dying (not
 useful in normal play; applies to explore mode);
-\item[{\tt bones~~}]
+\item[bones]
 require ``{\tt yes}'' rather than `{\tt y}' to confirm saving
 bones data when dying in debug mode
-\item[{\tt attack~}]
+\item[attack]
 require ``{\tt yes}'' rather than `{\tt y}' to confirm attacking
 a peaceful monster;
-\item[{\tt wand-break}]
+\item[wand-break]
 require ``{\tt yes}'' rather than `{\tt y}' to confirm breaking
 a wand with the {\it apply} command;
-\item[{\tt eating~}]
+\item[eating]
 require ``{\tt yes}'' rather than `{\tt y}' to confirm whether to
 continue eating;
-\item[{\tt Were-change}]
+\item[Were-change]
 require ``{\tt yes}'' rather than `{\tt y}' to confirm changing form due
 to lycanthropy when hero has polymorph control;
-\item[{\tt pray~~~}]
+\item[pray]
 require `{\tt y}' to confirm an attempt to pray rather
 than immediately praying; on by default;
 (to require ``yes'' rather than just `y', set Confirm too);
-\item[{\tt trap~~~}]
+\item[trap]
 require `{\tt y}' to confirm an attempt to move into or onto a known trap,
 unless doing so is considered to be harmless;
 when enabled, this confirmation is also used for moving into visible
 gas cloud regions;
 (to require ``yes'' rather than just `y', set Confirm too);
 confirmation can be skipped by using the `{\tt m}' movement prefix;
-\item[{\tt swim~~~}]
+\item[swim]
 prevent walking into water or lava; on by default; (to deliberately step
 onto/into such terrain when this is set, use the `{\tt m}'
 movement prefix when adjacent);
-\item[{\tt AutoAll}]
+\item[AutoAll]
 require confirmation when the `A' (Autoselect-All) choice is selected
 in object class filtering menus for {\it menustyle:Full};
 (to require ``yes'' rather than just `y', set Confirm too);
-\item[{\tt Remove~}]
+\item[Remove]
 require selection from inventory for `{\tt R}' and `{\tt T}'
 commands even when wearing just one applicable item;
-\item[{\tt all~~~~}]
+\item[all]
 turn on all of the above.
-\elist
+\end{description}
 %.ei
 %.ed
 By default, the pray, swim, and trap choices are enabled, the others disabled.
@@ -4835,10 +4830,10 @@ and entries to be removed by `{\tt !}' and name.
 The positive (no `!') and negative (with `!') entries
 can be intermixed.
 %.lp
-\item[\ib{pauper}]
+\item[pauper]
 Start the character with no possessions (default false).  Persistent.
 %.lp
-\item[\ib{perm\textunderscore invent}]
+\item[perm\textunderscore invent]
 If true, always display your current inventory in a window (default is false).
 %.lp ""
 \\
@@ -4851,7 +4846,7 @@ for {\it perm\textunderscore invent\/}.
 Setting that to a value other than {\it none\/}
 while {\it perm\textunderscore invent\/} is false will change it to true.
 %.lp
-\item[\ib{perminv\textunderscore mode}]
+\item[perminv\textunderscore mode]
 Augments the
 {\tt perm\textunderscore invent}
 option.
@@ -4859,7 +4854,7 @@ Value is one of
 %.PS "\f(CRin-use\fP"
 \settowidth{\pcwidth}{\tt in-use}  %reuse the paranoid_confirm width
 \addtolength{\pcwidth}{\labelsep}
-\blist{\leftmargin \pcwidth \topsep 1mm \itemsep 0mm}
+\begin{description}[leftmargin=\pcwidth, topsep=1mm, itemsep=0mm, labelwidth=*, font=\mdseries, align=right]
 %.PL
 \item[{\tt none}]
 behave as if {\it perm\textunderscore invent\/} is false;
@@ -4870,7 +4865,7 @@ show full inventory including gold;
 \item[{in-use}]
 only show items which are in use (worn, wielded, lit lamp).
 %.PE
-\elist
+\end{description}
 Default is {\it none\/} but if {\it perm\textunderscore invent\/} gets set to true
 while it is {\it none\/} it will be changed to {\it all\/}.
 %.lp ""
@@ -4879,7 +4874,7 @@ Note: if gold has been equipped in quiver/ammo-pouch then it will be
 included for {\it all\/} despite that mode normally omitting gold.
 %.lp
 %.\" petattr is a wincap option but we'll document it here...
-\item[\ib{petattr}]
+\item[petattr]
 Specifies one or more text highlighting attributes to use when showing
 pets on the map.
 Effectively a superset of the {\it hilite\textunderscore pet\/} boolean option.
@@ -4889,7 +4884,7 @@ Some of those choices might not work,
 depending upon terminal hardware or terminal emulation software.
 
 %.lp
-\item[\ib{pettype}]
+\item[pettype]
 Specify the type of your initial pet, if you are playing a character class
 that uses multiple types of pets; or choose to have no initial pet at all.
 Possible values are ``{\tt cat}'', ``{\tt dog}'', ``{\tt horse}''
@@ -4899,13 +4894,13 @@ it will be silently ignored.  For example, ``{\tt horse}'' will only be
 honored when playing a knight.
 Cannot be set with the `{\tt O}' command.
 %.lp
-\item[\ib{pickup\textunderscore burden}]
+\item[pickup\textunderscore burden]
 When you pick up an item that would exceed this encumbrance
 level (Unencumbered, Burdened, streSsed, straiNed, overTaxed,
 or overLoaded), you will be asked if you want to continue.
 (Default `S').  Persistent.
 %.lp
-\item[\ib{pickup\textunderscore stolen}]
+\item[pickup\textunderscore stolen]
 If this option is on and ``{\it autopickup\/}'' is also on, try to pick up
 things that a monster stole from you, even if they aren't in
 ``{\it pickup\textunderscore types\/}'' or
@@ -4913,7 +4908,7 @@ match an autopickup exception.
 Default is on.
 Persistent.
 %.lp
-\item[\ib{pickup\textunderscore thrown}]
+\item[pickup\textunderscore thrown]
 If this option is on and ``{\it autopickup\/}'' is also on, try to pick up
 things that you threw, even if they aren't in
 ``{\it pickup\textunderscore types\/}'' or
@@ -4921,7 +4916,7 @@ match an autopickup exception.
 Default is on.
 Persistent.
 %.lp
-\item[\ib{pickup\textunderscore types}]
+\item[pickup\textunderscore types]
 Specify the object types to be picked up when ``{\it autopickup\/}''
 is on.
 Default is all types.
@@ -4944,7 +4939,7 @@ up, you can set {\it pickup\textunderscore types\/} to `{\tt .}'.
 That is the type symbol for {\it venom\/} and you won't come across
 any venom items so won't unintentionally pick such up.
 %.lp
-\item[\ib{pile\textunderscore limit}]
+\item[pile\textunderscore limit]
 When walking across a pile of objects on the floor, threshold at which
 the message ``there are few/several/many objects here'' is given instead
 of showing a popup list of those objects.  A value of 0 means ``no limit''
@@ -4952,7 +4947,7 @@ of showing a popup list of those objects.  A value of 0 means ``no limit''
 the objects'' since the pile size will always be at least that big;
 default value is 5.  Persistent.
 %.lp
-\item[\ib{playmode}]
+\item[playmode]
 Values are {\it normal\/}, {\it explore\/}, or {\it debug\/}.
 Allows selection of explore mode (also known as discovery mode) or debug
 mode (also known as wizard mode) instead of normal play.
@@ -4962,16 +4957,16 @@ name (on single-user systems) or it might be disabled entirely.  Requesting
 it when not allowed or not possible results in explore mode instead.
 Default is normal play.
 %.lp
-\item[\ib{pushweapon}]
+\item[pushweapon]
 Using the `{\tt w}' (wield) command when already wielding
 something pushes the old item into your alternate weapon slot (default off).
 Likewise for the `{\tt a}' (apply) command if it causes the applied item to
 become wielded.  Persistent.
 %.lp
-\item[\ib{query\textunderscore menu}]
+\item[query\textunderscore menu]
 Use a menu when asked specific yes/no queries, instead of a prompt.
 %.lp
-\item[\ib{quick\textunderscore farsight}]
+\item[quick\textunderscore farsight]
 When set, usually prevents the ``you sense your surroundings'' message
 where play pauses to allow you to browse the map whenever clairvoyance
 randomly activates.
@@ -4980,7 +4975,7 @@ It does not affect the clairvoyance spell where pausing to examine revealed
 objects or monsters is less intrusive.
 Default is off.  Persistent.
 %.lp
-\item[\ib{race}]
+\item[race]
 Choices are {\tt human}, {\tt dwarf}, {\tt elf}, {\tt gnome}, and
 {\tt orc} but most roles restrict which of the non-human races are allowed.
 See {\it role\/}
@@ -4992,11 +4987,11 @@ player will be prompted unless role forces a choice for race.
 unless role forces a choice for race.
 Cannot be set with the `{\tt O}' command.  Persistent.
 %.lp
-\item[\ib{rest\textunderscore on\textunderscore space}]
+\item[rest\textunderscore on\textunderscore space]
 Make the space bar a synonym for the `{\tt .}' (\#wait) command (default off).
 Persistent.
 %.lp
-\item[\ib{role}]
+\item[role]
 Pick your type of character (for example, ``{\tt role:Samurai}'');
 synonym for ``{\it character\/}''.
 See ``{\it name\/}'' for an alternate method of specifying your role.
@@ -5028,17 +5023,17 @@ If {\tt role} is not specified, there is no default value;
 player will be prompted.
 Cannot be set with the `{\tt O}' command.  Persistent.
 %.lp
-\item[\ib{roguesymset}]
+\item[roguesymset]
 This option may be used to select one of the named symbol sets found within
 {\tt symbols} to alter the symbols displayed on the screen on the
 rogue level.
 %.lp
-\item[\ib{rlecomp}]
+\item[rlecomp]
 When writing out a save file, perform run length compression of the map.
 Not all ports support run length compression. It has no
 effect on reading an existing save file.
 %.lp
-\item[\ib{runmode}]
+\item[runmode]
 Controls the amount of screen updating for the map window when engaged
 in multi-turn movement (running via {\tt shift}+direction
 or {\tt control}+direction
@@ -5059,43 +5054,43 @@ results of moving.  The default is {\it run\/}; versions prior to 3.4.1
 used {\it teleport\/} only.  Whether or not the effect is noticeable will
 depend upon the window port used or on the type of terminal.  Persistent.
 %.lp
-\item[\ib{safe\textunderscore pet}]
+\item[safe\textunderscore pet]
 Prevent you from (knowingly) attacking your pets (default on).  Persistent.
 %.lp
-\item[\ib{safe\textunderscore wait}]
+\item[safe\textunderscore wait]
 Prevents you from waiting or searching when next to a hostile monster
 (default on).  Persistent.
 %.lp
-\item[\ib{sanity\textunderscore check}]
+\item[sanity\textunderscore check]
 Evaluate monsters, objects, and map prior to each turn (default off).
 Debug mode only.
 %.lp
-\item[\ib{scores}]
+\item[scores]
 Control what parts of the score list you are shown at the end (for example,
 ``{\tt scores:5top scores/4around my score/own scores}'').  Only the first
 letter of each category (`{\tt t}', `{\tt a}' or `{\tt o}') is necessary.
 Persistent.
 %.lp
-\item[\ib{showdamage}]
+\item[showdamage]
 Whenever your character takes damage, show a message of the damage taken,
 and the amount of hit points left.
 %.lp
-\item[\ib{showexp}]
+\item[showexp]
 Show your accumulated experience points on bottom line (default off).
 Persistent.
 %.lp
-\item[\ib{showrace}]
+\item[showrace]
 Display yourself as the glyph for your race, rather than the glyph
 for your role (default off).  Note that this setting affects only
 the appearance of the display, not the way the game treats you.
 Persistent.
 %.lp
-\item[\ib{showscore}]
+\item[showscore]
 Show your approximate accumulated score on bottom line (default off).
 By default, this feature is suppressed when building the program.
 Persistent.
 %.lp
-\item[\ib{showvers}]
+\item[showvers]
 Include the game's version number on the status lines (default off).
 Potentially useful if you switch between different versions or variants,
 or you are making screenshots or streaming video.
@@ -5106,10 +5101,10 @@ status information, unless you're using nethack's {\it Qt\/} interface
 or your terminal emulator window displays fewer than 25 lines.
 Persistent.
 %.lp
-\item[\ib{silent}]
+\item[silent]
 Suppress terminal beeps (default on).  Persistent.
 %.lp
-\item[\ib{sortdiscoveries}]
+\item[sortdiscoveries]
 Controls the sorting behavior for the output of the `{\tt $\backslash$}'
 and `{\tt \`{}}' commands.
 Persistent.
@@ -5134,7 +5129,7 @@ Can be interactively set via the `{\tt O}' command or via using
 the `{\tt m}' prefix before the `{\tt $\backslash$}'
 or `{\tt \`{}}' command.
 %.lp
-\item[\ib{sortloot}]
+\item[sortloot]
 Controls the sorting behavior of pickup lists for inventory
 and \#loot commands and some others.  Persistent.
 \\
@@ -5149,11 +5144,11 @@ The possible values are:
 %.ei
 %.ed
 %.lp
-\item[\ib{sortpack}]
+\item[sortpack]
 Sort the pack contents by type when displaying inventory (default on).
 Persistent.
 %.lp
-\item[\tb{sortvanquished}]
+\item[sortvanquished]
 Controls the sorting behavior for the output of the {\tt \#vanquished} command
 and also for the {\tt \#genocided} command.
 Persistent.
@@ -5194,60 +5189,60 @@ Can be interactively set via the `{\tt m O}' command or via using
 the `{\tt m}' prefix before either the {\tt \#vanquished} command
 or the {\tt \#genocided} command.
 %.lp
-\item[\ib{sounds}]
+\item[sounds]
 Allow sounds to be emitted from an integrated sound library (default on).
 %.lp
-\item[\ib{sparkle}]
+\item[sparkle]
 Display a sparkly effect when a monster (including yourself) is hit by an
 attack to which it is resistant (default on).  Persistent.
 %.lp
-\item[\ib{spot\textunderscore monsters}]
+\item[spot\textunderscore monsters]
 Show a message when hero notices a monster (default is off).
 %.lp
-\item[\ib{standout}]
+\item[standout]
 Boldface monsters and ``{\tt --More--}'' (default off).  Persistent.
 %.lp
-\item[\ib{statushilites}]
+\item[statushilites]
 Controls how many turns status hilite behaviors highlight
 the field. If negated or set to zero, disables status hiliting.
 See ``{\it Configuring Status Hilites\/}'' for further information.
 %.lp
-\item[\ib{status\textunderscore updates}]
+\item[status\textunderscore updates]
 Allow updates to the status lines at the bottom of the screen (default true).
 %.lp
-\item[\ib{suppress\textunderscore alert}]
+\item[suppress\textunderscore alert]
 This option may be set to a {\it NetHack\/} version level to suppress
 alert notification messages about feature changes for that
 and prior versions (for example, ``{\tt suppress\textunderscore alert:3.3.1}'')
 %.lp
-\item[\ib{symset}]
+\item[symset]
 This option may be used to select one of the named symbol sets found within
 {\tt symbols} to alter the symbols displayed on the screen.
 Use ``{\tt symset:default}'' to explicitly select the default symbols.
 %.lp
-\item[\ib{time}]
+\item[time]
 Show the elapsed game time in turns on bottom line (default off).  Persistent.
 %.lp
-\item[\ib{timed\textunderscore delay}]
+\item[timed\textunderscore delay]
 When pausing momentarily for display effect, such as with explosions and
 moving objects, use a timer rather than sending extra characters to the
 screen.  (Applies to ``tty'' and ``curses'' interfaces only; ``X11'' interface always
 uses a timer-based delay.  The default is on if configured into the
 program.)  Persistent.
 %.lp
-\item[\ib{tips}]
+\item[tips]
 Show some helpful tips during gameplay (default on).  Persistent.
 %.lp
-\item[\ib{tombstone}]
+\item[tombstone]
 Draw a tombstone graphic upon your death (default on).  Persistent.
 %.lp
-\item[\ib{toptenwin}]
+\item[toptenwin]
 Put the ending display in a {\it NetHack\/} window instead of on stdout (default off).
 Setting this option makes the score list visible when a windowing version
 of {\it NetHack\/} is started without a parent window, but it no longer leaves
 the score list around after game end on a terminal or emulating window.
 %.lp
-\item[\ib{travel}]
+\item[travel]
 Allow the travel command via mouse click (default on).
 Turning this option off will prevent the game from attempting unintended
 moves if you make inadvertent mouse clicks on the map window.
@@ -5258,14 +5253,14 @@ command.  Persistent.
 % Display intended path during each step of travel (default off).
 % Debug mode only.
 %.lp
-\item[\ib{tutorial}]
+\item[tutorial]
 Play a tutorial level at the start of the game.
 Setting this option on or off in the config file will skip the query.
 %.lp
-\item[\ib{verbose}]
+\item[verbose]
 Provide more commentary during the game (default on).  Persistent.
 %.lp
-\item[\ib{whatis\textunderscore coord}]
+\item[whatis\textunderscore coord]
 When using the `{\tt /}' or `{\tt ;}' commands to look around on the map with
 ``{\tt autodescribe}''
 on, display coordinates after the description.
@@ -5292,7 +5287,7 @@ the `{\tt /m}', `{\tt /M}', `{\tt /o}', and `{\tt /O}' sub-commands
 of `{\tt /}',
 where the `{\it none\/}' setting is overridden with `{\it map}'.
 %.lp
-\item[\ib{whatis\textunderscore filter}]
+\item[whatis\textunderscore filter]
 When getting a location on the map, and using the keys to cycle through
 next and previous targets, allows filtering the possible targets.
 (default none)\\
@@ -5315,18 +5310,18 @@ the door you were last moving towards.\\
 Filtering can also be changed when getting a location with
 the ``getpos.filter'' key.
 %.lp
-\item[\ib{whatis\textunderscore menu}]
+\item[whatis\textunderscore menu]
 When getting a location on the map, and using a key to cycle through
 next and previous targets, use a menu instead to pick a target.
 (default off)
 %.lp
-\item[\ib{whatis\textunderscore moveskip}]
+\item[whatis\textunderscore moveskip]
 When getting a location on the map, and using shifted movement keys or
 meta-digit keys to fast-move, instead of moving 8 units at a time,
 move by skipping the same glyphs.
 (default off)
 %.lp
-\item[\ib{windowtype}]
+\item[windowtype]
 When the program has been built to support multiple interfaces,
 select whichone to use, such as ``{\tt tty}'' or ``{\tt X11}''
 (default depends on build-time settings; use ``{\tt \#version}'' to check).
@@ -5340,15 +5335,15 @@ non-comment line.
 For a comma-separated list in NETHACKOPTIONS or an OPTIONS line in a
 configuration file, that would be the {\it rightmost\/} option in the list.
 %.lp
-\item[\ib{wizweight}]
+\item[wizweight]
 Augment object descriptions with their objects' weight (default off).
 Debug mode only.
 %.lp
-\item[\ib{zerocomp}]
+\item[zerocomp]
 When writing out a save file, perform zero-comp compression of the
 contents. Not all ports support zero-comp compression. It has no effect
 on reading an existing save file.
-\elist
+\end{description}
 
 %.hn 2
 \subsection*{Window Port Customization options}
@@ -5368,15 +5363,15 @@ using by checking to see if it shows up in the Options list.
 Some options are dynamic and can be specified during the game
 with the `{\tt O}' command.
 
-\blist{}
+\begin{description}[font=\itshape]
 %.lp
-\item[\ib{align\textunderscore message}]
+\item[align\textunderscore message]
  Where to align or place the message window (top, bottom, left, or right)
 %.lp
-\item[\ib{align\textunderscore status}]
+\item[align\textunderscore status]
  Where to align or place the status window (top, bottom, left, or right).
 %.lp
-\item[\ib{ascii\textunderscore map}]
+\item[ascii\textunderscore map]
 %.hw DECgraphics IBMgraphics \% don't hyphenate these
 \hyphenation{DECgraphics IBMgraphics}
 If {\it NetHack\/} can, it should display the map using simple
@@ -5388,94 +5383,94 @@ or {\it IBMgraphics\/} if your display supports them.
 Setting {\tt ascii\textunderscore map} to {\it True\/} forces
 {\tt tiled\textunderscore map} to be {\it False}.
 %.lp
-\item[\ib{color}]
+\item[color]
 If {\it NetHack\/} can, it should display color for different monsters,
 objects, and dungeon features (default on).
 %.lp
-\item[\ib{eight\textunderscore bit\textunderscore tty}]
+\item[eight\textunderscore bit\textunderscore tty]
 If {\it NetHack\/} can, it should pass eight-bit character values (for example, specified with the
 {\it traps \/} option) straight through to your terminal (default off).
 %.lp
-\item[\ib{font\textunderscore map}]
+\item[font\textunderscore map]
 If {\it NetHack\/} can, it should use a font by the chosen name for the
 map window.
 %.lp
-\item[\ib{font\textunderscore menu}]
+\item[font\textunderscore menu]
 If {\it NetHack\/} can, it should use a font by the chosen name for menu
 windows.
 %.lp
-\item[\ib{font\textunderscore message}]
+\item[font\textunderscore message]
 If {\it NetHack\/} can, it should use a font by the chosen name for the message window.
 %.lp
-\item[\ib{font\textunderscore status}]
+\item[font\textunderscore status]
 If {\it NetHack\/} can, it should use a font by the chosen name for the status window.
 %.lp
-\item[\ib{font\textunderscore text}]
+\item[font\textunderscore text]
 If {\it NetHack\/} can, it should use a font by the chosen name for text windows.
 %.lp
-\item[\ib{font\textunderscore size\textunderscore map}]
+\item[font\textunderscore size\textunderscore map]
 If {\it NetHack\/} can, it should use this size font for the map window.
 %.lp
-\item[\ib{font\textunderscore size\textunderscore menu}]
+\item[font\textunderscore size\textunderscore menu]
 If {\it NetHack\/} can, it  should use this size font for menu windows.
 %.lp
-\item[\ib{font\textunderscore size\textunderscore message}]
+\item[font\textunderscore size\textunderscore message]
 If {\it NetHack\/} can, it should use this size font for the message window.
 %.lp
-\item[\ib{font\textunderscore size\textunderscore status}]
+\item[font\textunderscore size\textunderscore status]
 If {\it NetHack\/} can, it should use this size font for the status window.
 %.lp
-\item[\ib{font\textunderscore size\textunderscore text}]
+\item[font\textunderscore size\textunderscore text]
 If {\it NetHack\/} can, it should use this size font for text windows.
 %.lp
-\item[\ib{fullscreen}]
+\item[fullscreen]
 If {\it NetHack\/} can, it should try to display on the entire screen rather than in a window.
 %.lp
-\item[\ib{guicolor}]
+\item[guicolor]
 Use color text and/or highlighting attributes when displaying some
 non-map data (such as menu selector letters).
 Curses interface only; default is on.
 %.lp
-\item[\ib{large\textunderscore font}]
+\item[large\textunderscore font]
 If {\it NetHack\/} can, it should use a large font.
 %.lp
-\item[\ib{map\textunderscore mode}]
+\item[map\textunderscore mode]
 If {\it NetHack\/} can, it should display the map in the manner specified.
 %.lp
-\item[\ib{player\textunderscore selection}]
+\item[player\textunderscore selection]
 If {\it NetHack\/} can, it should pop up dialog boxes or use prompts for character selection.
 %.lp
-\item[\ib{popup\textunderscore dialog}]
+\item[popup\textunderscore dialog]
 If {\it NetHack\/} can, it should pop up dialog boxes for input.
 %.lp
-\item[\ib{preload\textunderscore tiles}]
+\item[preload\textunderscore tiles]
 If {\it NetHack\/} can, it should preload tiles into memory.
 For example, in the protected mode MS-DOS version, control whether tiles
 get pre-loaded into RAM at the start of the game.  Doing so
 enhances performance of the tile graphics, but uses more memory. (default on).
 Cannot be set with the `{\tt O}' command.
 %.lp
-\item[\ib{scroll\textunderscore amount}]
+\item[scroll\textunderscore amount]
 If {\it NetHack\/} can, it should scroll the display by this number of cells
 when the hero reaches the scroll\textunderscore margin.
 %.lp
-\item[\ib{scroll\textunderscore margin}]
+\item[scroll\textunderscore margin]
 If {\it NetHack\/} can, it should scroll the display when the hero or cursor
 is this number of cells away from the edge of the window.
 %.lp
-\item[\ib{selectsaved}]
+\item[selectsaved]
 If {\it NetHack\/} can, it should display a menu of existing saved games for the player to
 choose from at game startup, if it can. Not all ports support this option.
 %.lp
-\item[\ib{softkeyboard}]
+\item[softkeyboard]
 If {\it NetHack\/} can, it should display an onscreen keyboard.
 Handhelds are most likely to support this option.
 %.lp
-\item[\ib{splash\textunderscore screen}]
+\item[splash\textunderscore screen]
 If {\it NetHack\/} can, it should display an opening splash screen when
 it starts up (default yes).
 %.lp
-\item[\ib{statuslines}]
+\item[statuslines]
 Number of lines for traditional below-the-map status display.
 Acceptable values are {\tt 2} and {\tt 3} (default is {\tt 2}).
 
@@ -5509,16 +5504,16 @@ older than {\tt qt-5.9},
 can only be set in the run-time configuration file or via NETHACKOPTIONS,
 not during play with the `{\tt O}' command.)
 %.lp
-\item[\ib{term\textunderscore cols} {\normalfont and}]
+\item[term\textunderscore cols \textrm{and}]
 %.lp
-\item[\ib{term\textunderscore rows}]
+\item[term\textunderscore rows]
 Curses interface only.
 Number of columns and rows to use for the display.
 Curses will attempt to resize to the values specified but will settle
 for smaller sizes if they are too big.
 Default is the current window size.
 %.lp
-\item[\ib{tile\textunderscore file}]
+\item[tile\textunderscore file]
 Specify the name of an alternative tile file to override the default.
 \\
 %.lp ""
@@ -5526,34 +5521,34 @@ Note: the X11 interface uses X resources rather than NetHack's options
 to select an alternate tile file.
 See {\tt NetHack.ad}, the sample X ``application defaults'' file.
 %.lp
-\item[\ib{tile\textunderscore height}]
+\item[tile\textunderscore height]
 Specify the preferred height of each tile in a tile capable port.
 %.lp
-\item[\ib{tile\textunderscore width}]
+\item[tile\textunderscore width]
 Specify the preferred width of each tile in a tile capable port
 %.lp
-\item[\ib{tiled\textunderscore map}]
+\item[tiled\textunderscore map]
 If {\it NetHack\/} can, it should display the map using {\it tiles} graphics
 rather than simple characters (letters and punctuation, possibly
 augmented by line-drawing symbols).
 Setting {\tt tiled\textunderscore map} to {\it True\/} forces
 {\tt ascii\textunderscore map} to be {\it False}.
 %.lp
-\item[\ib{use\textunderscore darkgray}]
+\item[use\textunderscore darkgray]
 Use bold black instead of blue for black glyphs (TTY only).
 %.lp
-\item[\ib{use\textunderscore inverse}]
+\item[use\textunderscore inverse]
 If {\it NetHack\/} can, it should display inverse when the game specifies it.
 %.lp
-\item[\ib{use\textunderscore menu\textunderscore glyphs}]
+\item[use\textunderscore menu\textunderscore glyphs]
 If {\it NetHack\/} can, it should display glyphs next to objects in the
 inventory.
 %.lp
-\item[\ib{vary\textunderscore msgcount}]
+\item[vary\textunderscore msgcount]
 If {\it NetHack\/} can, it should display this number of messages at a time
 in the message window.
 %.lp
-\item[\ib{windowborders}]
+\item[windowborders]
 Whether to draw boxes around the map, status area, message area, and
 persistent inventory window if enabled.
 Curses interface only.
@@ -5585,7 +5580,7 @@ setting the value to 3 or 4 instead will keep borders for the map, message,
 and status windows but have room for two additional lines of inventory
 plus widen each inventory line by two columns.
 %.lp
-\item[\ib{windowcolors}]
+\item[windowcolors]
 If {\it NetHack\/} can, it should display all windows of a particular style
 with the specified foreground and background colors.
 Windows GUI and curses windowport only.
@@ -5610,10 +5605,10 @@ or (for Windows only) one of Windows UI colors ({\it trueblack},
 {\it windowtext}).
 
 %.lp
-\item[\ib{wraptext}]
+\item[wraptext]
 If {\it NetHack\/} can, it should wrap long lines of text if they don't fit
 in the visible area of the window.
-\elist
+\end{description}
 
 %.hn 2
 \subsection*{Crash Report Options}
@@ -5622,21 +5617,21 @@ in the visible area of the window.
 Please note that NetHack does not send {\textbf any} information off your
 computer unless you manually click submit on a form.
 %.si
-\blist{}
+\begin{description}
 %.lp
 \item[OPTION=crash\textunderscore email:{\it email\textunderscore address}]
 %.lp
 \item[OPTION=crash\textunderscore name:{\it your\textunderscore name}]
 %.ei
-\elist
+\end{description}
 These options are used only to save you some typing on the crash
 report and \#bugreport forms.  
 %.si
-\blist{}
+\begin{description}
 %.lp
 \item[OPTION=crash\textunderscore urlmax:{\it bytes}]
 %.ei
-\elist
+\end{description}
 This option is used to limit the length of the URLs generated and is only
 needed if your browser cannot handle arbitrarily long URLs.
 
@@ -5647,16 +5642,16 @@ needed if your browser cannot handle arbitrarily long URLs.
 Here are explanations of options that are used by specific platforms
 or ports to customize and change the port behavior.
 
-\blist{}
+\begin{description}[font=\itshape]
 %.lp
-\item[\ib{altkeyhandling}]
+\item[altkeyhandling]
 Select an alternate way to handle keystrokes ({\it Win32 tty\/ NetHack\/} only).
 The name of the handling type is one of {\it default}, {\it ray}, {\it 340}
-%.\" \item[\ib{altmeta}]
+%.\" \item[altmeta]
 %.\" On Amiga, this option controls whether typing ``Alt'' plus another key
 %.\" functions as a meta-shift for that key (default on).
 %.lp
-\item[\ib{altmeta}]
+\item[altmeta]
 %.\" On other (non-Amiga) systems where this option is available, it can be
 On systems where this option is available, it can be
 set to tell {\it NetHack\/} to convert a two character sequence beginning with
@@ -5673,19 +5668,19 @@ character to complete the two character sequence.
 Type a second ESC to finish cancelling such a count.
 At other prompts a single ESC suffices.
 %.lp
-\item[\ib{BIOS}]
+\item[BIOS]
 Use BIOS calls to update the screen display quickly and to read the keyboard
 (allowing the use of arrow keys to move) on machines with an IBM PC
 compatible BIOS ROM (default off, {\it OS/2, PC\/ {\rm and} ST NetHack\/} only).
 %.lp
-\item[\ib{rawio}]
+\item[rawio]
 Force raw (non-cbreak) mode for faster output and more
 bulletproof input (MS-DOS sometimes treats `{\tt \^{}P}' as a printer toggle
 without it) (default off, {\it OS/2, PC\/ {\rm and} ST NetHack\/} only).
 Note:  DEC Rainbows hang if this is turned on.
 Cannot be set with the `{\tt O}' command.
 %.lp
-\item[\ib{subkeyvalue}]
+\item[subkeyvalue]
 ({\it Win32 tty NetHack \/} only).
 May be used to alter the value of keystrokes that the operating system
 returns to {\it NetHack\/} to help compensate for international keyboard
@@ -5696,7 +5691,7 @@ You can use multiple subkeyvalue assignments in the configuration file
 if needed.
 Cannot be set with the `{\tt O}' command.
 %.lp
-\item[\ib{video}]
+\item[video]
 Set the video mode used ({\it PC\/ NetHack\/} only).
 Values are {\it autodetect\/}, {\it default\/}, {\it vga\/}, or {\it vesa\/}.
 Setting {\it vesa\/} will cause the game to display tiles, using the full
@@ -5708,13 +5703,13 @@ Setting {\it autodetect\/} attempts {\it vesa\/}, then {\it vga\/}, and
 finally sets {\it default\/} if neither of those modes works.
 Cannot be set with the `{\tt O}' command.
 %.lp
-\item[\ib{video\textunderscore height}]
+\item[video\textunderscore height]
 Set the VGA mode resolution height (MS-DOS only, with video:vesa)
 %.lp
-\item[\ib{video\textunderscore width}]
+\item[video\textunderscore width]
 Set the VGA mode resolution width (MS-DOS only, with video:vesa)
 %.lp
-\item[\ib{videocolors}]
+\item[videocolors]
 \begin{sloppypar}
 Set the color palette for PC systems using NO\textunderscore TERMS
 (default 4-2-6-1-5-3-15-12-10-14-9-13-11, {\it PC\/ NetHack\/} only).
@@ -5724,13 +5719,13 @@ bright.magenta, and bright.cyan.
 Cannot be set with the `{\tt O}' command.
 \end{sloppypar}
 %.lp
-\item[\ib{videoshades}]
+\item[videoshades]
 Set the intensity level of the three gray scales available
 (default dark normal light, {\it PC\/ NetHack\/} only).
 If the game display is difficult to read, try adjusting these scales;
 if this does not correct the problem, try {\tt !color}.
 Cannot be set with the `{\tt O}' command.
-\elist
+\end{description}
 
 %.hn 2
 \subsection*{Regular Expressions}
@@ -5757,9 +5752,9 @@ By placing ``{\tt autopickup\textunderscore exception}'' lines in your configura
 file, you can define patterns to be checked when the game is about to
 autopickup something.
 
-\blist{}
+\begin{description}
 %.lp
-\item[\ib{autopickup\textunderscore exception}]
+\item[autopickup\textunderscore exception]
 Sets an exception to the ``{\it pickup\textunderscore types}'' option.
 The {\it autopickup\textunderscore exception\/} option should be followed by a regular
 expression to be used as a pattern to match against the singular form of the
@@ -5784,7 +5779,7 @@ Exceptions can be set with the `{\tt O}' command, but because they are not
 included in your configuration file, they won't be in effect if you save
 and then restore your game.
 {\it autopickup\textunderscore exception\/} rules are not saved with the game.
-\elist
+\end{description}
 
 %.lp "Here are some examples:"
 Here are some examples:
@@ -5822,35 +5817,35 @@ For example:
     BIND=v:loot
 \end{verbatim}
 
-\blist{}
+\begin{description}[font=\ttfamily]
 %.lp "Extended command keys"
-\item[\tb{Extended command keys}]
+\item[Extended command keys]
 You can bind multiple keys to the same extended command. Unbind a key by
 using ``{\tt nothing}'' as the extended command to bind to. You can also bind
 the ``{\tt <esc>}'', ``{\tt <enter>}'', and ``{\tt <space>}'' keys.
 
 %.lp "Menu accelerator keys"
-\item[\tb{Menu accelerator keys}]
+\item[Menu accelerator keys]
 The menu control or accelerator keys can also be rebound via OPTIONS lines
 in the configuration file.
 You cannot bind object symbols or selection letters into menu accelerators.
 Some interfaces only support some of the menu accelerators.
 
 %.lp "Mouse buttons"
-\item[\tb{Mouse buttons}]
+\item[Mouse buttons]
 You can bind ``mouse1'' or ``mouse2'' to ``{\tt nothing}'',
 ``{\tt therecmdmenu}'', ``{\tt clicklook}'', or ``{\tt mouseaction}''.
 
 %.lp "Special command keys"
-\item[\tb{Special command keys}]
+\item[Special command keys]
 Below are the special commands you can rebind. Some of them can be bound to
 same keys with no problems, others are in the same ``context'', and if bound
 to same keys, only one of those commands will be available. Special command
 can only be bound to a single key.
-\elist
+\end{description}
 
 %.pg
-\blist{\itemindent 10mm \labelwidth 15mm \rightmargin 15mm}
+\begin{description}[itemindent=10mm, labelwidth=15mm, rightmargin=15mm]
 %.lp
 \item[{\bb{count}}]
 Prefix key to start a count, to repeat a command this many times.
@@ -5975,7 +5970,7 @@ Default is~`{\tt z}'.
 \item[{\bb{getpos.valid.prev}}]
 When asked for a location, the key to go to previous closest valid location.
 Default is~`{\tt Z}'.
-\elist
+\end{description}
 
 
 %.hn 2
@@ -5991,9 +5986,9 @@ look like this:
 \begin{verbatim}
     MSGTYPE=type "pattern"
 \end{verbatim}
-\blist{}
+\begin{description}[font=\itshape]
 %.lp
-\item[\ib{type}]
+\item[type]
 how the message should be shown:
 %.sd
 %.si
@@ -6006,9 +6001,9 @@ shown in between.
 %.ei
 %.ed
 %.lp
-\item[\ib{pattern}]
+\item[pattern]
 the pattern to match. The pattern should be a regular expression.
-\elist
+\end{description}
 
 %.lp ""
 Here's an example of message types using {\it NetHack's\/} internal
@@ -6046,19 +6041,19 @@ look like this:
     MENUCOLOR="pattern"=color&attribute
 \end{verbatim}
 
-\blist{}
+\begin{description}[font=\itshape]
 %.lp
-\item[\ib{pattern}]
+\item[pattern]
 the pattern to match;
 %.lp
-\item[\ib{color}]
+\item[color]
 the color to use for lines matching the pattern;
 %.lp
-\item[\ib{attribute}]
+\item[attribute]
 the attribute to use for lines matching the pattern. The attribute is
 optional, and if left out, you must also leave out the preceding ampersand.
 If no attribute is defined, no attribute is used.
-\elist
+\end{description}
 
 %.lp ""
 The pattern should be a regular expression.
@@ -6117,12 +6112,12 @@ use of user sounds.
 The following configuration file entries are relevant to mapping user sounds
 to messages:
 
-\blist{}
+\begin{description}[font=\itshape]
 %.lp
-\item[\ib{SOUNDDIR}]
+\item[SOUNDDIR]
 The directory that houses the sound files to be played.
 %.lp
-\item[\ib{SOUND}]
+\item[SOUND]
 An entry that maps a sound file to a user-specified message pattern.
 Each SOUND entry is broken down into the following parts:
 
@@ -6136,7 +6131,7 @@ Each SOUND entry is broken down into the following parts:
 {\tt sound index} --- optional; the index corresponding to a sound file.
 %.ei
 %.ed
-\elist
+\end{description}
 
 %.lp ""
 The pattern should be a regular expression.
@@ -6248,7 +6243,7 @@ It overrides other behavior rules if
 hit points are at or below the {\it major problem\/} threshold
 (which varies depending upon maximum hit points and experience level).
 
-\blist{}
+\begin{description}
 %.lp "*"
 \item[{\tt always}] will set the default attributes for that field.
 %.lp "*"
@@ -6313,7 +6308,7 @@ and ``{\it title\/}''.
 For title, only the role's rank title
 is tested; the character's name is ignored.
 %.ei
-\elist
+\end{description}
 
 The in-game options menu can help you determine the correct syntax for a
 configuration file.
@@ -6345,17 +6340,17 @@ Example hilites:
 The options that are used to select a particular symbol set from the
 symbol file are:
 
-\blist{}
+\begin{description}[font=\itshape]
 %.lp
-\item[\ib{symset}]
+\item[symset]
 Set the name of the symbol set that you want to load.
 {\it symbols\/}.
 
 %.lp
-\item[\ib{roguesymset}]
+\item[roguesymset]
 Set the name of the symbol set that you want to load for display
 on the rogue level.
-\elist
+\end{description}
 
 You can also override one or more symbols using the {\it SYMBOLS\/} and
 {\it ROGUESYMBOLS\/} configuration file options.
@@ -6658,65 +6653,65 @@ only parameter.
 
 The most crucial settings to make the game more accessible are:
 %.pg
-\blist{}
+\begin{description}[font=\itshape]
 %.lp
-\item[\ib{symset:plain}]
+\item[symset:plain]
 Load a symbol set appropriate for use by blind players.
 %.lp
-\item[\ib{menustyle:traditional}]
+\item[menustyle:traditional]
 This will assist in the interface to speech synthesizers.
 %.lp
-\item[\ib{nomenu\textunderscore overlay}]
+\item[nomenu\textunderscore overlay]
 Show menus on a cleared screen and aligned to the left edge.
 %.lp
-\item[\ib{number\textunderscore pad}]
+\item[number\textunderscore pad]
 A lot of speech access programs use the number-pad to review the screen.
 If this is the case, disable the number\textunderscore pad option and use the
 traditional Rogue-like commands.
 %.lp
-\item[\ib{paranoid\textunderscore confirmation:swim}]
+\item[paranoid\textunderscore confirmation:swim]
 Prevent walking into water or lava.
 %.lp
-\item[\ib{accessiblemsg}]
+\item[accessiblemsg]
 Adds direction or location information to messages.
 %.lp
-\item[\ib{spot\textunderscore monsters}]
+\item[spot\textunderscore monsters]
 Shows a message when hero notices a monster; combine with accessiblemsg.
 %.lp
-\item[\ib{mon\textunderscore movement}]
+\item[mon\textunderscore movement]
 Shows a message when hero notices a monster movement;
 combine with spot\textunderscore monsters and accessiblemsg.
 %.lp
-\item[\ib{autodescribe}]
+\item[autodescribe]
 Automatically describe the terrain under the cursor when targeting.
 %.lp
-\item[\ib{mention\textunderscore map}]
+\item[mention\textunderscore map]
 Give feedback messages when interesting map locations change.
 %.lp
-\item[\ib{mention\textunderscore walls}]
+\item[mention\textunderscore walls]
 Give feedback messages when walking towards a wall or when travel command
 was interrupted.
 %.lp
-\item[\ib{whatis\textunderscore coord:compass}]
+\item[whatis\textunderscore coord:compass]
 When targeting with cursor, describe the cursor position with coordinates
 relative to your character.
 %.lp
-\item[\ib{whatis\textunderscore filter:area}]
+\item[whatis\textunderscore filter:area]
 When targeting with cursor, filter possible locations so only those in
 the same area (eg. same room, or same corridor) are considered.
 %.lp
-\item[\ib{whatis\textunderscore moveskip}]
+\item[whatis\textunderscore moveskip]
 When targeting with cursor and using fast-move, skip the same glyphs instead
 of moving 8 units at a time.
 %.lp
-\item[\ib{nostatus\textunderscore updates}]
+\item[nostatus\textunderscore updates]
 Prevent updates to the status lines at the bottom of the screen, if
 your screen-reader reads those lines. The same information can be
 seen via the {\tt \#attributes} command.
 %.lp
-\item[\ib{showdamage}]
+\item[showdamage]
 Give a message of damage taken and how many hit points are left.
-\elist
+\end{description}
 
 %.hn2
 \subsection*{Global Configuration for System Administrators}
@@ -6733,87 +6728,87 @@ set uses a compiled-in default (which may not be appropriate for your
 system).
 
 %.pg
-\blist{}
+\begin{description}[font=\itshape]
 %.lp
-\item[\ib{WIZARDS}]
+\item[WIZARDS]
 A space-separated list of user name who are allowed to
 play in debug mode (commonly referred to as wizard mode).
 A value of a single
 asterisk (*) allows anyone to start a game in debug mode.
 %.lp
-\item[\ib{SHELLERS}]
+\item[SHELLERS]
 A list of users who are allowed to use the shell escape command (`{\tt !}').
 The syntax is the same as WIZARDS.
 %.lp
-\item[\ib{EXPLORERS}]
+\item[EXPLORERS]
 A list of users who are allowed to use the explore mode.
 The syntax is the same as WIZARDS.
 %.lp
-\item[\ib{MSGHANDLER}]
+\item[MSGHANDLER]
 A path and filename of executable.  Whenever a message-window
 message is shown, NetHack runs this program.  The program will get
 the message as the only parameter.
 %.lp
-\item[\ib{MAXPLAYERS}]
+\item[MAXPLAYERS]
 Limit the maximum number of games that can be running at the same time.
 %.lp
-\item[\ib{SUPPORT}]
+\item[SUPPORT]
 A string explaining how to get local support (no default value).
 %.lp
-\item[\ib{RECOVER}]
+\item[RECOVER]
 A string explaining how to recover a game on this system (no default value).
 %.lp
-\item[\ib{SEDUCE}]
+\item[SEDUCE]
 0 or 1 to disable or enable, respectively, the SEDUCE option.
 When disabled, incubi and succubi behave like nymphs.
 %.lp
-\item[\ib{CHECK\textunderscore PLNAME}]
+\item[CHECK\textunderscore PLNAME]
 Setting this to 1 will make the EXPLORERS, WIZARDS, and SHELLERS check
 for the player name instead of the user's login name.
 %.lp
-\item[\ib{CHECK\textunderscore SAVE\textunderscore UID}]
+\item[CHECK\textunderscore SAVE\textunderscore UID]
 0 or 1 to disable or enable, respectively, the UID
 (used identification number) checking for save files (to verify that the
 user who is restoring is the same one who saved).
-\elist
+\end{description}
 
 %.pg
 The following four options affect the score file:
-\blist {}
+\begin{description}[font=\itshape]
 %.pg
 %.lp
-\item[\ib{PERSMAX}]
+\item[PERSMAX]
 Maximum number of entries for one person.
 %.lp
-\item[\ib{ENTRYMAX}]
+\item[ENTRYMAX]
 Maximum number of entries in the score file.
 %.lp
-\item[\ib{POINTSMIN}]
+\item[POINTSMIN]
 Minimum number of points to get an entry in the score file.
 %.lp
-\item[\ib{PERS\textunderscore IS\textunderscore UID}]
+\item[PERS\textunderscore IS\textunderscore UID]
 0 or 1 to use user names or numeric userids, respectively, to identify
 unique people for the score file.
 %.lp
-\item[\ib{HIDEUSAGE}]
+\item[HIDEUSAGE]
 0 or 1 to control whether the help menu entry for command
 line usage is shown or suppressed.
 %.lp
-\item[\ib{MAX\textunderscore STATUENAME\textunderscore RANK}]
+\item[MAX\textunderscore STATUENAME\textunderscore RANK]
 Maximum number of score file entries to use for
 random statue names (default is 10).
 %.lp
-\item[\ib{ACCESSIBILITY}]
+\item[ACCESSIBILITY]
 0 or 1 to disable or enable, respectively, the ability for players
 to set S\textunderscore pet\textunderscore override and S\textunderscore hero\textunderscore override 
 symbols in their configuration file.
 %.lp
-\item[\ib{PORTABLE\textunderscore DEVICE\textunderscore PATHS}]
+\item[PORTABLE\textunderscore DEVICE\textunderscore PATHS]
 0 or 1 Windows OS only, the game will look for all of its external
 files, and write to all of its output files in one place 
 rather than at the standard locations.
 %.lp
-\item[\ib{DUMPLOGFILE}]
+\item[DUMPLOGFILE]
 A filename where the end-of-game dumplog is saved.
 Not defining this will prevent dumplog from being created.
 Only available if your game is compiled with DUMPLOG.
@@ -6829,7 +6824,7 @@ Allows the following placeholders:
 {\tt \%n}  --- player name\\
 {\tt \%N}  --- first character of player name
 %.lp
-\item[\ib{LIVELOG}]
+\item[LIVELOG]
 A bit-mask of types of events that should be written to
 the {\it livelog\/} file if one is present.
 The sample {\it sysconf\/} file accompanying the program contains a
@@ -6842,14 +6837,14 @@ When available, it should be left commented out on single player
 installations because over time the file could grow to be extremely
 large unless it is actively maintained.
 %.lp
-\item[\ib{CRASHREPORTURL}]
+\item[CRASHREPORTURL]
 If set to
 {\tt https://www.nethack.org/links/cr-37BETA.html}
 and support is compiled in, brings up a browser window populated with
 the information needed to report a problem if the game panics or ends
 up in an internally inconsistent state, or if the \#bugreport command is
 invoked.
-\elist
+\end{description}
 
 %.hn 1
 \section{Scoring}

--- a/doc/Guidebook.tex
+++ b/doc/Guidebook.tex
@@ -1,6 +1,6 @@
 % NetHack 3.7  Guidebook.tex $NHDT-Date: 1745139202 2025/04/20 00:53:22 $  $NHDT-Branch: NetHack-3.7 $:$NHDT-Revision: 1.579 $ */
 \documentclass[titlepage]{article}
-\usepackage{hyperref}
+\usepackage[hidelinks]{hyperref}
 \usepackage{longtable}
 \usepackage{enumitem}
 \usepackage[a4paper, text={160mm, 220mm}, centering]{geometry}
@@ -19,7 +19,7 @@
 
 %.mt
 \title{\LARGE A Guide to the Mazes of Menace:\\
-\Large Guidebook for {\it NetHack\/}}
+\Large Guidebook for \textit{NetHack}}
 
 %.au
 \author{Original version - Eric S. Raymond\\
@@ -83,7 +83,7 @@ dungeon\ldots
 \section{What is going on here?}
 
 %.pg
-You have just begun a game of {\it NetHack}.  Your goal is to grab as much
+You have just begun a game of \textit{NetHack}.  Your goal is to grab as much
 treasure as you can, retrieve the Amulet of Yendor, and escape the
 Mazes of Menace alive.
 
@@ -106,7 +106,7 @@ They begin their quests with naught but uncommon strength, a trusty hauberk,
 and a great two-handed sword.
 %.pg
 %
-\item[Cavemen \textrm{and} Cavewomen]
+\item[Cavemen \textrm{\textmd{and}} Cavewomen]
 start with exceptional strength, but unfortunately, neolithic weapons.
 %.pg
 %
@@ -131,7 +131,7 @@ disciplines have become capable of fighting as effectively without weapons
 as with.  They wear no armor but make up for it with increased mobility.
 %.pg
 %
-\item[Priests \textrm{and} Priestesses]
+\item[Priests \textrm{\textmd{and}} Priestesses]
 are clerics militant, crusaders
 advancing the cause of righteousness with arms, armor, and arts
 thaumaturgic.  Their ability to commune with deities via prayer
@@ -153,7 +153,7 @@ to great advantage.
 \item[Samurai]
 are the elite warriors of feudal Nippon.  They are lightly
 armored and quick, and wear the %
-{\it dai-sho}, two swords of the deadliest
+\textit{dai-sho}, two swords of the deadliest
 keenness.
 %.pg
 %
@@ -223,28 +223,28 @@ seen on the current dungeon level; as you explore more of the level,
 it appears on the screen in front of you.
 
 %.pg
-When {\it NetHack\/}'s ancestor {\it rogue\/} first appeared, its screen
+When \textit{NetHack}'s ancestor \textit{rogue} first appeared, its screen
 orientation was almost unique among computer fantasy games.  Since
 then, screen orientation has become the norm rather than the
-exception; {\it NetHack\/} continues this fine tradition.  Unlike text
+exception; \textit{NetHack} continues this fine tradition.  Unlike text
 adventure games that accept commands in pseudo-English sentences and
-explain the results in words, {\it NetHack\/} commands are all one or two
+explain the results in words, \textit{NetHack} commands are all one or two
 keystrokes and the results are displayed graphically on the screen.  A
 minimum screen size of 24 lines by 80 columns is recommended; if the
 screen is larger, only a $21\times80$ section will be used for the map.
 
 %.pg
-{\it NetHack\/} can even be played by blind players, with the assistance of
+\textit{NetHack} can even be played by blind players, with the assistance of
 Braille readers or speech synthesisers.  Instructions for configuring
-{\it NetHack\/} for the blind are included later in this document.
+\textit{NetHack} for the blind are included later in this document.
 
 %.pg
-{\it NetHack\/} generates a new dungeon every time you play it; even the
+\textit{NetHack} generates a new dungeon every time you play it; even the
 authors still find it an entertaining and exciting game despite
 having won several times.
 
 %.pg
-{\it NetHack\/} offers a variety of display options.  The options available to
+\textit{NetHack} offers a variety of display options.  The options available to
 you will vary from port to port, depending on the capabilities of your
 hardware and software, and whether various compile-time options were
 enabled when your executable was created.  The three possible display
@@ -258,10 +258,10 @@ colors in the Guidebook, and because it is common to all ports, we will
 use the default ASCII characters from the monochrome character display
 when referring to things you might see on the screen during your game.
 %.pg
-In order to understand what is going on in {\it NetHack}, first you must
-understand what {\it NetHack\/} is doing with the screen.  The {\it NetHack\/}
+In order to understand what is going on in \textit{NetHack}, first you must
+understand what \textit{NetHack} is doing with the screen.  The \textit{NetHack}
 screen replaces the ``You see \ldots'' descriptions of text adventure games.
-Figure 1 is a sample of what a {\it NetHack\/} screen might look like.
+Figure 1 is a sample of what a \textit{NetHack} screen might look like.
 The way the screen looks for you depends on your platform.
 %.BR 2
 
@@ -314,13 +314,13 @@ Figure 2
 The bottom two (or three) lines of the screen contain several cryptic
 pieces of information describing your current status.
 Figure 1 shows the traditional two-line status area below the map.
-Figure 2 shows just the status area, when the {\it statuslines:3\/}
+Figure 2 shows just the status area, when the \textit{statuslines:3}
 option has been set (not all interfaces support this option).
 If any status line becomes wider than the screen, you might not see all
 of it due to truncation.
-When the numbers grow bigger and multiple {\it conditions\/} are present,
+When the numbers grow bigger and multiple \textit{conditions} are present,
 the two-line format will run out of room on the second line, but
-{\it statuslines:2\/}
+\textit{statuslines:2}
 is the default because a basic 24-line terminal isn't tall enough for
 the third line.
 
@@ -331,7 +331,7 @@ Here are explanations of what the various status items mean:
 \begin{description}
 \item[Title]
 Your character's name and professional ranking (based on role and
-{\it experience level\/}, see below).
+\textit{experience level}, see below).
 %.lp
 \item[Strength]
 A measure of your character's strength; one of your six basic
@@ -367,7 +367,7 @@ particular, it can affect the prices shopkeepers offer you.
 %.lp
 \item[Alignment]
 %
-{\it Lawful}, {\it Neutral\/} or {\it Chaotic}.  Often, Lawful is
+\textit{Lawful}, \textit{Neutral} or \textit{Chaotic}.  Often, Lawful is
 taken as good and Chaotic as evil, but legal and ethical do not always
 coincide.  Your alignment influences how other
 monsters react toward you.  Monsters of a like alignment are more likely
@@ -392,7 +392,7 @@ certain magical items or spells.  The number in parentheses is the maximum
 number your hit points can reach.
 %.lp
 \item[Power]
-Spell points.  This tells you how much mystic energy ({\it mana\/})
+Spell points.  This tells you how much mystic energy (\textit{mana})
 you have available for spell casting.  Again, resting will regenerate the
 amount available.
 %.lp
@@ -400,11 +400,11 @@ amount available.
 A measure of how effectively your armor stops blows from unfriendly
 creatures.  The lower this number is, the more effective the armor; it
 is quite possible to have negative armor class.
-See the {\it Armor\/} subsection of {\it Objects\/} for more information.
+See the \textit{Armor} subsection of \textit{Objects} for more information.
 %.lp
 \item[Experience]
 Your current experience level.
-If the {\it showexp\/}
+If the \textit{showexp}
 option is set, it will be followed by a slash and experience points.
 As you adventure, you gain experience points.
 At certain experience point totals, you gain an experience level.
@@ -412,51 +412,51 @@ The more experienced you are, the better you fight and withstand magical
 attacks.
 (By the time your level reaches double digits, the usefulness of showing
 the points with it has dropped significantly.
-You can use the `{\tt O}' command to turn {\it showexp\/}
+You can use the `\texttt{O}' command to turn \textit{showexp}
 off to avoid using up the limited status line space.)
 %.lp
 \item[Time]
 The number of turns elapsed so far, displayed if you have the
-{\it time\/} option set.
+\textit{time} option set.
 %.lp
 \item[Status]
 Hunger:
 your current hunger status.
-Values are {\it Satiated}, {\it Not~Hungry\/} (or {\it Normal\/}),
-{\it Hungry}, {\it Weak}, and {\it Fainting}.
+Values are \textit{Satiated}, \textit{Not~Hungry} (or \textit{Normal}),
+\textit{Hungry}, \textit{Weak}, and \textit{Fainting}.
 %.\" not mentioned: Fainted
-Not shown when {\it Normal}.
+Not shown when \textit{Normal}.
 
 %.lp ""
 Encumbrance:
 an indication of how what you are carrying affects your ability to move.
-Values are {\it Unencumbered}, {\it Burdened}, {\it Stressed},
-{\it Strained}, {\it Overtaxed}, and {\it Overloaded}.
-Not shown when {\it Unencumbered}.
+Values are \textit{Unencumbered}, \textit{Burdened}, \textit{Stressed},
+\textit{Strained}, \textit{Overtaxed}, and \textit{Overloaded}.
+Not shown when \textit{Unencumbered}.
 
 %.lp ""
 Fatal~conditions:
-{\it Stone\/} (aka {\it Petrifying}, turning to stone),
-{\it Slime\/} (turning into green slime),
-{\it Strngl\/} (being strangled),
-{\it FoodPois\/} (suffering from acute food poisoning),
-{\it TermIll\/} (suffering from a terminal illness).
+\textit{Stone} (aka \textit{Petrifying}, turning to stone),
+\textit{Slime} (turning into green slime),
+\textit{Strngl} (being strangled),
+\textit{FoodPois} (suffering from acute food poisoning),
+\textit{TermIll} (suffering from a terminal illness).
 
 %.lp ""
 Non-fatal~conditions:
-{\it Blind\/} (can't see), {\it Deaf\/} (can't hear),
-{\it Stun\/} (stunned), {\it Conf\/} (confused), {\it Hallu\/} (hallucinating).
+\textit{Blind} (can't see), \textit{Deaf} (can't hear),
+\textit{Stun} (stunned), \textit{Conf} (confused), \textit{Hallu} (hallucinating).
 
 %.lp ""
 Movement~modifiers:
-{\it Lev\/} (levitating), {\it Fly\/} (flying), {\it Ride\/} (riding).
+\textit{Lev} (levitating), \textit{Fly} (flying), \textit{Ride} (riding).
 
 %.lp ""
 Other conditions and modifiers exist, but there isn't enough room to
 display them with the other status fields.
 \\
 % unindented paragraph
-The {\tt \#attributes} command (default key {\tt \^{}X}) will show
+The \texttt{\#attributes} command (default key \texttt{\textasciicircum X}) will show
 all current status information in unabbreviated format.
 It also shows other information which might be included on the status
 lines if those had more room.
@@ -469,14 +469,14 @@ lines if those had more room.
 %.pg
 The top line of the screen is reserved for messages that describe
 things that are impossible to represent visually.  If you see a
-``{\tt --More--}'' on the top line, this means that {\it NetHack\/} has
+``\texttt{--More--}'' on the top line, this means that \textit{NetHack} has
 another message to display on the screen, but it wants to make certain
 that you've read the one that is there first.  To read the next message,
 just press the space bar.
 
 %.pg
 To change how and what messages are shown on the message line,
-see ``{\it Configuring Message Types\/}`` and the {\it verbose\/}
+see ``\textit{Configuring Message Types}`` and the \textit{verbose}
 option.
 
 %.hn 2
@@ -490,7 +490,7 @@ options to change some of the symbols the game uses; otherwise, the
 game will use default symbols.  Here is a list of what the default
 symbols mean:
 
-\begin{description}[font=\ttfamily]
+\begin{description}[font=\mdseries\ttfamily]
 \item[-]
 The horizontal or corner walls of a room, or an open east/west door.
 \item[|]
@@ -540,7 +540,7 @@ A gem or rock (possibly valuable, possibly worthless).
 A boulder or statue or an engraving on the floor of a room.\\
 %.lp ""
 Note: statues are displayed as if they were the monsters they depict
-so won't appear as a {\it grave accent\/} (aka {\it back-tick}).
+so won't appear as a \textit{grave accent} (aka \textit{back-tick}).
 \item[0]
 An iron ball.
 \item[\textunderscore]
@@ -554,7 +554,6 @@ or a pool of lava or a wall of lava.
 An opulent throne.
 \item[a-z \textrm{\textmd{and}}]
 \item[A-HJ-Z \textrm{\textmd{and}}]
-%should probably change \item[@\&\textquotesingle:;] to \item[\verb+@&':;+]
 \item[@\&\textquotesingle :;]
 Letters and certain other symbols represent the various inhabitants
 of the Mazes of Menace.
@@ -564,17 +563,17 @@ Sometimes, however, they can be helpful.
 Rather than a specific type of monster, this marks the last known
 location of an invisible or otherwise unseen monster.
 Note that the monster could have moved.
-The `{\tt s}', `{\tt F}', and `{\tt m}' commands may be useful here.
+The `\texttt{s}', `\texttt{F}', and `\texttt{m}' commands may be useful here.
 \item[1-5]
 The digits 1 through 5 may be displayed, marking unseen monsters sensed
-via the {\it Warning\/} attribute.
+via the \textit{Warning} attribute.
 Less dangerous monsters are indicated by lower values, more dangerous by
 higher values.
 
 \end{description}
 %.pg
 You need not memorize all these symbols; you can ask the game what any
-symbol represents with the `{\tt /}' command (see the next section for
+symbol represents with the `\texttt{/}' command (see the next section for
 more info).
 
 %.hn 1
@@ -584,23 +583,23 @@ more info).
 Commands can be initiated by typing one or two characters to which
 the command is bound to, or typing the command name in the extended
 commands entry.  Some commands,
-like ``{\tt search}'', do not require that any more information be collected
-by {\it NetHack\/}.  Other commands might require additional information, for
+like ``\texttt{search}'', do not require that any more information be collected
+by \textit{NetHack}.  Other commands might require additional information, for
 example a direction, or an object to be used.  For those commands that
-require additional information, {\it NetHack\/} will present you with either
+require additional information, \textit{NetHack} will present you with either
 a menu of choices, or with a command line prompt requesting information.
 Which you are presented with will depend chiefly on how you have set the
-`{\it menustyle\/}'
+`\textit{menustyle}'
 option.
 
 %.pg
-For example, a common question in the form ``{\tt What do you want to
+For example, a common question in the form ``\texttt{What do you want to
 use? [a-zA-Z\ ?*]}'', asks you to choose an object you are carrying.
-Here, ``{\tt a-zA-Z}'' are the inventory letters of your possible choices.
-Typing `{\tt ?}' gives you an inventory list of these items, so you can see
-what each letter refers to.  In this example, there is also a `{\tt *}'
+Here, ``\texttt{a-zA-Z}'' are the inventory letters of your possible choices.
+Typing `\texttt{?}' gives you an inventory list of these items, so you can see
+what each letter refers to.  In this example, there is also a `\texttt{*}'
 indicating that you may choose an object not on the list, if you
-wanted to use something unexpected.  Typing a `{\tt *}' lists your entire
+wanted to use something unexpected.  Typing a `\texttt{*}' lists your entire
 inventory, so you can see the inventory letters of every object you're
 carrying.  Finally, if you change your mind and decide you don't want
 to do this command after all, you can press the `ESC' key to abort the
@@ -608,50 +607,50 @@ command.
 
 %.pg
 You can put a number before some commands to repeat them that many
-times; for example, ``{\tt 10s}'' will search ten times.  If you have the
-{\it number\textunderscore pad\/}
-option set, you must type `{\tt n}' to prefix a count, so the example above
-would be typed ``{\tt n10s}'' instead.  Commands for which counts make no
+times; for example, ``\texttt{10s}'' will search ten times.  If you have the
+\textit{number\textunderscore pad}
+option set, you must type `\texttt{n}' to prefix a count, so the example above
+would be typed ``\texttt{n10s}'' instead.  Commands for which counts make no
 sense ignore them.  In addition, movement commands can be prefixed for
 greater control (see below).  To cancel a count or a prefix, press the
 `ESC' key.
 
 %.pg
 The list of commands is rather long, but it can be read at any time
-during the game through the `{\tt ?}' command, which accesses a menu of
+during the game through the `\texttt{?}' command, which accesses a menu of
 helpful texts.  Here are the default key bindings for your reference:
 
-\begin{description}[font=\ttfamily]
+\begin{description}[font=\mdseries\ttfamily]
 %.lp
 \item[?]
 Help menu:  display one of several help texts available.
 %.lp
 \item[/]
-The {\tt whatis} command, to
+The \texttt{whatis} command, to
 tell what a symbol represents.  You may choose to specify a location
 or type a symbol (or even a whole word) to explain.
 Specifying a location is done by moving the cursor to a particular spot
-on the map and then pressing one of `{\tt .}', `{\tt ,}', `{\tt ;}',
-or `{\tt :}'.  `{\tt .}' will explain the symbol at the chosen location,
-conditionally check for ``{\tt More info?}'' depending upon whether the
-`{\it help\/}'
+on the map and then pressing one of `\texttt{.}', `\texttt{,}', `\texttt{;}',
+or `\texttt{:}'.  `\texttt{.}' will explain the symbol at the chosen location,
+conditionally check for ``\texttt{More info?}'' depending upon whether the
+`\textit{help}'
 option is on, and then you will be asked to pick another location;
-`{\tt ,}' will explain the symbol but skip any additional
+`\texttt{,}' will explain the symbol but skip any additional
 information, then let you pick another location;
-`{\tt ;}' will skip additional info and also not bother asking
-you to choose another location to examine; `{\tt :}' will show additional
+`\texttt{;}' will skip additional info and also not bother asking
+you to choose another location to examine; `\texttt{:}' will show additional
 info, if any, without asking for confirmation.  When picking a location,
-pressing the {\tt ESC} key will terminate this command, or pressing `{\tt ?}'
+pressing the \texttt{ESC} key will terminate this command, or pressing `\texttt{?}'
 will give a brief reminder about how it works.
 
 %.lp ""
 If the
-{\it autodescribe\/}
+\textit{autodescribe}
 option is on, a short description of what you see at each location is
-shown as you move the cursor.  Typing `{\tt \#}' while picking a location will
+shown as you move the cursor.  Typing `\texttt{\#}' while picking a location will
 toggle that option on or off.
 The
-{\it whatis\textunderscore coord\/}
+\textit{whatis\textunderscore coord}
 option controls whether the short description includes map coordinates.
 
 %.lp ""
@@ -662,7 +661,7 @@ always gives any additional information available about that name.
 You may also request a description of nearby monsters,
 all monsters currently displayed, nearby objects, or all objects.
 The
-{\it whatis\textunderscore coord\/}
+\textit{whatis\textunderscore coord}
 option controls which format of map coordinate is included with their
 descriptions.
 %.lp
@@ -689,7 +688,7 @@ one-step movement commands cause you to fight monsters; the others
 \verb+   h- . -l   + & \verb+   4- . -6   +\\
 \verb+    / | \    + & \verb+    / | \    +\\
 \verb+   b  j  n   + & \verb+   1  2  3   +\\
-                     & (if {\it number\textunderscore pad\/} set)
+                     & (if \textit{number\textunderscore pad} set)
 \end{tabular}
 \end{center}
 %.ed
@@ -704,36 +703,36 @@ Go in that direction until you hit a wall or run into something.
 Prefix:  move without picking up objects or fighting (even if you remember
 a monster there).\\
 %.lp ""
-A few non-movement commands use the `{\tt m}' prefix to request
+A few non-movement commands use the `\texttt{m}' prefix to request
 operating via menu (to temporarily override the
-{\it menustyle:Traditional\/}
+\textit{menustyle:Traditional}
 option).
-Primarily useful for `{\tt ,}' (pickup) when there is only one class of
+Primarily useful for `\texttt{,}' (pickup) when there is only one class of
 objects present (where there won't be any ``what kinds of objects?'' prompt,
-so no opportunity to answer `{\tt m}' at that prompt).
+so no opportunity to answer `\texttt{m}' at that prompt).
 \\
 %.lp ""
 The prefix will
-make ``{\tt \#travel}'' command show a menu of interesting targets in sight.
-It can also be used with the `{\tt $\backslash$}' (known, show a
-list of all discovered objects) and the `{\tt \`{}}' (knownclass,
+make ``\texttt{\#travel}'' command show a menu of interesting targets in sight.
+It can also be used with the `\texttt{\textbackslash}' (known, show a
+list of all discovered objects) and the `\texttt{\`{}}' (knownclass,
 show a list of discovered objects in a particular class) commands to offer
 a menu of several sorting alternatives (which sets a new value for the
-{\it sortdiscoveries\/}
-option); also for ``{\tt \#vanquished}'' and ``{\tt \#genocided}'' commands
+\textit{sortdiscoveries}
+option); also for ``\texttt{\#vanquished}'' and ``\texttt{\#genocided}'' commands
 to offer a sorting menu.
 \\
 %.lp ""
 A few other commands (eat food, offer sacrifice, apply tinning-kit,
 drink/quaff, dip, tip container) use
-the `{\tt m}' prefix to skip checking for applicable objects on
+the `\texttt{m}' prefix to skip checking for applicable objects on
 the floor and go straight to checking inventory,
-or (for ``{\tt \#loot}'' to remove a saddle),
+or (for ``\texttt{\#loot}'' to remove a saddle),
 skip containers and go straight to adjacent monsters.
 \\
 %.lp ""
-In debug mode (aka ``wizard mode''), the `{\tt m}' prefix may also be
-used with the ``{\tt \#teleport}'' and ``{\tt \#wizlevelport}'' commands.
+In debug mode (aka ``wizard mode''), the `\texttt{m}' prefix may also be
+used with the ``\texttt{\#teleport}'' and ``\texttt{\#wizlevelport}'' commands.
 %.lp
 \item[F{[yuhjklbn]}]
 Prefix:  fight a monster (even if you only guess one is there).
@@ -742,22 +741,22 @@ Prefix:  fight a monster (even if you only guess one is there).
 Prefix:  Move until something interesting is found.
 %.lp
 \item[G{[yuhjklbn]} \textrm{\textmd{or}} <Control>+{[yuhjklbn]}]
-Prefix:  Similar to `{\tt g}', but forking of corridors is not considered
+Prefix:  Similar to `\texttt{g}', but forking of corridors is not considered
 interesting.
 \\
-Note:  {\tt <Control>+<key>} means holding the {\tt <Control>} or
-{\tt <Ctrl>} key down like {\tt <Shift>} while typing and releasing
-{\tt <key>}, then releasing {\tt <Control>}.  {\tt \^{}<key>} is used as
+Note:  \texttt{<Control>+<key>} means holding the \texttt{<Control>} or
+\texttt{<Ctrl>} key down like \texttt{<Shift>} while typing and releasing
+\texttt{<key>}, then releasing \texttt{<Control>}.  \texttt{\textasciicircum <key>} is used as
 shorthand elsewhere in the Guidebook to mean the same thing.  Control
-characters are case-insensitive so {\tt \^{}x} and {\tt \^{}X} are the same.
+characters are case-insensitive so \texttt{\textasciicircum x} and \texttt{\textasciicircum X} are the same.
 %.lp
 \item[M{[yuhjklbn]}]
-Old versions supported `{\tt M}' as a movement prefix which
-combined the effect of `{\tt m}' with {\tt <Control>+<direction>}.
+Old versions supported `\texttt{M}' as a movement prefix which
+combined the effect of `\texttt{m}' with \texttt{<Control>+<direction>}.
 That is no longer supported as a prefix but similar effect can be achieved
-by using {\tt m} and {\tt G<direction>} in combination.
-{\tt m} can also be used in combination with {\tt g<direction>},
-{\tt <Control>+<direction>}, or {\tt <Shift>+<direction>}.
+by using \texttt{m} and \texttt{G<direction>} in combination.
+\texttt{m} can also be used in combination with \texttt{g<direction>},
+\texttt{<Control>+<direction>}, or \texttt{<Shift>+<direction>}.
 %.lp
 \item[\textunderscore]
 Travel to a map location via a shortest-path algorithm.\\
@@ -767,16 +766,16 @@ is computed over map locations the hero knows about (e.g. seen or
 previously traversed).
 If there is no known path, a guess is made instead.
 Stops on most of
-the same conditions as the `{\tt G}' command, but without picking up
-objects, so implicitly forces the `{\tt m}' prefix.
+the same conditions as the `\texttt{G}' command, but without picking up
+objects, so implicitly forces the `\texttt{m}' prefix.
 For ports with mouse
 support, the command is also invoked when a mouse-click takes place on a
 location other than the current position.
 %.lp
 \item[.]
 Wait or rest, do nothing for one turn.
-Precede with the `{\tt m}' prefix
-to wait for a turn even next to a hostile monster, if {\it safe\textunderscore wait\/}
+Precede with the `\texttt{m}' prefix
+to wait for a turn even next to a hostile monster, if \textit{safe\textunderscore wait}
 is on.
 %.lp
 \item[a]
@@ -789,8 +788,8 @@ Confirmation is required.
 \item[A]
 Remove one or more worn items, such as armor.\\
 %.lp ""
-Use `{\tt T}' (take off) to take off only one piece of armor
-or `{\tt R}' (remove) to take off only one accessory.
+Use `\texttt{T}' (take off) to take off only one piece of armor
+or `\texttt{R}' (remove) to take off only one accessory.
 %.lp
 \item[\textasciicircum A]
 Repeat the previous command.
@@ -801,57 +800,57 @@ Close a door.
 \item[C]
 Call (name) a monster, an individual object, or a type of object.\\
 %.lp ""
-Same as extended command ``{\tt \#name}''.
+Same as extended command ``\texttt{\#name}''.
 %.lp
 \item[\textasciicircum C]
 Panic button.  Quit the game.
 %.lp
 \item[d]
 Drop something.\\
-For example {\tt d7a} --- drop seven items of object
-{\it a}.
+For example \texttt{d7a} --- drop seven items of object
+\textit{a}.
 %.lp
 \item[D]
 Drop several things.\\
 %.lp ""
 In answer to the question\\
-``{\tt What kinds of things do you want to drop? [!\%= BUCXPaium]}''\\
+``\texttt{What kinds of things do you want to drop? [!\%= BUCXPaium]}''\\
 you should type zero or more object symbols possibly followed by
-`{\tt a}' and/or `{\tt i}' and/or `{\tt u}' and/or `{\tt m}'.
+`\texttt{a}' and/or `\texttt{i}' and/or `\texttt{u}' and/or `\texttt{m}'.
 In addition, one or more of
 the bless\-ed/\-un\-curs\-ed/\-curs\-ed groups may be typed.\\
 %.sd
 %.si
-{\tt DB}  --- drop all objects known to be blessed.\\
-{\tt DU}  --- drop all objects known to be uncursed.\\
-{\tt DC}  --- drop all objects known to be cursed.\\
-{\tt DX}  --- drop all objects of unknown B/U/C status.\\
-{\tt DP}  --- drop objects picked up last.\\
-{\tt Da}  --- drop all objects, without asking for confirmation.\\
-{\tt Di}  --- examine your inventory before dropping anything.\\
-{\tt Du}  --- drop only unpaid objects (when in a shop).\\
-{\tt Dm}  --- use a menu to pick which object(s) to drop.\\
-{\tt D\%u} --- drop only unpaid food.
+\texttt{DB}  --- drop all objects known to be blessed.\\
+\texttt{DU}  --- drop all objects known to be uncursed.\\
+\texttt{DC}  --- drop all objects known to be cursed.\\
+\texttt{DX}  --- drop all objects of unknown B/U/C status.\\
+\texttt{DP}  --- drop objects picked up last.\\
+\texttt{Da}  --- drop all objects, without asking for confirmation.\\
+\texttt{Di}  --- examine your inventory before dropping anything.\\
+\texttt{Du}  --- drop only unpaid objects (when in a shop).\\
+\texttt{Dm}  --- use a menu to pick which object(s) to drop.\\
+\texttt{D\%u} --- drop only unpaid food.
 %.ei
 %.ed
 The last example shows a combination.
-There are four categories of object filtering: class (`{\tt !}' for
-potions, `{\tt ?}' for scrolls, and so on), shop status (`{\tt u}' for
+There are four categories of object filtering: class (`\texttt{!}' for
+potions, `\texttt{?}' for scrolls, and so on), shop status (`\texttt{u}' for
 unpaid, in other words, owned by the shop), bless/curse state
-(`{\tt B}', `{\tt U}', `{\tt C}', and `{\tt X}' as shown above),
-and novelty (`{\tt P}', recently picked up items; controlled by picking
+(`\texttt{B}', `\texttt{U}', `\texttt{C}', and `\texttt{X}' as shown above),
+and novelty (`\texttt{P}', recently picked up items; controlled by picking
 up or dropping things rather than by any time factor).
 %.lp ""
 \\
-If you specify more than one value in a category (such as ``{\tt !?}'' for
-potions and scrolls or ``{\tt BU}'' for blessed and uncursed), an inventory
+If you specify more than one value in a category (such as ``\texttt{!?}'' for
+potions and scrolls or ``\texttt{BU}'' for blessed and uncursed), an inventory
 object will meet the criteria if it matches any of the specified
-values (so ``{\tt !?}'' means `{\tt !}' or `{\tt ?}').
+values (so ``\texttt{!?}'' means `\texttt{!}' or `\texttt{?}').
 If you specify more than one category, an inventory object must meet
-each of the category criteria (so ``{\tt \%u}'' means class `{\tt \%}' and
-unpaid `{\tt u}').
+each of the category criteria (so ``\texttt{\%u}'' means class `\texttt{\%}' and
+unpaid `\texttt{u}').
 Lastly, you may specify multiple values within multiple categories:
-``{\tt !?BU}'' will select all potions and scrolls which are known to be
+``\texttt{!?BU}'' will select all potions and scrolls which are known to be
 blessed or uncursed.
 (In versions prior to 3.6, filter combinations behaved differently.)
 %.lp
@@ -863,15 +862,15 @@ Eat food.\\
 %.lp ""
 Normally checks for edible item(s) on the floor, then if none are found
 or none are chosen, checks for edible item(s) in inventory.
-Precede `{\tt e}' with the `{\tt m}' prefix to bypass attempting to eat
+Precede `\texttt{e}' with the `\texttt{m}' prefix to bypass attempting to eat
 anything off the floor.\\
 %.lp ""
 If you attempt to eat while already satiated, you might choke to death.
 If you risk it, you will be asked whether
-to ``continue eating?'' {\it if you survive the first bite\/}.
+to ``continue eating?'' \textit{if you survive the first bite}.
 You can set the
-{\it paranoid\textunderscore confirmation:eating\/}
-option to require a response of ``{\tt yes}'' instead of just `{\tt y}'.
+\textit{paranoid\textunderscore confirmation:eating}
+option to require a response of ``\texttt{yes}'' instead of just `\texttt{y}'.
 %.lp
 % Make sure Elbereth is not hyphenated below, the exact spelling matters.
 % (Only specified here to parallel Guidebook.mn; use of \tt font implicitly
@@ -881,49 +880,49 @@ option to require a response of ``{\tt yes}'' instead of just `{\tt y}'.
 Engrave a message on the floor.\\
 %.sd
 %.si
-{\tt E-} --- write in the dust with your fingers.\\
+\texttt{E-} --- write in the dust with your fingers.\\
 %.ei
 %.ed
 %.lp ""
-Engraving the word ``{\tt Elbereth}'' will cause most monsters to not attack
+Engraving the word ``\texttt{Elbereth}'' will cause most monsters to not attack
 you hand-to-hand (but if you attack, you will rub it out); this is
 often useful to give yourself a breather.
 %.lp
 \item[f]
 Fire (shoot or throw) one of the objects placed in your quiver (or
 quiver sack, or that you have at the ready).
-You may select ammunition with a previous `{\tt Q}' command, or let the
-computer pick something appropriate if {\it autoquiver\/} is true.
+You may select ammunition with a previous `\texttt{Q}' command, or let the
+computer pick something appropriate if \textit{autoquiver} is true.
 If your wielded weapon has the throw-and-return property, your quiver
-is empty, and {\it autoquiver\/}
+is empty, and \textit{autoquiver}
 is false, you will throw that wielded weapon instead of filling the quiver.
 This will also automatically use a polearm if wielded.
-If {\it fireassist\/} is true, firing will automatically try to wield a launcher
+If \textit{fireassist} is true, firing will automatically try to wield a launcher
 (for example, a bow or a sling) matching the ammo in the quiver; this might
 take multiple turns, and get interrupted by a monster.
 Remember to swap back to your main melee weapon afterwards.
 %.lp ""
 \\
-See also `{\tt t}' (throw) for more general throwing and shooting.
+See also `\texttt{t}' (throw) for more general throwing and shooting.
 %.lp
 \item[i]
 List your inventory (everything you're carrying).
 %.lp
 \item[I]
 List selected parts of your inventory, usually be specifying the character
-for a particular set of objects, like `{\tt [}' for armor or `{\tt !}'
+for a particular set of objects, like `\texttt{[}' for armor or `\texttt{!}'
 for potions.\\
 %.sd
 %.si
-{\tt I*} --- list all gems in inventory;\\
-{\tt Iu} --- list all unpaid items;\\
-{\tt Ix} --- list all used up items that are on your shopping bill;\\
-{\tt IB} --- list all items known to be blessed;\\
-{\tt IU} --- list all items known to be uncursed;\\
-{\tt IC} --- list all items known to be cursed;\\
-{\tt IX} --- list all items whose bless/curse status is unknown;\\
-{\tt IP} --- list items picked up last;\\
-{\tt I\$} --- count your money.
+\texttt{I*} --- list all gems in inventory;\\
+\texttt{Iu} --- list all unpaid items;\\
+\texttt{Ix} --- list all used up items that are on your shopping bill;\\
+\texttt{IB} --- list all items known to be blessed;\\
+\texttt{IU} --- list all items known to be uncursed;\\
+\texttt{IC} --- list all items known to be cursed;\\
+\texttt{IX} --- list all items whose bless/curse status is unknown;\\
+\texttt{IP} --- list items picked up last;\\
+\texttt{I\$} --- count your money.
 %.ei
 %.ed
 %.lp
@@ -940,18 +939,18 @@ it, depending on your user interface).  For the non-boolean choices,
 a further menu or prompt will appear once you've closed this menu.
 The available options
 are listed later in this Guidebook.  Options are usually set before the
-game rather than with the `{\tt O}' command; see the section on options below.
-Precede {\tt O} with the {\tt m} prefix to show advanced options.
+game rather than with the `\texttt{O}' command; see the section on options below.
+Precede \texttt{O} with the \texttt{m} prefix to show advanced options.
 %.lp
 \item[\textasciicircum O]
 Show overview.\\
 %.lp ""
-Shortcut for ``{\tt \#overview}'':
+Shortcut for ``\texttt{\#overview}'':
 list interesting dungeon levels visited.\\
 %.lp ""
-(Prior to 3.6.0, `{\tt \^{}O}' was a debug mode command which listed
+(Prior to 3.6.0, `\texttt{\textasciicircum O}' was a debug mode command which listed
 the placement of all special levels.
-Use ``{\tt \#wizwhere}'' to run that command.)
+Use ``\texttt{\#wizwhere}'' to run that command.)
 %.lp
 \item[p]
 Pay your shopping bill.
@@ -962,15 +961,15 @@ Put on an accessory (ring, amulet, or blindfold).\\
 This command may also be used to wear armor.  The prompt for
 which inventory item to use will only list accessories, but choosing
 an unlisted item of armor will attempt to wear it.
-(See the `{\tt W}' command below.  It lists armor as the inventory
+(See the `\texttt{W}' command below.  It lists armor as the inventory
 choices but will accept an accessory and attempt to put that on.)
 %.lp
 \item[\textasciicircum P]
 Repeat previous message.\\
 %.lp ""
-Subsequent {\tt \^{}P}'s repeat earlier messages.
+Subsequent \texttt{\textasciicircum P}'s repeat earlier messages.
 For some interfaces, the behavior can be varied via the
-{\it msg\textunderscore window\/} option.
+\textit{msg\textunderscore window} option.
 %.lp
 \item[q]
 Quaff (drink) something (potion, water, etc).\\
@@ -979,13 +978,13 @@ When there is a fountain or sink present, it asks whether to drink
 from that.
 If that is declined, then it offers a chance to choose a potion from
 inventory.
-Precede {\tt q} with the {\tt m} prefix to skip asking about
+Precede \texttt{q} with the \texttt{m} prefix to skip asking about
 drinking from a fountain or sink.
 %.lp
 \item[Q]
 Select an object for your quiver, quiver sack, or just generally at
 the ready (only one of these is available at a time).  You can then throw
-this (or one of these) using the `{\tt f}' command.
+this (or one of these) using the `\texttt{f}' command.
 %.lp
 \item[r]
 Read a scroll or spellbook.
@@ -996,13 +995,13 @@ Remove a worn accessory (ring, amulet, or blindfold).\\
 If you're wearing more than one, you'll be prompted for which one to
 remove.  When you're only wearing one, then by default it will be removed
 without asking, but you can set the
-{\it paranoid\textunderscore confirmation:Remove\/}
+\textit{paranoid\textunderscore confirmation:Remove}
 option to require a prompt.\\
 %.lp ""
 This command may also be used to take off armor.  The prompt for which
 inventory item to remove only lists worn accessories, but an item of
 worn armor can be chosen.
-(See the `{\tt T}' command below.  It lists armor as the inventory
+(See the `\texttt{T}' command below.  It lists armor as the inventory
 choices but will accept an accessory and attempt to remove it.)
 %.lp
 \item[\textasciicircum R]
@@ -1011,8 +1010,8 @@ Redraw the screen.
 \item[s]
 Search for secret doors and traps around you.
 It usually takes several tries to find something.
-Precede with the `{\tt m}' prefix to wait for a turn
-even next to a hostile monster, if {\it safe\textunderscore wait\/}
+Precede with the `\texttt{m}' prefix to wait for a turn
+even next to a hostile monster, if \textit{safe\textunderscore wait}
 is on.\\
 %.lp ""
 Can also be used to figure out whether there is still a monster at
@@ -1042,8 +1041,8 @@ that arrow and any weapon skill bonus or penalty for bow applies.
 If you ``throw'' an arrow while not wielding a bow, you are throwing
 it by hand and it will generally be less effective than when shot.\\
 %.lp ""
-See also `{\tt f}' (fire) for throwing or shooting an item pre-selected
-via the `{\tt Q}' (quiver) command, with some extra assistance.
+See also `\texttt{f}' (fire) for throwing or shooting an item pre-selected
+via the `\texttt{Q}' (quiver) command, with some extra assistance.
 %.lp
 \item[T]
 Take off armor.\\
@@ -1054,13 +1053,13 @@ and/or a shirt, or a suit covering a shirt, as if the underlying items
 weren't there.)
 When you're only wearing one, then by default it will
 be taken off without asking, but you can set the
-{\it paranoid\textunderscore confirmation:Remove\/}
+\textit{paranoid\textunderscore confirmation:Remove}
 option to require a prompt.\\
 %.lp ""
 This command may also be used to remove accessories.  The prompt
 for which inventory item to take off only lists worn armor, but a worn
 accessory can be chosen.
-(See the `{\tt R}' command above.  It lists accessories as the inventory
+(See the `\texttt{R}' command above.  It lists accessories as the inventory
 choices but will accept an item of armor and attempt to take it off.)
 %.lp
 \item[\textasciicircum T]
@@ -1076,11 +1075,11 @@ Display the game history.
 Wield weapon.\\
 %.sd
 %.si
-{\tt w-} --- wield nothing, use your bare (or gloved) hands.\\
+\texttt{w-} --- wield nothing, use your bare (or gloved) hands.\\
 %.ei
 %.ed
-Some characters can wield two weapons at once; use the `{\tt X}' command
-(or the ``{\tt \#twoweapon}'' extended command) to do so.
+Some characters can wield two weapons at once; use the `\texttt{X}' command
+(or the ``\texttt{\#twoweapon}'' extended command) to do so.
 %.lp
 \item[W]
 Wear armor.\\
@@ -1088,7 +1087,7 @@ Wear armor.\\
 This command may also be used to put on an accessory (ring, amulet, or
 blindfold).  The prompt for which inventory item to use will only list
 armor, but choosing an unlisted accessory will attempt to put it on.
-(See the `{\tt P}' command above.  It lists accessories as the inventory
+(See the `\texttt{P}' command above.  It lists accessories as the inventory
 choices but will accept an item of armor and attempt to wear it.)
 %.lp
 \item[x]
@@ -1100,31 +1099,31 @@ the exchange still takes place.
 %.lp
 \item[X]
 Toggle two-weapon combat, if your character can do it.  Also available
-via the ``{\tt \#twoweapon}'' extended command.\\
+via the ``\texttt{\#twoweapon}'' extended command.\\
 %.lp ""
 (In versions prior to 3.6 this keystroke ran the command to switch from normal
 play to ``explore mode'', also known as ``discovery mode'', which has now
-been moved to ``{\tt \#exploremode}'' and {\tt M-X}.)
+been moved to ``\texttt{\#exploremode}'' and \texttt{M-X}.)
 %.lp
 \item[\textasciicircum X]
 Display basic information about your character.\\
 %.lp ""
 Displays name, role, race, gender (unless role name makes that
-redundant, such as {\tt Caveman} or {\tt Priestess}), and alignment,
+redundant, such as \texttt{Caveman} or \texttt{Priestess}), and alignment,
 along with your patron deity and his or her opposition.  It also
 shows most of the various items of information from the status line(s)
 in a less terse form, including several additional things which don't
 appear in the normal status display due to space considerations.\\
 %.lp ""
-In normal play, that's all that `{\tt \^{}X}' displays.
+In normal play, that's all that `\texttt{\textasciicircum X}' displays.
 In explore mode, the role and status feedback is augmented by the
-information provided by {\it enlightenment\/} magic.
+information provided by \textit{enlightenment} magic.
 %.lp
 \item[z]
 Zap a wand.\\
 %.sd
 %.si
-{\tt z.} --- to aim at yourself, use `{\tt .}' for the direction.
+\texttt{z.} --- to aim at yourself, use `\texttt{.}' for the direction.
 %.ei
 %.ed
 %.lp
@@ -1132,7 +1131,7 @@ Zap a wand.\\
 Zap (cast) a spell.\\
 %.sd
 %.si
-{\tt Z.} --- to cast at yourself, use `{\tt .}' for the direction.
+\texttt{Z.} --- to cast at yourself, use `\texttt{.}' for the direction.
 %.ei
 %.ed
 %.lp
@@ -1149,10 +1148,10 @@ Show what type of thing a visible symbol corresponds to.
 \item[,]
 Pick up some things from the floor beneath you.\\
 %.lp ""
-May be preceded by `{\tt m}' to force a selection menu.
+May be preceded by `\texttt{m}' to force a selection menu.
 %.lp
 \item[@]
-Toggle the {\it autopickup\/} option on and off.
+Toggle the \textit{autopickup} option on and off.
 %.lp
 \item[\textasciicircum]
 Ask for the type of an adjacent trap you found earlier.
@@ -1188,9 +1187,9 @@ Using this command, you can also rearrange
 the order in which your spells are listed, either by sorting the entire
 list or by picking one spell from the menu then picking another to swap
 places with it.  Swapping pairs of spells changes their casting letters,
-so the change lasts after the current `{\tt +}' command finishes.  Sorting
+so the change lasts after the current `\texttt{+}' command finishes.  Sorting
 the whole list is temporary.  To make the most recent sort order persist
-beyond the current `{\tt +}' command, choose the sort option again and then
+beyond the current `\texttt{+}' command, choose the sort option again and then
 pick ``reassign casting letters''.  (Any spells learned after that will
 be added to the end of the list rather than be inserted into the sorted
 ordering.)
@@ -1199,28 +1198,28 @@ ordering.)
 Show what types of objects have been discovered.
 \\
 %.lp ""
-May be preceded by `{\tt m}' to select preferred display order.
+May be preceded by `\texttt{m}' to select preferred display order.
 %.lp
 \item[\textasciigrave]
 Show discovered types for one class of objects.
 \\
 %.lp ""
-May be preceded by `{\tt m}' to select preferred display order.
+May be preceded by `\texttt{m}' to select preferred display order.
 
 %.lp
 \item[|]
 If persistent inventory display is supported and enabled (with the
-{\it perm\textunderscore invent\/}
+\textit{perm\textunderscore invent}
 option), interact with it instead of with the map.
 \\
 %.lp ""
 Allows scrolling with the
 menu\textunderscore first\textunderscore page, menu\textunderscore previous\textunderscore page,
 menu\textunderscore next\textunderscore page, and menu\textunderscore last\textunderscore page
-keys (`{\tt \^{}}', `{\tt <}', `{\tt >}', `{\tt \verb+|+}' by default).
+keys (`\texttt{\textasciicircum}', `\texttt{<}', `\texttt{>}', `\texttt{|}' by default).
 Some interfaces also support menu\textunderscore shift\textunderscore left and menu\textunderscore shift\textunderscore right
-keys (`{\tt \verb+{+}' and `{\tt \verb+}+}' by default).
-Use the {\it Return\/} (aka {\it Enter\/}) or {\it Escape\/} key to
+keys (`\texttt{\textbraceleft}' and `\texttt{\textbraceright}' by default).
+Use the \textit{Return} (aka \textit{Enter}) or \textit{Escape} key to
 resume play.
 
 %.lp
@@ -1234,19 +1233,19 @@ You can view the explored portion of the current level's map without
 monsters; without monsters and objects; or without monsters, objects,
 and traps.\\
 %.lp ""
-The {\tt <del>} key is also shown as {\tt <delete>} on some keyboards or
-{\tt <rubout>} on others.
-It is sometimes displayed as {\tt \^{}?} even though that is not an actual
+The \texttt{<del>} key is also shown as \texttt{<delete>} on some keyboards or
+\texttt{<rubout>} on others.
+It is sometimes displayed as \texttt{\textasciicircum ?} even though that is not an actual
 control character.\\
 %.lp ""
-Many terminals have an option to swap the {\tt <delete>} and {\tt <backspace>}
-keys, so typing the {\tt <del>} key might not execute this command.
-If that happens, you can use the extended command ``{\tt \#terrain}'' instead.
+Many terminals have an option to swap the \texttt{<delete>} and \texttt{<backspace>}
+keys, so typing the \texttt{<del>} key might not execute this command.
+If that happens, you can use the extended command ``\texttt{\#terrain}'' instead.
 %.lp
 \item[\#]
 Perform an extended command.\\
 %.lp ""
-As you can see, the authors of {\it NetHack\/}
+As you can see, the authors of \textit{NetHack}
 used up all the letters, so this is a way to introduce the less frequently
 used commands.
 What extended commands are available depends on what features
@@ -1254,8 +1253,8 @@ the game was compiled with.
 %.lp
 \item[\#adjust]
 Adjust inventory letters (most useful when the
-{\it fixinv\/}
-option is ``on''). Autocompletes. Default key is `{\tt M-a}'.\\
+\textit{fixinv}
+option is ``on''). Autocompletes. Default key is `\texttt{M-a}'.\\
 %.lp ""
 This command allows you to move an item from one particular inventory
 slot to another so that it has a letter which is more meaningful for you
@@ -1264,17 +1263,17 @@ are displayed.
 You can move to a currently empty slot, or if the destination is
 occupied---and won't merge---the
 item there will swap slots with the one being moved.
-``{\tt \#adjust}'' can also be used to split a stack of objects; when
+``\texttt{\#adjust}'' can also be used to split a stack of objects; when
 choosing the item to adjust, enter a count prior to its letter.\\
 %.lp ""
 Adjusting without a count used to collect all compatible stacks when
 moving to the destination.  That behavior has been changed; to gather
-compatible stacks, ``{\tt \#adjust}'' a stack into its own inventory slot.
+compatible stacks, ``\texttt{\#adjust}'' a stack into its own inventory slot.
 If it has a name assigned, other stacks with the same name or with
 no name will merge provided that all their other attributes match.
 If it does not have a name, only other stacks with no name are eligible.
 In either case, otherwise compatible stacks with a different name
-will not be merged.  This contrasts with using ``{\tt \#adjust}'' to move
+will not be merged.  This contrasts with using ``\texttt{\#adjust}'' to move
 from one slot to a different slot.  In that situation, moving (no
 count given) a compatible stack will merge if either stack has a
 name when the other doesn't and give that name to the result, while
@@ -1284,28 +1283,28 @@ deciding whether to merge with the destination stack.
 \item[\#annotate]
 Allows you to specify one line of text to associate with the current
 dungeon level.  All levels with annotations are displayed by the
-``{\tt \#overview}'' command. Autocompletes.
-Default key is `{\tt M-A}',
-and also `{\tt \^{}N}' if {\it number\textunderscore pad\/} is on.
+``\texttt{\#overview}'' command. Autocompletes.
+Default key is `\texttt{M-A}',
+and also `\texttt{\textasciicircum N}' if \textit{number\textunderscore pad} is on.
 %.lp
 \item[\#apply]
 Apply (use) a tool such as a pick-axe, a key, or a lamp.
-Default key is `{\tt a}'.\\
+Default key is `\texttt{a}'.\\
 %.lp ""
-If the tool used acts on items on the floor, using the `{\tt m}' prefix
+If the tool used acts on items on the floor, using the `\texttt{m}' prefix
 skips those items.\\
 %.lp ""
 If used on a wand, that wand will be broken, releasing its magic in the
 process.  Confirmation is required.
 %.lp
 \item[\#attributes]
-Show your attributes. Default key is `{\tt \^{}X}'.
+Show your attributes. Default key is `\texttt{\textasciicircum X}'.
 %.lp
 \item[\#autopickup]
-Toggle the {\it autopickup\/} option. Default key is `{\tt @}'.
+Toggle the \textit{autopickup} option. Default key is `\texttt{@}'.
 %.lp
 \item[\#bugreport]
-Bring up a browser window to submit a report to the {\it NetHack Development
+Bring up a browser window to submit a report to the \textit{NetHack Development
 Team}.
 Can be disabled at the time the program is built; when enabled,
 CRASHREPORTURL must be set in the system configuration file.
@@ -1313,23 +1312,23 @@ CRASHREPORTURL must be set in the system configuration file.
 \item[\#call]
 Call (name) a monster, or an object in inventory, on the floor,
 or in the discoveries list, or add an annotation for the
-current level (same as ``{\tt \#annotate}''). Default key is `{\tt C}'.
+current level (same as ``\texttt{\#annotate}''). Default key is `\texttt{C}'.
 %.lp
 \item[\#cast]
-Cast a spell. Default key is `{\tt Z}'.
+Cast a spell. Default key is `\texttt{Z}'.
 %.lp
 \item[\#chat]
-Talk to someone. Default key is `{\tt M-c}'.
+Talk to someone. Default key is `\texttt{M-c}'.
 %.lp
 \item[\#chronicle]
 Show a list of important game events.
 %.lp
 \item[\#close]
-Close a door. Default key is `{\tt c}'.
+Close a door. Default key is `\texttt{c}'.
 %.lp
 \item[\#conduct]
 List voluntary challenges you have maintained. Autocompletes.
-Default key is `{\tt M-C}'.\\
+Default key is `\texttt{M-C}'.\\
 %.lp ""
 See the section below entitled ``Conduct'' for details.
 %.lp
@@ -1338,54 +1337,54 @@ Start the fuzz tester.
 Debug mode only.
 %.lp
 \item[\#dip]
-Dip an object into something. Autocompletes. Default key is `{\tt M-d}'.\\
+Dip an object into something. Autocompletes. Default key is `\texttt{M-d}'.\\
 %.lp ""
-The {\tt m} prefix skips dipping into a fountain or pool if there
+The \texttt{m} prefix skips dipping into a fountain or pool if there
 is one at your location.
 %.lp
 \item[\#down]
-Go down a staircase. Default key is `{\tt >}'.
+Go down a staircase. Default key is `\texttt{>}'.
 %.lp
 \item[\#drop]
-Drop an item. Default key is `{\tt d}'.
+Drop an item. Default key is `\texttt{d}'.
 %.lp
 \item[\#droptype]
-Drop specific item types. Default key is `{\tt D}'.
+Drop specific item types. Default key is `\texttt{D}'.
 %.lp
 \item[\#eat]
-Eat something. Default key is `{\tt e}'.
-The `{\tt m}' prefix skips eating items on the floor.
+Eat something. Default key is `\texttt{e}'.
+The `\texttt{m}' prefix skips eating items on the floor.
 %.lp
 \item[\#engrave]
-Engrave writing on the floor. Default key is `{\tt E}'.
+Engrave writing on the floor. Default key is `\texttt{E}'.
 %.lp
 \item[\#enhance]
 Advance or check weapon and spell skills. Autocompletes.
-Default key is `{\tt M-e}'.
+Default key is `\texttt{M-e}'.
 %.lp
 \item[\#exploremode]
 Switch from normal play to non-scoring explore mode.
-Default key is `{\tt M-X}'.\\
+Default key is `\texttt{M-X}'.\\
 %.lp ""
-Requires confirmation; default response is `{\tt n}' (no).
-To really switch to explore mode, respond with `{\tt y}'.
+Requires confirmation; default response is `\texttt{n}' (no).
+To really switch to explore mode, respond with `\texttt{y}'.
 You can set the
-{\it paranoid\textunderscore confirmation:quit\/}
-option to require a response of ``{\tt yes}'' instead.
+\textit{paranoid\textunderscore confirmation:quit}
+option to require a response of ``\texttt{yes}'' instead.
 %.lp
 \item[\#fight]
 Prefix key to force fight a direction, even if you see nothing
 to fight there.
-Default key is `{\tt F}', or `{\tt -}' with
-{\it number\textunderscore pad\/}
+Default key is `\texttt{F}', or `\texttt{-}' with
+\textit{number\textunderscore pad}
 %.lp
 \item[\#fire]
 Fire ammunition from quiver, possibly autowielding a launcher,
 or hit with a wielded polearm.
-Default key is `{\tt f}'.
+Default key is `\texttt{f}'.
 %.lp
 \item[\#force]
-Force a lock. Autocompletes. Default key is `{\tt M-f}'.
+Force a lock. Autocompletes. Default key is `\texttt{M-f}'.
 %.lp
 \item[\#genocided]
 List any monster types which have been genocided.
@@ -1393,27 +1392,27 @@ In explore mode and debug mode it also shows types which have become
 extinct.
 \\
 %.lp ""
-The display order is the same as is used by {\\tt \#vanquished}.
-The `{\tt m}' prefix brings up a menu of available sorting orders, and
-doing that for either {\\tt \#genocided} or {\\tt \#vanquished} changes the order for both.
+The display order is the same as is used by \texttt{\#vanquished}.
+The `\texttt{m}' prefix brings up a menu of available sorting orders, and
+doing that for either \texttt{\#genocided} or \texttt{\#vanquished} changes the order for both.
 \\
 %.lp ""
 If the sorting order is ``count high to low'' or ``count low to high''
-(which are applicable for {\tt \#vanquished}), that will be ignored
-for {\tt \#genocided} and alphabetical will be used instead.
-The menu omits those two choices when used for {\tt \#genocide}.
+(which are applicable for \texttt{\#vanquished}), that will be ignored
+for \texttt{\#genocided} and alphabetical will be used instead.
+The menu omits those two choices when used for \texttt{\#genocide}.
 \\
 %.lp ""
 Autocompletes.
-Default key is `{\tt M-g}'.
+Default key is `\texttt{M-g}'.
 %.lp
 \item[\#glance]
-Show what type of thing a map symbol corresponds to. Default key is `{\tt ;}'.
+Show what type of thing a map symbol corresponds to. Default key is `\texttt{;}'.
 %.lp
 \item[\#help]
 Show the help menu.
-Default key is `{\tt ?}',
-and also `{\tt h}' if {\it number\textunderscore pad\/} is on.
+Default key is `\texttt{?}',
+and also `\texttt{h}' if \textit{number\textunderscore pad} is on.
 %.lp
 \item[\#herecmdmenu]
 Show a menu of possible actions directed at your current location.
@@ -1421,47 +1420,47 @@ The menu is limited to a subset of the likeliest actions, not an
 exhaustive set of all possibilities.
 Autocompletes.\\
 %.lp ""
-If mouse support is enabled and the {\it herecmd\textunderscore menu\/}
+If mouse support is enabled and the \textit{herecmd\textunderscore menu}
 option is On, clicking on the hero (or steed when mounted) will
 execute this command.
 %.lp
 \item[\#history]
-Show long version and game history. Default key is `{\tt V}'.
+Show long version and game history. Default key is `\texttt{V}'.
 %.lp
 \item[\#inventory]
-Show your inventory. Default key is `{\tt i}'.
+Show your inventory. Default key is `\texttt{i}'.
 %.lp
 \item[\#inventtype]
-Inventory specific item types. Default key is `{\tt I}'.
+Inventory specific item types. Default key is `\texttt{I}'.
 %.lp
 \item[\#invoke]
-Invoke an object's special powers. Autocompletes. Default key is `{\tt M-i}'.
+Invoke an object's special powers. Autocompletes. Default key is `\texttt{M-i}'.
 %.lp
 \item[\#jump]
 Jump to another location. Autocompletes.
-Default key is `{\tt M-j}',
-and also `{\tt j}' if {\it number\textunderscore pad\/} is on.
+Default key is `\texttt{M-j}',
+and also `\texttt{j}' if \textit{number\textunderscore pad} is on.
 %.lp
 \item[\#kick]
 Kick something.
-Default key is `{\tt \^{}D}',
-and also `{\tt k}' if {\it number\textunderscore pad\/} is on.
+Default key is `\texttt{\textasciicircum D}',
+and also `\texttt{k}' if \textit{number\textunderscore pad} is on.
 %.lp
 \item[\#known]
 Show what object types have been discovered.
-Default key is `{\tt $\backslash$}'.
+Default key is `\texttt{\textbackslash}'.
 \\
 %.lp ""
-The `{\tt m}' prefix allows assigning a new value to the
-{\it sortdiscoveries\/}
+The `\texttt{m}' prefix allows assigning a new value to the
+\textit{sortdiscoveries}
 option to control the order in which the discoveries are displayed.
 %.lp
 \item[\#knownclass]
 Show discovered types for one class of objects.
-Default key is `{\tt `}'.
+Default key is `\texttt{`}'.
 \\
 %.lp ""
-The `{\tt m}' prefix operates the same as for {\tt \#known}.
+The `\texttt{m}' prefix operates the same as for \texttt{\#known}.
 %.lp
 \item[\#levelchange]
 Change your experience level.
@@ -1474,7 +1473,7 @@ Autocompletes.
 Debug mode only.
 %.lp
 \item[\#look]
-Look at what is here, under you. Default key is `{\tt :}'.
+Look at what is here, under you. Default key is `\texttt{:}'.
 %.lp
 \item[\#lookaround]
 Describe what you can see, or remember, of your surroundings.
@@ -1482,42 +1481,42 @@ Describe what you can see, or remember, of your surroundings.
 \item[\#loot]
 Loot a box or bag on the floor beneath you, or the saddle
 from a steed standing next to you. Autocompletes.
-Precede with the `{\tt m}' prefix to skip containers at your location
+Precede with the `\texttt{m}' prefix to skip containers at your location
 and go directly to removing a saddle.
-Default key is `{\tt M-l}',
-and also `{\tt l}' if {\it number\textunderscore pad\/} is on.
+Default key is `\texttt{M-l}',
+and also `\texttt{l}' if \textit{number\textunderscore pad} is on.
 %.lp
 \item[\#monster]
 Use a monster's special ability (when polymorphed into monster form).
-Autocompletes. Default key is `{\tt M-m}'.
+Autocompletes. Default key is `\texttt{M-m}'.
 %.lp
 \item[\#name]
 Name a monster, an individual object, or a type of object.
-Same as ``{\tt \#call}''.
+Same as ``\texttt{\#call}''.
 Autocompletes.
-Default keys are `{\tt N}', `{\tt M-n}', and `{\tt M-N}'.
+Default keys are `\texttt{N}', `\texttt{M-n}', and `\texttt{M-N}'.
 %.lp
 \item[\#offer]
-Offer a sacrifice to the gods. Autocompletes. Default key is `{\tt M-o}'.\\
+Offer a sacrifice to the gods. Autocompletes. Default key is `\texttt{M-o}'.\\
 %.lp ""
 You'll need to find an altar to have any chance at success.
 Corpses of recently killed monsters are the fodder of choice.
 %.lp ""
-The `{\tt m}' prefix skips offering any items which are on the altar.\\
+The `\texttt{m}' prefix skips offering any items which are on the altar.\\
 %.lp
 \item[\#open]
-Open a door. Default key is `{\tt o}'.
+Open a door. Default key is `\texttt{o}'.
 %.lp
 \item[\#options]
-Show and change option settings. Default key is `{\tt O}'.
-Precede with the {\tt m} prefix to show advanced options.
+Show and change option settings. Default key is `\texttt{O}'.
+Precede with the \texttt{m} prefix to show advanced options.
 %.lp
 \item[\#optionsfull]
 Show advanced game option settings.
 No default key.
-Precede with the `{\tt m}' prefix to execute the simpler options command.
-(Mainly useful if you use {\tt BINDING=O:optionsfull} to switch
-`{\tt O}' from simple options back to traditional advanced options.)
+Precede with the `\texttt{m}' prefix to execute the simpler options command.
+(Mainly useful if you use \texttt{BINDING=O:optionsfull} to switch
+`\texttt{O}' from simple options back to traditional advanced options.)
 %.lp
 \item[\#overview]
 Display information you've discovered about the dungeon.
@@ -1531,7 +1530,7 @@ If dungeon overview is chosen during end-of-game disclosure, every visited
 level will be included regardless of annotations.
 \\
 %.lp ""
-Precede \#overview with the `{\tt m}' prefix to display the dungeon
+Precede \#overview with the `\texttt{m}' prefix to display the dungeon
 overview as a menu where you can select any visited level to add or
 remove an annotation without needing to return to that level.
 This will also force all visited levels to be displayed rather than just
@@ -1539,7 +1538,7 @@ the ``interesting'' subset.
 \\
 %.lp ""
 Autocompletes.
-Default keys are `{\tt \^{}O}', and `{\tt M-O}'.
+Default keys are `\texttt{\textasciicircum O}', and `\texttt{M-O}'.
 % DON'T PANIC!
 %.lp
 \item[\#panic]
@@ -1548,26 +1547,26 @@ Terminates the current game.
 Autocompletes.
 Debug mode only.\\
 %.lp ""
-Asks for confirmation; default is `{\tt n}' (no); continue playing.
-To really panic, respond with `{\tt y}'.
+Asks for confirmation; default is `\texttt{n}' (no); continue playing.
+To really panic, respond with `\texttt{y}'.
 You can set the
-{\it paranoid\textunderscore confirmation:quit\/}
-option to require a response of ``{\tt yes}'' instead.
+\textit{paranoid\textunderscore confirmation:quit}
+option to require a response of ``\texttt{yes}'' instead.
 %.lp
 \item[\#pay]
-Pay your shopping bill. Default key is `{\tt p}'.
+Pay your shopping bill. Default key is `\texttt{p}'.
 %.lp
 \item[\#perminv]
 If persistent inventory display is supported and enabled (with the
-{\it perm\textunderscore invent\/} option), interact with it instead of with the map.
+\textit{perm\textunderscore invent} option), interact with it instead of with the map.
 You'll be prompted for menu scrolling keystrokes such
-as `{\tt \verb+>+}' and `{\tt \verb+<+}'.
-Press {\tt Return} or {\tt Escape} to resume normal play.
-Default key is {\tt \verb+|+}.
+as `\texttt{>}' and `\texttt{<}'.
+Press \texttt{Return} or \texttt{Escape} to resume normal play.
+Default key is \texttt{|}.
 %.lp
 \item[\#pickup]
-Pick up things at the current location. Default key is `{\tt ,}'.
-The `{\tt m}' prefix forces use of a menu.
+Pick up things at the current location. Default key is `\texttt{,}'.
+The `\texttt{m}' prefix forces use of a menu.
 %.lp
 \item[\#polyself]
 Polymorph self.
@@ -1575,7 +1574,7 @@ Autocompletes.
 Debug mode only.
 %.lp
 \item[\#pray]
-Pray to the gods for help. Autocompletes. Default key is `{\tt M-p}'.\\
+Pray to the gods for help. Autocompletes. Default key is `\texttt{M-p}'.\\
 %.lp ""
 Praying too soon after receiving prior help is a bad idea.
 (Hint: entering the dungeon alive is treated as having received help.
@@ -1583,19 +1582,19 @@ You probably shouldn't start off a new game by praying right away.)
 Since using this command by accident can cause trouble, there is an
 option to make you confirm your intent before praying.  It is enabled
 by default, and you can reset the
-{\it paranoid\textunderscore confirmation\/}
+\textit{paranoid\textunderscore confirmation}
 option to disable it.
 %.lp
 \item[\#prevmsg]
-Show previously displayed game messages. Default key is `{\tt \^{}P}'.
+Show previously displayed game messages. Default key is `\texttt{\textasciicircum P}'.
 %.lp
 \item[\#puton]
-Put on an accessory (ring, amulet, etc). Default key is `{\tt P}'.
+Put on an accessory (ring, amulet, etc). Default key is `\texttt{P}'.
 %.lp
 \item[\#quaff]
-Quaff (drink) something. Default key is `{\tt q}'.\\
+Quaff (drink) something. Default key is `\texttt{q}'.\\
 %.lp ""
-The {\tt m} prefix skips drinking from a fountain or sink if there
+The \texttt{m} prefix skips drinking from a fountain or sink if there
 is one at your location.
 %.lp
 \item[\#quit]
@@ -1603,70 +1602,70 @@ Quit the program without saving your game. Autocompletes.\\
 %.lp ""
 Since using this command by accident would throw away the current game,
 you are asked to confirm your intent before quitting.
-Default response is `{\tt n}' (no); continue playing.
-To really quit, respond with `{\tt y}'.
+Default response is `\texttt{n}' (no); continue playing.
+To really quit, respond with `\texttt{y}'.
 You can set the
-{\it paranoid\textunderscore confirmation:quit\/}
-option to require a response of ``{\tt yes}'' instead.
+\textit{paranoid\textunderscore confirmation:quit}
+option to require a response of ``\texttt{yes}'' instead.
 %.lp
 \item[\#quiver]
-Select ammunition for quiver. Default key is `{\tt Q}'.
+Select ammunition for quiver. Default key is `\texttt{Q}'.
 %.lp
 \item[\#read]
-Read a scroll, a spellbook, or something else. Default key is `{\tt r}'.
+Read a scroll, a spellbook, or something else. Default key is `\texttt{r}'.
 %.lp
 \item[\#redraw]
 Redraw the screen.
-Default key is `{\tt \^{}R}',
-and also `{\tt \^{}L}' if {\it number\textunderscore pad\/} is on.
+Default key is `\texttt{\textasciicircum R}',
+and also `\texttt{\textasciicircum L}' if \textit{number\textunderscore pad} is on.
 %.lp
 \item[\#remove]
-Remove an accessory (ring, amulet, etc). Default key is `{\tt R}'.
+Remove an accessory (ring, amulet, etc). Default key is `\texttt{R}'.
 %.lp
 \item[\#repeat]
 Repeat the previous command.
-Default key is~`{\tt \^{}A}'.
+Default key is~`\texttt{\textasciicircum A}'.
 %.lp
 \item[\#reqmenu]
 Prefix key to modify the behavior or request menu from some commands.
 Prevents autopickup when used with movement commands.
-Default key is `{\tt m}'.
+Default key is `\texttt{m}'.
 %.lp
 \item[\#retravel]
 Travel to a previously selected travel destination.
-Default key is `{\tt C-\textunderscore }'.
-See also {\tt \#travel}.
+Default key is `\texttt{C-\textunderscore }'.
+See also \texttt{\#travel}.
 %.lp
 \item[\#ride]
 Ride (or stop riding) a saddled creature. Autocompletes.
-Default key is `{\tt M-R}'.
+Default key is `\texttt{M-R}'.
 %.lp
 \item[\#rub]
-Rub a lamp or a stone. Autocompletes. Default key is `{\tt M-r}'.
+Rub a lamp or a stone. Autocompletes. Default key is `\texttt{M-r}'.
 %.lp
 \item[\#run]
 Prefix key to run towards a direction.
-Default key is `{\tt G}' when
-{\it number\textunderscore pad\/}
+Default key is `\texttt{G}' when
+\textit{number\textunderscore pad}
 is off,
-`{\tt 5}' when
-{\it number\textunderscore pad\/}
+`\texttt{5}' when
+\textit{number\textunderscore pad}
 is set to 1~or~3,
-otherwise `{\tt M-5}' when it is set to 2~or~4.
+otherwise `\texttt{M-5}' when it is set to 2~or~4.
 %.lp
 \item[\#rush]
 Prefix key to rush towards a direction.
-Default key is `{\tt g}' when
-{\it number\textunderscore pad\/}
+Default key is `\texttt{g}' when
+\textit{number\textunderscore pad}
 is off,
-`{\tt M-5}' when
-{\it number\textunderscore pad\/}
+`\texttt{M-5}' when
+\textit{number\textunderscore pad}
 is set to 1~or~3,
-otherwise `{\tt 5}' when it is set to 2~or~4.
+otherwise `\texttt{5}' when it is set to 2~or~4.
 %.lp
 \item[\#save]
 Save the game and exit the program.
-Default key is `{\tt S}'.
+Default key is `\texttt{S}'.
 %.lp
 \item[\#saveoptions]
 Save configuration options to the config file.
@@ -1674,49 +1673,49 @@ This will overwrite the file, removing all comments, so if you have
 manually edited the config file, don't use this.
 %.lp
 \item[\#search]
-Search for traps and secret doors around you. Default key is `{\tt s}'.
+Search for traps and secret doors around you. Default key is `\texttt{s}'.
 %.lp
 \item[\#seeall]
-Show all equipment in use. Default key is `{\tt *}'.
+Show all equipment in use. Default key is `\texttt{*}'.
 %.lp ""
 \\
 Will display in-use items in a menu even when there is only one.
 %.lp
 \item[\#seeamulet]
-Show the amulet currently worn. Default key is `{\tt "}'.
+Show the amulet currently worn. Default key is `\texttt{"}'.
 %.lp ""
 \\
-Using the `{\tt m}' prefix will force the display of a worn
+Using the `\texttt{m}' prefix will force the display of a worn
 amulet in a menu rather than with just a message.
 %.lp
 \item[\#seearmor]
-Show the armor currently worn. Default key is `{\tt [}'.
+Show the armor currently worn. Default key is `\texttt{[}'.
 %.lp ""
 \\
 Will display worn armor in a menu even when there is only thing worn.
 %.lp
 \item[\#seerings]
-Show the ring(s) currently worn. Default key is `{\tt =}'.
+Show the ring(s) currently worn. Default key is `\texttt{=}'.
 %.lp ""
 Will display worn rings in a menu if there are two (or there is
 just one and is a meat ring rather than a ``real'' ring).
-Use the `{\tt m}' prefix to force a menu for one ring.
+Use the `\texttt{m}' prefix to force a menu for one ring.
 %.lp
 \item[\#seetools]
-Show the tools currently in use. Default key is `{\tt (}'.
+Show the tools currently in use. Default key is `\texttt{(}'.
 %.lp ""
 Will display the result in a message if there is one tool in use (worn
 blindfold or towel or lenses, lit lamp(s) and/or candle(s), leashes
 attached to pets).
 Will display a menu if there are more than one or if the command is
-preceded by the `{\tt m}' prefix.
+preceded by the `\texttt{m}' prefix.
 %.lp
 \item[\#seeweapon]
-Show the weapon currently wielded. Default key is `{\tt )}'.
+Show the weapon currently wielded. Default key is `\texttt{)}'.
 %.lp ""
 If dual-wielding, a separate message about the secondary weapon will be
 given.
-Using the `{\tt m}' prefix will force a menu and it will include
+Using the `\texttt{m}' prefix will force a menu and it will include
 primary weapon, alternate weapon even when not dual-wielding, and also
 whatever is currently assigned to the quiver slot.
 %.lp
@@ -1725,29 +1724,29 @@ Do a shell escape, switching from NetHack to a subprocess.
 Can be disabled at the time the program is built.
 When enabled, access for specific users can be controlled by the system
 configuration file.
-Use the shell command `{\tt exit}' to return to the game.
-Default key is `{\tt !}'.
+Use the shell command `\texttt{exit}' to return to the game.
+Default key is `\texttt{!}'.
 %.lp
 \item[\#showgold]
 Report the gold in your inventory, including gold you know about in
 containers you're carrying.  If you are inside a shop, report any credit
 or debt you have in that shop.
-Default key is `{\tt \$}'.
+Default key is `\texttt{\$}'.
 %.lp
 \item[\#showspells]
 List and reorder known spells.
-Default key is `{\tt +}'.
+Default key is `\texttt{+}'.
 %.lp
 \item[\#showtrap]
 Describe an adjacent trap, possibly covered by objects or a monster.
 To be eligible, the trap must already be discovered.
-(The ``{\tt \#terrain}'' command can display your map with all objects and
+(The ``\texttt{\#terrain}'' command can display your map with all objects and
 monsters temporarily removed, making it possible to see all discovered
 traps.)
-Default key is `{\tt \^{}}'.
+Default key is `\texttt{\textasciicircum }'.
 %.lp
 \item[\#sit]
-Sit down. Autocompletes. Default key is `{\tt M-s}'.
+Sit down. Autocompletes. Default key is `\texttt{M-s}'.
 %.lp
 \item[\#stats]
 Show memory usage statistics.
@@ -1758,23 +1757,23 @@ Debug mode only.
 Suspend the game, switching from NetHack to the terminal it was started
 from without performing save-and-exit.
 Can be disabled at the time the program is built.
-When enabled, mainly useful for {\it tty\/} and {\it curses\/} interfaces on
+When enabled, mainly useful for \textit{tty} and \textit{curses} interfaces on
 %.UX \. \" yields "UNIX."
 UNIX.
-Use the shell command `{\tt fg}' to return to the game.
-Default key is `{\tt \^{}Z}'.
+Use the shell command `\texttt{fg}' to return to the game.
+Default key is `\texttt{\textasciicircum Z}'.
 %.lp
 \item[\#swap]
-Swap wielded and secondary weapons. Default key is `{\tt x}'.
+Swap wielded and secondary weapons. Default key is `\texttt{x}'.
 %.lp
 \item[\#takeoff]
-Take off one piece of armor. Default key is `{\tt T}'.
+Take off one piece of armor. Default key is `\texttt{T}'.
 %.lp
 \item[\#takeoffall]
-Remove all armor. Default key is `{\tt A}'.
+Remove all armor. Default key is `\texttt{A}'.
 %.lp
 \item[\#teleport]
-Teleport around the level. Default key is `{\tt \^{}T}'.
+Teleport around the level. Default key is `\texttt{\textasciicircum T}'.
 %.lp
 \item[\#terrain]
 Show map without obstructions.
@@ -1790,7 +1789,7 @@ its explored portion.
 In debug mode there are additional choices.\\
 %.lp ""
 Autocompletes.
-Default key is `{\tt <del>}' or `{\tt <delete>}' (see {\it Del\/} above).
+Default key is `\texttt{<del>}' or `\texttt{<delete>}' (see \textit{Del} above).
 %.lp
 \item[\#therecmdmenu]
 Show a menu of possible actions directed at a location next to you.
@@ -1800,11 +1799,11 @@ Autocompletes.
 %%--invoking it by mouse seems to be broken
 %% \\
 %% .lp ""
-%% If mouse support is enabled and the {\it herecmd\textunderscore menu\/}
+%% If mouse support is enabled and the \textit{herecmd\textunderscore menu}
 %% option is On, clicking on an adjacent location will execute this command.
 %.lp
 \item[\#throw]
-Throw something. Default key is `{\tt t}'.
+Throw something. Default key is `\texttt{t}'.
 %.lp
 \item[\#timeout]
 Look at the timeout queue.
@@ -1819,32 +1818,32 @@ of them or ``tip something being carried''.
 %.lp ""
 If the latter is chosen, there will be another prompt for which item
 from inventory to tip.
-The `{\tt m}' prefix makes the command skip containers on the
+The `\texttt{m}' prefix makes the command skip containers on the
 floor and pick one from inventory, except for the special case of
-{\it menustyle:Traditional\/}
+\textit{menustyle:Traditional}
 with two or more containers present; that situation will start with the
 floor container menu.
 \\
 %.lp ""
-Autocompletes. Default key is `{\tt M-T}'.
+Autocompletes. Default key is `\texttt{M-T}'.
 %.lp
 \item[\#travel]
 Travel to a specific location on the map.
-Default key is `{\tt \textunderscore }'.
+Default key is `\texttt{\textunderscore }'.
 Using the ``request menu'' prefix shows a menu of interesting targets in sight
 without asking to move the cursor.
-When picking a target with cursor and the {\it autodescribe\/}
+When picking a target with cursor and the \textit{autodescribe}
 option is on, the top line will show ``(no travel path)'' if
 your character does not know of a path to that location.
-See also {\tt \#retravel}.
+See also \texttt{\#retravel}.
 %.lp
 \item[\#turn]
-Turn undead away. Autocompletes. Default key is `{\tt M-t}'.
+Turn undead away. Autocompletes. Default key is `\texttt{M-t}'.
 %.lp
 \item[\#twoweapon]
 Toggle two-weapon combat on or off. Autocompletes.
-Default key is `{\tt X}',
-and also `{\tt M-2}' if {\it number\textunderscore pad\/} is off.\\
+Default key is `\texttt{X}',
+and also `\texttt{M-2}' if \textit{number\textunderscore pad} is off.\\
 %.lp ""
 Note that you must
 use suitable weapons for this type of combat, or it will
@@ -1852,12 +1851,12 @@ be automatically turned off.
 %.lp
 \item[\#untrap]
 Untrap something (trap, door, or chest).
-Default key is `{\tt M-u}', and `{\tt u}' if {\it number\textunderscore pad\/} is on.\\
+Default key is `\texttt{M-u}', and `\texttt{u}' if \textit{number\textunderscore pad} is on.\\
 %.lp ""
 In some circumstances it can also be used to rescue trapped monsters.
 %.lp
 \item[\#up]
-Go up a staircase. Default key is `{\tt <}'.
+Go up a staircase. Default key is `\texttt{<}'.
 %.lp
 \item[\#vanquished]
 List vanquished monsters by type and count.
@@ -1873,33 +1872,33 @@ on the map.
 Using the ``request menu'' prefix prior to \#vanquished brings up
 a menu of sorting orders available (provided that the vanquished monsters
 list contains at least two types of monsters).
-Whichever ordering is picked gets assigned to the {\it sortvanquished}
+Whichever ordering is picked gets assigned to the \textit{sortvanquished}
 option so is remembered for subsequent \#vanquished requests.
-The {\tt \#genocided} command shares this sorting order.
+The \texttt{\#genocided} command shares this sorting order.
 \\
 %.lp ""
 During end-of-game disclosure, when asked whether to show vanquished
-monsters answering `{\tt a}' will let you choose from the sort menu.
+monsters answering `\texttt{a}' will let you choose from the sort menu.
 \\
 %.lp ""
 Autocompletes.
-Default key is `{\tt M-V}'.
+Default key is `\texttt{M-V}'.
 %.lp
 \item[\#version]
-Print compile time options for this version of {\it NetHack\/}.
+Print compile time options for this version of \textit{NetHack}.
 
 %.lp
 The second paragraph lists the user interface(s) that are included.
-If there are more than one, you can use the {\it windowtype\/}
+If there are more than one, you can use the \textit{windowtype}
 option in your run-time configuration file to select the one you want.
 
 %.lp
-Autocompletes. Default key is `{\tt M-v}'.
+Autocompletes. Default key is `\texttt{M-v}'.
 %.lp
 \item[\#versionshort]
 Show the program's version number, plus the date and time that the
 running copy was built from sources (not the version's release date).
-Default key is `{\tt v}'.
+Default key is `\texttt{v}'.
 %.lp
 \item[\#vision]
 Show vision array.
@@ -1908,23 +1907,23 @@ Debug mode only.
 %.lp
 \item[\#wait]
 Rest one move while doing nothing.
-Default key is `{\tt .}', and also `{\tt{ }}' if
-{\it rest\textunderscore on\textunderscore space\/} is on.
+Default key is `\texttt{.}', and also `{\tt{ }}' if
+\textit{rest\textunderscore on\textunderscore space} is on.
 %.lp
 \item[\#wear]
-Wear a piece of armor. Default key is `{\tt W}'.
+Wear a piece of armor. Default key is `\texttt{W}'.
 %.lp
 \item[\#whatdoes]
-Tell what a key does. Default key is `{\tt \&}'.
+Tell what a key does. Default key is `\texttt{\&}'.
 %.lp
 \item[\#whatis]
-Show what type of thing a symbol corresponds to. Default key is `{\tt /}'.
+Show what type of thing a symbol corresponds to. Default key is `\texttt{/}'.
 %.lp
 \item[\#wield]
-Wield a weapon. Default key is `{\tt w}'.
+Wield a weapon. Default key is `\texttt{w}'.
 %.lp
 \item[\#wipe]
-Wipe off your face. Autocompletes. Default key is `{\tt M-w}'.
+Wipe off your face. Autocompletes. Default key is `\texttt{M-w}'.
 %.lp
 \item[\#wizborn]
 Show monster birth, death, genocide, and extinct statistics.
@@ -1945,20 +1944,20 @@ within a modest radius.
 No time elapses.
 Autocompletes.
 Debug mode only.
-Default key is `{\tt \^{}E}'.
+Default key is `\texttt{\textasciicircum E}'.
 %.lp
 \item[\#wizgenesis]
 Create a monster.
 May be prefixed by a count to create more than one.
 Autocompletes.
 Debug mode only.
-Default key is `{\tt \^{}G}'.
+Default key is `\texttt{\textasciicircum G}'.
 %.lp
 \item[\#wizidentify]
 Identify all items in inventory.
 Autocompletes.
 Debug mode only.
-Default key is `{\tt \^{}I}'.
+Default key is `\texttt{\textasciicircum I}'.
 %.lp
 \item[\#wizintrinsic]
 Set one or more intrinsic attributes.
@@ -1968,7 +1967,7 @@ Debug mode only.
 \item[\#wizkill]
 Remove monsters from play by just pointing at them.
 By default the hero gets credit or blame for killing the targets.
-Precede this command with the `{\tt m}' prefix to override that.
+Precede this command with the `\texttt{m}' prefix to override that.
 Autocompletes.
 Debug mode only.
 %.lp
@@ -1976,13 +1975,13 @@ Debug mode only.
 Teleport to another level.
 Autocompletes.
 Debug mode only.
-Default key is `{\tt \^{}V}'.
+Default key is `\texttt{\textasciicircum V}'.
 %.lp
 \item[\#wizmap]
 Map the level.
 Autocompletes.
 Debug mode only.
-Default key is `{\tt \^{}F}'.
+Default key is `\texttt{\textasciicircum F}'.
 %.lp
 \item[\#wizrumorcheck]
 Verify rumor boundaries by displaying first and last true rumors and
@@ -2013,7 +2012,7 @@ Debug mode only.
 Wish for something.
 Autocompletes.
 Debug mode only.
-Default key is `{\tt \^{}W}'.
+Default key is `\texttt{\textasciicircum W}'.
 %.lp
 \item[\#wmode]
 Show wall modes.
@@ -2021,7 +2020,7 @@ Autocompletes.
 Debug mode only.
 %.lp
 \item[\#zap]
-Zap a wand. Default key is `{\tt z}'.
+Zap a wand. Default key is `\texttt{z}'.
 %.lp
 \item[\#?]
 Help menu:  get the list of available extended commands.
@@ -2033,32 +2032,32 @@ with another key, modifies it by setting the `meta' [8th, or `high']
 bit), you can invoke many extended commands by meta-ing the first
 letter of the command.
 
-On {\it Windows\/} and {\it MS-DOS\/},
+On \textit{Windows} and \textit{MS-DOS},
 the `Alt' key can be used in this fashion.
 On other systems, if typing `Alt' plus another key transmits a
-two character sequence consisting of an {\tt Escape}
-followed by the other key, you may set the {\it altmeta\/}
-option to have {\it NetHack\/} combine them into {\tt meta+<key>}.
+two character sequence consisting of an \texttt{Escape}
+followed by the other key, you may set the \textit{altmeta}
+option to have \textit{NetHack} combine them into \texttt{meta+<key>}.
 (This combining action only takes place when NetHack is expecting a
 command to execute, not when accepting input to name something or to
 make a wish.)
 
 %.pg
-Unlike control characters, where {\tt \^{}x} and {\tt \^{}X} denote the same
-thing, meta characters are case-sensitive:  {\tt M-x} and {\tt M-X}
+Unlike control characters, where \texttt{\textasciicircum x} and \texttt{\textasciicircum X} denote the same
+thing, meta characters are case-sensitive:  \texttt{M-x} and \texttt{M-X}
 represent different things.  Some commands which can be run via a meta
 character require that the letter be capitalized because the lower-case
 equivalent is used for another command, so the three key combination
-{\tt meta+Shift+letter} is needed.
+\texttt{meta+Shift+letter} is needed.
 
 %.BR 1
-\begin{description}[font=\ttfamily]
+\begin{description}[font=\mdseries\ttfamily]
 %.lp
 \item[M-?]
 {\tt\#?} (not supported by all platforms)
 %.lp
 \item[M-2]
-{\tt\#twoweapon} (unless the {\it number\textunderscore pad\/} option is enabled)
+{\tt\#twoweapon} (unless the \textit{number\textunderscore pad} option is enabled)
 %.lp
 \item[M-a]
 {\tt\#adjust}
@@ -2140,9 +2139,9 @@ equivalent is used for another command, so the three key combination
 \end{description}
 
 %.pg
-\noindent If the {\it number\textunderscore pad\/} option is on, some additional letter commands
+\noindent If the \textit{number\textunderscore pad} option is on, some additional letter commands
 are available:
-\begin{description}[font=\ttfamily]
+\begin{description}[font=\mdseries\ttfamily]
 %.lp
 \item[h]
 {\tt\#help}
@@ -2176,7 +2175,7 @@ Walls and corridors remain on the map as you explore them.
 
 %.pg
 Secret corridors are hidden and appear to be solid rock.
-You can find them with the `{\tt s}' (search) command when adjacent
+You can find them with the `\texttt{s}' (search) command when adjacent
 to them.
 Multiple search attempts may be needed.
 When searching is successful, secret corridors become ordinary open
@@ -2191,16 +2190,16 @@ corridors and shows them as such.
 Doorways connect rooms and corridors.
 Some doorways have no doors; you can walk right through.
 Others have doors in them, which may be open, closed, or locked.
-To open a closed door, use the `{\tt o}' (open)
-command; to close it again, use the `{\tt c}' (close) command.
+To open a closed door, use the `\texttt{o}' (open)
+command; to close it again, use the `\texttt{c}' (close) command.
 By default the
-{\it autoopen}
+\textit{autoopen}
 option is enabled, so simply attempting to walk onto a closed door's
-location will attempt to open it without needing `{\tt o}'.
+location will attempt to open it without needing `\texttt{o}'.
 Opening via
-{\it autoopen}
-will not work if you are {\it confused\/} or {\it stunned\/} or suffer from
-the {\it fumbling\/} attribute.
+\textit{autoopen}
+will not work if you are \textit{confused} or \textit{stunned} or suffer from
+the \textit{fumbling} attribute.
 
 %.pg
 Open doors cannot be entered diagonally; you must approach them
@@ -2208,20 +2207,20 @@ straight on, horizontally or vertically.
 Doorways without doors are
 not restricted in this fashion except on one particular level
 %.\" the rogue level
-(described by ``{\tt \#overview}'' as ``a primitive area'').
+(described by ``\texttt{\#overview}'' as ``a primitive area'').
 
 %.pg
 Unlocking magic exists but usually won't be available early on.
 You can get through a locked door without magic by first using an
-unlocking tool with the `{\tt a}' (apply) command, and then opening it.
+unlocking tool with the `\texttt{a}' (apply) command, and then opening it.
 By default the
-{\it autounlock}
-option is also enabled, so if you attempt to open (via `{\tt o}' or
-{\it autoopen})
+\textit{autounlock}
+option is also enabled, so if you attempt to open (via `\texttt{o}' or
+\textit{autoopen})
 a locked door while carrying an unlocking tool, you'll be asked whether
 to use it on the door's lock.
 Alternatively, you can break a closed door (whether locked or not) down
-by kicking it via the ``{\tt \^{}D}'' (kick) command.
+by kicking it via the ``\texttt{\textasciicircum D}'' (kick) command.
 Kicking down a door destroys it and makes a lot of noise which might
 wake sleeping monsters.
 
@@ -2229,7 +2228,7 @@ wake sleeping monsters.
 Some closed doors are booby-trapped and will explode if an attempt is made
 to open (when unlocked) or unlock (when locked) or kick down.
 Like kicking, an explosion destroys the door and makes a lot of noise.
-The ``{\tt \#untrap}'' command can be used to search a door for traps but
+The ``\texttt{\#untrap}'' command can be used to search a door for traps but
 might take multiple attempts to find one.
 When one is found, you'll be asked whether to try to disarm it.
 If you accede, success will eliminate the trap but
@@ -2247,13 +2246,13 @@ And some (giants) can smash doors.
 %.pg
 Secret doors are hidden and appear to be ordinary wall (from inside a
 room) or solid rock (from outside).
-You can find them with the `{\tt s}' (search) command but it might
+You can find them with the `\texttt{s}' (search) command but it might
 take multiple tries (possibly many tries if your luck is poor).
 Once found they are in all ways equivalent to normal doors.
 Mapping magic does not reveal secret doors.
 
 %.hn 2
-\subsection*{Traps (`{\tt \^{}}')}
+\subsection*{Traps (`\texttt{\textasciicircum }')}
 
 %.pg
 There are traps throughout the dungeon to snare the unwary intruder.
@@ -2261,9 +2260,9 @@ For example, you may suddenly fall into a pit and be stuck for a few
 turns trying to climb out (see below).
 A trap usually won't appear on your map until you trigger it by moving
 onto it, you see someone else trigger it, or you discover it with
-the `{\tt s}' (search) command (multiple attempts are often needed;
+the `\texttt{s}' (search) command (multiple attempts are often needed;
 if your luck is poor, many attempts might be needed).
-{\it Wands of secret door detection\/} and the spell of {\it detect unseen}
+\textit{Wands of secret door detection} and the spell of \textit{detect unseen}
 also reveal traps within a modest radius but only if the trap is also within
 line-of-sight (whether you can see at the time or not).
 There is also other magic which can reveal traps.
@@ -2300,7 +2299,7 @@ necessarily to a specific location there.
 
 %.pg
 There is a special multi-level branch of the dungeon with pre-mapped levels
-based on the classic computer game ``{\it Sokoban}.''
+based on the classic computer game ``\textit{Sokoban}.''
 In that game, you operate as a warehouse worker who pushes crates around
 obstacles to position them at designated locations.
 In NetHack, the goal is to push boulders into pits or holes until those
@@ -2317,24 +2316,24 @@ With careful foresight, it is possible to complete all of the levels
 according to the traditional rules of Sokoban.
 (Hint: to solve Sokoban puzzles, you often need to move things away from
 their eventual destinations in order to open up more room to maneuver.)
-Since NetHack does not support an {\it undo\/} capability, some allowances
+Since NetHack does not support an \textit{undo} capability, some allowances
 are permitted in case you get stuck.
 For example, each level has at least one extra boulder.
 Also, it is possible to drop everything in order to be able to squeeze
 into the same location as a boulder (and then presumably move past it),
 or to destroy a boulder with magic or tools, or to create new boulders
-with a {\it scroll of earth}.
+with a \textit{scroll of earth}.
 However, doing such things will lower your luck without any specific
 message given about that.
-See the {\it Conduct\/} section for information about getting feedback for
+See the \textit{Conduct} section for information about getting feedback for
 your actions in Sokoban.
 
 %.hn 2
-\subsection*{Stairs and ladders (`{\tt <}', `{\tt >}')}
+\subsection*{Stairs and ladders (`\texttt{<}', `\texttt{>}')}
 
 %.pg
 In general, each level in the dungeon will have a staircase going up
-(`{\tt <}') to the previous level and another going down (`{\tt >}')
+(`\texttt{<}') to the previous level and another going down (`\texttt{>}')
 to the next
 level.  There are some exceptions though.  For instance, fairly early
 in the dungeon you will find a level with two down staircases, one
@@ -2373,8 +2372,8 @@ inter-level connections are nearly indistinguishable during game play.
 %.pg
 Occasionally you will run across a room with a shopkeeper near the door
 and many items lying on the floor.  You can buy items by picking them
-up and then using the `{\tt p}' command.  You can inquire about the price
-of an item prior to picking it up by using the ``{\tt \#chat}'' command
+up and then using the `\texttt{p}' command.  You can inquire about the price
+of an item prior to picking it up by using the ``\texttt{\#chat}'' command
 while standing on it.  Using an item prior to paying for it will incur a
 charge, and the shopkeeper won't allow you to leave the shop until you
 have paid any debt you owe.
@@ -2402,11 +2401,11 @@ find a ``credit card'' in the dungeon, don't bother trying to use it in
 shops; shopkeepers will not accept it.)
 
 %.pg
-The {\tt \$} command, which reports the amount of gold you are carrying,
+The \texttt{\$} command, which reports the amount of gold you are carrying,
 will also show current shop debt or credit, if any.
-The {\tt Iu} command lists unpaid items (those which still belong to the
+The \texttt{Iu} command lists unpaid items (those which still belong to the
 shop) if you are carrying any.
-The {\tt Ix} command shows an inventory-like display of any unpaid items
+The \texttt{Ix} command shows an inventory-like display of any unpaid items
 which have been used up, along with other shop fees, if any.
 
 %.hn 3
@@ -2448,29 +2447,29 @@ There are several options which can be used to augment the normal feedback.
 
 %.pg
 The
-{\it pile\textunderscore limit\/}
+\textit{pile\textunderscore limit}
 option controls how many objects can be in a
 pile---sharing the same map location---for
 the game to state ``there are objects here'' instead of listing them.
-The default is {\tt 5}.
-Setting it to {\tt 1} would always give that message instead of listing
+The default is \texttt{5}.
+Setting it to \texttt{1} would always give that message instead of listing
 any objects.
-Setting it to {\tt 0} is a special case which will always list all
+Setting it to \texttt{0} is a special case which will always list all
 objects no matter how big a pile is.
 Note that the number refers to the count of separate stacks of objects
 present rather than the sum of the quantities of those stacks (so
-{\tt 7 arrows} or {\tt 25 gold pieces} will each count as 1 rather
+\texttt{7 arrows} or \texttt{25 gold pieces} will each count as 1 rather
 than as 7 and 25, respectively, and total to 2 when both are at the
 same location).
 
 %.pg
-The {\tt nopickup} command prefix (default `{\tt m}') can be
+The \texttt{nopickup} command prefix (default `\texttt{m}') can be
 used before a movement direction to step on objects without attempting
 auto-pickup and without giving feedback about them.
 
 %.pg
 The
-{\it mention\textunderscore walls\/}
+\textit{mention\textunderscore walls}
 option controls whether you get feedback if you try to walk into a wall
 or solid stone or off the edge of the map.
 Normally nothing happens (unless the hero is blind and no wall is shown,
@@ -2480,7 +2479,7 @@ some non-obvious reason.
 
 %.pg
 The
-{\it mention\textunderscore decor\/}
+\textit{mention\textunderscore decor}
 option controls whether you get feedback when walking on ``furniture.''
 Normally stepping onto stairs or a fountain or an altar or various other
 things doesn't elicit anything unless it is covered by one or more objects
@@ -2499,27 +2498,27 @@ case the back on land circumstance is implied.
 
 %.pg
 The
-{\it confirm\/}
+\textit{confirm}
 and
-{\it safe\textunderscore pet\/}
+\textit{safe\textunderscore pet}
 options control what happens when you try to move onto a peaceful monster's
 spot or a tame one's spot.
 
 %.\" getting away from "Movement feedback" here; oh well...
 %.pg
-The {\tt nopickup} command prefix (default `{\tt m}') is
+The \texttt{nopickup} command prefix (default `\texttt{m}') is
 also the move-without-attacking prefix and can be used to try to step
 onto a visible monster's spot without the move being considered an attack
-(see the {\it Fighting\/} subsection of {\it Monsters\/} below).
-The `{\tt fight}' command prefix (default `{\tt F}';
-also `{\tt -}' if
-{\it number\textunderscore pad\/}
+(see the \textit{Fighting} subsection of \textit{Monsters} below).
+The `\texttt{fight}' command prefix (default `\texttt{F}';
+also `\texttt{-}' if
+\textit{number\textunderscore pad}
 is on) can be used to force an attack, when guessing where an unseen
 monster is or when deliberately attacking a peaceful or tame creature.
 
 %.pg
 The
-{\it run\textunderscore mode}
+\textit{run\textunderscore mode}
 option controls how frequently the map gets redrawn when moving more
 than one step in a single command (so when rushing, running, or traveling).
 
@@ -2528,13 +2527,13 @@ than one step in a single command (so when rushing, running, or traveling).
 
 %.pg
 One dungeon level (occurring in mid to late teens of the main dungeon)
-is a tribute to the ancestor game {\it hack}'s inspiration {\it rogue}.
+is a tribute to the ancestor game \textit{hack}'s inspiration \textit{rogue}.
 
 %.pg
 It is usually displayed differently from other levels: possibly in
 characters instead of tiles, or without line-drawing symbols if already
-in characters; also, gold is shown as {\tt *} rather than {\tt \verb+$+}
-and stairs are shown as {\tt \verb+%+} rather than {\tt <} and {\tt >}.
+in characters; also, gold is shown as \texttt{*} rather than \texttt{\textdollar}
+and stairs are shown as \texttt{\%} rather than \texttt{<} and \texttt{>}.
 There are some minor differences in actual game play: doorways lack
 doors; a scroll, wand, or spell of light used in a room lights up the
 whole room rather than within a radius around your character.
@@ -2554,16 +2553,16 @@ help you locate them before they locate you (which some monsters can do
 very well).
 
 %.pg
-The commands `{\tt /}' and `{\tt ;}' may be used to obtain information
+The commands `\texttt{/}' and `\texttt{;}' may be used to obtain information
 about those
-monsters who are displayed on the screen.  The command ``{\tt \#name}''
-(by default bound to `{\tt C}'), allows you
+monsters who are displayed on the screen.  The command ``\texttt{\#name}''
+(by default bound to `\texttt{C}'), allows you
 to assign a name to a monster, which may be useful to help distinguish
 one from another when multiple monsters are present.  Assigning a name
 which is just a space will remove any prior name.
 
 %.pg
-The extended command ``{\tt \#chat}'' can be used to interact with an adjacent
+The extended command ``\texttt{\#chat}'' can be used to interact with an adjacent
 monster.  There is no actual dialog (in other words, you don't get to
 choose what you'll say), but chatting with some monsters such as a
 shopkeeper or the Oracle of Delphi can produce useful results.
@@ -2580,27 +2579,27 @@ Remember:  discretion is the better part of valor.
 %.pg
 In most circumstances, if you attempt to attack a peaceful monster by
 moving into its location, you'll be asked to confirm your intent.  By
-default an answer of `{\tt y}' acknowledges that intent,
-which can be error prone if you're using `{\tt y}' to move.  You can set the
-{\it paranoid\textunderscore confirmation:attack\/}
-option to require a response of ``{\tt yes}'' instead.
+default an answer of `\texttt{y}' acknowledges that intent,
+which can be error prone if you're using `\texttt{y}' to move.  You can set the
+\textit{paranoid\textunderscore confirmation:attack}
+option to require a response of ``\texttt{yes}'' instead.
 %.pg
 
 If you can't see a monster (if it is invisible, or if you are blinded),
-the symbol `{\tt I}' will be shown when you learn of its presence.
+the symbol `\texttt{I}' will be shown when you learn of its presence.
 If you attempt to walk into it, you will try to fight it just like
 a monster that you can see; of course,
 if the monster has moved, you will attack empty air.  If you guess
 that the monster has moved and you don't wish to fight, you can use the
-`{\tt m}' command to move without fighting; likewise, if you don't remember
-a monster but want to try fighting anyway, you can use the `{\tt F}' command.
+`\texttt{m}' command to move without fighting; likewise, if you don't remember
+a monster but want to try fighting anyway, you can use the `\texttt{F}' command.
 
 %.hn 2
 \subsection*{Your pet}
 
 %.pg
-You start the game with a little dog (`{\tt d}'), kitten (`{\tt f}'),
-or pony (`{\tt u}'), which follows
+You start the game with a little dog (`\texttt{d}'), kitten (`\texttt{f}'),
+or pony (`\texttt{u}'), which follows
 you about the dungeon and fights monsters with you.
 Like you, your pet needs food to survive.
 Dogs and cats usually feed themselves on fresh carrion and other meats;
@@ -2633,22 +2632,22 @@ have the right equipment and skill.  Convincing a wild beast to let
 you saddle it up is difficult to say the least.  Many a dungeoneer
 has had to resort to magic and wizardry in order to forge the alliance.
 Once you do have the beast under your control however, you can
-easily climb in and out of the saddle with the ``{\tt \#ride}'' command.  Lead
+easily climb in and out of the saddle with the ``\texttt{\#ride}'' command.  Lead
 the beast around the dungeon when riding, in the same manner as
 you would move yourself.  It is the beast that you will see displayed
 on the map.
 
 %.pg
-Riding skill is managed by the ``{\tt \#enhance}'' command.  See the section
+Riding skill is managed by the ``\texttt{\#enhance}'' command.  See the section
 on Weapon proficiency for more information about that.
 
 %.pg
-Use the `{\tt a}' (apply) command and pick a saddle in your inventory to
+Use the `\texttt{a}' (apply) command and pick a saddle in your inventory to
 attempt to put that saddle on an adjacent creature.  If successful,
 it will be transferred to that creature's inventory.
 
 %.pg
-Use the ``{\tt \#loot}'' command while adjacent to a saddled creature to
+Use the ``\texttt{\#loot}'' command while adjacent to a saddled creature to
 try to remove the saddle from that creature.  If successful, it will
 be transferred to your inventory.
 
@@ -2689,11 +2688,11 @@ location ordinarily wouldn't be seen any more.
 
 %.pg
 When you find something in the dungeon, it is common to want to pick
-it up.  In {\it NetHack}, this is accomplished by using the `{\tt ,}' command.
-If {\it autopickup\/} option is on, you will automatically pick up the object
-by walking over it, unless you move with the `{\tt m}' prefix.
+it up.  In \textit{NetHack}, this is accomplished by using the `\texttt{,}' command.
+If \textit{autopickup} option is on, you will automatically pick up the object
+by walking over it, unless you move with the `\texttt{m}' prefix.
 %.pg
-If you're carrying too many items, {\it NetHack\/} will tell you so and you
+If you're carrying too many items, \textit{NetHack} will tell you so and you
 won't be able to pick up anything more.  Otherwise, it will add the object(s)
 to your pack and tell you what you just picked up.
 %.pg
@@ -2708,16 +2707,16 @@ will get slower and you'll burn calories faster, requiring food more frequently
 to cope with it.  Eventually, you'll be so overloaded that you'll either have
 to discard some of what you're carrying or collapse under its weight.
 %.pg
-{\it NetHack\/} will tell you how badly you have loaded yourself.
+\textit{NetHack} will tell you how badly you have loaded yourself.
 If you are encumbered, one of the conditions
-{\tt Burdened}, {\tt Stressed}, {\tt Strained},
-{\tt Overtaxed}, or {\tt Overloaded} will be
+\texttt{Burdened}, \texttt{Stressed}, \texttt{Strained},
+\texttt{Overtaxed}, or \texttt{Overloaded} will be
 shown on the bottom line status display.
 
 %.pg
 When you pick up an object, it is assigned an inventory letter.  Many
 commands that operate on objects must ask you to find out which object
-you want to use.  When {\it NetHack\/} asks you to choose a particular object
+you want to use.  When \textit{NetHack} asks you to choose a particular object
 you are carrying, you are usually presented with a list of inventory
 letters to choose from (see Commands, above).
 
@@ -2728,13 +2727,13 @@ type.  During a game, any two objects with the same description are
 the same type.  However, the descriptions will vary from game to game.
 
 %.pg
-When you use one of these objects, if its effect is obvious, {\it NetHack\/}
+When you use one of these objects, if its effect is obvious, \textit{NetHack}
 will remember what it is for you.  If its effect isn't extremely
 obvious, you will be asked what you want to call this type of object
-so you will recognize it later.  You can also use the ``{\tt \#name}''
+so you will recognize it later.  You can also use the ``\texttt{\#name}''
 command, for the same purpose at any time, to name
 all objects of a particular type or just an individual object.
-When you use ``{\tt \#name}'' on an object which has already been named,
+When you use ``\texttt{\#name}'' on an object which has already been named,
 specifying a space as the value will remove the prior name instead
 of assigning a new one.
 
@@ -2776,23 +2775,23 @@ provided that you can see them land.
 %.pg
 An item with unknown status will be reported in your inventory with no prefix.
 An item which you know the state of will be distinguished in your inventory
-by the presence of the word {\tt cursed}, {\tt uncursed} or
-{\tt blessed} in the description of the item.
-In some cases {\tt uncursed} will be omitted as being redundant when
+by the presence of the word \texttt{cursed}, \texttt{uncursed} or
+\texttt{blessed} in the description of the item.
+In some cases \texttt{uncursed} will be omitted as being redundant when
 enough other information is displayed.
 The
-{\it implicit\textunderscore uncursed\/}
-option can be used to control this; toggle it off to have {\tt uncursed}
+\textit{implicit\textunderscore uncursed}
+option can be used to control this; toggle it off to have \texttt{uncursed}
 be displayed even when that can be deduced from other attributes.
 
 %.pg
 Sometimes the bless or curse state of objects is referred to as their
-``{\tt BUC}'' attribute, for Blessed, Uncursed, or Cursed state,
-or ``{\tt BUCX}'' for Blessed, Uncursed, Cursed, or unknown.
-(The term {\it beatitude\/} is occasionally used as well.)
+``\texttt{BUC}'' attribute, for Blessed, Uncursed, or Cursed state,
+or ``\texttt{BUCX}'' for Blessed, Uncursed, Cursed, or unknown.
+(The term \textit{beatitude} is occasionally used as well.)
 
 %.hn 2
-\subsection*{Weapons (`{\tt )}')}
+\subsection*{Weapons (`\texttt{)}')}
 
 %.pg
 Given a chance, most monsters in the Mazes of Menace will gratuitously try to
@@ -2833,11 +2832,11 @@ vulnerable to certain types of weapons.
 Many weapons can be wielded in one hand; some require both hands.
 When wielding a two-handed weapon, you can not wear a shield, and
 vice versa.  When wielding a one-handed weapon, you can have another
-weapon ready to use by setting things up with the `{\tt x}' command, which
+weapon ready to use by setting things up with the `\texttt{x}' command, which
 exchanges your primary (the one being wielded) and alternate weapons.
 And if you have proficiency in the ``two weapon combat'' skill, you
 may wield both weapons simultaneously as primary and secondary; use the
-`{\tt X}' command to engage or disengage that.
+`\texttt{X}' command to engage or disengage that.
 Only some types of characters (barbarians, for instance) have the necessary
 skill available.  Even with that skill, using two weapons at once incurs
 a penalty in the chance to hit your target compared to using just one
@@ -2845,30 +2844,30 @@ weapon at a time.
 
 %.pg
 There might be times when you'd rather not wield any weapon at all.
-To accomplish that, wield `{\tt -}', or else use the `{\tt A}' command which
+To accomplish that, wield `\texttt{-}', or else use the `\texttt{A}' command which
 allows you to unwield the current weapon in addition to taking off
 other worn items.
 
 %.pg
 Those of you in the audience who are AD\&D players, be aware that each
 weapon which existed in AD\&D does roughly the same damage to monsters in
-{\it NetHack}.  Some of the more obscure weapons (such as the
-{\it aklys}, {\it lucern hammer}, and {\it bec-de-corbin\/}) are defined
-in an appendix to {\it Unearthed Arcana}, an AD\&D supplement.
+\textit{NetHack}.  Some of the more obscure weapons (such as the
+\textit{aklys}, \textit{lucern hammer}, and \textit{bec-de-corbin}) are defined
+in an appendix to \textit{Unearthed Arcana}, an AD\&D supplement.
 
 %.pg
-The commands to use weapons are `{\tt w}' (wield), `{\tt t}' (throw),
-`{\tt f}' (fire), `{\tt Q}' (quiver),
-`{\tt x}' (exchange), `{\tt X}' (twoweapon), and ``{\tt \#enhance}''
+The commands to use weapons are `\texttt{w}' (wield), `\texttt{t}' (throw),
+`\texttt{f}' (fire), `\texttt{Q}' (quiver),
+`\texttt{x}' (exchange), `\texttt{X}' (twoweapon), and ``\texttt{\#enhance}''
 (see below).
 
 %.hn 3
 \subsection*{Throwing and shooting}
 
 %.pg
-You can throw just about anything via the `{\tt t}' command.  It will prompt
-for the item to throw; picking `{\tt ?}' will list things in your inventory
-which are considered likely to be thrown, or picking `{\tt *}' will list
+You can throw just about anything via the `\texttt{t}' command.  It will prompt
+for the item to throw; picking `\texttt{?}' will list things in your inventory
+which are considered likely to be thrown, or picking `\texttt{*}' will list
 your entire inventory.  After you've chosen what to throw, you will
 be prompted for a direction rather than for a specific target.  The
 distance something can be thrown depends mainly on the type of object
@@ -2881,26 +2880,26 @@ Some weapons will return when thrown.
 A boomerang---provided it fails to hit anything---is an obvious example.
 If an aklys (thonged club) is thrown while it is wielded, it will return
 even when it hits something.
-A sufficiently strong hero can throw the warhammer {\it Mjollnir\/};
-when thrown by a {\it Valkyrie\/} it will return too.
-However, aklyses and {\it Mjollnir\/} occasionally fail to return.
+A sufficiently strong hero can throw the warhammer \textit{Mjollnir};
+when thrown by a \textit{Valkyrie} it will return too.
+However, aklyses and \textit{Mjollnir} occasionally fail to return.
 Returning thrown objects occasionally fail to be caught, sometimes even
 hitting the thrower, but when caught they become re-wielded.
 
 %.pg
-You can simplify the throwing operation by using the `{\tt Q}' command to
-select your preferred ``missile'', then using the `{\tt f}' command to
+You can simplify the throwing operation by using the `\texttt{Q}' command to
+select your preferred ``missile'', then using the `\texttt{f}' command to
 throw it.  You'll be prompted for a direction as above, but you don't
-have to specify which item to throw each time you use `{\tt f}'.  There is
+have to specify which item to throw each time you use `\texttt{f}'.  There is
 also an option,
-{\it autoquiver},
-which has {\it NetHack\/} choose another item to automatically fill your
+\textit{autoquiver},
+which has \textit{NetHack} choose another item to automatically fill your
 quiver (or quiver sack, or have at the ready) when the inventory slot used
-for `{\tt Q}' runs out.
-If your quiver is empty, {\it autoquiver\/}
+for `\texttt{Q}' runs out.
+If your quiver is empty, \textit{autoquiver}
 is false, and you are wielding a weapon which returns when thrown,
 you will throw that weapon instead of filling the quiver.
-The fire command also has extra assistance, if {\it fireassist\/}
+The fire command also has extra assistance, if \textit{fireassist}
 is on it will try to wield a launcher matching the ammo in the quiver.
 
 %.pg
@@ -2916,12 +2915,12 @@ shoot arrows, in crossbow skill if you're wielding one to shoot bolts,
 or in sling skill if you're wielding one to shoot stones).
 The number of items that the character has a chance to fire varies from
 turn to turn.  You can explicitly limit the number of shots by using a
-numeric prefix before the `{\tt t}' or `{\tt f}' command.
-For example, ``{\tt 2f}'' (or ``{\tt n2f}'' if using
-{\it number\textunderscore pad\/}
+numeric prefix before the `\texttt{t}' or `\texttt{f}' command.
+For example, ``\texttt{2f}'' (or ``\texttt{n2f}'' if using
+\textit{number\textunderscore pad}
 mode) would ensure that at most 2 arrows are shot
 even if you could have fired 3.  If you specify
-a larger number than would have been shot (``{\tt 4f}'' in this example),
+a larger number than would have been shot (``\texttt{4f}'' in this example),
 you'll just end up shooting the same number (3, here) as if no limit
 had been specified.  Once the volley is in motion, all of the items
 will travel in the same direction; if the first ones kill a monster,
@@ -2945,14 +2944,14 @@ can achieve for each group.  For instance, wizards can become highly
 skilled in daggers or staves but not in swords or bows.
 
 %.pg
-The ``{\tt \#enhance}'' extended command is used to review current weapons
+The ``\texttt{\#enhance}'' extended command is used to review current weapons
 proficiency
 (also spell proficiency) and to choose which skill(s) to improve when
 you've used one or more skills enough to become eligible to do so.  The
 skill rankings are ``none'' (sometimes also referred to as ``restricted'',
 because you won't be able to advance), ``unskilled'', ``basic'', ``skilled'',
 and ``expert''.  Restricted skills simply will not appear in the list
-shown by ``{\tt \#enhance}''.
+shown by ``\texttt{\#enhance}''.
 (Divine intervention might unrestrict a particular
 skill, in which case it will start at unskilled and be limited to basic.)
 Some characters can enhance their barehanded combat or martial arts skill
@@ -2968,7 +2967,7 @@ higher.  A successful hit has a chance to boost your training towards
 the next skill level (unless you've already reached the limit for this
 skill).  Once such training reaches the threshold for that next level,
 you'll be told that you feel more confident in your skills.  At that
-point you can use ``{\tt \#enhance}'' to increase one or more skills.
+point you can use ``\texttt{\#enhance}'' to increase one or more skills.
 Such skills
 are not increased automatically because there is a limit to your total
 overall skills, so you need to actively choose which skills to enhance
@@ -2980,7 +2979,7 @@ and which to ignore.
 %.pg
 Some characters can use two weapons at once.  Setting things up to
 do so can seem cumbersome but becomes second nature with use.
-To wield two weapons, you need to use the ``{\tt \#twoweapon}'' command.
+To wield two weapons, you need to use the ``\texttt{\#twoweapon}'' command.
 But first you need to have a weapon in each hand.
 (Note that your two weapons are not fully equal; the one in the
 hand you normally wield with is considered primary and the other
@@ -2994,35 +2993,35 @@ as alternate weapon.)
 
 %.pg
 If your primary weapon is wielded but your off hand is empty or has
-the wrong weapon, use the sequence `{\tt x}', `{\tt w}', `{\tt x}' to
+the wrong weapon, use the sequence `\texttt{x}', `\texttt{w}', `\texttt{x}' to
 first swap your
 primary into your off hand, wield whatever you want as secondary
 weapon, then swap them both back into the intended hands.
 If your secondary or alternate weapon is correct but your primary
-one is not, simply use `{\tt w}' to wield the primary.
+one is not, simply use `\texttt{w}' to wield the primary.
 Lastly, if neither hand holds the correct weapon,
-use `{\tt w}', `{\tt x}', `{\tt w}'
+use `\texttt{w}', `\texttt{x}', `\texttt{w}'
 to first wield the intended secondary, swap it to off hand, and then
 wield the primary.
 
 %.pg
 The whole process can be simplified via use of the
-{\it pushweapon\/}
-option.  When it is enabled, then using `{\tt w}' to wield something
+\textit{pushweapon}
+option.  When it is enabled, then using `\texttt{w}' to wield something
 causes the currently wielded weapon to become your alternate weapon.
-So the sequence `{\tt w}', `{\tt w}' can be used to first wield the weapon you
+So the sequence `\texttt{w}', `\texttt{w}' can be used to first wield the weapon you
 intend to be secondary, and then wield the one you want as primary
 which will push the first into secondary position.
 
 %.pg
-When in two-weapon combat mode, using the `{\tt X}' command
+When in two-weapon combat mode, using the `\texttt{X}' command
 toggles back to single-weapon mode.
 Throwing or dropping either of the
 weapons or having one of them be stolen or destroyed will also make you
 revert to single-weapon combat.
 
 %.hn 2
-\subsection*{Armor (`{\tt [}')}
+\subsection*{Armor (`\texttt{[}')}
 
 %.pg
 Lots of unfriendly things lurk about; you need armor to protect
@@ -3031,7 +3030,7 @@ protection than others.  Your armor class is a measure of this
 protection.  Armor class (AC) is measured as in AD\&D, with 10 being
 the equivalent of no armor, and lower numbers meaning better armor.
 Each suit of armor which exists in AD\&D gives the same protection in
-{\it NetHack}.
+\textit{NetHack}.
 
 Here is a list of the armor class values provided by suits of armor:
 
@@ -3062,7 +3061,7 @@ enchanted.
 Shirts are an exception; they don't provide any protection unless enchanted.
 Some cloaks also don't improve AC when unenchanted but all cloaks offer
 some protection against rust or corrosion to suits worn under them and
-against some monster {\it touch\/} attacks.
+against some monster \textit{touch} attacks.
 
 %.pg
 If a piece of armor is enchanted, its armor protection will be better
@@ -3079,21 +3078,21 @@ Many types of armor are subject to some kind of damage like rust.  Such
 damage can be repaired.  Some types of armor may inhibit spell casting.
 
 %.pg
-The {\it nudist\/}
+The \textit{nudist}
 option can be set (prior to game start) to attempt to play the entire
 game without wearing any armor (a self-imposed challenge which is
 extremely difficult to accomplish).
 
 %.pg
-The commands to use armor are `{\tt W}' (wear) and `{\tt T}' (take off).
-The `{\tt A}' command can be used to take off armor as well as other
+The commands to use armor are `\texttt{W}' (wear) and `\texttt{T}' (take off).
+The `\texttt{A}' command can be used to take off armor as well as other
 worn items.
-Also, `{\tt P}' (put on) and `{\tt R}' (remove) which are normally for
+Also, `\texttt{P}' (put on) and `\texttt{R}' (remove) which are normally for
 accessories can be used for armor, but pieces of armor won't be shown
 as likely candidates in a prompt for choosing what to put on or remove.
 
 %.hn 2
-\subsection*{Food (`{\tt \%}')}
+\subsection*{Food (`\texttt{\%}')}
 
 %.pg
 Food is necessary to survive.  If you go too long without eating you
@@ -3117,13 +3116,13 @@ but with some rather unpleasant side-effects.
 
 %.pg
 You can name one food item after something you like to eat with the
-{\it fruit\/} option.
+\textit{fruit} option.
 
 %.pg
-The command to eat food is `{\tt e}'.
+The command to eat food is `\texttt{e}'.
 
 %.hn 2
-\subsection*{Scrolls (`{\tt ?}')}
+\subsection*{Scrolls (`\texttt{?}')}
 
 %.pg
 Scrolls are labeled with various titles, probably chosen by ancient wizards
@@ -3133,7 +3132,7 @@ magic spells on them).
 
 %.pg
 One of the most useful of these is the %
-{\it scroll of identify}, which
+\textit{scroll of identify}, which
 can be used to determine what another object is, whether it is cursed or
 blessed, and how many uses it has left.
 Some objects of subtle enchantment are difficult to identify without these.
@@ -3150,24 +3149,24 @@ cursed, or read while the hero is confused.
 
 %.pg
 A mail daemon may run up and deliver mail to you as a %
-{\it scroll of mail} (on versions compiled with this feature).
-To use this feature on versions where {\it NetHack\/}
+\textit{scroll of mail} (on versions compiled with this feature).
+To use this feature on versions where \textit{NetHack}
 mail delivery is triggered by electronic mail appearing in your system mailbox,
-you must let {\it NetHack\/} know where to look for new mail by setting the
-{\tt MAIL} environment variable to the file name of your mailbox.
-You may also want to set the {\tt MAILREADER} environment variable to the
-file name of your favorite reader, so {\it NetHack\/} can shell to it when you
+you must let \textit{NetHack} know where to look for new mail by setting the
+\texttt{MAIL} environment variable to the file name of your mailbox.
+You may also want to set the \texttt{MAILREADER} environment variable to the
+file name of your favorite reader, so \textit{NetHack} can shell to it when you
 read the scroll.
-On versions of {\it NetHack\/} where mail is randomly
+On versions of \textit{NetHack} where mail is randomly
 generated internal to the game, these environment variables are ignored.
 You can disable the mail daemon by turning off the
-{\it mail\/} option.
+\textit{mail} option.
 
 %.pg
-The command to read a scroll is `{\tt r}'.
+The command to read a scroll is `\texttt{r}'.
 
 %.hn 2
-\subsection*{Potions (`{\tt !}')}
+\subsection*{Potions (`\texttt{!}')}
 
 %.pg
 Potions are distinguished by the color of the liquid inside the flask.
@@ -3177,20 +3176,20 @@ They disappear after you quaff them.
 Clear potions are potions of water.  Sometimes these are
 blessed or cursed, resulting in holy or unholy water.  Holy water is
 the bane of the undead, so potions of holy water are good things to
-throw (`{\tt t}') at them.  It is also sometimes very useful to dip
-(``{\tt \#dip}'') an object into a potion.
+throw (`\texttt{t}') at them.  It is also sometimes very useful to dip
+(``\texttt{\#dip}'') an object into a potion.
 
 %.pg
-The command to drink a potion is `{\tt q}' (quaff).
+The command to drink a potion is `\texttt{q}' (quaff).
 
 %.hn 2
-\subsection*{Wands (`{\tt /}')}
+\subsection*{Wands (`\texttt{/}')}
 
 %.pg
 Wands usually have multiple magical charges.
 Some types of wands require a direction in which to zap them.
 You can also
-zap them at yourself (just give a `{\tt .}' or `{\tt s}' for the direction).
+zap them at yourself (just give a `\texttt{.}' or `\texttt{s}' for the direction).
 Be warned, however, for this is often unwise.
 Other types of wands
 don't require a direction.  The number of charges in a
@@ -3215,15 +3214,15 @@ magical energies.
 When you have fully identified a particular wand, inventory display will
 include additional information in parentheses: the number of times it has
 been recharged followed by a colon and then by its current number of charges.
-A current charge count of {\tt -1} is a special case indicating that the wand
+A current charge count of \texttt{-1} is a special case indicating that the wand
 has been cancelled.
 
 %.pg
-The command to use a wand is `{\tt z}' (zap).  To break one, use the `{\tt a}'
+The command to use a wand is `\texttt{z}' (zap).  To break one, use the `\texttt{a}'
 (apply) command.
 
 %.hn 2
-\subsection*{Rings (`{\tt =}')}
+\subsection*{Rings (`\texttt{=}')}
 
 %.pg
 Rings are very useful items, since they are relatively permanent
@@ -3248,14 +3247,14 @@ off before putting on or removing a ring and then re-wear them after.
 That's done implicitly to avoid unnecessary tedium.
 
 %.pg
-The commands to use rings are `{\tt P}' (put on) and `{\tt R}' (remove).
-`{\tt A}', `{\tt W}', and `{\tt T}' can also be used; see {\it Amulets\/}.
+The commands to use rings are `\texttt{P}' (put on) and `\texttt{R}' (remove).
+`\texttt{A}', `\texttt{W}', and `\texttt{T}' can also be used; see \textit{Amulets}.
 
 %.hn 2
-\subsection*{Spellbooks (`{\tt +}')}
+\subsection*{Spellbooks (`\texttt{+}')}
 
 %.pg
-Spellbooks are tomes of mighty magic.  When studied with the `{\tt r}' (read)
+Spellbooks are tomes of mighty magic.  When studied with the `\texttt{r}' (read)
 command, they transfer to the reader the knowledge of a spell (and
 therefore eventually become
 unreadable)---unless the attempt backfires.
@@ -3281,7 +3280,7 @@ your memory of each spell will dim, and you will need to relearn it.
 
 %.pg
 Some spells require a direction in which to cast them, similar to wands.
-To cast one at yourself, just give a `{\tt .}' or `{\tt s}' for the direction.
+To cast one at yourself, just give a `\texttt{.}' or `\texttt{s}' for the direction.
 A few spells require you to pick a target location rather than just specify
 a particular direction.
 Other spells don't require any direction or target.
@@ -3290,7 +3289,7 @@ Other spells don't require any direction or target.
 Just as weapons are divided into groups in which a character can become
 proficient (to varying degrees), spells are similarly grouped.
 Successfully casting a spell exercises its skill group; using the
-``{\tt \#enhance}'' command to advance a sufficiently exercised skill
+``\texttt{\#enhance}'' command to advance a sufficiently exercised skill
 will affect all spells within the group.  Advanced skill may increase the
 potency of spells, reduce their risk of failure during casting attempts,
 and improve the accuracy of the estimate for how much longer they will
@@ -3303,14 +3302,14 @@ Casting a spell also requires flexible movement, and wearing various types
 of armor may interfere with that.
 
 %.pg
-The command to read a spellbook is the same as for scrolls, `{\tt r}' (read).
-The `{\tt +}' command lists each spell you know along with its level, skill
+The command to read a spellbook is the same as for scrolls, `\texttt{r}' (read).
+The `\texttt{+}' command lists each spell you know along with its level, skill
 category, chance of failure when casting, and an estimate of how strongly
 it is remembered.
-The `{\tt Z}' (cast) command casts a spell.
+The `\texttt{Z}' (cast) command casts a spell.
 
 %.hn 2
-\subsection*{Tools (`{\tt (}')}
+\subsection*{Tools (`\texttt{(}')}
 
 %.pg
 Tools are miscellaneous objects with various purposes.  Some tools
@@ -3319,8 +3318,8 @@ out after a while.  Other tools are containers, which objects can
 be placed into or taken out of.
 
 %.pg
-Some tools (such as a blindfold) can be {\it worn\/} and can be put on and
-removed like other accessories (rings, amulets); see {\it Amulets\/}.
+Some tools (such as a blindfold) can be \textit{worn} and can be put on and
+removed like other accessories (rings, amulets); see \textit{Amulets}.
 Other tools (such as pick-axe) can be wielded as weapons in addition to
 being applied for their usual purpose, and in some cases (again, pick-axe)
 become wielded as a weapon even when applied.
@@ -3329,38 +3328,38 @@ become wielded as a weapon even when applied.
 % Mentioned here because of the old method of attempting "Zen" conduct:
 % restart until there's a blindfold in starting inventory and put it on
 % first thing.
-The {\it blind\/}
+The \textit{blind}
 option can be set (prior to game start) to attempt to play the entire
 game without being able to see (a self-imposed challenge which is
 very difficult to accomplish).
 
 %.pg
-The command to use a tool is `{\tt a}' (apply).
+The command to use a tool is `\texttt{a}' (apply).
 
 %.hn 3
 \subsection*{Containers}
 
 %.pg
 You may encounter bags, boxes, and chests in your travels.  A tool of
-this sort can be opened with the ``{\tt \#loot}'' extended command when
+this sort can be opened with the ``\texttt{\#loot}'' extended command when
 you are standing on top of it (that is, on the same floor spot),
-or with the `{\tt a}' (apply) command when you are carrying it.  However,
+or with the `\texttt{a}' (apply) command when you are carrying it.  However,
 chests are often locked, and are in any case unwieldy objects.
 You must set one down before unlocking it by
-using a key or lock-picking tool with the `{\tt a}' (apply) command,
-by kicking it with the `{\tt \^{}D}' command,
-or by using a weapon to force the lock with the ``{\tt \#force}''
+using a key or lock-picking tool with the `\texttt{a}' (apply) command,
+by kicking it with the `\texttt{\textasciicircum D}' command,
+or by using a weapon to force the lock with the ``\texttt{\#force}''
 extended command.
 
 %.pg
 Some chests are trapped, causing nasty things to happen when you
 unlock or open them.  You can check for and try to deactivate traps
-with the ``{\tt \#untrap}'' extended command.
+with the ``\texttt{\#untrap}'' extended command.
 
 %.pg
 When the contents of a container are known, that container will be
 described as something like ``a sack containing 3 items''.
-In this example, the 3 refers to number of {\it stacks\/} of compatible
+In this example, the 3 refers to number of \textit{stacks} of compatible
 items, not to the total number of individual items.
 So a sack holding 2 sky blue potions, 7 arrows, and 350 gold pieces would be
 described as having 3 items rather than 10 or 359.
@@ -3373,10 +3372,10 @@ If a chest or large box is described as ``broken'', that means that it
 can't be locked rather than that it no longer functions as a container.
 
 %.pg
-The {\it apply\/} and {\it loot\/} commands allow you to take out and/or
+The \textit{apply} and \textit{loot} commands allow you to take out and/or
 put in an arbitrary number of items in a single operation.
 If you want to take everything out of a container, you can use the
-``{\tt \#tip}'' command to pour the contents onto the floor.
+``\texttt{\#tip}'' command to pour the contents onto the floor.
 This may be your only way to get things out if your hands are stuck
 to a cursed two-handed weapon.
 When your hands aren't stuck, you have the potential to pour the
@@ -3385,7 +3384,7 @@ contents into another container.
 the floor.)
 
 %.hn 2
-\subsection*{Amulets (`{\tt "}')}
+\subsection*{Amulets (`\texttt{"}')}
 
 %.pg
 Amulets are very similar to rings, and often more powerful.  Like
@@ -3398,16 +3397,16 @@ Like wearing rings, wearing an amulet affects your metabolism, causing
 you to grow hungry more rapidly.
 
 %.pg
-The commands to use amulets are the same as for rings, `{\tt P}' (put on)
-and `{\tt R}' (remove).
-`{\tt A}' can be used to remove various worn items including amulets.
-Also, '{\tt W}' (wear) and `{\tt T}' (take off) which are normally for
+The commands to use amulets are the same as for rings, `\texttt{P}' (put on)
+and `\texttt{R}' (remove).
+`\texttt{A}' can be used to remove various worn items including amulets.
+Also, '\texttt{W}' (wear) and `\texttt{T}' (take off) which are normally for
 armor can be used for amulets and other accessories (rings and eyewear),
 but accessories won't be shown as likely candidates in a prompt for
 choosing what to wear or take off.
 
 %.hn 2
-\subsection*{Gems (`{\tt *}')}
+\subsection*{Gems (`\texttt{*}')}
 
 %.pg
 Some gems are valuable, and can be sold for a lot of gold.
@@ -3421,7 +3420,7 @@ All rocks, however, can be used as projectile weapons (if you have a sling).
 In the most desperate of cases, you can still throw them by hand.
 
 %.hn 2
-\subsection*{Large rocks (`{\tt `}')}
+\subsection*{Large rocks (`\texttt{`}')}
 %.pg
 Statues and boulders are not particularly useful, and are generally heavy.
 It is rumored that some statues are not what they seem.
@@ -3429,12 +3428,12 @@ It is rumored that some statues are not what they seem.
 %.pg
 Boulders occasionally block your path.
 You can push one forward (by attempting to walk onto its spot)
-when nothing blocks {\it its\/} path, or you can
+when nothing blocks \textit{its} path, or you can
 smash it into a pile of small rocks with breaking magic or a pick-axe.
 It is possible to move onto a boulder's location if certain conditions
 are met; ordinarily one of those conditions is that pushing it any
 further be blocked.
-Using the move-without-picking-up prefix (default key `{\tt m}')
+Using the move-without-picking-up prefix (default key `\texttt{m}')
 prior to the direction of movement will attempt to move to a boulder's
 location without pushing it in addition to the prefix's usual action of
 suppressing auto-pickup at the destination.
@@ -3451,11 +3450,11 @@ They can be smashed into rocks though.
 
 %.pg
 For some configurations of the program, statues are no longer shown
-as `{\tt `}'
+as `\texttt{`}'
 but by the letter representing the monster they depict instead.
 
 %.hn 2
-\subsection*{Gold (`{\tt \$}')}
+\subsection*{Gold (`\texttt{\$}')}
 
 %.pg
 Gold adds to your score, and you can buy things in shops with it.
@@ -3467,12 +3466,12 @@ you are carrying (shopkeepers aside).
 Gold pieces are the only type of object where bless/curse state does not
 apply.
 They're always uncursed but never described as uncursed even if you turn
-off the ``{\it implicit\textunderscore uncursed\/}'' option.
-You can set the ``{\it goldX\/}''
+off the ``\textit{implicit\textunderscore uncursed}'' option.
+You can set the ``\textit{goldX}''
 option if you prefer to have gold pieces be treated as bless/curse state
-{\it unknown\/} rather than as known to be uncursed.
+\textit{unknown} rather than as known to be uncursed.
 Only matters when you're using an object selection prompt that can filter
-by ``{\tt BUCX}'' state.
+by ``\texttt{BUCX}'' state.
 
 %.hn 2
 \subsection*{Persistence of Objects}
@@ -3497,7 +3496,7 @@ again you will re-discover the object and resume remembering it.
 The situation is the same for a pile of objects, except that only the
 top item of the pile is displayed.
 The
-{\it hilite\textunderscore pile\/}
+\textit{hilite\textunderscore pile}
 option can be enabled in order to show an item differently when it is
 the top one of a pile.
 
@@ -3505,10 +3504,10 @@ the top one of a pile.
 \section{Conduct}
 
 %.pg
-As if winning {\it NetHack\/} were not difficult enough, certain players
+As if winning \textit{NetHack} were not difficult enough, certain players
 seek to challenge themselves by imposing restrictions on the
 way they play the game.  The game automatically tracks some of
-these challenges, which can be checked at any time with the {\tt \#conduct}
+these challenges, which can be checked at any time with the \texttt{\#conduct}
 command or at the end of the game.  When you perform an action which
 breaks a challenge, it will no longer be listed.  This gives
 players extra ``bragging rights'' for winning the game with these
@@ -3528,8 +3527,8 @@ not violate any food challenges either.
 %.pg
 A strict vegan diet is one which avoids any food derived from animals.
 The primary source of nutrition is fruits and vegetables.  The
-corpses and tins of blobs (`{\tt b}'), jellies (`{\tt j}'), and fungi
-(`{\tt F}') are also considered to be vegetable matter.  Certain human
+corpses and tins of blobs (`\texttt{b}'), jellies (`\texttt{j}'), and fungi
+(`\texttt{F}') are also considered to be vegetable matter.  Certain human
 food is prepared without animal products; namely, lembas wafers, cram
 rations, food rations (gunyoki), K-rations, and C-rations.
 Metal or another normally indigestible material eaten while polymorphed
@@ -3540,7 +3539,7 @@ Note however that eating such items still counts against foodless conduct.
 Vegetarians do not eat animals;
 however, they are less selective about eating animal byproducts than vegans.
 In addition to the vegan items listed above, they may eat any kind
-of pudding (`{\tt P}') other than the black puddings,
+of pudding (`\texttt{P}') other than the black puddings,
 eggs and food made from eggs (fortune cookies and pancakes),
 food made with milk (cream pies and candy bars), and lumps of
 royal jelly.  Monks are expected to observe a vegetarian diet.
@@ -3571,8 +3570,8 @@ from ``cherries'' to ``pork chops'', are also assumed to be vegan.
 
 %.pg
 An atheist is one who rejects religion.  This means that you cannot
-{\tt \#pray}, {\tt \#offer} sacrifices to any god,
-{\tt \#turn} undead, or {\tt \#chat} with a priest.
+\texttt{\#pray}, \texttt{\#offer} sacrifices to any god,
+\texttt{\#turn} undead, or \texttt{\#chat} with a priest.
 Particularly selective readers may argue that playing Monk or Priest
 characters should violate this conduct; that is a choice left to the
 player.  Offering the Amulet of Yendor to your god is necessary to
@@ -3589,7 +3588,7 @@ fire, and kick weapons; use a wand, spell, or other type of item;
 or fight with your hands and feet.
 
 %.pg
-In {\it NetHack}, a pacifist refuses to cause the death of any other monster
+In \textit{NetHack}, a pacifist refuses to cause the death of any other monster
 (i.e. if you would get experience for the death).  This is a particularly
 difficult challenge, although it is still possible to gain experience
 by other means.
@@ -3607,7 +3606,7 @@ counted.
 
 %.pg
 There is a side-branch to the main dungeon called ``Sokoban,'' briefly
-described in the earlier section about {\it Traps}.
+described in the earlier section about \textit{Traps}.
 As mentioned there, the goal is to push boulders into pits and/or holes
 to plug those in order to both get the boulders out of your way and be
 able to go past the traps.
@@ -3618,7 +3617,7 @@ diagonally.
 Other rules can, such as not smashing boulders with magic or tools,
 but doing so causes you to receive a luck penalty.
 No message about that is given at the time, but it is tracked as a conduct.
-The {\tt \#conduct} command and end of game disclosure will report whether
+The \texttt{\#conduct} command and end of game disclosure will report whether
 you have abided by the special rules of Sokoban, and if not, how many
 times you violated them, providing you with a way to discover which
 actions incur bad luck so that you can be better informed about whether
@@ -3630,7 +3629,7 @@ you haven't done anything interesting there.
 Ending the game with ``never broke the Sokoban rules'' conduct is most
 meaningful if you also manage to perform
 the ``obtained the Sokoban prize'' achievement
-(see {\it Achievements\/} below).)
+(see \textit{Achievements} below).)
 
 %.pg
 There are several other challenges tracked by the game.  It is possible
@@ -3656,7 +3655,7 @@ choose ``nothing'' if you want to decline.
 End of game disclosure will also display various achievements
 representing progress toward ultimate ascension, if any have been
 attained.
-They aren't directly related to {\it conduct\/} but are grouped with
+They aren't directly related to \textit{conduct} but are grouped with
 it because they fall into the same category of ``bragging rights''
 and to limit the number of questions during disclosure.
 Listed here roughly in order of difficulty and not necessarily in the order
@@ -3665,12 +3664,12 @@ in which you might accomplish them.
 % [length stuff copied from paranoid_confirmation]
 \newlength{\achwidth}
 %.PS "Mines'\~End\~"
-\settowidth{\achwidth}{\tt Mines'~End~}
+\settowidth{\achwidth}{\texttt{Mines'~End~}}
 \addtolength{\achwidth}{\labelsep}
 \begin{description}[leftmargin=\achwidth, topsep=1mm, itemsep=0mm, labelwidth=*, font=\ttfamily, align=right]
 %.PL Shop
 \item[<Rank>]
-Attained rank title {\it Rank}.
+Attained rank title \textit{Rank}.
 \item[Shop]
 Entered a shop.
 \item[Temple]
@@ -3735,20 +3734,20 @@ Achievements are recorded and subsequently reported in the order in which
 they happen during your current game rather than the order listed here.
 
 %.pg
-There are nine {\it Rank} titles for each role, bestowed at experience
+There are nine \textit{Rank} titles for each role, bestowed at experience
 levels 1, 3, 6, 10, 14, 18, 22, 26, and 30.
 The one for experience level 1 is not recorded as an achievement.
 Losing enough levels to revert to lower rank(s) does not discard the
 corresponding achievement(s).
 
 %.pg
-There's no guaranteed {\it Novel} so the achievement to read one might
+There's no guaranteed \textit{Novel} so the achievement to read one might
 not always be attainable (except perhaps by wishing).
-Similarly, the {\it Big Room} level is not always present.
+Similarly, the \textit{Big Room} level is not always present.
 Unlike with the Novel, there's no way to wish for this opportunity.
 
 %.pg
-The ``special items'' hidden in {\it Mines'~End\/} and {\it Sokoban\/}
+The ``special items'' hidden in \textit{Mines'~End} and \textit{Sokoban}
 are not unique but are considered to be prizes or rewards
 for exploring those levels since doing so is not necessary to complete
 the game.
@@ -3756,20 +3755,20 @@ Finding other instances of the same objects doesn't record the
 corresponding achievement.
 
 %.pg
-The {\it Medusa\/} achievement is recorded if she dies for any reason,
+The \textit{Medusa} achievement is recorded if she dies for any reason,
 even if you are not directly responsible, and only if she dies.
 
 %.pg
-The 5-note {\it tune\/} can be learned via trial and error with a musical
+The 5-note \textit{tune} can be learned via trial and error with a musical
 instrument played closely
 enough---but not too close!---to
 the Castle level's drawbridge or can be given to you via prayer boon.
 
 %.pg
-{\it Blind\/}, {\it Deaf\/}, {\it Nudist\/}, and {\it Pauper\/} are also conducts, and they can only be
-enabled by setting the correspondingly named option in {\tt NETHACKOPTIONS}
+\textit{Blind}, \textit{Deaf}, \textit{Nudist}, and \textit{Pauper} are also conducts, and they can only be
+enabled by setting the correspondingly named option in \texttt{NETHACKOPTIONS}
 or run-time configuration file prior to game start.
-In the case of {\it Blind\/} and {\it Deaf\/}, the option also enforces the conduct.
+In the case of \textit{Blind} and \textit{Deaf}, the option also enforces the conduct.
 They aren't really significant accomplishments unless/until you make
 substantial progress into the dungeon.
 
@@ -3777,19 +3776,19 @@ substantial progress into the dungeon.
 \section{Options}
 
 %.pg
-Due to variations in personal tastes and conceptions of how {\it NetHack\/}
-should do things, there are options you can set to change how {\it NetHack\/}
+Due to variations in personal tastes and conceptions of how \textit{NetHack}
+should do things, there are options you can set to change how \textit{NetHack}
 behaves.
 
 %.hn 2
 \subsection*{Setting the options}
 
 %.pg
-Options may be set in a number of ways.  Within the game, the `{\tt O}'
+Options may be set in a number of ways.  Within the game, the `\texttt{O}'
 command allows you to view all options and change most of them.
 You can also set options automatically by placing them in a configuration
-file, or in the ``{\tt NETHACKOPTIONS}'' environment variable.
-Some versions of {\it NetHack\/} also have front-end programs that allow
+file, or in the ``\texttt{NETHACKOPTIONS}'' environment variable.
+Some versions of \textit{NetHack} also have front-end programs that allow
 you to set options before starting the game or a global configuration
 for system administrators.
 
@@ -3812,24 +3811,24 @@ On Windows, the name is \mbox{``.nethackrc''} location in the folder
 The file may not exist,
 but it is a normal ASCII text file and can be created with any
 text editor.
-After running {\it NetHack\/} for the first time, you should find a default
+After running \textit{NetHack} for the first time, you should find a default
 template for ths configuration file named \mbox{``.nethackrc.template''} in
 \mbox{{``\%USERPROFILE\%\textbackslash NetHack\textbackslash''}}.
-If you have not created the configuration file, {\it NetHack\/} will create
+If you have not created the configuration file, \textit{NetHack} will create
 the configuration file for you using the default template file.\\
 
 %.lp ""
 On MS-DOS it is \mbox{``defaults.nh''} in the same folder as
-\mbox{{\it nethack.exe\/}}.\\
+\mbox{\textit{nethack.exe}}.\\
 
 %.lp ""
-Any line in the configuration file starting with `{\tt \#}' is treated
+Any line in the configuration file starting with `\texttt{\#}' is treated
 as a comment and ignored.
 Empty lines are ignored.
 
-Any line beginning with `{\tt \verb+[+}' and ending in `{\tt \verb+]+}'
-is a section marker (the closing `{\tt \verb+]+}' can be followed
-by whitespace and then an arbitrary comment beginning with `{\tt \#}').
+Any line beginning with `\texttt{[}' and ending in `\texttt{]}'
+is a section marker (the closing `\texttt{]}' can be followed
+by whitespace and then an arbitrary comment beginning with `\texttt{\#}').
 The text between the square brackets is the section name.
 Section markers are only valid after a CHOOSE directive and their names
 are case insensitive.
@@ -3872,8 +3871,8 @@ Example:
 
 %.lp
 \item[HACKDIR]
-Default location of files {\it NetHack\/} needs. On Windows HACKDIR
-defaults to the location of the {\it NetHack.exe\/} or {\it NetHackw.exe\/} file
+Default location of files \textit{NetHack} needs. On Windows HACKDIR
+defaults to the location of the \textit{NetHack.exe} or \textit{NetHackw.exe} file
 so setting HACKDIR to override that is not usually necessary or recommended.
 %.lp
 \item[LEVELDIR]
@@ -3904,7 +3903,7 @@ Enable or disable an extended command autocompletion.
 Autocompletion has no effect for the X11 windowport.
 You can specify multiple autocompletions. To enable
 autocompletion, list the extended command. Prefix the
-command with ``{{\tt !}}'' to disable the autocompletion
+command with ``\texttt{!}'' to disable the autocompletion
 for that command.
 
 %.lp ""
@@ -3917,7 +3916,7 @@ Example:
 
 %.lp
 \item[AUTOPICKUP\textunderscore EXCEPTION]
-Set exceptions to the {{\it pickup\textunderscore types\/}}
+Set exceptions to the {\textit{pickup\textunderscore types}}
 option. See the ``Configuring Autopickup Exceptions'' section.
 %.lp
 \item[BINDINGS]
@@ -3956,7 +3955,7 @@ Example:
 %.ed
 
 %.lp ""
-If {\tt []} is present, the preceding section is closed and no new
+If \texttt{[]} is present, the preceding section is closed and no new
 section begins; whatever follows will be common to all sections.
 Otherwise the last section extends to the end of the options file.
 
@@ -3971,7 +3970,7 @@ See the ``Configuring Message Types`` section.
 %.lp
 \item[ROGUESYMBOLS]
 Custom symbols for the rogue level's symbol set.
-See {\it SYMBOLS} below.
+See \textit{SYMBOLS} below.
 %.lp
 \item[SOUND]
 Define a sound mapping.
@@ -3984,7 +3983,7 @@ See the ``Configuring User Sounds'' section.
 \item[SYMBOLS]
 Override one or more symbols in the symbol set used for all dungeon
 levels except for the special rogue level.
-See the ``Modifying {\it NetHack\/} Symbols'' section.
+See the ``Modifying \textit{NetHack} Symbols'' section.
 %.pg
 
 %.lp ""
@@ -4038,13 +4037,13 @@ Here is an example of configuration file contents:
 %.BR 2
 
 %.hn 2
-\subsection*{Using the {\tt NETHACKOPTIONS} environment variable}
+\subsection*{Using the \texttt{NETHACKOPTIONS} environment variable}
 
 %.pg
 The NETHACKOPTIONS variable is a comma-separated list of initial
 values for the various options.  Some can only be turned on or off.
 You turn one of these on by adding the name of the option to the list,
-and turn it off by typing a `{\tt !}' or ``{\tt no}'' before the name.
+and turn it off by typing a `\texttt{!}' or ``\texttt{no}'' before the name.
 Others take a
 character string as a value.  You can set string options by typing
 the option name, a colon or equals sign, and then the value of the string.
@@ -4052,10 +4051,10 @@ The value is terminated by the next comma or the end of string.
 
 %.pg
 For example, to set up an environment variable so that
-{\it color\/} is {\tt on},
-{\it legacy\/} is {\tt off},
-character {\it name\/} is set to ``{\tt Blue Meanie}'',
-and named {\it fruit\/} is set to ``{\tt lime}'',
+\textit{color} is \texttt{on},
+\textit{legacy} is \texttt{off},
+character \textit{name} is set to ``\texttt{Blue Meanie}'',
+and named \textit{fruit} is set to ``\texttt{lime}'',
 you would enter the command
 %.SD i
 \begin{verbatim}
@@ -4063,7 +4062,7 @@ you would enter the command
 \end{verbatim}
 %.ED
 
-\noindent in {\it csh}
+\noindent in \textit{csh}
 (note the need to escape the `!' since it's special
 to that shell), or the pair of commands
 %.SD i
@@ -4073,7 +4072,7 @@ to that shell), or the pair of commands
 \end{verbatim}
 %.ED
 
-\noindent in {\it sh}, {\it ksh}, or {\it bash}.
+\noindent in \textit{sh}, \textit{ksh}, or \textit{bash}.
 
 %.pg
 The NETHACKOPTIONS value is effectively the same as a single OPTIONS
@@ -4087,9 +4086,9 @@ not allowed.
 Instead of a comma-separated list of options,
 NETHACKOPTIONS can be set to the full name of a configuration file you
 want to use.
-If that full name doesn't start with a slash, precede it with `{\tt @}'
+If that full name doesn't start with a slash, precede it with `\texttt{@}'
 (at-sign) to let NetHack know that the rest is intended as a file name.
-If it does start with `{\tt /}', the at-sign is optional.
+If it does start with `\texttt{/}', the at-sign is optional.
 
 %.hn 2
 \subsection*{Customization options}
@@ -4104,7 +4103,7 @@ Some options are persistent, and are saved and reloaded along with
 the game.  Changing a persistent option in the configuration file
 applies only to new games.
 
-\begin{description}[font=\itshape]
+\begin{description}[font=\mdseries\itshape]
 %.lp
 \item[accessiblemsg]
 Add location or direction information to messages (default is off).
@@ -4115,22 +4114,22 @@ Note that this has nothing to do with your computer's audio capabilities.
 Persistent.
 %.lp
 \item[alignment]
-Your starting alignment ({\tt align:lawful}, {\tt align:neutral},
-or {\tt align:chaotic}).
+Your starting alignment (\texttt{align:lawful}, \texttt{align:neutral},
+or \texttt{align:chaotic}).
 You may specify just the first letter.
 Many roles and the non-human races restrict which alignments are allowed.
-See {\it role\/}
+See \textit{role}
 for a description of how to use negation to exclude choices.
 %.lp ""
 \\
-If {\tt align} is not specified, there is no default value;
+If \texttt{align} is not specified, there is no default value;
 player will be prompted unless role and/or race forces a choice for alignment.
-Cannot be set with the `{\tt O}' command.  Persistent.
+Cannot be set with the `\texttt{O}' command.  Persistent.
 %.lp
 \item[autodescribe]
 Automatically describe the terrain under cursor when asked to get a location
 on the map (default true).
-The {\it whatis\textunderscore coord\/}
+The \textit{whatis\textunderscore coord}
 option controls whether the description includes map coordinates.
 %.lp
 \item[autodig]
@@ -4146,14 +4145,14 @@ Automatically pick up things onto which you move (default off).
 Persistent.
 \\
 %.lp ""
-See ``{\it pickup\textunderscore types\/}'' and also
-``{\it autopickup\textunderscore exception\/}'' for ways to refine the behavior.
+See ``\textit{pickup\textunderscore types}'' and also
+``\textit{autopickup\textunderscore exception}'' for ways to refine the behavior.
 \\
 %.lp ""
-Note: prior to version 3.7.0, the default for {\it autopickup\/} was {\it on}.
+Note: prior to version 3.7.0, the default for \textit{autopickup} was \textit{on}.
 %.lp
 \item[autoquiver]
-This option controls what happens when you attempt the `{\tt f}' (fire)
+This option controls what happens when you attempt the `\texttt{f}' (fire)
 command when nothing is quivered or readied (default false).
 When true, the computer will fill
 your quiver or quiver sack or make ready some suitable weapon.
@@ -4161,9 +4160,9 @@ Note that it will not take
 into account the blessed/cursed status, enchantment, damage, or
 quality of the weapon; you are free to manually fill your quiver
 or quiver sack or make ready
-with the `{\tt Q}' command instead.
+with the `\texttt{Q}' command instead.
 If no weapon is found or the option is
-false, the `{\tt t}' (throw) command is executed instead.  Persistent.
+false, the `\texttt{t}' (throw) command is executed instead.  Persistent.
 %.lp
 \item[autounlock]
 %\hyphenation{apply\-key}%this needs to be tested...
@@ -4174,7 +4173,7 @@ Takes a plus-sign separated list of values:
 % au => autounlock
 \newlength{\auwidth}
 %.PS Apply-Key
-\settowidth{\auwidth}{\tt Apply-Key}
+\settowidth{\auwidth}{\texttt{Apply-Key}}
 \addtolength{\auwidth}{\labelsep}
 \begin{description}[leftmargin=\auwidth, topsep=1mm, itemsep=0mm, labelwidth=*, font=\ttfamily, align=right]
 %.PL Untrap
@@ -4202,9 +4201,9 @@ has no effect on doors);
 none of the above; can't be combined with the other choices.
 %.PE
 \end{description}
-Omitting the value is treated as if {\tt autounlock:apply-key}.
-Preceding {\tt autounlock} with `{\tt !}' or ``{\tt no}'' is treated as
-{\tt autounlock:none}.
+Omitting the value is treated as if \texttt{autounlock:apply-key}.
+Preceding \texttt{autounlock} with `\texttt{!}' or ``\texttt{no}'' is treated as
+\texttt{autounlock:none}.
 \\
 %.lp ""
 Applying a key might set off a trap if the door or container is trapped.
@@ -4224,15 +4223,15 @@ Allow saving and loading bones files (default true).  Persistent.
 %.lp
 \item[boulder]
 Set the character used to display boulders (default is the ``large rock''
-class symbol, `{\tt `}').
+class symbol, `\texttt{`}').
 %.lp
 \item[catname]
-Name your starting cat (for example, ``{\tt catname:Morris}'').
-Cannot be set with the `{\tt O}' command.
+Name your starting cat (for example, ``\texttt{catname:Morris}'').
+Cannot be set with the `\texttt{O}' command.
 %.lp character
 \item[character]
-Synonym for ``{\tt role}'' to pick the type of your character
-(for example ``{\tt character:Monk}'').  See {\it role\/} for more details.
+Synonym for ``\texttt{role}'' to pick the type of your character
+(for example ``\texttt{character:Monk}'').  See \textit{role} for more details.
 %.lp
 \item[checkpoint]
 Save game state after each level change, for possible recovery after
@@ -4254,26 +4253,26 @@ Start the character permanently deaf (default false).  Persistent.
 %.lp
 \item[dropped\textunderscore nopick]
 If this option is on, items you dropped will not be automatically picked up,
-even if ``{\it autopickup\/}'' is also on and they are in
-``{\it pickup\textunderscore types\/}'' or match a positive autopickup exception
+even if ``\textit{autopickup}'' is also on and they are in
+``\textit{pickup\textunderscore types}'' or match a positive autopickup exception
 (default on).  Persistent.
 %.lp
 \item[disclose]
 Controls what information the program reveals when the game ends.
 Value is a space separated list of prompting/category pairs
-(default is `{\tt ni na nv ng nc no}',
-prompt with default response of `{\tt n}' for each candidate).
+(default is `\texttt{ni na nv ng nc no}',
+prompt with default response of `\texttt{n}' for each candidate).
 Persistent.
 The possibilities are:
 
 %.sd
 %.si
-{\tt i} --- disclose your inventory;\\
-{\tt a} --- disclose your attributes;\\
-{\tt v} --- summarize monsters that have been vanquished;\\
-{\tt g} --- list monster species that have been genocided;\\
-{\tt c} --- display your conduct; also achievements, if any;\\
-{\tt o} --- display dungeon overview.
+\texttt{i} --- disclose your inventory;\\
+\texttt{a} --- disclose your attributes;\\
+\texttt{v} --- summarize monsters that have been vanquished;\\
+\texttt{g} --- list monster species that have been genocided;\\
+\texttt{c} --- display your conduct; also achievements, if any;\\
+\texttt{o} --- display dungeon overview.
 %.ei
 %.ed
 
@@ -4282,45 +4281,45 @@ lets you refine how it behaves.  Here are the valid prefixes:
 
 %.sd
 %.si
-{\tt y} --- prompt you and default to yes on the prompt;\\
-{\tt n} --- prompt you and default to no on the prompt;\\
-{\tt +} --- disclose it without prompting;\\
-{\tt -} --- do not disclose it and do not prompt.
+\texttt{y} --- prompt you and default to yes on the prompt;\\
+\texttt{n} --- prompt you and default to no on the prompt;\\
+\texttt{+} --- disclose it without prompting;\\
+\texttt{-} --- do not disclose it and do not prompt.
 %.ei
 %.ed
 
 The listing of vanquished monsters can be sorted,
-so there are two additional choices for `{\tt v}':
+so there are two additional choices for `\texttt{v}':
 The listings of vanquished monsters and of genocided types can be sorted,
 so there are two additional choices for `q' and `g':
 %.sd
 %.si
-{\tt ?} --- prompt you and default to ask on the prompt;\\
+\texttt{?} --- prompt you and default to ask on the prompt;\\
 {\tt\#} --- disclose it without prompting, ask for sort order.
 %.ei
 %.ed
 
 Asking refers to picking one of the orderings from a menu.
-The `{\tt +}' disclose without prompting choice,
-or being prompted and answering `{\tt y}' rather than `{\tt a}',
+The `\texttt{+}' disclose without prompting choice,
+or being prompted and answering `\texttt{y}' rather than `\texttt{a}',
 will default to showing monsters in the order specified by the
-{\it sortvanquished\/} option.
+\textit{sortvanquished} option.
 \\
 %.lp ""
-Omitted categories are implicitly added with `{\tt n}' prefix.
-Specified categories with omitted prefix implicitly use `{\tt +}' prefix.
+Omitted categories are implicitly added with `\texttt{n}' prefix.
+Specified categories with omitted prefix implicitly use `\texttt{+}' prefix.
 Order of the disclosure categories does not matter, program display for
 end-of-game disclosure follows a set sequence.
 
 %.lp ""
-(for example, ``{\tt disclose:yi na +v -g o}'')
+(for example, ``\texttt{disclose:yi na +v -g o}'')
 The example sets
-{\tt inventory} to {\it prompt\/} and default to {\it yes\/},
-{\tt attributes} to {\it prompt\/} and default to {\it no\/},
-{\tt vanquished} to {\it disclose without prompting\/},
-{\tt genocided} to {\it not disclose\/} and {\it not prompt\/},
-{\tt conduct} to implicitly {\it prompt\/} and default to {\it no\/},
-{\tt overview} to {\it disclose without prompting\/}.
+\texttt{inventory} to \textit{prompt} and default to \textit{yes},
+\texttt{attributes} to \textit{prompt} and default to \textit{no},
+\texttt{vanquished} to \textit{disclose without prompting},
+\texttt{genocided} to \textit{not disclose} and \textit{not prompt},
+\texttt{conduct} to implicitly \textit{prompt} and default to \textit{no},
+\texttt{overview} to \textit{disclose without prompting}.
 
 %.lp ""
 Note that the vanquished monsters list includes all monsters killed by
@@ -4329,8 +4328,8 @@ And the dungeon overview shows all levels you had visited but does not
 reveal things about them that you hadn't discovered.
 %.lp
 \item[dogname]
-Name your starting dog (for example, ``{\tt dogname:Fang}'').
-Cannot be set with the `{\tt O}' command.
+Name your starting dog (for example, ``\texttt{dogname:Fang}'').
+Cannot be set with the `\texttt{O}' command.
 %.lp
 \item[extmenu]
 Changes the extended commands interface to pop-up a menu of available commands.
@@ -4344,11 +4343,11 @@ or just the subset of commands which have traditionally been considered
 extended ones (off).
 %.lp
 \item[female]
-An obsolete synonym for ``{\tt gender:female}''.  Cannot be set with the
-`{\tt O}' command.
+An obsolete synonym for ``\texttt{gender:female}''.  Cannot be set with the
+`\texttt{O}' command.
 %.lp
 \item[fireassist]
-This option controls what happens when you attempt the `{\tt f}' (fire)
+This option controls what happens when you attempt the `\texttt{f}' (fire)
 and don't have an appropriate launcher, such as a bow or a sling, wielded.
 If on, you will automatically wield the launcher. Default is on.
 %.lp
@@ -4362,45 +4361,45 @@ Commands asking for an inventory item show a menu instead of
 a text query with possible menu letters. Default is off.
 %.lp
 \item[fruit]
-Name a fruit after something you enjoy eating (for example, ``{\tt fruit:mango}'')
-(default ``{\tt slime mold}''). Basically a nostalgic whimsy that
-{\it NetHack\/} uses from time to time.  You should set this to something you
+Name a fruit after something you enjoy eating (for example, ``\texttt{fruit:mango}'')
+(default ``\texttt{slime mold}''). Basically a nostalgic whimsy that
+\textit{NetHack} uses from time to time.  You should set this to something you
 find more appetizing than slime mold.  Apples, oranges, pears, bananas, and
-melons already exist in {\it NetHack\/}, so don't use those.
+melons already exist in \textit{NetHack}, so don't use those.
 %.lp
 \item[gender]
-Your starting gender ({\tt gender:male} or {\tt gender:female}).
+Your starting gender (\texttt{gender:male} or \texttt{gender:female}).
 You may specify just the first letter.
 Although you can
 still denote your gender using either of the deprecated
-``{\it male\/}'' and ``{\it female\/}''
-options, the ``{\it gender\/}'' option will take precedence.
-See {\it role\/}
+``\textit{male}'' and ``\textit{female}''
+options, the ``\textit{gender}'' option will take precedence.
+See \textit{role}
 for a description of how to use negation to exclude choices.
 %.lp ""
 \\
-If {\tt gender} is not specified, there is no default value;
+If \texttt{gender} is not specified, there is no default value;
 player will be prompted unless role and/or race forces a choice for gender.
-Cannot be set with the `{\tt O}' command.  Persistent.
+Cannot be set with the `\texttt{O}' command.  Persistent.
 %.lp
 \item[goldX]
 When filtering objects based on bless/curse state (BUCX), whether to
-treat gold pieces as {\tt X} (unknown bless/curse state, when `on')
-or {\tt U} (known to be uncursed, when `off', the default).
+treat gold pieces as \texttt{X} (unknown bless/curse state, when `on')
+or \texttt{U} (known to be uncursed, when `off', the default).
 Gold is never blessed or cursed, but it is not described as ``uncursed''
-even when the {\it implicit\textunderscore uncursed\/} option is `off'.
+even when the \textit{implicit\textunderscore uncursed} option is `off'.
 %.lp
 \item[help]
 If more information is available for an object looked at
-with the `{\tt /}' command, ask if you want to see it (default on).
+with the `\texttt{/}' command, ask if you want to see it (default on).
 Turning help off makes just looking at things faster, since you aren't
-interrupted with the ``{\tt More info?}'' prompt, but it also means that you
+interrupted with the ``\texttt{More info?}'' prompt, but it also means that you
 might miss some interesting and/or important information.  Persistent.
 %.lp
 \item[herecmd\textunderscore menu]
 When using a windowport that supports mouse and clicking on yourself or
 next to you, show a menu of possible actions for the location.
-Same as ``{\tt \#herecmdmenu}'' and ``{\tt \#therecmdmenu}'' commands.
+Same as ``\texttt{\#herecmdmenu}'' and ``\texttt{\#therecmdmenu}'' commands.
 %.lp
 \item[hilite\textunderscore pet]
 Visually distinguish pets from similar animals (default off).
@@ -4409,9 +4408,9 @@ In text windowing, text highlighting or inverse video is often used;
 with tiles, generally displays a heart symbol near pets.
 
 %.lp ""
-With the tty or curses interface, the {\it petattr\/}
+With the tty or curses interface, the \textit{petattr}
 option controls how to highlight pets and setting it will turn the
-{\it hilite\textunderscore pet\/} option on or off as warranted.
+\textit{hilite\textunderscore pet} option on or off as warranted.
 %.lp
 \item[hilite\textunderscore pile]
 Visually distinguish piles of objects from individual objects (default off).
@@ -4434,22 +4433,22 @@ the bar.
 If there is one for hitpoints in effect and it specifies color, that
 color will be used for the bar.
 However if it specifies video attributes, they will be ignored in
-favor of {\it inverse}.
-For tty and curses, {\it blink\/} will also be used if the current
-hitpoint value is at or below the {\it critical HP\/} threshold.
+favor of \textit{inverse}.
+For tty and curses, \textit{blink} will also be used if the current
+hitpoint value is at or below the \textit{critical HP} threshold.
 \\
 %.lp
 The ``Qt'' interface also supports hitpointbar, by drawing
 a solid bar above the name and title with a hard-coded color scheme.
 (As of this writing, having the bar enabled unintentionally inhibits
 resizing the status panel.
-To resize that, use the {\tt \#optionsfull} command to toggle the
-{\it hitpointbar\/} option off, perform the resize while it's off, then
+To resize that, use the \texttt{\#optionsfull} command to toggle the
+\textit{hitpointbar} option off, perform the resize while it's off, then
 use the same command to toggle it back on.)
 %.lp
 \item[horsename]
-Name your starting horse (for example, ``{\tt horsename:Trigger}'').
-Cannot be set with the `{\tt O}' command.
+Name your starting horse (for example, ``\texttt{horsename:Trigger}'').
+Cannot be set with the `\texttt{O}' command.
 %.lp
 \item[ignintr]
 Ignore interrupt signals, including breaks (default off).  Persistent.
@@ -4472,16 +4471,16 @@ character as lit (default off).  Persistent.
 %.lp
 \item[lootabc]
 When using a menu to interact with a container,
-use the old `{\tt a}', `{\tt b}', and `{\tt c}' keyboard shortcuts
-rather than the mnemonics `{\tt o}', `{\tt i}', and `{\tt b}' (default off).
+use the old `\texttt{a}', `\texttt{b}', and `\texttt{c}' keyboard shortcuts
+rather than the mnemonics `\texttt{o}', `\texttt{i}', and `\texttt{b}' (default off).
 Persistent.
 %.lp
 \item[mail]
 Enable mail delivery during the game (default on).  Persistent.
 %.lp
 \item[male]
-An obsolete synonym for ``{\tt gender:male}''.  Cannot be set with the
-`{\tt O}' command.
+An obsolete synonym for ``\texttt{gender:male}''.  Cannot be set with the
+`\texttt{O}' command.
 %.lp
 \item[mention\textunderscore decor]
 Give feedback when walking onto various dungeon features such as stairs,
@@ -4496,14 +4495,14 @@ Give feedback when walking against a wall (default off).  Persistent.
 %.lp
 \item[menucolors]
 Enable coloring menu lines (default off).
-See ``{\it Configuring Menu Colors\/}'' on how to configure the colors.
+See ``\textit{Configuring Menu Colors}'' on how to configure the colors.
 %.lp
 \item[menustyle]
 Controls the method used when you need to choose various objects (in
-response to the {\tt Drop} (aka {\tt droptype}) command, for instance).
+response to the \texttt{Drop} (aka \texttt{droptype}) command, for instance).
 The value specified should be the first letter of one of the following:
 traditional, combination, full, or partial.
-Default is {\tt full}.
+Default is \texttt{full}.
 Persistent.
 \\
 %.lp ""
@@ -4519,7 +4518,7 @@ object classes rather than a character prompt, and then a menu of matching
 objects for selection.
 (Choosing its `A' (Autoselect-All) choice skips the second menu.
 To avoid choosing that by accident,
-set {\it paranoid\textunderscore confirm:AutoAll\/} to require confirmation.)
+set \textit{paranoid\textunderscore confirm:AutoAll} to require confirmation.)
 Partial skips the object class filtering and
 immediately displays a menu of all objects.
 \item[menu\textunderscore deselect\textunderscore all]
@@ -4529,15 +4528,15 @@ Default `-'.
 \item[menu\textunderscore deselect\textunderscore page]
 Key to deselect all items on this page of a menu.
 Implemented by the Amiga, Gem and tty ports.
-Default `\verb+\+'.
+Default `\textbackslash'.
 \item[menu\textunderscore first\textunderscore page]
 Key to jump to the first page in a menu.
 Implemented by the Amiga, Gem and tty ports.
-Default `\verb+^+'.
+Default `\textasciicircum'.
 \item[menu\textunderscore headings]
 Controls how the headings in a menu are highlighted.
 Takes a text attribute, or text color and attribute separated by ampersand.
-For allowed attributes and colors, see ``{\it Configuring Menu Colors\/}``.
+For allowed attributes and colors, see ``\textit{Configuring Menu Colors}``.
 Not all ports can actually display all types.
 \item[menu\textunderscore invert\textunderscore all]
 Key to invert all items in a menu.
@@ -4546,15 +4545,15 @@ Default `@'.
 \item[menu\textunderscore invert\textunderscore page]
 Key to invert all items on this page of a menu.
 Implemented by the Amiga, Gem and tty ports.
-Default `\verb+~+'.
+Default `\textasciitilde'.
 \item[menu\textunderscore last\textunderscore page]
 Key to jump to the last page in a menu.
 Implemented by the Amiga, Gem and tty ports.
-Default `\verb+|+'.
+Default `|'.
 \item[menu\textunderscore next\textunderscore page]
 Key to go to the next menu page.
 Implemented by the Amiga, Gem and tty ports.
-Default `\verb+>+'.
+Default `>'.
 \item[menu\textunderscore objsyms]
 % [originally menu_objsyms was a boolean]
 % Show object symbols in menu headings in menus where
@@ -4589,7 +4588,7 @@ objects among classes.
 
 Supported by tty and curses.
 When setting the value, it can be specified by digit or keyword.
-The default value is {\tt Conditional} (4).
+The default value is \texttt{Conditional} (4).
 \item[menu\textunderscore overlay]
 Do not clear the screen before drawing menus, and align
 menus to the right edge of the screen. Only for the tty port.
@@ -4597,7 +4596,7 @@ menus to the right edge of the screen. Only for the tty port.
 \item[menu\textunderscore previous\textunderscore page]
 Key to go to the previous menu page.
 Implemented by the Amiga, Gem and tty ports.
-Default `\verb+<+'.
+Default `<'.
 \item[menu\textunderscore search]
 Key to search for some text and toggle selection state of matching menu items.
 Default `:'.
@@ -4614,15 +4613,15 @@ Default `,'.
 \item[menu\textunderscore shift\textunderscore left]
 Key to scroll a menu---one which has been
 scrolled right---back to the left.
-Implemented for {\it perm\textunderscore invent\/} only by curses and X11.
-Default `{\tt \verb+{+}'.
+Implemented for \textit{perm\textunderscore invent} only by curses and X11.
+Default `\texttt{\textbraceleft}'.
 
 %.lp
 \item[menu\textunderscore shift\textunderscore right]
 Key to scroll a menu which has text beyond the
 right edge to the right.
-Implemented for {\it perm\textunderscore invent\/} only by curses by X11.
-Default `{\tt \verb+}+}'.
+Implemented for \textit{perm\textunderscore invent} only by curses by X11.
+Default `\texttt{\textbraceright}'.
 % %.lp
 % \item[menu\textunderscore tab\textunderscore sep]
 % Format menu entries using TAB to separate columns (default off).
@@ -4646,47 +4645,47 @@ Valid settings are:
 
 %.sd
 %.si
-{\tt 0} --- disabled\\
-{\tt 1} --- enabled and make OS adjustments to support mouse use\\
-{\tt 2} --- like {\tt 1}, but does not make any OS adjustments\\
+\texttt{0} --- disabled\\
+\texttt{1} --- enabled and make OS adjustments to support mouse use\\
+\texttt{2} --- like \texttt{1}, but does not make any OS adjustments\\
 %.ei
 %.ed
 
-Omitting a value is the same as specifying {\tt 1}
+Omitting a value is the same as specifying \texttt{1}
 and negating
-{\it mouse\textunderscore support\/}
-is the same as specifying {\tt 0}.
+\textit{mouse\textunderscore support}
+is the same as specifying \texttt{0}.
 %.lp
 \item[msghistory]
 The number of top line messages to save (and be able to recall
-with `{\tt \^{}P}') (default 20).
-Cannot be set with the `{\tt O}' command.
+with `\texttt{\textasciicircum P}') (default 20).
+Cannot be set with the `\texttt{O}' command.
 %.lp
 \item[msg\textunderscore window]
 Allows you to change the way recalled messages are displayed.
 Currently it is only supported for tty (all four choices) and for curses
-(`{\tt f}' and `{\tt r}' choices, default `{\tt r}').
+(`\texttt{f}' and `\texttt{r}' choices, default `\texttt{r}').
 The possible values are:
 
 %.sd
 %.si
-{\tt s} --- single message (default; only choice prior to 3.4.0);\\
-{\tt c} --- combination, two messages as {\it single\/}, then as {\it full\/};\\
-{\tt f} --- full window, oldest message first;\\
-{\tt r} --- full window reversed, newest message first.
+\texttt{s} --- single message (default; only choice prior to 3.4.0);\\
+\texttt{c} --- combination, two messages as \textit{single}, then as \textit{full};\\
+\texttt{f} --- full window, oldest message first;\\
+\texttt{r} --- full window reversed, newest message first.
 %.ei
 %.ed
 
 For backward compatibility, no value needs to be specified (which
-defaults to {\it full\/}), or it can be negated (which defaults
-to {\it single\/}).
+defaults to \textit{full}), or it can be negated (which defaults
+to \textit{single}).
 %.lp
 \item[name]
 Set your character's name (defaults to your user name).  You can also
 set your character's role by appending a dash and one or more letters of
 the role (that is, by suffixing one of
-``{\tt -A -B -C -H -K -M -P -Ra -Ro -S -T -V -W}'').
-If ``{\tt -@}'' is used for the role, then a random one will be
+``\texttt{-A -B -C -H -K -M -P -Ra -Ro -S -T -V -W}'').
+If ``\texttt{-@}'' is used for the role, then a random one will be
 automatically chosen.
 %.lp
 \\
@@ -4694,12 +4693,12 @@ On some systems, the default is the player's user name;
 on others, there is no default and the player will be prompted.
 The former can made to behave like the latter by specifying a generic name
 such as ``player''.
-Cannot be set with the `{\tt O}' command.
+Cannot be set with the `\texttt{O}' command.
 %.lp
 \item[news]
-Read the {\it NetHack\/} news file, if present (default on).
+Read the \textit{NetHack} news file, if present (default on).
 Since the news is shown at the beginning of the game, there's no point
-in setting this with the `{\tt O}' command.
+in setting this with the `\texttt{O}' command.
 %.lp
 \item[nudist]
 Start the character with no armor (default false).  Persistent.
@@ -4714,44 +4713,44 @@ Valid settings are:
 %.sd
 %.si
 \newlength{\mwidth}
-\settowidth{\mwidth}{\tt -0}
-\newcommand{\numbox}[1]{\makebox[\mwidth][r]{{\tt #1}}}
-\numbox{0} --- move by letters; `{\tt yuhjklbn}'\\
-\numbox{1} --- move by numbers; digit `{\tt 5}' acts as `{\tt G}' movement prefix\\
-\numbox{2} --- like {\tt 1} but `{\tt 5}' works as `{\tt g}' prefix instead of as `{\tt G}'\\
-\numbox{3} --- by numbers using phone key layout; {\tt 123} above, {\tt 789} below\\
-\numbox{4} --- combines {\tt 3} with {\tt 2}; phone layout plus MS-DOS compatibility\\
-\numbox{-1} --- by letters but use `{\tt z}' to go northwest, `{\tt y}' to zap wands
+\settowidth{\mwidth}{\texttt{-0}}
+\newcommand{\numbox}[1]{\makebox[\mwidth][r]{\texttt{#1}}}
+\numbox{0} --- move by letters; `\texttt{yuhjklbn}'\\
+\numbox{1} --- move by numbers; digit `\texttt{5}' acts as `\texttt{G}' movement prefix\\
+\numbox{2} --- like \texttt{1} but `\texttt{5}' works as `\texttt{g}' prefix instead of as `\texttt{G}'\\
+\numbox{3} --- by numbers using phone key layout; \texttt{123} above, \texttt{789} below\\
+\numbox{4} --- combines \texttt{3} with \texttt{2}; phone layout plus MS-DOS compatibility\\
+\numbox{-1} --- by letters but use `\texttt{z}' to go northwest, `\texttt{y}' to zap wands
 %.ei
 %.ed
 
-For backward compatibility, omitting a value is the same as specifying {\tt 1}
+For backward compatibility, omitting a value is the same as specifying \texttt{1}
 and negating
-{\it number\textunderscore pad\/}
-is the same as specifying {\tt 0}.
-(Settings {\tt 2} and {\tt 4} are for compatibility with MS-DOS or old PC Hack;
-in addition to the different behavior for `{\tt 5}', `{\tt Alt-5}' acts as `{\tt G}'
-and `{\tt Alt-0}' acts as `{\tt I}'.
-Setting {\tt -1} is to accommodate some QWERTZ keyboards which have the
-location of the `{\tt y}' and `{\tt z}' keys swapped.)
+\textit{number\textunderscore pad}
+is the same as specifying \texttt{0}.
+(Settings \texttt{2} and \texttt{4} are for compatibility with MS-DOS or old PC Hack;
+in addition to the different behavior for `\texttt{5}', `\texttt{Alt-5}' acts as `\texttt{G}'
+and `\texttt{Alt-0}' acts as `\texttt{I}'.
+Setting \texttt{-1} is to accommodate some QWERTZ keyboards which have the
+location of the `\texttt{y}' and `\texttt{z}' keys swapped.)
 When moving by numbers, to enter a count prefix for those commands
-which accept one (such as ``{\tt 12s}'' to search twelve times), precede it
-with the letter `{\tt n}' (``{\tt n12s}'').
+which accept one (such as ``\texttt{12s}'' to search twelve times), precede it
+with the letter `\texttt{n}' (``\texttt{n12s}'').
 %.lp
 \item[packorder]
 Specify the order to list object types in (default
-``\verb&")[%?+!=/(*`0_&''). The value of this option should be a string
+``\texttt{")[\%?+!=/(*\textasciigrave 0\textunderscore}''). The value of this option should be a string
 containing the symbols for the various object types.  Any omitted types
 are filled in at the end from the previous order.
 %.lp
 \item[paranoid\textunderscore confirmation]
 A space separated list of specific situations where alternate
 prompting is desired.
-The default is ``{\it paranoid\textunderscore confirmation:pray swim trap}''.
+The default is ``\textit{paranoid\textunderscore confirmation:pray swim trap}''.
 %.sd
 %.si
 \newlength{\pcwidth}
-\settowidth{\pcwidth}{\tt Were-change}
+\settowidth{\pcwidth}{\texttt{Were-change}}
 \addtolength{\pcwidth}{\labelsep}
 \begin{description}[leftmargin=\pcwidth, topsep=1mm, itemsep=0mm, labelwidth=*, font=\ttfamily, align=right]
 \item[Confirm]
@@ -4759,47 +4758,47 @@ for any prompts which are set to require ``yes'' rather than `y',
 also require ``no'' to reject instead of accepting any non-yes response
 as no; changes pray and AutoAll to require ``yes'' or ``no'' too;
 \item[quit]
-require ``{\tt yes}'' rather than `{\tt y}' to confirm quitting
+require ``\texttt{yes}'' rather than `\texttt{y}' to confirm quitting
 the game or switching into non-scoring explore mode;
 \item[die]
-require ``{\tt yes}'' rather than `{\tt y}' to confirm dying (not
+require ``\texttt{yes}'' rather than `\texttt{y}' to confirm dying (not
 useful in normal play; applies to explore mode);
 \item[bones]
-require ``{\tt yes}'' rather than `{\tt y}' to confirm saving
+require ``\texttt{yes}'' rather than `\texttt{y}' to confirm saving
 bones data when dying in debug mode
 \item[attack]
-require ``{\tt yes}'' rather than `{\tt y}' to confirm attacking
+require ``\texttt{yes}'' rather than `\texttt{y}' to confirm attacking
 a peaceful monster;
 \item[wand-break]
-require ``{\tt yes}'' rather than `{\tt y}' to confirm breaking
-a wand with the {\it apply} command;
+require ``\texttt{yes}'' rather than `\texttt{y}' to confirm breaking
+a wand with the \textit{apply} command;
 \item[eating]
-require ``{\tt yes}'' rather than `{\tt y}' to confirm whether to
+require ``\texttt{yes}'' rather than `\texttt{y}' to confirm whether to
 continue eating;
 \item[Were-change]
-require ``{\tt yes}'' rather than `{\tt y}' to confirm changing form due
+require ``\texttt{yes}'' rather than `\texttt{y}' to confirm changing form due
 to lycanthropy when hero has polymorph control;
 \item[pray]
-require `{\tt y}' to confirm an attempt to pray rather
+require `\texttt{y}' to confirm an attempt to pray rather
 than immediately praying; on by default;
 (to require ``yes'' rather than just `y', set Confirm too);
 \item[trap]
-require `{\tt y}' to confirm an attempt to move into or onto a known trap,
+require `\texttt{y}' to confirm an attempt to move into or onto a known trap,
 unless doing so is considered to be harmless;
 when enabled, this confirmation is also used for moving into visible
 gas cloud regions;
 (to require ``yes'' rather than just `y', set Confirm too);
-confirmation can be skipped by using the `{\tt m}' movement prefix;
+confirmation can be skipped by using the `\texttt{m}' movement prefix;
 \item[swim]
 prevent walking into water or lava; on by default; (to deliberately step
-onto/into such terrain when this is set, use the `{\tt m}'
+onto/into such terrain when this is set, use the `\texttt{m}'
 movement prefix when adjacent);
 \item[AutoAll]
 require confirmation when the `A' (Autoselect-All) choice is selected
-in object class filtering menus for {\it menustyle:Full};
+in object class filtering menus for \textit{menustyle:Full};
 (to require ``yes'' rather than just `y', set Confirm too);
 \item[Remove]
-require selection from inventory for `{\tt R}' and `{\tt T}'
+require selection from inventory for `\texttt{R}' and `\texttt{T}'
 commands even when wearing just one applicable item;
 \item[all]
 turn on all of the above.
@@ -4808,19 +4807,19 @@ turn on all of the above.
 %.ed
 By default, the pray, swim, and trap choices are enabled, the others disabled.
 To disable them without setting
-any of the other choices, use ``{\it paranoid\textunderscore confirmation:none}''.
+any of the other choices, use ``\textit{paranoid\textunderscore confirmation:none}''.
 To keep them enabled while setting any of the others, you can
 include them in the list, such as
-``{\it par\-a\-noid\textunderscore con\-fir\-ma\-tion:attack~pray~swim~Remove\/}''
+``\textit{par\-a\-noid\textunderscore con\-fir\-ma\-tion:attack~pray~swim~Remove}''
 or you can precede the first entry in the list with a plus sign,
-``{\it paranoid\textunderscore confirmation:\verb|+|attack~Remove\/}''.
+``\textit{paranoid\textunderscore confirmation:+attack~Remove}''.
 To remove an entry that has been previously set without removing others,
 precede the first entry in the list with a minus sign,
-``{\it paranoid\textunderscore confirmation:-swim\/}.
+``\textit{paranoid\textunderscore confirmation:-swim}.
 To both add some new entries and remove some old ones, you can use
-multiple {\it paranoid\textunderscore confirmation\/} option settings, or you can
-use the `{\tt \verb|+|}' form and list entries to be added by their name
-and entries to be removed by `{\tt !}' and name.
+multiple \textit{paranoid\textunderscore confirmation} option settings, or you can
+use the `\texttt{+}' form and list entries to be added by their name
+and entries to be removed by `\texttt{!}' and name.
 The positive (no `!') and negative (with `!') entries
 can be intermixed.
 %.lp
@@ -4834,24 +4833,24 @@ If true, always display your current inventory in a window (default is false).
 This only
 makes sense for windowing system interfaces that implement this feature.
 For those that do, the
-{\tt perminv\textunderscore mode}
+\texttt{perminv\textunderscore mode}
 option can be used to refine what gets displayed
-for {\it perm\textunderscore invent\/}.
-Setting that to a value other than {\it none\/}
-while {\it perm\textunderscore invent\/} is false will change it to true.
+for \textit{perm\textunderscore invent}.
+Setting that to a value other than \textit{none}
+while \textit{perm\textunderscore invent} is false will change it to true.
 %.lp
 \item[perminv\textunderscore mode]
 Augments the
-{\tt perm\textunderscore invent}
+\texttt{perm\textunderscore invent}
 option.
 Value is one of
 %.PS "\f(CRin-use\fP"
-\settowidth{\pcwidth}{\tt in-use}  %reuse the paranoid_confirm width
+\settowidth{\pcwidth}{\texttt{in-use}}  %reuse the paranoid_confirm width
 \addtolength{\pcwidth}{\labelsep}
 \begin{description}[leftmargin=\pcwidth, topsep=1mm, itemsep=0mm, labelwidth=*, font=\mdseries, align=right]
 %.PL
-\item[{\tt none}]
-behave as if {\it perm\textunderscore invent\/} is false;
+\item[\texttt{none}]
+behave as if \textit{perm\textunderscore invent} is false;
 \item[{all}]
 show all inventory except for gold;
 \item[{full}]
@@ -4860,18 +4859,18 @@ show full inventory including gold;
 only show items which are in use (worn, wielded, lit lamp).
 %.PE
 \end{description}
-Default is {\it none\/} but if {\it perm\textunderscore invent\/} gets set to true
-while it is {\it none\/} it will be changed to {\it all\/}.
+Default is \textit{none} but if \textit{perm\textunderscore invent} gets set to true
+while it is \textit{none} it will be changed to \textit{all}.
 %.lp ""
 \\
 Note: if gold has been equipped in quiver/ammo-pouch then it will be
-included for {\it all\/} despite that mode normally omitting gold.
+included for \textit{all} despite that mode normally omitting gold.
 %.lp
 %.\" petattr is a wincap option but we'll document it here...
 \item[petattr]
 Specifies one or more text highlighting attributes to use when showing
 pets on the map.
-Effectively a superset of the {\it hilite\textunderscore pet\/} boolean option.
+Effectively a superset of the \textit{hilite\textunderscore pet} boolean option.
 Curses or tty interface only; value is one of
 none, bold, dim, underline, italic, blink, and inverse.
 Some of those choices might not work,
@@ -4881,12 +4880,12 @@ depending upon terminal hardware or terminal emulation software.
 \item[pettype]
 Specify the type of your initial pet, if you are playing a character class
 that uses multiple types of pets; or choose to have no initial pet at all.
-Possible values are ``{\tt cat}'', ``{\tt dog}'', ``{\tt horse}''
-and ``{\tt none}''.
+Possible values are ``\texttt{cat}'', ``\texttt{dog}'', ``\texttt{horse}''
+and ``\texttt{none}''.
 If the choice is not allowed for the role you are currently playing,
-it will be silently ignored.  For example, ``{\tt horse}'' will only be
+it will be silently ignored.  For example, ``\texttt{horse}'' will only be
 honored when playing a knight.
-Cannot be set with the `{\tt O}' command.
+Cannot be set with the `\texttt{O}' command.
 %.lp
 \item[pickup\textunderscore burden]
 When you pick up an item that would exceed this encumbrance
@@ -4895,42 +4894,42 @@ or overLoaded), you will be asked if you want to continue.
 (Default `S').  Persistent.
 %.lp
 \item[pickup\textunderscore stolen]
-If this option is on and ``{\it autopickup\/}'' is also on, try to pick up
+If this option is on and ``\textit{autopickup}'' is also on, try to pick up
 things that a monster stole from you, even if they aren't in
-``{\it pickup\textunderscore types\/}'' or
+``\textit{pickup\textunderscore types}'' or
 match an autopickup exception.
 Default is on.
 Persistent.
 %.lp
 \item[pickup\textunderscore thrown]
-If this option is on and ``{\it autopickup\/}'' is also on, try to pick up
+If this option is on and ``\textit{autopickup}'' is also on, try to pick up
 things that you threw, even if they aren't in
-``{\it pickup\textunderscore types\/}'' or
+``\textit{pickup\textunderscore types}'' or
 match an autopickup exception.
 Default is on.
 Persistent.
 %.lp
 \item[pickup\textunderscore types]
-Specify the object types to be picked up when ``{\it autopickup\/}''
+Specify the object types to be picked up when ``\textit{autopickup}''
 is on.
 Default is all types.
 Persistent.
 \\
 %.lp ""
 The value is a list of object symbols, such as
-{\tt \verb&pickup_types:$?!&} to pick up gold, scrolls, and potions.
+\texttt{pickup\textunderscore types:\textdollar ?!\&} to pick up gold, scrolls, and potions.
 You can use
-``{\it autopickup\textunderscore exception\/}''
-configuration file lines to further refine ``{\it autopickup\/}'' behavior.
+``\textit{autopickup\textunderscore exception}''
+configuration file lines to further refine ``\textit{autopickup}'' behavior.
 \\
 %.lp ""
-There is no way to set {\it pickup\textunderscore types\/} to ``{\it none}''.
-(Setting it to an empty value reverts to ``{\it all}''.)
+There is no way to set \textit{pickup\textunderscore types} to ``\textit{none}''.
+(Setting it to an empty value reverts to ``\textit{all}''.)
 If you want to avoid automatically picking up any types of items but do
-want to have {\it autopickup\/} on in order to have
-{\it autopickup\textunderscore exceptions\/} control what you do and don't pick
-up, you can set {\it pickup\textunderscore types\/} to `{\tt .}'.
-That is the type symbol for {\it venom\/} and you won't come across
+want to have \textit{autopickup} on in order to have
+\textit{autopickup\textunderscore exceptions} control what you do and don't pick
+up, you can set \textit{pickup\textunderscore types} to `\texttt{.}'.
+That is the type symbol for \textit{venom} and you won't come across
 any venom items so won't unintentionally pick such up.
 %.lp
 \item[pile\textunderscore limit]
@@ -4942,7 +4941,7 @@ the objects'' since the pile size will always be at least that big;
 default value is 5.  Persistent.
 %.lp
 \item[playmode]
-Values are {\it normal\/}, {\it explore\/}, or {\it debug\/}.
+Values are \textit{normal}, \textit{explore}, or \textit{debug}.
 Allows selection of explore mode (also known as discovery mode) or debug
 mode (also known as wizard mode) instead of normal play.
 Debug mode might only be allowed for someone logged in under a particular
@@ -4952,9 +4951,9 @@ it when not allowed or not possible results in explore mode instead.
 Default is normal play.
 %.lp
 \item[pushweapon]
-Using the `{\tt w}' (wield) command when already wielding
+Using the `\texttt{w}' (wield) command when already wielding
 something pushes the old item into your alternate weapon slot (default off).
-Likewise for the `{\tt a}' (apply) command if it causes the applied item to
+Likewise for the `\texttt{a}' (apply) command if it causes the applied item to
 become wielded.  Persistent.
 %.lp
 \item[query\textunderscore menu]
@@ -4970,35 +4969,35 @@ objects or monsters is less intrusive.
 Default is off.  Persistent.
 %.lp
 \item[race]
-Choices are {\tt human}, {\tt dwarf}, {\tt elf}, {\tt gnome}, and
-{\tt orc} but most roles restrict which of the non-human races are allowed.
-See {\it role\/}
+Choices are \texttt{human}, \texttt{dwarf}, \texttt{elf}, \texttt{gnome}, and
+\texttt{orc} but most roles restrict which of the non-human races are allowed.
+See \textit{role}
 for a description of how to use negation to exclude choices.
 %.lp ""
 \\
-If {\tt race} is not specified, there is no default value;
+If \texttt{race} is not specified, there is no default value;
 player will be prompted unless role forces a choice for race.
 unless role forces a choice for race.
-Cannot be set with the `{\tt O}' command.  Persistent.
+Cannot be set with the `\texttt{O}' command.  Persistent.
 %.lp
 \item[rest\textunderscore on\textunderscore space]
-Make the space bar a synonym for the `{\tt .}' (\#wait) command (default off).
+Make the space bar a synonym for the `\texttt{.}' (\#wait) command (default off).
 Persistent.
 %.lp
 \item[role]
-Pick your type of character (for example, ``{\tt role:Samurai}'');
-synonym for ``{\it character\/}''.
-See ``{\it name\/}'' for an alternate method of specifying your role.
+Pick your type of character (for example, ``\texttt{role:Samurai}'');
+synonym for ``\textit{character}''.
+See ``\textit{name}'' for an alternate method of specifying your role.
 %.\" Normally only the first letter of the
-%.\" value is examined; `r' is an exception with ``{\tt Rogue}'',
-%.\" ``{\tt Ranger}'', and ``{\tt random}'' values.
+%.\" value is examined; `r' is an exception with ``\texttt{Rogue}'',
+%.\" ``\texttt{Ranger}'', and ``\texttt{random}'' values.
 %.lp ""
 This option can also be used to limit selection when role is chosen
 randomly.
 Use a space-separated list of roles and either negate each one or negate
 the option itself instead.
-Negation is accomplished in the same manner as with {\it boolean options\/},
-by prefixing the option or its value(s) with `{\tt \verb+!+}' or ``{\tt no}''.
+Negation is accomplished in the same manner as with \textit{boolean options},
+by prefixing the option or its value(s) with `\texttt{!}' or ``\texttt{no}''.
 %.BR 0
 \\
 Examples:
@@ -5007,19 +5006,19 @@ Examples:
 OPTIONS=role:!arc !bar !kni
 OPTIONS=!role:arc bar kni
 \end{verbatim}
-There can be multiple instances of the {\it role\/}
+There can be multiple instances of the \textit{role}
 option if they're all negations.
 %.\" Only one positive value is allowed, and if present, it overrides any
 %.\" negations.
 %.lp ""
 \\
-If {\tt role} is not specified, there is no default value;
+If \texttt{role} is not specified, there is no default value;
 player will be prompted.
-Cannot be set with the `{\tt O}' command.  Persistent.
+Cannot be set with the `\texttt{O}' command.  Persistent.
 %.lp
 \item[roguesymset]
 This option may be used to select one of the named symbol sets found within
-{\tt symbols} to alter the symbols displayed on the screen on the
+\texttt{symbols} to alter the symbols displayed on the screen on the
 rogue level.
 %.lp
 \item[rlecomp]
@@ -5029,23 +5028,23 @@ effect on reading an existing save file.
 %.lp
 \item[runmode]
 Controls the amount of screen updating for the map window when engaged
-in multi-turn movement (running via {\tt shift}+direction
-or {\tt control}+direction
+in multi-turn movement (running via \texttt{shift}+direction
+or \texttt{control}+direction
 and so forth, or via the travel command or mouse click).
 The possible values are:
 
 %.sd
 %.si
-{\tt teleport} --- update the map after movement has finished;\\
-{\tt run} --- update the map after every seven or so steps;\\
-{\tt walk} --- update the map after each step;\\
-{\tt crawl} --- like {\it walk\/}, but pause briefly after each step.
+\texttt{teleport} --- update the map after movement has finished;\\
+\texttt{run} --- update the map after every seven or so steps;\\
+\texttt{walk} --- update the map after each step;\\
+\texttt{crawl} --- like \textit{walk}, but pause briefly after each step.
 %.ei
 %.ed
 
 This option only affects the game's screen display, not the actual
-results of moving.  The default is {\it run\/}; versions prior to 3.4.1
-used {\it teleport\/} only.  Whether or not the effect is noticeable will
+results of moving.  The default is \textit{run}; versions prior to 3.4.1
+used \textit{teleport} only.  Whether or not the effect is noticeable will
 depend upon the window port used or on the type of terminal.  Persistent.
 %.lp
 \item[safe\textunderscore pet]
@@ -5061,8 +5060,8 @@ Debug mode only.
 %.lp
 \item[scores]
 Control what parts of the score list you are shown at the end (for example,
-``{\tt scores:5top scores/4around my score/own scores}'').  Only the first
-letter of each category (`{\tt t}', `{\tt a}' or `{\tt o}') is necessary.
+``\texttt{scores:5top scores/4around my score/own scores}'').  Only the first
+letter of each category (`\texttt{t}', `\texttt{a}' or `\texttt{o}') is necessary.
 Persistent.
 %.lp
 \item[showdamage]
@@ -5089,9 +5088,9 @@ Include the game's version number on the status lines (default off).
 Potentially useful if you switch between different versions or variants,
 or you are making screenshots or streaming video.
 Using the
-{\it statuslines:3\/}
+\textit{statuslines:3}
 option is recommended so that there will be more room available for
-status information, unless you're using nethack's {\it Qt\/} interface
+status information, unless you're using nethack's \textit{Qt} interface
 or your terminal emulator window displays fewer than 25 lines.
 Persistent.
 %.lp
@@ -5099,29 +5098,29 @@ Persistent.
 Suppress terminal beeps (default on).  Persistent.
 %.lp
 \item[sortdiscoveries]
-Controls the sorting behavior for the output of the `{\tt $\backslash$}'
-and `{\tt \`{}}' commands.
+Controls the sorting behavior for the output of the `\texttt{\textbackslash}'
+and `\texttt{\`{}}' commands.
 Persistent.
 \\
 %.lp ""
 The possible values are:
 \\
 %.PS
-{\tt o} --- list object types by class, in discovery order within each class;
+\texttt{o} --- list object types by class, in discovery order within each class;
 default;
 \\
-{\tt s} --- list object types by {\it sortloot\/}
+\texttt{s} --- list object types by \textit{sortloot}
 classification: by class, by sub-class within class for classes which
 have substantial groupings (like helmets, boots, gloves, and so forth
 for armor), with object types partly-discovered via assigned name coming
 before fully identified types;
 \\
-{\tt c} --- list by class, alphabetically within each class;\\
-{\tt a} --- list alphabetically across all classes.\\
+\texttt{c} --- list by class, alphabetically within each class;\\
+\texttt{a} --- list alphabetically across all classes.\\
 %.PE
-Can be interactively set via the `{\tt O}' command or via using
-the `{\tt m}' prefix before the `{\tt $\backslash$}'
-or `{\tt \`{}}' command.
+Can be interactively set via the `\texttt{O}' command or via using
+the `\texttt{m}' prefix before the `\texttt{\textbackslash}'
+or `\texttt{\textasciigrave}' command.
 %.lp
 \item[sortloot]
 Controls the sorting behavior of pickup lists for inventory
@@ -5131,10 +5130,10 @@ The possible values are:
 \\
 %.sd
 %.si
-{\tt full} --- always sort the lists;\\
-{\tt loot} --- only sort the lists that don't use inventory
+\texttt{full} --- always sort the lists;\\
+\texttt{loot} --- only sort the lists that don't use inventory
        letters, like with the \#loot and pickup commands;\\
-{\tt none} --- show lists the traditional way without sorting; default.
+\texttt{none} --- show lists the traditional way without sorting; default.
 %.ei
 %.ed
 %.lp
@@ -5143,45 +5142,45 @@ Sort the pack contents by type when displaying inventory (default on).
 Persistent.
 %.lp
 \item[sortvanquished]
-Controls the sorting behavior for the output of the {\tt \#vanquished} command
-and also for the {\tt \#genocided} command.
+Controls the sorting behavior for the output of the \texttt{\#vanquished} command
+and also for the \texttt{\#genocided} command.
 Persistent.
 \\
 %.lp ""
 The possible values are:
 \\
 %.PS
-{\tt t} ---
+\texttt{t} ---
 traditional: order by monster level; ties are broken by internal
 monster index;
 default;
 \\
-{\tt d} ---
+\texttt{d} ---
 order by monster difficulty rating; ties broken by internal index;
 \\
-{\tt a} ---
+\texttt{a} ---
 order alphabetically, first any unique monsters then all the others;
 \\
 %note: 'A' and 'C' can be set in RC file or NETHACKOPTIONS but not by 'O'
-% {\tt A} ---
+% \texttt{A} ---
 % order alphabetically, unique monsters intermixed with other monsters;
 % \\
-% {\tt C} ---
+% \texttt{C} ---
 % order by monster class, by high to low level within each class;
 % \\
-{\tt c} ---
+\texttt{c} ---
 order by monster class, by low to high level within each class;
 \\
-{\tt n} ---
+\texttt{n} ---
 order by count, high to low; ties are broken by internal monster index;
 \\
-{\tt z} ---
+\texttt{z} ---
 order by count, low to high; ties broken by internal index.
 \\
 %.PE
-Can be interactively set via the `{\tt m O}' command or via using
-the `{\tt m}' prefix before either the {\tt \#vanquished} command
-or the {\tt \#genocided} command.
+Can be interactively set via the `\texttt{m O}' command or via using
+the `\texttt{m}' prefix before either the \texttt{\#vanquished} command
+or the \texttt{\#genocided} command.
 %.lp
 \item[sounds]
 Allow sounds to be emitted from an integrated sound library (default on).
@@ -5194,25 +5193,25 @@ attack to which it is resistant (default on).  Persistent.
 Show a message when hero notices a monster (default is off).
 %.lp
 \item[standout]
-Boldface monsters and ``{\tt --More--}'' (default off).  Persistent.
+Boldface monsters and ``\texttt{--More--}'' (default off).  Persistent.
 %.lp
 \item[statushilites]
 Controls how many turns status hilite behaviors highlight
 the field. If negated or set to zero, disables status hiliting.
-See ``{\it Configuring Status Hilites\/}'' for further information.
+See ``\textit{Configuring Status Hilites}'' for further information.
 %.lp
 \item[status\textunderscore updates]
 Allow updates to the status lines at the bottom of the screen (default true).
 %.lp
 \item[suppress\textunderscore alert]
-This option may be set to a {\it NetHack\/} version level to suppress
+This option may be set to a \textit{NetHack} version level to suppress
 alert notification messages about feature changes for that
-and prior versions (for example, ``{\tt suppress\textunderscore alert:3.3.1}'')
+and prior versions (for example, ``\texttt{suppress\textunderscore alert:3.3.1}'')
 %.lp
 \item[symset]
 This option may be used to select one of the named symbol sets found within
-{\tt symbols} to alter the symbols displayed on the screen.
-Use ``{\tt symset:default}'' to explicitly select the default symbols.
+\texttt{symbols} to alter the symbols displayed on the screen.
+Use ``\texttt{symset:default}'' to explicitly select the default symbols.
 %.lp
 \item[time]
 Show the elapsed game time in turns on bottom line (default off).  Persistent.
@@ -5231,16 +5230,16 @@ Show some helpful tips during gameplay (default on).  Persistent.
 Draw a tombstone graphic upon your death (default on).  Persistent.
 %.lp
 \item[toptenwin]
-Put the ending display in a {\it NetHack\/} window instead of on stdout (default off).
+Put the ending display in a \textit{NetHack} window instead of on stdout (default off).
 Setting this option makes the score list visible when a windowing version
-of {\it NetHack\/} is started without a parent window, but it no longer leaves
+of \textit{NetHack} is started without a parent window, but it no longer leaves
 the score list around after game end on a terminal or emulating window.
 %.lp
 \item[travel]
 Allow the travel command via mouse click (default on).
 Turning this option off will prevent the game from attempting unintended
 moves if you make inadvertent mouse clicks on the map window.
-Does not affect traveling via the `{\tt \textunderscore }' (``{\tt \#travel}'')
+Does not affect traveling via the `\texttt{\textunderscore}' (``\texttt{\#travel}'')
 command.  Persistent.
 % %.lp
 % \item[ib{travel\textunderscore debug}]
@@ -5255,8 +5254,8 @@ Setting this option on or off in the config file will skip the query.
 Provide more commentary during the game (default on).  Persistent.
 %.lp
 \item[whatis\textunderscore coord]
-When using the `{\tt /}' or `{\tt ;}' commands to look around on the map with
-``{\tt autodescribe}''
+When using the `\texttt{/}' or `\texttt{;}' commands to look around on the map with
+``\texttt{autodescribe}''
 on, display coordinates after the description.
 Also works in other situations where you are asked to pick a location.\\
 
@@ -5265,21 +5264,21 @@ The possible settings are:
 
 %.sd
 %.si
-{\tt c} --- \verb#compass ('east' or '3s' or '2n,4w')#;\\
-{\tt f} --- \verb#full compass ('east' or '3south' or '2north,4west')#;\\
-{\tt m} --- \verb#map <x,y> (map column x=0 is not used)#;\\
-{\tt s} --- \verb#screen [row,column] (row is offset to match tty usage)#;\\
-{\tt n} --- \verb#none (no coordinates shown) [default]#.
+\texttt{c} --- \texttt{compass ('east' or '3s' or '2n,4w')};\\
+\texttt{f} --- \texttt{full compass ('east' or '3south' or '2north,4west')};\\
+\texttt{m} --- \texttt{map <x,y> (map column x=0 is not used)};\\
+\texttt{s} --- \texttt{screen [row,column] (row is offset to match tty usage)};\\
+\texttt{n} --- \texttt{none (no coordinates shown) [default]}.
 %.ei
 %.ed
 
 %.lp ""
 The
-{\it whatis\textunderscore coord\/}
+\textit{whatis\textunderscore coord}
 option is also used with
-the `{\tt /m}', `{\tt /M}', `{\tt /o}', and `{\tt /O}' sub-commands
-of `{\tt /}',
-where the `{\it none\/}' setting is overridden with `{\it map}'.
+the `\texttt{/m}', `\texttt{/M}', `\texttt{/o}', and `\texttt{/O}' sub-commands
+of `\texttt{/}',
+where the `\textit{none}' setting is overridden with `\textit{map}'.
 %.lp
 \item[whatis\textunderscore filter]
 When getting a location on the map, and using the keys to cycle through
@@ -5290,9 +5289,9 @@ The possible settings are:
 
 %.sd
 %.si
-{\tt n} --- \verb#no filtering#;\\
-{\tt v} --- \verb#in view only#;\\
-{\tt a} --- \verb#in same area (room, corridor, etc)#.
+\texttt{n} --- \texttt{no filtering};\\
+\texttt{v} --- \texttt{in view only};\\
+\texttt{a} --- \texttt{in same area (room, corridor, etc)}.
 %.ei
 %.ed
 %.lp ""
@@ -5317,9 +5316,9 @@ move by skipping the same glyphs.
 %.lp
 \item[windowtype]
 When the program has been built to support multiple interfaces,
-select whichone to use, such as ``{\tt tty}'' or ``{\tt X11}''
-(default depends on build-time settings; use ``{\tt \#version}'' to check).
-Cannot be set with the `{\tt O}' command.
+select whichone to use, such as ``\texttt{tty}'' or ``\texttt{X11}''
+(default depends on build-time settings; use ``\texttt{\#version}'' to check).
+Cannot be set with the `\texttt{O}' command.
 
 %.lp ""
 When used, it should be the first option set since its value might
@@ -5327,7 +5326,7 @@ enable or disable the availability of various other options.
 For multiple lines in a configuration file, that would be the first
 non-comment line.
 For a comma-separated list in NETHACKOPTIONS or an OPTIONS line in a
-configuration file, that would be the {\it rightmost\/} option in the list.
+configuration file, that would be the \textit{rightmost} option in the list.
 %.lp
 \item[wizweight]
 Augment object descriptions with their objects' weight (default off).
@@ -5355,9 +5354,9 @@ can't it will silently ignore it.  You can find out if an
 option is supported by the window port that you are currently
 using by checking to see if it shows up in the Options list.
 Some options are dynamic and can be specified during the game
-with the `{\tt O}' command.
+with the `\texttt{O}' command.
 
-\begin{description}[font=\itshape]
+\begin{description}[font=\mdseries\itshape]
 %.lp
 \item[align\textunderscore message]
  Where to align or place the message window (top, bottom, left, or right)
@@ -5368,57 +5367,57 @@ with the `{\tt O}' command.
 \item[ascii\textunderscore map]
 %.hw DECgraphics IBMgraphics \% don't hyphenate these
 \hyphenation{DECgraphics IBMgraphics}
-If {\it NetHack\/} can, it should display the map using simple
-characters (letters and punctuation) rather than {\it tiles\/} graphics.
+If \textit{NetHack} can, it should display the map using simple
+characters (letters and punctuation) rather than \textit{tiles} graphics.
 In some cases, characters can be augmented with line-drawing symbols;
-use the {\tt symset}
-option to select a symbol set such as {\it DECgraphics\/}
-or {\it IBMgraphics\/} if your display supports them.
-Setting {\tt ascii\textunderscore map} to {\it True\/} forces
-{\tt tiled\textunderscore map} to be {\it False}.
+use the \texttt{symset}
+option to select a symbol set such as \textit{DECgraphics}
+or \textit{IBMgraphics} if your display supports them.
+Setting \texttt{ascii\textunderscore map} to \textit{True} forces
+\texttt{tiled\textunderscore map} to be \textit{False}.
 %.lp
 \item[color]
-If {\it NetHack\/} can, it should display color for different monsters,
+If \textit{NetHack} can, it should display color for different monsters,
 objects, and dungeon features (default on).
 %.lp
 \item[eight\textunderscore bit\textunderscore tty]
-If {\it NetHack\/} can, it should pass eight-bit character values (for example, specified with the
-{\it traps \/} option) straight through to your terminal (default off).
+If \textit{NetHack} can, it should pass eight-bit character values (for example, specified with the
+\textit{traps } option) straight through to your terminal (default off).
 %.lp
 \item[font\textunderscore map]
-If {\it NetHack\/} can, it should use a font by the chosen name for the
+If \textit{NetHack} can, it should use a font by the chosen name for the
 map window.
 %.lp
 \item[font\textunderscore menu]
-If {\it NetHack\/} can, it should use a font by the chosen name for menu
+If \textit{NetHack} can, it should use a font by the chosen name for menu
 windows.
 %.lp
 \item[font\textunderscore message]
-If {\it NetHack\/} can, it should use a font by the chosen name for the message window.
+If \textit{NetHack} can, it should use a font by the chosen name for the message window.
 %.lp
 \item[font\textunderscore status]
-If {\it NetHack\/} can, it should use a font by the chosen name for the status window.
+If \textit{NetHack} can, it should use a font by the chosen name for the status window.
 %.lp
 \item[font\textunderscore text]
-If {\it NetHack\/} can, it should use a font by the chosen name for text windows.
+If \textit{NetHack} can, it should use a font by the chosen name for text windows.
 %.lp
 \item[font\textunderscore size\textunderscore map]
-If {\it NetHack\/} can, it should use this size font for the map window.
+If \textit{NetHack} can, it should use this size font for the map window.
 %.lp
 \item[font\textunderscore size\textunderscore menu]
-If {\it NetHack\/} can, it  should use this size font for menu windows.
+If \textit{NetHack} can, it  should use this size font for menu windows.
 %.lp
 \item[font\textunderscore size\textunderscore message]
-If {\it NetHack\/} can, it should use this size font for the message window.
+If \textit{NetHack} can, it should use this size font for the message window.
 %.lp
 \item[font\textunderscore size\textunderscore status]
-If {\it NetHack\/} can, it should use this size font for the status window.
+If \textit{NetHack} can, it should use this size font for the status window.
 %.lp
 \item[font\textunderscore size\textunderscore text]
-If {\it NetHack\/} can, it should use this size font for text windows.
+If \textit{NetHack} can, it should use this size font for text windows.
 %.lp
 \item[fullscreen]
-If {\it NetHack\/} can, it should try to display on the entire screen rather than in a window.
+If \textit{NetHack} can, it should try to display on the entire screen rather than in a window.
 %.lp
 \item[guicolor]
 Use color text and/or highlighting attributes when displaying some
@@ -5426,77 +5425,77 @@ non-map data (such as menu selector letters).
 Curses interface only; default is on.
 %.lp
 \item[large\textunderscore font]
-If {\it NetHack\/} can, it should use a large font.
+If \textit{NetHack} can, it should use a large font.
 %.lp
 \item[map\textunderscore mode]
-If {\it NetHack\/} can, it should display the map in the manner specified.
+If \textit{NetHack} can, it should display the map in the manner specified.
 %.lp
 \item[player\textunderscore selection]
-If {\it NetHack\/} can, it should pop up dialog boxes or use prompts for character selection.
+If \textit{NetHack} can, it should pop up dialog boxes or use prompts for character selection.
 %.lp
 \item[popup\textunderscore dialog]
-If {\it NetHack\/} can, it should pop up dialog boxes for input.
+If \textit{NetHack} can, it should pop up dialog boxes for input.
 %.lp
 \item[preload\textunderscore tiles]
-If {\it NetHack\/} can, it should preload tiles into memory.
+If \textit{NetHack} can, it should preload tiles into memory.
 For example, in the protected mode MS-DOS version, control whether tiles
 get pre-loaded into RAM at the start of the game.  Doing so
 enhances performance of the tile graphics, but uses more memory. (default on).
-Cannot be set with the `{\tt O}' command.
+Cannot be set with the `\texttt{O}' command.
 %.lp
 \item[scroll\textunderscore amount]
-If {\it NetHack\/} can, it should scroll the display by this number of cells
+If \textit{NetHack} can, it should scroll the display by this number of cells
 when the hero reaches the scroll\textunderscore margin.
 %.lp
 \item[scroll\textunderscore margin]
-If {\it NetHack\/} can, it should scroll the display when the hero or cursor
+If \textit{NetHack} can, it should scroll the display when the hero or cursor
 is this number of cells away from the edge of the window.
 %.lp
 \item[selectsaved]
-If {\it NetHack\/} can, it should display a menu of existing saved games for the player to
+If \textit{NetHack} can, it should display a menu of existing saved games for the player to
 choose from at game startup, if it can. Not all ports support this option.
 %.lp
 \item[softkeyboard]
-If {\it NetHack\/} can, it should display an onscreen keyboard.
+If \textit{NetHack} can, it should display an onscreen keyboard.
 Handhelds are most likely to support this option.
 %.lp
 \item[splash\textunderscore screen]
-If {\it NetHack\/} can, it should display an opening splash screen when
+If \textit{NetHack} can, it should display an opening splash screen when
 it starts up (default yes).
 %.lp
 \item[statuslines]
 Number of lines for traditional below-the-map status display.
-Acceptable values are {\tt 2} and {\tt 3} (default is {\tt 2}).
+Acceptable values are \texttt{2} and \texttt{3} (default is \texttt{2}).
 
 %.lp ""
-When set to {\tt 3}, the {\tt tty} interface moves some fields around and
+When set to \texttt{3}, the \texttt{tty} interface moves some fields around and
 mainly shows status conditions on their own line.
 A display capable of showing at least 25 lines is recommended.
-The value can be toggled back and forth during the game with the `{\tt O}'
+The value can be toggled back and forth during the game with the `\texttt{O}'
 command.
 
 %.lp ""
-The {\tt curses} interface does likewise if the
-{\it align\textunderscore status\/}
-option is set to {\it top\/} or {\it bottom\/} but ignores
-{\it statuslines\/}
-when set to {\it left\/} or {\it right}.
+The \texttt{curses} interface does likewise if the
+\textit{align\textunderscore status}
+option is set to \textit{top} or \textit{bottom} but ignores
+\textit{statuslines}
+when set to \textit{left} or \textit{right}.
 
 %.lp ""
-The {\tt Qt} interface already displays more than 3 lines for status
+The \texttt{Qt} interface already displays more than 3 lines for status
 so uses the
-{\it statuslines\/}
+\textit{statuslines}
 value differently.
-A value of {\tt 3} renders status in the {\tt Qt} interface's
+A value of \texttt{3} renders status in the \texttt{Qt} interface's
 original format, with the status window spread out vertically.
-A value of {\tt 2} makes status be slightly condensed, moving some
+A value of \texttt{2} makes status be slightly condensed, moving some
 fields to different lines to eliminate one whole line, reducing the
 height needed.
-(If NetHack has been built using a version of {\tt Qt}
-older than {\tt qt-5.9},
-{\it statuslines\/}
+(If NetHack has been built using a version of \texttt{Qt}
+older than \texttt{qt-5.9},
+\textit{statuslines}
 can only be set in the run-time configuration file or via NETHACKOPTIONS,
-not during play with the `{\tt O}' command.)
+not during play with the `\texttt{O}' command.)
 %.lp
 \item[term\textunderscore cols \textrm{and}]
 %.lp
@@ -5513,7 +5512,7 @@ Specify the name of an alternative tile file to override the default.
 %.lp ""
 Note: the X11 interface uses X resources rather than NetHack's options
 to select an alternate tile file.
-See {\tt NetHack.ad}, the sample X ``application defaults'' file.
+See \texttt{NetHack.ad}, the sample X ``application defaults'' file.
 %.lp
 \item[tile\textunderscore height]
 Specify the preferred height of each tile in a tile capable port.
@@ -5522,24 +5521,24 @@ Specify the preferred height of each tile in a tile capable port.
 Specify the preferred width of each tile in a tile capable port
 %.lp
 \item[tiled\textunderscore map]
-If {\it NetHack\/} can, it should display the map using {\it tiles} graphics
+If \textit{NetHack} can, it should display the map using \textit{tiles} graphics
 rather than simple characters (letters and punctuation, possibly
 augmented by line-drawing symbols).
-Setting {\tt tiled\textunderscore map} to {\it True\/} forces
-{\tt ascii\textunderscore map} to be {\it False}.
+Setting \texttt{tiled\textunderscore map} to \textit{True} forces
+\texttt{ascii\textunderscore map} to be \textit{False}.
 %.lp
 \item[use\textunderscore darkgray]
 Use bold black instead of blue for black glyphs (TTY only).
 %.lp
 \item[use\textunderscore inverse]
-If {\it NetHack\/} can, it should display inverse when the game specifies it.
+If \textit{NetHack} can, it should display inverse when the game specifies it.
 %.lp
 \item[use\textunderscore menu\textunderscore glyphs]
-If {\it NetHack\/} can, it should display glyphs next to objects in the
+If \textit{NetHack} can, it should display glyphs next to objects in the
 inventory.
 %.lp
 \item[vary\textunderscore msgcount]
-If {\it NetHack\/} can, it should display this number of messages at a time
+If \textit{NetHack} can, it should display this number of messages at a time
 in the message window.
 %.lp
 \item[windowborders]
@@ -5550,21 +5549,21 @@ Acceptable values are
 
 %.sd
 %.si
-{\tt 0} --- off, never show borders\\
-{\tt 1} --- on, always show borders\\
-{\tt 2} --- auto, on display is at least
-(\verb&24+2&)x(\verb&80+2&) [default]\\
-{\tt 3} --- on, except forced off for perm\textunderscore invent\\
-{\tt 4} --- auto, except forced off for perm\textunderscore invent\\
+\texttt{0} --- off, never show borders\\
+\texttt{1} --- on, always show borders\\
+\texttt{2} --- auto, on display is at least
+$(24+2)\times(80+2)$ [default]\\
+\texttt{3} --- on, except forced off for perm\textunderscore invent\\
+\texttt{4} --- auto, except forced off for perm\textunderscore invent\\
 %.ei
 %.ed
 
 %.lp ""
 (The 26x82 size threshold for `2' refers to number of rows and
 columns of the display.
-A width of at least 110 columns (\verb&80+2+26+2&) is needed for
-{\it align\textunderscore status\/}
-set to {\tt left} or {\tt right}.)
+A width of at least 110 columns ($80+2+26+2$) is needed for
+\textit{align\textunderscore status}
+set to \texttt{left} or \texttt{right}.)
 
 %.lp ""
 The persistent inventory window, when enabled, can grow until it is
@@ -5575,32 +5574,32 @@ and status windows but have room for two additional lines of inventory
 plus widen each inventory line by two columns.
 %.lp
 \item[windowcolors]
-If {\it NetHack\/} can, it should display all windows of a particular style
+If \textit{NetHack} can, it should display all windows of a particular style
 with the specified foreground and background colors.
 Windows GUI and curses windowport only.
 The format is\\
-{\tt ~~~~OPTION=windowcolors:}{\it style foreground\/}{\tt /}{\it background}\\
-where {\it style} is one of {\tt menu}, {\tt message}, {\tt status},
-or {\tt text}, and
-{\it foreground} and {\it background} are colors, either numeric (hash
-sign followed by three pairs of hexadecimal digits, {\it \#rrggbb\/}),
-one of the named colors ({\it black}, {\it red}, {\it green}, {\it brown},
-{\it blue}, {\it magenta}, {\it cyan}, {\it orange},
-{\it bright-green}, {\it yellow}, {\it bright-blue}, {\it bright-magenta},
-{\it bright-cyan}, {\it white}, {\it gray}, {\it purple},
-{\it silver}, {\it maroon}, {\it fuchsia}, {\it lime}, {\it olive},
-{\it navy}, {\it teal}, {\it aqua}),
-or (for Windows only) one of Windows UI colors ({\it trueblack},
-{\it activeborder}, {\it activecaption}, {\it appworkspace}, {\it background},
-{\it btnface}, {\it btnshadow}, {\it btntext}, {\it captiontext},
-{\it graytext}, {\it greytext}, {\it highlight},
-{\it highlighttext}, {\it inactiveborder}, {\it inactivecaption}, {\it menu},
-{\it menutext}, {\it scrollbar}, {\it window}, {\it windowframe},
-{\it windowtext}).
+\texttt{~~~~OPTION=windowcolors:}\textit{style foreground}\texttt{/}\textit{background}\\
+where \textit{style} is one of \texttt{menu}, \texttt{message}, \texttt{status},
+or \texttt{text}, and
+\textit{foreground} and \textit{background} are colors, either numeric (hash
+sign followed by three pairs of hexadecimal digits, \textit{\#rrggbb}),
+one of the named colors (\textit{black}, \textit{red}, \textit{green}, \textit{brown},
+\textit{blue}, \textit{magenta}, \textit{cyan}, \textit{orange},
+\textit{bright-green}, \textit{yellow}, \textit{bright-blue}, \textit{bright-magenta},
+\textit{bright-cyan}, \textit{white}, \textit{gray}, \textit{purple},
+\textit{silver}, \textit{maroon}, \textit{fuchsia}, \textit{lime}, \textit{olive},
+\textit{navy}, \textit{teal}, \textit{aqua}),
+or (for Windows only) one of Windows UI colors (\textit{trueblack},
+\textit{activeborder}, \textit{activecaption}, \textit{appworkspace}, \textit{background},
+\textit{btnface}, \textit{btnshadow}, \textit{btntext}, \textit{captiontext},
+\textit{graytext}, \textit{greytext}, \textit{highlight},
+\textit{highlighttext}, \textit{inactiveborder}, \textit{inactivecaption}, \textit{menu},
+\textit{menutext}, \textit{scrollbar}, \textit{window}, \textit{windowframe},
+\textit{windowtext}).
 
 %.lp
 \item[wraptext]
-If {\it NetHack\/} can, it should wrap long lines of text if they don't fit
+If \textit{NetHack} can, it should wrap long lines of text if they don't fit
 in the visible area of the window.
 \end{description}
 
@@ -5613,9 +5612,9 @@ computer unless you manually click submit on a form.
 %.si
 \begin{description}
 %.lp
-\item[OPTION=crash\textunderscore email:{\it email\textunderscore address}]
+\item[OPTION=crash\textunderscore email:\textit{email\textunderscore address}]
 %.lp
-\item[OPTION=crash\textunderscore name:{\it your\textunderscore name}]
+\item[OPTION=crash\textunderscore name:\textit{your\textunderscore name}]
 %.ei
 \end{description}
 These options are used only to save you some typing on the crash
@@ -5623,7 +5622,7 @@ report and \#bugreport forms.
 %.si
 \begin{description}
 %.lp
-\item[OPTION=crash\textunderscore urlmax:{\it bytes}]
+\item[OPTION=crash\textunderscore urlmax:\textit{bytes}]
 %.ei
 \end{description}
 This option is used to limit the length of the URLs generated and is only
@@ -5636,11 +5635,11 @@ needed if your browser cannot handle arbitrarily long URLs.
 Here are explanations of options that are used by specific platforms
 or ports to customize and change the port behavior.
 
-\begin{description}[font=\itshape]
+\begin{description}[font=\mdseries\itshape]
 %.lp
 \item[altkeyhandling]
-Select an alternate way to handle keystrokes ({\it Win32 tty\/ NetHack\/} only).
-The name of the handling type is one of {\it default}, {\it ray}, {\it 340}
+Select an alternate way to handle keystrokes (\textit{Win32 tty NetHack} only).
+The name of the handling type is one of \textit{default}, \textit{ray}, \textit{340}
 %.\" \item[altmeta]
 %.\" On Amiga, this option controls whether typing ``Alt'' plus another key
 %.\" functions as a meta-shift for that key (default on).
@@ -5648,16 +5647,16 @@ The name of the handling type is one of {\it default}, {\it ray}, {\it 340}
 \item[altmeta]
 %.\" On other (non-Amiga) systems where this option is available, it can be
 On systems where this option is available, it can be
-set to tell {\it NetHack\/} to convert a two character sequence beginning with
+set to tell \textit{NetHack} to convert a two character sequence beginning with
 ESC into a meta-shifted version of the second character (default off).
 
 %.lp ""
 This conversion is only done for commands, not for other input prompts.
 Note that typing one or more digits as a count prefix prior to a
-command---preceded by {\tt n} if the {\it number\textunderscore pad\/}
+command---preceded by \texttt{n} if the \textit{number\textunderscore pad}
 option is set---is
 also subject to this conversion, so attempting to
-abort the count by typing ESC will leave {\it NetHack\/} waiting for another
+abort the count by typing ESC will leave \textit{NetHack} waiting for another
 character to complete the two character sequence.
 Type a second ESC to finish cancelling such a count.
 At other prompts a single ESC suffices.
@@ -5665,37 +5664,37 @@ At other prompts a single ESC suffices.
 \item[BIOS]
 Use BIOS calls to update the screen display quickly and to read the keyboard
 (allowing the use of arrow keys to move) on machines with an IBM PC
-compatible BIOS ROM (default off, {\it OS/2, PC\/ {\rm and} ST NetHack\/} only).
+compatible BIOS ROM (default off, \textit{OS/2, PC {\rm and} ST NetHack} only).
 %.lp
 \item[rawio]
 Force raw (non-cbreak) mode for faster output and more
-bulletproof input (MS-DOS sometimes treats `{\tt \^{}P}' as a printer toggle
-without it) (default off, {\it OS/2, PC\/ {\rm and} ST NetHack\/} only).
+bulletproof input (MS-DOS sometimes treats `\texttt{\textasciicircum P}' as a printer toggle
+without it) (default off, \textit{OS/2, PC {\rm and} ST NetHack} only).
 Note:  DEC Rainbows hang if this is turned on.
-Cannot be set with the `{\tt O}' command.
+Cannot be set with the `\texttt{O}' command.
 %.lp
 \item[subkeyvalue]
-({\it Win32 tty NetHack \/} only).
+(\textit{Win32 tty NetHack } only).
 May be used to alter the value of keystrokes that the operating system
-returns to {\it NetHack\/} to help compensate for international keyboard
+returns to \textit{NetHack} to help compensate for international keyboard
 issues.
 OPTIONS=subkeyvalue:171/92
-will return 92 to {\it NetHack\/}, if 171 was originally going to be returned.
+will return 92 to \textit{NetHack}, if 171 was originally going to be returned.
 You can use multiple subkeyvalue assignments in the configuration file
 if needed.
-Cannot be set with the `{\tt O}' command.
+Cannot be set with the `\texttt{O}' command.
 %.lp
 \item[video]
-Set the video mode used ({\it PC\/ NetHack\/} only).
-Values are {\it autodetect\/}, {\it default\/}, {\it vga\/}, or {\it vesa\/}.
-Setting {\it vesa\/} will cause the game to display tiles, using the full
+Set the video mode used (\textit{PC NetHack} only).
+Values are \textit{autodetect}, \textit{default}, \textit{vga}, or \textit{vesa}.
+Setting \textit{vesa} will cause the game to display tiles, using the full
 capability of the VGA hardware.
-Setting {\it vga\/} will cause the game to display tiles, fixed at 640x480
+Setting \textit{vga} will cause the game to display tiles, fixed at 640x480
 in 16 colors, a mode that is compatible with all VGA hardware. Third party
 tilesets will probably not work.
-Setting {\it autodetect\/} attempts {\it vesa\/}, then {\it vga\/}, and
-finally sets {\it default\/} if neither of those modes works.
-Cannot be set with the `{\tt O}' command.
+Setting \textit{autodetect} attempts \textit{vesa}, then \textit{vga}, and
+finally sets \textit{default} if neither of those modes works.
+Cannot be set with the `\texttt{O}' command.
 %.lp
 \item[video\textunderscore height]
 Set the VGA mode resolution height (MS-DOS only, with video:vesa)
@@ -5706,19 +5705,19 @@ Set the VGA mode resolution width (MS-DOS only, with video:vesa)
 \item[videocolors]
 \begin{sloppypar}
 Set the color palette for PC systems using NO\textunderscore TERMS
-(default 4-2-6-1-5-3-15-12-10-14-9-13-11, {\it PC\/ NetHack\/} only).
+(default 4-2-6-1-5-3-15-12-10-14-9-13-11, \textit{PC NetHack} only).
 The order of colors is red, green, brown, blue, magenta, cyan,
 bright.white, bright.red, bright.green, yellow, bright.blue,
 bright.magenta, and bright.cyan.
-Cannot be set with the `{\tt O}' command.
+Cannot be set with the `\texttt{O}' command.
 \end{sloppypar}
 %.lp
 \item[videoshades]
 Set the intensity level of the three gray scales available
-(default dark normal light, {\it PC\/ NetHack\/} only).
+(default dark normal light, \textit{PC NetHack} only).
 If the game display is difficult to read, try adjusting these scales;
-if this does not correct the problem, try {\tt !color}.
-Cannot be set with the `{\tt O}' command.
+if this does not correct the problem, try \texttt{!color}.
+Cannot be set with the `\texttt{O}' command.
 \end{description}
 
 %.hn 2
@@ -5726,10 +5725,10 @@ Cannot be set with the `{\tt O}' command.
 
 %.pg
 Regular expressions are normally POSIX extended regular expressions. It is
-possible to compile {\it NetHack\/} without regular expression support on
+possible to compile \textit{NetHack} without regular expression support on
 a platform where
 there is no regular expression library. While this is not true of any modern
-platform, if your {\it NetHack\/} was built this way, patterns are instead glob
+platform, if your \textit{NetHack} was built this way, patterns are instead glob
 patterns; regardless, this document refers to both as ``regular expressions.''
 This applies to Autopickup exceptions, Message types, Menu colors,
 and User sounds.
@@ -5738,19 +5737,19 @@ and User sounds.
 \subsection*{Configuring Autopickup Exceptions}
 
 %.pg
-You can further refine the behavior of the ``{\tt autopickup}'' option
-beyond what is available through the ``{\tt pickup\textunderscore types}'' option.
+You can further refine the behavior of the ``\texttt{autopickup}'' option
+beyond what is available through the ``\texttt{pickup\textunderscore types}'' option.
 
 %.pg
-By placing ``{\tt autopickup\textunderscore exception}'' lines in your configuration
+By placing ``\texttt{autopickup\textunderscore exception}'' lines in your configuration
 file, you can define patterns to be checked when the game is about to
 autopickup something.
 
 \begin{description}
 %.lp
 \item[autopickup\textunderscore exception]
-Sets an exception to the ``{\it pickup\textunderscore types}'' option.
-The {\it autopickup\textunderscore exception\/} option should be followed by a regular
+Sets an exception to the ``\textit{pickup\textunderscore types}'' option.
+The \textit{autopickup\textunderscore exception} option should be followed by a regular
 expression to be used as a pattern to match against the singular form of the
 description of an object at your location.
 
@@ -5759,20 +5758,20 @@ character in the pattern, specifically:
 
 %.sd
 %.si
-{\tt <} --- always pickup an object that matches rest of pattern;\\
-{\tt >} --- never pickup an object that matches rest of pattern.
+\texttt{<} --- always pickup an object that matches rest of pattern;\\
+\texttt{>} --- never pickup an object that matches rest of pattern.
 %.ei
 %.ed
 
-The {\it autopickup\textunderscore exception\/} rules are processed in the order
+The \textit{autopickup\textunderscore exception} rules are processed in the order
 in which they appear in your configuration file, thus allowing a
 later rule to override an earlier rule.
 
 %.lp ""
-Exceptions can be set with the `{\tt O}' command, but because they are not
+Exceptions can be set with the `\texttt{O}' command, but because they are not
 included in your configuration file, they won't be in effect if you save
 and then restore your game.
-{\it autopickup\textunderscore exception\/} rules are not saved with the game.
+\textit{autopickup\textunderscore exception} rules are not saved with the game.
 \end{description}
 
 %.lp "Here are some examples:"
@@ -5798,8 +5797,8 @@ autopickup.
 It is possible to change the default key bindings of some special commands,
 menu accelerator keys, extended commands, by using BIND stanzas in the
 configuration file. Format is key, followed by the command to bind to,
-separated by a colon. The key can be a single character (``{\tt x}''),
-a control key (``{\tt \^{}X}'', ``{\tt C-x}''), a meta key (``{\tt M-x}''),
+separated by a colon. The key can be a single character (``\texttt{x}''),
+a control key (``\texttt{\textasciicircum X}'', ``\texttt{C-x}''), a meta key (``\texttt{M-x}''),
 a mouse button, or a three-digit decimal ASCII code.
 
 %.pg
@@ -5811,12 +5810,12 @@ For example:
     BIND=v:loot
 \end{verbatim}
 
-\begin{description}[font=\ttfamily]
+\begin{description}[font=\mdseries\ttfamily]
 %.lp "Extended command keys"
 \item[Extended command keys]
 You can bind multiple keys to the same extended command. Unbind a key by
-using ``{\tt nothing}'' as the extended command to bind to. You can also bind
-the ``{\tt <esc>}'', ``{\tt <enter>}'', and ``{\tt <space>}'' keys.
+using ``\texttt{nothing}'' as the extended command to bind to. You can also bind
+the ``\texttt{<esc>}'', ``\texttt{<enter>}'', and ``\texttt{<space>}'' keys.
 
 %.lp "Menu accelerator keys"
 \item[Menu accelerator keys]
@@ -5827,8 +5826,8 @@ Some interfaces only support some of the menu accelerators.
 
 %.lp "Mouse buttons"
 \item[Mouse buttons]
-You can bind ``mouse1'' or ``mouse2'' to ``{\tt nothing}'',
-``{\tt therecmdmenu}'', ``{\tt clicklook}'', or ``{\tt mouseaction}''.
+You can bind ``mouse1'' or ``mouse2'' to ``\texttt{nothing}'',
+``\texttt{therecmdmenu}'', ``\texttt{clicklook}'', or ``\texttt{mouseaction}''.
 
 %.lp "Special command keys"
 \item[Special command keys]
@@ -5843,127 +5842,127 @@ can only be bound to a single key.
 %.lp
 \item[count]
 Prefix key to start a count, to repeat a command this many times.
-With {\it number\textunderscore pad\/} only. Default is~`{\tt n}'.
+With \textit{number\textunderscore pad} only. Default is~`\texttt{n}'.
 %.lp
 \item[getdir.help]
-When asked for a direction, the key to show the help. Default is~`{\tt ?}'.
+When asked for a direction, the key to show the help. Default is~`\texttt{?}'.
 %.lp
 \item[getdir.mouse]
 When asked for a direction, the key to initiate a simulated mouse click.
 You will be asked to pick a location.
 Use movement keystrokes to move the cursor around the map, then type
-the getpos.pick.once key (default `{\tt ,}')
-or the getpos.pick key (default `{\tt .}')
+the getpos.pick.once key (default `\texttt{,}')
+or the getpos.pick key (default `\texttt{.}')
 to finish as if performing a left or right click.
-Only useful when using the {\tt \#therecmdmenu} command.
-Default is~`{\tt \textunderscore }'.
+Only useful when using the \texttt{\#therecmdmenu} command.
+Default is~`\texttt{\textunderscore}'.
 %.lp
 \item[getdir.self]
-When asked for a direction, the key to target yourself. Default is~`{\tt .}'.
+When asked for a direction, the key to target yourself. Default is~`\texttt{.}'.
 %.lp
 \item[getdir.self2]
 When asked for a direction, an alternate key to target yourself.
-Default is~`{\tt s}'.
+Default is~`\texttt{s}'.
 %.lp
 \item[getpos.autodescribe]
-When asked for a location, the key to toggle {\it autodescribe\/}.
-Default is~`{\tt \#}'.
+When asked for a location, the key to toggle \textit{autodescribe}.
+Default is~`\texttt{\#}'.
 %.lp
 \item[getpos.all.next]
 When asked for a location, the key to go to next closest interesting thing.
-Default is~`{\tt a}'.
+Default is~`\texttt{a}'.
 %.lp
 \item[getpos.all.prev]
 When asked for a location, the key to go to previous closest interesting thing.
-Default is~`{\tt A}'.
+Default is~`\texttt{A}'.
 %.lp
 \item[getpos.door.next]
 When asked for a location, the key to go to next closest door or doorway.
-Default is~`{\tt d}'.
+Default is~`\texttt{d}'.
 %.lp
 \item[getpos.door.prev]
 When asked for a location, the key to go to previous closest door or doorway.
-Default is~`{\tt D}'.
+Default is~`\texttt{D}'.
 %.lp
 \item[getpos.help]
-When asked for a location, the key to show help. Default is~`{\tt ?}'.
+When asked for a location, the key to show help. Default is~`\texttt{?}'.
 %.lp
 \item[getpos.mon.next]
 When asked for a location, the key to go to next closest monster.
-Default is~`{\tt m}'.
+Default is~`\texttt{m}'.
 %.lp
 \item[getpos.mon.prev]
 When asked for a location, the key to go to previous closest monster.
-Default is~`{\tt M}'.
+Default is~`\texttt{M}'.
 %.lp
 \item[getpos.obj.next]
 When asked for a location, the key to go to next closest object.
-Default is~`{\tt o}'.
+Default is~`\texttt{o}'.
 %.lp
 \item[getpos.obj.prev]
 When asked for a location, the key to go to previous closest object.
-Default is~`{\tt O}'.
+Default is~`\texttt{O}'.
 %.lp
 \item[getpos.menu]
 When asked for a location, and using one of the next or previous keys to
-cycle through targets, toggle showing a menu instead. Default is~`{\tt !}'.
+cycle through targets, toggle showing a menu instead. Default is~`\texttt{!}'.
 %.lp
 \item[getpos.moveskip]
 When asked for a location, and using the shifted movement keys or
 meta-digit keys to fast-move around, move by skipping the same glyphs
 instead of by 8 units.
-Default is~`{\tt *}'.
+Default is~`\texttt{*}'.
 %.lp
 \item[getpos.filter]
 When asked for a location, change the filtering mode when using one of
 the next or previous keys to cycle through targets. Toggles between no
-filtering, in view only, and in the same area only. Default is~`{\tt "}'.
+filtering, in view only, and in the same area only. Default is~`\texttt{"}'.
 %.lp
 \item[getpos.pick]
 When asked for a location, the key to choose the location, and possibly
 ask for more info.
 When simulating a mouse click after being asked for a direction (see
 getdir.mouse above), the key to use to respond as right click.
-Default is~`{\tt .}'.
+Default is~`\texttt{.}'.
 %.lp
 \item[getpos.pick.once]
 When asked for a location, the key to choose the location, and skip
 asking for more info.
 When simulating a mouse click after being asked for a direction,
 the key to respond as left click.
-Default is~`{\tt ,}'.
+Default is~`\texttt{,}'.
 %.lp
 \item[getpos.pick.quick]
 When asked for a location, the key to choose the location, skip asking
-for more info, and exit the location asking loop. Default is~`{\tt ;}'.
+for more info, and exit the location asking loop. Default is~`\texttt{;}'.
 %.lp
 \item[getpos.pick.verbose]
 When asked for a location, the key to choose the location, and show more
-info without asking. Default is~`{\tt :}'.
+info without asking. Default is~`\texttt{:}'.
 %.lp
 \item[getpos.self]
 When asked for a location, the key to go to your location.
-Default is~`{\tt @}'.
+Default is~`\texttt{@}'.
 %.lp
 \item[getpos.unexplored.next]
 When asked for a location, the key to go to next closest unexplored location.
-Default is~`{\tt x}'.
+Default is~`\texttt{x}'.
 %.lp
 \item[getpos.unexplored.prev]
 When asked for a location, the key to go to previous closest unexplored
-location. Default is~`{\tt X}'.
+location. Default is~`\texttt{X}'.
 %.lp
 \item[getpos.valid]
 When asked for a location, the key to go to show valid target locations.
-Default is~`{\tt \$}'.
+Default is~`\texttt{\$}'.
 %.lp
 \item[getpos.valid.next]
 When asked for a location, the key to go to next closest valid location.
-Default is~`{\tt z}'.
+Default is~`\texttt{z}'.
 %.lp
 \item[getpos.valid.prev]
 When asked for a location, the key to go to previous closest valid location.
-Default is~`{\tt Z}'.
+Default is~`\texttt{Z}'.
 \end{description}
 
 
@@ -5980,17 +5979,17 @@ look like this:
 \begin{verbatim}
     MSGTYPE=type "pattern"
 \end{verbatim}
-\begin{description}[font=\itshape]
+\begin{description}[font=\mdseries\itshape]
 %.lp
 \item[type]
 how the message should be shown:
 %.sd
 %.si
 \\
-{\tt show}  --- show message normally.\\
-{\tt hide}  --- never show the message.\\
-{\tt stop}  --- wait for user with more-prompt.\\
-{\tt norep} --- show the message once, but not again if no other message is
+\texttt{show}  --- show message normally.\\
+\texttt{hide}  --- never show the message.\\
+\texttt{stop}  --- wait for user with more-prompt.\\
+\texttt{norep} --- show the message once, but not again if no other message is
 shown in between.
 %.ei
 %.ed
@@ -6000,7 +5999,7 @@ the pattern to match. The pattern should be a regular expression.
 \end{description}
 
 %.lp ""
-Here's an example of message types using {\it NetHack's\/} internal
+Here's an example of message types using \textit{NetHack's} internal
 pattern matching facility:
 
 \begin{verbatim}
@@ -6010,7 +6009,7 @@ pattern matching facility:
 
 specifies that whenever a message ``You feel hungry'' is shown,
 the user is prompted with more-prompt, and a message matching
-``You displaced  \verb+<+something\verb+>+'' is not shown at all.
+``You displaced  <something>'' is not shown at all.
 
 %.lp
 The order of the defined MSGTYPE lines is important; the last matching
@@ -6035,7 +6034,7 @@ look like this:
     MENUCOLOR="pattern"=color&attribute
 \end{verbatim}
 
-\begin{description}[font=\itshape]
+\begin{description}[font=\mdseries\itshape]
 %.lp
 \item[pattern]
 the pattern to match;
@@ -6053,22 +6052,22 @@ If no attribute is defined, no attribute is used.
 The pattern should be a regular expression.
 
 %.lp ""
-Allowed colors are {\it black}, {\it red}, {\it green}, {\it brown},
-{\it blue}, {\it magenta}, {\it cyan}, {\it gray}, {\it orange},
-{\it light-green}, {\it yellow}, {\it light-blue}, {\it light-magenta},
-{\it light-cyan}, and {\it white}.
-And {\it no-color}, the default foreground color, which isn't necessarily
+Allowed colors are \textit{black}, \textit{red}, \textit{green}, \textit{brown},
+\textit{blue}, \textit{magenta}, \textit{cyan}, \textit{gray}, \textit{orange},
+\textit{light-green}, \textit{yellow}, \textit{light-blue}, \textit{light-magenta},
+\textit{light-cyan}, and \textit{white}.
+And \textit{no-color}, the default foreground color, which isn't necessarily
 the same as any of the other colors.
 
 %.lp ""
-Allowed attributes are {\it none}, {\it bold}, {\it dim}, {\it italic},
-{\it underline},{\it blink}, and {\it inverse}.
-{\it Normal\/} is a synonym for {\it none}.
+Allowed attributes are \textit{none}, \textit{bold}, \textit{dim}, \textit{italic},
+\textit{underline},\textit{blink}, and \textit{inverse}.
+\textit{Normal} is a synonym for \textit{none}.
 Note that the platform used may interpret the attributes any way it
 wants.
 
 %.lp ""
-Here's an example of menu colors using {\it NetHack's\/} internal
+Here's an example of menu colors using \textit{NetHack's} internal
 pattern matching facility:
 
 \begin{verbatim}
@@ -6088,7 +6087,7 @@ a menu line will be used for the line.
 %.pg
 Note that if you intend to have one or more color specifications match
 ``~uncursed~'', you will probably want to turn the
-{\it implicit\textunderscore uncursed\/}
+\textit{implicit\textunderscore uncursed}
 option off so that all items known to be uncursed are actually
 displayed with the ``uncursed'' description.
 
@@ -6106,7 +6105,7 @@ use of user sounds.
 The following configuration file entries are relevant to mapping user sounds
 to messages:
 
-\begin{description}[font=\itshape]
+\begin{description}[font=\mdseries\itshape]
 %.lp
 \item[SOUNDDIR]
 The directory that houses the sound files to be played.
@@ -6117,12 +6116,12 @@ Each SOUND entry is broken down into the following parts:
 
 %.sd
 %.si
-{\tt MESG       } --- message window mapping (the only one supported in 3.7.0);\\
-{\tt msgtype    } --- optional; message type to use, see ``Configuring User Sounds''\\
-{\tt pattern    } --- the pattern to match;\\
-{\tt sound file } --- the sound file to play;\\
-{\tt volume     } --- the volume to be set while playing the sound file;\\
-{\tt sound index} --- optional; the index corresponding to a sound file.
+\texttt{MESG} --- message window mapping (the only one supported in 3.7.0);\\
+\texttt{msgtype} --- optional; message type to use, see ``Configuring User Sounds''\\
+\texttt{pattern} --- the pattern to match;\\
+\texttt{sound file} --- the sound file to play;\\
+\texttt{volume} --- the volume to be set while playing the sound file;\\
+\texttt{sound index} --- optional; the index corresponding to a sound file.
 %.ei
 %.ed
 \end{description}
@@ -6144,8 +6143,8 @@ For example:
 \subsection*{Configuring Status Hilites}
 
 %.pg
-Your copy of {\it NetHack\/} may have been compiled with support
-for {\it Status Hilites}.
+Your copy of \textit{NetHack} may have been compiled with support
+for \textit{Status Hilites}.
 If so, you can customize your game display by setting thresholds to
 change the color or appearance of fields in the status display.
 
@@ -6160,8 +6159,8 @@ drop to or below a threshold of 30%:\\
 \begin{verbatim}
 OPTION=hilite_status:hitpoints/<=30%/red/normal
 \end{verbatim}
-(That example is actually specifying {\tt red\&normal} for  {\tt <=30\%}
-and {\tt no-color\&normal} for {\tt >30\%}.)\\
+(That example is actually specifying \texttt{red\& normal} for  \texttt{<=30\%}
+and \texttt{no-color\& normal} for \texttt{>30\%}.)\\
 
 For another example, the following line in your configuration file will cause
 wisdom to be displayed red if it drops and green if it rises:\\
@@ -6171,7 +6170,7 @@ OPTION=hilite_status:wisdom/down/red/up/green
 
 Allowed colors are black, red, green, brown, blue, magenta, cyan, gray,
 orange, light-green, yellow, light-blue, light-magenta, light-cyan, and white.
-And {\it no-color}, the default foreground color on the display, which
+And \textit{no-color}, the default foreground color on the display, which
 is not necessarily the same as black or white or any of the other colors.
 
 Allowed attributes are none, bold, dim, underline, italic, blink, and inverse.
@@ -6182,7 +6181,7 @@ To specify both a color and an attribute, use `\&' to combine them.
 To specify multiple attributes, use `+' to combine those.
 
 %.lp ""
-For example: {\tt magenta\&inverse+dim}.
+For example: \texttt{magenta\& inverse+dim}.
 
 Note that the display may substitute or ignore particular attributes
 depending upon its capabilities, and in general may interpret the
@@ -6192,7 +6191,7 @@ blink or vice versa.
 On others, issuing an attribute request while another is already
 set up will replace the earlier attribute rather than combine with it.
 Since nethack issues attribute requests sequentially (at least with
-the {\it tty} interface) rather than all at once, the only way a
+the \textit{tty} interface) rather than all at once, the only way a
 situation like that can be controlled is to specify just one attribute.
 
 You can adjust the display of the following status fields:
@@ -6221,9 +6220,9 @@ depending upon your other option settings.
 
 %.lp ""
 Instead of a behavior, `condition' takes the following condition flags:
-{\it stone}, {\it slime}, {\it strngl}, {\it foodpois}, {\it termill},
-{\it blind}, {\it deaf}, {\it stun}, {\it conf}, {\it hallu},
-{\it lev}, {\it fly}, and {\it ride}.
+\textit{stone}, \textit{slime}, \textit{strngl}, \textit{foodpois}, \textit{termill},
+\textit{blind}, \textit{deaf}, \textit{stun}, \textit{conf}, \textit{hallu},
+\textit{lev}, \textit{fly}, and \textit{ride}.
 You can use `major\textunderscore troubles' as an alias
 for stone through termill, `minor\textunderscore troubles' for blind through hallu,
 `movement' for lev, fly, and ride, and `all' for every condition.
@@ -6231,41 +6230,41 @@ for stone through termill, `minor\textunderscore troubles' for blind through hal
 %.lp ""
 Allowed behaviors are ``always'', ``up'', ``down'', ``changed'', a
 percentage or absolute number threshold, or text to match against.
-For the {\it hitpoints\/} field, the additional behavior ``criticalhp''
+For the \textit{hitpoints} field, the additional behavior ``criticalhp''
 is available.
 It overrides other behavior rules if
-hit points are at or below the {\it major problem\/} threshold
+hit points are at or below the \textit{major problem} threshold
 (which varies depending upon maximum hit points and experience level).
 
-\begin{description}
+\begin{description}[font=\mdseries\ttfamily]
 %.lp "*"
-\item[{\tt always}] will set the default attributes for that field.
+\item[always] will set the default attributes for that field.
 %.lp "*"
-\item[{\tt up}{\normalfont, }{\tt down}] set the field attributes
+\item[up \textrm{\textmd{,}} down] set the field attributes
 for when the field value changes upwards or downwards. This attribute
-times out after {\tt statushilites} turns.
+times out after \texttt{statushilites} turns.
 %.lp "*"
-\item[{\tt changed}] sets the field attribute for when the field value
-changes. This attribute times out after {\tt statushilites} turns.
+\item[changed] sets the field attribute for when the field value
+changes. This attribute times out after \texttt{statushilites} turns.
 (If a field has both a ``changed'' rule and an ``up'' or ``down''
 rule which matches a change in the field's value,
 the ``up'' or ``down'' one takes precedence.)
 %.lp "*"
-\item[{\tt percentage}] sets the field attribute when the field value
+\item[percentage] sets the field attribute when the field value
 matches the percentage.
-It is specified as a number between 0 and 100, followed by `{\tt \%}'
+It is specified as a number between 0 and 100, followed by `\texttt{\%}'
 (percent sign).
-If the percentage is prefixed with `{\tt <=}' or `{\tt >=}',
+If the percentage is prefixed with `\texttt{<=}' or `\texttt{>=}',
 it also matches when value is below or above the percentage.
-Use prefix `{\tt <}' or `{\tt >}' to match when strictly below or above.
-(The numeric limit is relaxed slightly for those: {\tt >-1\%}
-and {\tt <101\%} are allowed.)
+Use prefix `\texttt{<}' or `\texttt{>}' to match when strictly below or above.
+(The numeric limit is relaxed slightly for those: \texttt{>-1\%}
+and \texttt{<101\%} are allowed.)
 Only four fields support percentage rules.
-Percentages for ``{\it hitpoints\/}'' and ``{\it power\/}'' are
+Percentages for ``\textit{hitpoints}'' and ``\textit{power}'' are
 straightforward; they're based on the corresponding maximum field.
-Percentage highlight rules are also allowed for ``{\it experience level\/}''
-and ``{\it experience points\/}'' (valid when the
-{\it showexp\/}
+Percentage highlight rules are also allowed for ``\textit{experience level}''
+and ``\textit{experience points}'' (valid when the
+\textit{showexp}
 option is enabled).
 For those, the percentage is based on the progress from the start of
 the current experience level to the start of the next level.
@@ -6273,32 +6272,32 @@ So if level 2 starts at 20 points and level 3 starts at 40 points,
 having 30 points is 50\% and 35 points is 75\%.
 100\% is unattainable for experience because you'll gain a level and
 the calculations will be reset for that new level, but a rule for
-{\tt =100\%} is allowed and matches the special case of being
+\texttt{=100\%} is allowed and matches the special case of being
 exactly 1 experience point short of the next level.
 % (If you manage to reach level 30, there is no next level and the
 % percentage will remain at 0\% no matter have many additional experience
 % points you earn.)
 %.lp "*"
-\item[{\tt absolute}] value sets the attribute when the field value
+\item[absolute] value sets the attribute when the field value
 matches that number.
-The number must be 0 or higher, except for ``{\it armor-class\/} which
-allows negative values, and may optionally be preceded by `{\tt =}'.
-If the number is preceded by `{\tt <=}' or `{\tt >=}' instead,
+The number must be 0 or higher, except for ``\textit{armor-class} which
+allows negative values, and may optionally be preceded by `\texttt{=}'.
+If the number is preceded by `\texttt{<=}' or `\texttt{>=}' instead,
 it also matches when value is below or above.
-If the prefix is `{\tt <}' or `{\tt >}', only match when strictly
+If the prefix is `\texttt{<}' or `\texttt{>}', only match when strictly
 above or below.
 %.lp "*"
-\item[{\tt criticalhp}] only applies to the hitpoints field and only
+\item[criticalhp] only applies to the hitpoints field and only
 when current hit points are below a threshold (which varies by maximum
 hit points and experience level).
 When the threshold is met, a criticalhp rule takes precedence over all
 other hitpoints rules.
 %.lp "*"
-\item[{\tt text}] match sets the attribute when the field value
+\item[text] match sets the attribute when the field value
 matches the text.
-Text matches can only be used for ``{\it alignment\/}'',
-``{\it carrying-capacity\/}'', ``{\it hunger\/}'', ``{\it dungeon-level\/}'',
-and ``{\it title\/}''.
+Text matches can only be used for ``\textit{alignment}'',
+``\textit{carrying-capacity}'', ``\textit{hunger}'', ``\textit{dungeon-level}'',
+and ``\textit{title}''.
 For title, only the role's rank title
 is tested; the character's name is ignored.
 %.ei
@@ -6307,7 +6306,7 @@ is tested; the character's name is ignored.
 The in-game options menu can help you determine the correct syntax for a
 configuration file.
 
-The whole feature can be disable by setting option {\it statushilites} to 0.
+The whole feature can be disable by setting option \textit{statushilites} to 0.
 
 Example hilites:
 \begin{verbatim}
@@ -6325,20 +6324,20 @@ Example hilites:
 
 %.lp
 %.hn 2
-\subsection*{Modifying {\it NetHack\/} Symbols}
+\subsection*{Modifying \textit{NetHack} Symbols}
 
 %.pg
-{\it NetHack\/} can load entire symbol sets from the symbol file.
+\textit{NetHack} can load entire symbol sets from the symbol file.
 
 %.pg
 The options that are used to select a particular symbol set from the
 symbol file are:
 
-\begin{description}[font=\itshape]
+\begin{description}[font=\mdseries\itshape]
 %.lp
 \item[symset]
 Set the name of the symbol set that you want to load.
-{\it symbols\/}.
+\textit{symbols}.
 
 %.lp
 \item[roguesymset]
@@ -6346,212 +6345,210 @@ Set the name of the symbol set that you want to load for display
 on the rogue level.
 \end{description}
 
-You can also override one or more symbols using the {\it SYMBOLS\/} and
-{\it ROGUESYMBOLS\/} configuration file options.
-Symbols are specified as {\it name:value\/} pairs.
-Note that {\it NetHack\/} escape-processes
-the {\it value\/} string in conventional C fashion.
-This means that `\verb+\+' is a prefix to take the following character
+You can also override one or more symbols using the \textit{SYMBOLS} and
+\textit{ROGUESYMBOLS} configuration file options.
+Symbols are specified as \textit{name:value} pairs.
+Note that \textit{NetHack} escape-processes
+the \textit{value} string in conventional C fashion.
+This means that `\texttt{\textbackslash}' is a prefix to take the following character
 literally.
-Thus `\verb+\+' needs to be represented as `\verb+\\+'.
+Thus `\texttt{\textbackslash}' needs to be represented as `\texttt{\textbackslash\textbackslash}'.
 The special prefix
-`\verb+\m+' switches on the meta bit in the symbol value, and the
-`{\tt \^{}}' prefix causes the following character to be treated as a control
+`\texttt{\textbackslash m}' switches on the meta bit in the symbol value, and the
+`\texttt{\textasciicircum}' prefix causes the following character to be treated as a control
 character.
 
-{
 \small
 \begin{longtable}{lll}
 \caption[]{NetHack Symbols}\\
 Default                      & Symbol Name                & Description\\
 \hline \hline
 \endhead
-\verb@ @ & S\textunderscore air                     &	(air)\\
+\space @ & S\textunderscore air                     &	(air)\\
 \textunderscore  & S\textunderscore altar                   &	(altar)\\
-\verb@"@ & S\textunderscore amulet                  &	(amulet)\\
-\verb@A@ & S\textunderscore angel                   &	(angelic being)\\
-\verb@a@ & S\textunderscore ant                     &	(ant or other insect)\\
-\verb@^@ & S\textunderscore anti\textunderscore magic\textunderscore trap       &	(anti-magic field)\\
-\verb@[@ & S\textunderscore armor                   &	(suit or piece of armor)\\
-\verb@[@ & S\textunderscore armour                  &	(suit or piece of armor)\\
-\verb@^@ & S\textunderscore arrow\textunderscore trap             &	(arrow trap)\\
-\verb@0@ & S\textunderscore ball                    &	(iron ball)\\
+" & S\textunderscore amulet                  &	(amulet)\\
+A & S\textunderscore angel                   &	(angelic being)\\
+a & S\textunderscore ant                     &	(ant or other insect)\\
+\textasciicircum & S\textunderscore anti\textunderscore magic\textunderscore trap       &	(anti-magic field)\\
+{[} & S\textunderscore armor                   &	(suit or piece of armor)\\
+{[} & S\textunderscore armour                  &	(suit or piece of armor)\\
+\textasciicircum & S\textunderscore arrow\textunderscore trap             &	(arrow trap)\\
+0 & S\textunderscore ball                    &	(iron ball)\\
 \# & S\textunderscore bars                    &	(iron bars)\\
-\verb@B@ & S\textunderscore bat                     &	(bat or bird)\\
-\verb@^@ & S\textunderscore bear\textunderscore trap              &	(bear trap)\\
-\verb@-@ & S\textunderscore blcorn                  &	(bottom left corner)\\
-\verb@b@ & S\textunderscore blob                    &	(blob)\\
-\verb@+@ & S\textunderscore book                    &	(spellbook)\\
-\verb@)@ & S\textunderscore boomleft                &	(boomerang open left)\\
-\verb@(@ & S\textunderscore boomright               &	(boomerang open right)\\
-\verb@`@ & S\textunderscore boulder                 &	(boulder)\\
-\verb@-@ & S\textunderscore brcorn                  &	(bottom right corner)\\
-\verb@>@ & S\textunderscore brdnladder              &	(branch ladder down)\\
-\verb@>@ & S\textunderscore brdnstair               &	(branch staircase down)\\
-\verb@<@ & S\textunderscore brupladder              &	(branch ladder up)\\
-\verb@<@ & S\textunderscore brupstair               &	(branch staircase up)\\
-\verb@C@ & S\textunderscore centaur                 &	(centaur)\\
-\verb@_@ & S\textunderscore chain                   &	(iron chain)\\
+B & S\textunderscore bat                     &	(bat or bird)\\
+\textasciicircum & S\textunderscore bear\textunderscore trap              &	(bear trap)\\
+- & S\textunderscore blcorn                  &	(bottom left corner)\\
+b & S\textunderscore blob                    &	(blob)\\
++ & S\textunderscore book                    &	(spellbook)\\
+) & S\textunderscore boomleft                &	(boomerang open left)\\
+( & S\textunderscore boomright               &	(boomerang open right)\\
+\textasciigrave & S\textunderscore boulder                 &	(boulder)\\
+- & S\textunderscore brcorn                  &	(bottom right corner)\\
+> & S\textunderscore brdnladder              &	(branch ladder down)\\
+> & S\textunderscore brdnstair               &	(branch staircase down)\\
+< & S\textunderscore brupladder              &	(branch ladder up)\\
+< & S\textunderscore brupstair               &	(branch staircase up)\\
+C & S\textunderscore centaur                 &	(centaur)\\
+\textunderscore & S\textunderscore chain                   &	(iron chain)\\
 \# & S\textunderscore cloud                   &	(cloud)\\
-\verb@c@ & S\textunderscore cockatrice              &	(cockatrice)\\
-\$ & S\textunderscore coin                    &	(pile of coins)\\
+c & S\textunderscore cockatrice              &	(cockatrice)\\
+\textdollar & S\textunderscore coin                    &	(pile of coins)\\
 \# & S\textunderscore corr                    &	(corridor)\\
-\verb@-@ & S\textunderscore crwall                  &	(wall)\\
-\verb@-@ & S\textunderscore darkroom                &	(dark room)\\
-\verb@^@ & S\textunderscore dart\textunderscore trap              &	(dart trap)\\
-\verb@&@ & S\textunderscore demon                   &	(major demon)\\
-\verb@*@ & S\textunderscore digbeam                 &	(dig beam)\\
-\verb@>@ & S\textunderscore dnladder                &	(ladder down)\\
-\verb@>@ & S\textunderscore dnstair                 &	(staircase down)\\
-\verb@d@ & S\textunderscore dog                     &	(dog or other canine)\\
-\verb@D@ & S\textunderscore dragon                  &	(dragon)\\
-\verb@;@ & S\textunderscore eel                     &	(sea monster)\\
-\verb@E@ & S\textunderscore elemental               &	(elemental)\\
+- & S\textunderscore crwall                  &	(wall)\\
+- & S\textunderscore darkroom                &	(dark room)\\
+\textasciicircum & S\textunderscore dart\textunderscore trap              &	(dart trap)\\
+\& & S\textunderscore demon                   &	(major demon)\\
+* & S\textunderscore digbeam                 &	(dig beam)\\
+> & S\textunderscore dnladder                &	(ladder down)\\
+> & S\textunderscore dnstair                 &	(staircase down)\\
+d & S\textunderscore dog                     &	(dog or other canine)\\
+D & S\textunderscore dragon                  &	(dragon)\\
+; & S\textunderscore eel                     &	(sea monster)\\
+E & S\textunderscore elemental               &	(elemental)\\
 \# & S\textunderscore engrcorr                      &	(engraving in a corridor)\\
-\verb@`@ & S\textunderscore engroom                 &	(engraving in a room)\\
-\verb@/@ & S\textunderscore expl\textunderscore tl          &	(explosion top left)\\
-\verb@-@ & S\textunderscore expl\textunderscore tc          &	(explosion top center)\\
-\verb@\@ & S\textunderscore expl\textunderscore tr          &	(explosion top right)\\
-\verb@|@ & S\textunderscore expl\textunderscore ml          &	(explosion middle left)\\
-\verb@ @ & S\textunderscore expl\textunderscore mc          &	(explosion middle center)\\
-\verb@|@ & S\textunderscore expl\textunderscore mr          &	(explosion middle right)\\
-\verb@\@ & S\textunderscore expl\textunderscore bl          &	(explosion bottom left)\\
-\verb@-@ & S\textunderscore expl\textunderscore bc          &	(explosion bottom center)\\
-\verb@/@ & S\textunderscore expl\textunderscore br          &	(explosion bottom right)\\
-\verb@e@ & S\textunderscore eye                     &	(eye or sphere)\\
-\verb@^@ & S\textunderscore falling\textunderscore rock\textunderscore trap     &	(falling rock trap)\\
-\verb@f@ & S\textunderscore feline                  &	(cat or other feline)\\
-\verb@^@ & S\textunderscore fire\textunderscore trap              &	(fire trap)\\
-\verb@!@ & S\textunderscore flashbeam               &	(flash beam)\\
+\textasciigrave & S\textunderscore engroom                 &	(engraving in a room)\\
+/ & S\textunderscore expl\textunderscore tl          &	(explosion top left)\\
+- & S\textunderscore expl\textunderscore tc          &	(explosion top center)\\
+\textbackslash & S\textunderscore expl\textunderscore tr          &	(explosion top right)\\
+| & S\textunderscore expl\textunderscore ml          &	(explosion middle left)\\
+~ & S\textunderscore expl\textunderscore mc          &	(explosion middle center)\\
+| & S\textunderscore expl\textunderscore mr          &	(explosion middle right)\\
+\textbackslash & S\textunderscore expl\textunderscore bl          &	(explosion bottom left)\\
+- & S\textunderscore expl\textunderscore bc          &	(explosion bottom center)\\
+/ & S\textunderscore expl\textunderscore br          &	(explosion bottom right)\\
+e & S\textunderscore eye                     &	(eye or sphere)\\
+\textasciicircum & S\textunderscore falling\textunderscore rock\textunderscore trap     &	(falling rock trap)\\
+f & S\textunderscore feline                  &	(cat or other feline)\\
+\textasciicircum & S\textunderscore fire\textunderscore trap              &	(fire trap)\\
+! & S\textunderscore flashbeam               &	(flash beam)\\
 \% & S\textunderscore food                    &	(piece of food)\\
-\{ & S\textunderscore fountain                &	(fountain)\\
-\verb@F@ & S\textunderscore fungus                  &	(fungus or mold)\\
-\verb@*@ & S\textunderscore gem                     &	(gem or rock)\\
-\verb@ @ & S\textunderscore ghost                   &	(ghost)\\
-\verb@H@ & S\textunderscore giant                   &	(giant humanoid)\\
-\verb@G@ & S\textunderscore gnome                   &	(gnome)\\
-\verb@'@ & S\textunderscore golem                   &	(golem)\\
-\verb@|@ & S\textunderscore grave                   &	(grave)\\
-\verb@g@ & S\textunderscore gremlin                 &	(gremlin)\\
-\verb@-@ & S\textunderscore hbeam                   &	(wall)\\
+\textbraceleft & S\textunderscore fountain                &	(fountain)\\
+F & S\textunderscore fungus                  &	(fungus or mold)\\
+* & S\textunderscore gem                     &	(gem or rock)\\
+~ & S\textunderscore ghost                   &	(ghost)\\
+H & S\textunderscore giant                   &	(giant humanoid)\\
+G & S\textunderscore gnome                   &	(gnome)\\
+\textquotesingle & S\textunderscore golem                   &	(golem)\\
+| & S\textunderscore grave                   &	(grave)\\
+g & S\textunderscore gremlin                 &	(gremlin)\\
+- & S\textunderscore hbeam                   &	(wall)\\
 \# & S\textunderscore hcdbridge               &	(horizontal raised drawbridge)\\
-\verb@+@ & S\textunderscore hcdoor                  &	(closed door)\\
-\verb@.@ & S\textunderscore hodbridge               &	(horizontal lowered drawbridge)\\
-\verb@|@ & S\textunderscore hodoor                  &	(open door)\\
-\verb\^\ & S\textunderscore hole                    &	(hole)\\
-\verb~@~ & S\textunderscore human                   &	(human or elf)\\
-\verb@h@ & S\textunderscore humanoid                &	(humanoid)\\
-\verb@-@ & S\textunderscore hwall                   &	(horizontal wall)\\
-\verb@.@ & S\textunderscore ice                     &	(ice)\\
-\verb@i@ & S\textunderscore imp                     &	(imp or minor demon)\\
-\verb@I@ & S\textunderscore invisible               &	(invisible monster)\\
-\verb@J@ & S\textunderscore jabberwock              &	(jabberwock)\\
-\verb@j@ & S\textunderscore jelly                   &	(jelly)\\
-\verb@k@ & S\textunderscore kobold                  &	(kobold)\\
-\verb@K@ & S\textunderscore kop                     &	(Keystone Kop)\\
-\verb@^@ & S\textunderscore land\textunderscore mine              &	(land mine)\\
-\verb@}@ & S\textunderscore lava                    &	(molten lava)\\
-\verb@}@ & S\textunderscore lavawall                &	(wall of lava)\\
-\verb@l@ & S\textunderscore leprechaun              &	(leprechaun)\\
-\verb@^@ & S\textunderscore level\textunderscore teleporter       &	(level teleporter)\\
-\verb@L@ & S\textunderscore lich                    &	(lich)\\
-\verb@y@ & S\textunderscore light                   &	(light)\\
++ & S\textunderscore hcdoor                  &	(closed door)\\
+. & S\textunderscore hodbridge               &	(horizontal lowered drawbridge)\\
+| & S\textunderscore hodoor                  &	(open door)\\
+\textasciicircum & S\textunderscore hole                    &	(hole)\\
+@ & S\textunderscore human                   &	(human or elf)\\
+h & S\textunderscore humanoid                &	(humanoid)\\
+- & S\textunderscore hwall                   &	(horizontal wall)\\
+. & S\textunderscore ice                     &	(ice)\\
+i & S\textunderscore imp                     &	(imp or minor demon)\\
+I & S\textunderscore invisible               &	(invisible monster)\\
+J & S\textunderscore jabberwock              &	(jabberwock)\\
+j & S\textunderscore jelly                   &	(jelly)\\
+k & S\textunderscore kobold                  &	(kobold)\\
+K & S\textunderscore kop                     &	(Keystone Kop)\\
+\textasciicircum & S\textunderscore land\textunderscore mine              &	(land mine)\\
+\textbraceright & S\textunderscore lava                    &	(molten lava)\\
+\textbraceright & S\textunderscore lavawall                &	(wall of lava)\\
+1 & S\textunderscore leprechaun              &	(leprechaun)\\
+\textasciicircum & S\textunderscore level\textunderscore teleporter       &	(level teleporter)\\
+L & S\textunderscore lich                    &	(lich)\\
+y & S\textunderscore light                   &	(light)\\
 \# & S\textunderscore litcorr                 &	(lit corridor)\\
-\verb@:@ & S\textunderscore lizard                  &	(lizard)\\
-\verb@\@ & S\textunderscore lslant                  &	(wall)\\
-\verb@^@ & S\textunderscore magic\textunderscore portal           &	(magic portal)\\
-\verb@^@ & S\textunderscore magic\textunderscore trap             &	(magic trap)\\
-\verb@m@ & S\textunderscore mimic                   &	(mimic)\\
-\verb@]@ & S\textunderscore mimic\textunderscore def              &	(mimic)\\
-\verb@M@ & S\textunderscore mummy                   &	(mummy)\\
-\verb@N@ & S\textunderscore naga                    &	(naga)\\
-\verb@.@ & S\textunderscore ndoor                   &	(doorway)\\
-\verb@n@ & S\textunderscore nymph                   &	(nymph)\\
-\verb@O@ & S\textunderscore ogre                    &	(ogre)\\
-\verb@o@ & S\textunderscore orc                     &	(orc)\\
-\verb@p@ & S\textunderscore piercer                 &	(piercer)\\
-\verb@^@ & S\textunderscore pit                     &	(pit)\\
+: & S\textunderscore lizard                  &	(lizard)\\
+\textbackslash & S\textunderscore lslant                  &	(wall)\\
+\textasciicircum & S\textunderscore magic\textunderscore portal           &	(magic portal)\\
+\textasciicircum & S\textunderscore magic\textunderscore trap             &	(magic trap)\\
+m & S\textunderscore mimic                   &	(mimic)\\
+{]} & S\textunderscore mimic\textunderscore def              &	(mimic)\\
+M & S\textunderscore mummy                   &	(mummy)\\
+N & S\textunderscore naga                    &	(naga)\\
+. & S\textunderscore ndoor                   &	(doorway)\\
+n & S\textunderscore nymph                   &	(nymph)\\
+O & S\textunderscore ogre                    &	(ogre)\\
+o & S\textunderscore orc                     &	(orc)\\
+p & S\textunderscore piercer                 &	(piercer)\\
+\textasciicircum & S\textunderscore pit                     &	(pit)\\
 \# & S\textunderscore poisoncloud             &	(poison cloud)\\
-\verb@^@ & S\textunderscore polymorph\textunderscore trap         &	(polymorph trap)\\
-\verb@}@ & S\textunderscore pool                    &	(water)\\
-\verb@!@ & S\textunderscore potion                  &	(potion)\\
-\verb@P@ & S\textunderscore pudding                 &	(pudding or ooze)\\
-\verb@q@ & S\textunderscore quadruped               &	(quadruped)\\
-\verb@Q@ & S\textunderscore quantmech               &	(quantum mechanic)\\
-\verb@=@ & S\textunderscore ring                    &	(ring)\\
-\verb@`@ & S\textunderscore rock                    &	(boulder or statue)\\
-\verb@r@ & S\textunderscore rodent                  &	(rodent)\\
-\verb@^@ & S\textunderscore rolling\textunderscore boulder\textunderscore trap  &	(rolling boulder trap)\\
-\verb@.@ & S\textunderscore room                    &	(floor of a room)\\
-\verb@/@ & S\textunderscore rslant                  &	(wall)\\
-\verb@^@ & S\textunderscore rust\textunderscore trap              &	(rust trap)\\
-\verb@R@ & S\textunderscore rustmonst               &	(rust monster or disenchanter)\\
-\verb@?@ & S\textunderscore scroll                  &	(scroll)\\
+\textasciicircum & S\textunderscore polymorph\textunderscore trap         &	(polymorph trap)\\
+\textbraceright & S\textunderscore pool                    &	(water)\\
+! & S\textunderscore potion                  &	(potion)\\
+P & S\textunderscore pudding                 &	(pudding or ooze)\\
+q & S\textunderscore quadruped               &	(quadruped)\\
+Q & S\textunderscore quantmech               &	(quantum mechanic)\\
+= & S\textunderscore ring                    &	(ring)\\
+\textasciigrave & S\textunderscore rock                    &	(boulder or statue)\\
+r & S\textunderscore rodent                  &	(rodent)\\
+\textasciicircum & S\textunderscore rolling\textunderscore boulder\textunderscore trap  &	(rolling boulder trap)\\
+. & S\textunderscore room                    &	(floor of a room)\\
+/ & S\textunderscore rslant                  &	(wall)\\
+\textasciicircum & S\textunderscore rust\textunderscore trap              &	(rust trap)\\
+R & S\textunderscore rustmonst               &	(rust monster or disenchanter)\\
+? & S\textunderscore scroll                  &	(scroll)\\
 \# & S\textunderscore sink                    &	(sink)\\
-\verb@^@ & S\textunderscore sleeping\textunderscore gas\textunderscore trap     &	(sleeping gas trap)\\
-\verb@S@ & S\textunderscore snake                   &	(snake)\\
-\verb@s@ & S\textunderscore spider                  &	(arachnid or centipede)\\
-\verb@^@ & S\textunderscore spiked\textunderscore pit             &	(spiked pit)\\
-\verb@^@ & S\textunderscore squeaky\textunderscore board          &	(squeaky board)\\
-\verb@0@ & S\textunderscore ss1                     &	(magic shield 1 of 4)\\
+\textasciicircum & S\textunderscore sleeping\textunderscore gas\textunderscore trap     &	(sleeping gas trap)\\
+S & S\textunderscore snake                   &	(snake)\\
+s & S\textunderscore spider                  &	(arachnid or centipede)\\
+\textasciicircum & S\textunderscore spiked\textunderscore pit             &	(spiked pit)\\
+\textasciicircum & S\textunderscore squeaky\textunderscore board          &	(squeaky board)\\
+0 & S\textunderscore ss1                     &	(magic shield 1 of 4)\\
 \# & S\textunderscore ss2                     &	(magic shield 2 of 4)\\
-\verb+@+ & S\textunderscore ss3                     &	(magic shield 3 of 4)\\
-\verb@*@ & S\textunderscore ss4                     &	(magic shield 4 of 4)\\
-\verb@^@ & S\textunderscore statue\textunderscore trap            &	(statue trap)\\
-\verb@ @ & S\textunderscore stone                   &	(solid rock)\\
-\verb@]@ & S\textunderscore strange\textunderscore obj      &	(strange object)\\
-\verb@-@ & S\textunderscore sw\textunderscore bc                  &	(swallow bottom center)\\
-\verb@\@ & S\textunderscore sw\textunderscore bl                  &	(swallow bottom left)\\
-\verb@/@ & S\textunderscore sw\textunderscore br                  &	(swallow bottom right	)\\
-\verb@|@ & S\textunderscore sw\textunderscore ml                  &	(swallow middle left)\\
-\verb@|@ & S\textunderscore sw\textunderscore mr                  &	(swallow middle right)\\
-\verb@-@ & S\textunderscore sw\textunderscore tc                  &	(swallow top center)\\
-\verb@/@ & S\textunderscore sw\textunderscore tl                  &	(swallow top left)\\
-\verb@\@ & S\textunderscore sw\textunderscore tr                  &	(swallow top right)\\
-\verb@-@ & S\textunderscore tdwall                  &	(wall)\\
-\verb@^@ & S\textunderscore teleportation\textunderscore trap     &	(teleportation trap)\\
-\verb@\@ & S\textunderscore throne                  &	(opulent throne)\\
-\verb@-@ & S\textunderscore tlcorn                  &	(top left corner)\\
-\verb@|@ & S\textunderscore tlwall                  &	(wall)\\
-\verb@(@ & S\textunderscore tool                    &	(useful item (pick-axe, key, lamp...))\\
-\verb@^@ & S\textunderscore trap\textunderscore door              &	(trap door)\\
-\verb@t@ & S\textunderscore trapper                 &	(trapper or lurker above)\\
-\verb@-@ & S\textunderscore trcorn                  &	(top right corner)\\
+@ & S\textunderscore ss3                     &	(magic shield 3 of 4)\\
+* & S\textunderscore ss4                     &	(magic shield 4 of 4)\\
+\textasciicircum & S\textunderscore statue\textunderscore trap            &	(statue trap)\\
+~ & S\textunderscore stone                   &	(solid rock)\\
+{]} & S\textunderscore strange\textunderscore obj      &	(strange object)\\
+- & S\textunderscore sw\textunderscore bc                  &	(swallow bottom center)\\
+\textbackslash & S\textunderscore sw\textunderscore bl                  &	(swallow bottom left)\\
+/ & S\textunderscore sw\textunderscore br                  &	(swallow bottom right	)\\
+| & S\textunderscore sw\textunderscore ml                  &	(swallow middle left)\\
+| & S\textunderscore sw\textunderscore mr                  &	(swallow middle right)\\
+- & S\textunderscore sw\textunderscore tc                  &	(swallow top center)\\
+/ & S\textunderscore sw\textunderscore tl                  &	(swallow top left)\\
+\textbackslash & S\textunderscore sw\textunderscore tr                  &	(swallow top right)\\
+- & S\textunderscore tdwall                  &	(wall)\\
+\textasciicircum & S\textunderscore teleportation\textunderscore trap     &	(teleportation trap)\\
+\textbackslash & S\textunderscore throne                  &	(opulent throne)\\
+- & S\textunderscore tlcorn                  &	(top left corner)\\
+| & S\textunderscore tlwall                  &	(wall)\\
+( & S\textunderscore tool                    &	(useful item (pick-axe, key, lamp...))\\
+\textasciicircum & S\textunderscore trap\textunderscore door              &	(trap door)\\
+t & S\textunderscore trapper                 &	(trapper or lurker above)\\
+- & S\textunderscore trcorn                  &	(top right corner)\\
 \# & S\textunderscore tree                    &	(tree)\\
-\verb@T@ & S\textunderscore troll                   &	(troll)\\
-\verb@|@ & S\textunderscore trwall                  &	(wall)\\
-\verb@-@ & S\textunderscore tuwall                  &	(wall)\\
-\verb@U@ & S\textunderscore umber                   &	(umber hulk)\\
-\verb@ @ & S\textunderscore unexplored              &	(unexplored terrain)\\
-\verb@u@ & S\textunderscore unicorn                 &	(unicorn or horse)\\
-\verb@<@ & S\textunderscore upladder                &	(ladder up)\\
-\verb@<@ & S\textunderscore upstair                 &	(staircase up)\\
-\verb@V@ & S\textunderscore vampire                 &	(vampire)\\
-\verb@|@ & S\textunderscore vbeam                   &	(wall)\\
+T & S\textunderscore troll                   &	(troll)\\
+| & S\textunderscore trwall                  &	(wall)\\
+- & S\textunderscore tuwall                  &	(wall)\\
+U & S\textunderscore umber                   &	(umber hulk)\\
+~ & S\textunderscore unexplored              &	(unexplored terrain)\\
+u & S\textunderscore unicorn                 &	(unicorn or horse)\\
+< & S\textunderscore upladder                &	(ladder up)\\
+< & S\textunderscore upstair                 &	(staircase up)\\
+V & S\textunderscore vampire                 &	(vampire)\\
+| & S\textunderscore vbeam                   &	(wall)\\
 \# & S\textunderscore vcdbridge               &	(vertical raised drawbridge)\\
-\verb@+@ & S\textunderscore vcdoor                  &	(closed door)\\
-\verb@.@ & S\textunderscore venom                   &	(splash of venom)\\
-\verb@^@ & S\textunderscore vibrating\textunderscore square       &	(vibrating square)\\
-\verb@.@ & S\textunderscore vodbridge               &	(vertical lowered drawbridge)\\
-\verb@-@ & S\textunderscore vodoor                  &	(open door)\\
-\verb@v@ & S\textunderscore vortex                  &	(vortex)\\
-\verb@|@ & S\textunderscore vwall                   &	(vertical wall)\\
-\verb@/@ & S\textunderscore wand                    &	(wand)\\
-\verb@}@ & S\textunderscore water                   &	(water)\\
-\verb@)@ & S\textunderscore weapon                  &	(weapon)\\
-\verb@"@ & S\textunderscore web                     &	(web)\\
-\verb@w@ & S\textunderscore worm                    &	(worm)\\
-\verb@~@ & S\textunderscore worm\textunderscore tail              &	(long worm tail)\\
-\verb@W@ & S\textunderscore wraith                  &	(wraith)\\
-\verb@x@ & S\textunderscore xan                     &	(xan or other extraordinary insect)\\
-\verb@X@ & S\textunderscore xorn                    &	(xorn)\\
-\verb@Y@ & S\textunderscore yeti                    &	(apelike creature)\\
-\verb@Z@ & S\textunderscore zombie                  &	(zombie)\\
-\verb@z@ & S\textunderscore zruty                   &	(zruty)\\
-\verb@ @ & S\textunderscore pet\textunderscore override     &	(any pet if ACCESSIBILITY=1 is set)\\
-\verb@ @ & S\textunderscore hero\textunderscore override    &	(hero if ACCESSIBILITY=1 is set)
-\end{longtable}%
-}
++ & S\textunderscore vcdoor                  &	(closed door)\\
+. & S\textunderscore venom                   &	(splash of venom)\\
+\textasciicircum & S\textunderscore vibrating\textunderscore square       &	(vibrating square)\\
+. & S\textunderscore vodbridge               &	(vertical lowered drawbridge)\\
+- & S\textunderscore vodoor                  &	(open door)\\
+v & S\textunderscore vortex                  &	(vortex)\\
+| & S\textunderscore vwall                   &	(vertical wall)\\
+/ & S\textunderscore wand                    &	(wand)\\
+\textbraceright & S\textunderscore water                   &	(water)\\
+\textbraceright & S\textunderscore weapon                  &	(weapon)\\
+" & S\textunderscore web                     &	(web)\\
+w & S\textunderscore worm                    &	(worm)\\
+\textasciitilde & S\textunderscore worm\textunderscore tail              &	(long worm tail)\\
+W & S\textunderscore wraith                  &	(wraith)\\
+x & S\textunderscore xan                     &	(xan or other extraordinary insect)\\
+X & S\textunderscore xorn                    &	(xorn)\\
+Y & S\textunderscore yeti                    &	(apelike creature)\\
+Z & S\textunderscore zombie                  &	(zombie)\\
+z & S\textunderscore zruty                   &	(zruty)\\
+~ & S\textunderscore pet\textunderscore override     &	(any pet if ACCESSIBILITY=1 is set)\\
+~ @ & S\textunderscore hero\textunderscore override    &	(hero if ACCESSIBILITY=1 is set)
+\end{longtable}
 
 \hyphenation{sysconf}	%no syllable breaks => don't hyphenate file name
 %.lp
@@ -6612,11 +6609,11 @@ display of the customizations, such as the Enhanced symset.
 
 %.pg
 %.hn 2
-\subsection*{Configuring {\it NetHack\/} for Play by the Blind}
+\subsection*{Configuring \textit{NetHack} for Play by the Blind}
 
 %.pg
-{\it NetHack\/} can be set up to use only standard ASCII characters for making
-maps of the dungeons. This makes even the MS-DOS versions of {\it NetHack}
+\textit{NetHack} can be set up to use only standard ASCII characters for making
+maps of the dungeons. This makes even the MS-DOS versions of \textit{NetHack}
 (which use special line-drawing characters by default) completely
 accessible to the blind who use speech and/or Braille access technologies.
 Players will require a good working knowledge of their screen-reader's
@@ -6632,22 +6629,22 @@ gives you the row and column of your review cursor and the PC cursor.
 These co-ordinates are often useful in giving players a better sense of the
 overall location of items on the screen.
 %.pg
-{\it NetHack\/} can also be compiled with support for sending the game
+\textit{NetHack} can also be compiled with support for sending the game
 messages to an external program, such as a text-to-speech synthesizer. If
-the ``{\tt \#version}'' extended command shows ``external program as a
-message handler'', your {\it NetHack\/}
-has been compiled with the capability. When compiling {\it NetHack\/}
+the ``\texttt{\#version}'' extended command shows ``external program as a
+message handler'', your \textit{NetHack}
+has been compiled with the capability. When compiling \textit{NetHack}
 from source
-on Linux and other POSIX systems, define {\tt MSGHANDLER\/} to enable it.
+on Linux and other POSIX systems, define \texttt{MSGHANDLER} to enable it.
 To use
-the capability, set the environment variable {\tt NETHACK\textunderscore MSGHANDLER\/} to
+the capability, set the environment variable \texttt{NETHACK\textunderscore MSGHANDLER} to
 an executable, which will be executed with the game message as the program's
 only parameter.
 %.pg
 
 The most crucial settings to make the game more accessible are:
 %.pg
-\begin{description}[font=\itshape]
+\begin{description}[font=\mdseries\itshape]
 %.lp
 \item[symset:plain]
 Load a symbol set appropriate for use by blind players.
@@ -6701,7 +6698,7 @@ of moving 8 units at a time.
 \item[nostatus\textunderscore updates]
 Prevent updates to the status lines at the bottom of the screen, if
 your screen-reader reads those lines. The same information can be
-seen via the {\tt \#attributes} command.
+seen via the \texttt{\#attributes} command.
 %.lp
 \item[showdamage]
 Give a message of damage taken and how many hit points are left.
@@ -6711,18 +6708,18 @@ Give a message of damage taken and how many hit points are left.
 \subsection*{Global Configuration for System Administrators}
 
 %.pg
-If {\it NetHack\/} is compiled with the SYSCF option, a system administrator
+If \textit{NetHack} is compiled with the SYSCF option, a system administrator
 should set up a global configuration; this is a file in the
 same format as the traditional per-user configuration file (see above).
 
 This file should be named sysconf and placed in the same directory as
-the other {\it NetHack\/} support files.
+the other \textit{NetHack} support files.
 The options recognized in this file are listed below. Any option not
 set uses a compiled-in default (which may not be appropriate for your
 system).
 
 %.pg
-\begin{description}[font=\itshape]
+\begin{description}[font=\mdseries\itshape]
 %.lp
 \item[WIZARDS]
 A space-separated list of user name who are allowed to
@@ -6731,7 +6728,7 @@ A value of a single
 asterisk (*) allows anyone to start a game in debug mode.
 %.lp
 \item[SHELLERS]
-A list of users who are allowed to use the shell escape command (`{\tt !}').
+A list of users who are allowed to use the shell escape command (`\texttt{!}').
 The syntax is the same as WIZARDS.
 %.lp
 \item[EXPLORERS]
@@ -6768,7 +6765,7 @@ user who is restoring is the same one who saved).
 
 %.pg
 The following four options affect the score file:
-\begin{description}[font=\itshape]
+\begin{description}[font=\mdseries\itshape]
 %.pg
 %.lp
 \item[PERSMAX]
@@ -6808,20 +6805,20 @@ Not defining this will prevent dumplog from being created.
 Only available if your game is compiled with DUMPLOG.
 Allows the following placeholders:
 % FIXME: this should be changed to a nested list or else be forcibly indented
-{\tt \%\%}  --- literal `{\tt \%}'\\
-{\tt \%v}  --- version (eg. ``{\tt 3.7.0-0}'')\\
-{\tt \%u}  --- game UID\\
-{\tt \%t}  --- game start time, UNIX timestamp format\\
-{\tt \%T}  --- current time, UNIX timestamp format\\
-{\tt \%d}  --- game start time, YYYYMMDDhhmmss format\\
-{\tt \%D}  --- current time, YYYYMMDDhhmmss format\\
-{\tt \%n}  --- player name\\
-{\tt \%N}  --- first character of player name
+\texttt{\%\%}  --- literal `\texttt{\%}'\\
+\texttt{\%v}  --- version (eg. ``\texttt{3.7.0-0}'')\\
+\texttt{\%u}  --- game UID\\
+\texttt{\%t}  --- game start time, UNIX timestamp format\\
+\texttt{\%T}  --- current time, UNIX timestamp format\\
+\texttt{\%d}  --- game start time, YYYYMMDDhhmmss format\\
+\texttt{\%D}  --- current time, YYYYMMDDhhmmss format\\
+\texttt{\%n}  --- player name\\
+\texttt{\%N}  --- first character of player name
 %.lp
 \item[LIVELOG]
 A bit-mask of types of events that should be written to
-the {\it livelog\/} file if one is present.
-The sample {\it sysconf\/} file accompanying the program contains a
+the \textit{livelog} file if one is present.
+The sample \textit{sysconf} file accompanying the program contains a
 comment which lists the meaning of the various bits used.
 Intended for server systems supporting simultaneous play by multiple
 players (to be clear, each one running a separate single player game),
@@ -6833,7 +6830,7 @@ large unless it is actively maintained.
 %.lp
 \item[CRASHREPORTURL]
 If set to
-{\tt https://www.nethack.org/links/cr-37BETA.html}
+\url{https://www.nethack.org/links/cr-37BETA.html}
 and support is compiled in, brings up a browser window populated with
 the information needed to report a problem if the game panics or ends
 up in an internally inconsistent state, or if the \#bugreport command is
@@ -6844,13 +6841,13 @@ invoked.
 \section{Scoring}
 
 %.pg
-{\it NetHack\/} maintains a list of the top scores or scorers on your machine,
+\textit{NetHack} maintains a list of the top scores or scorers on your machine,
 depending on how it is set up.  In the latter case, each account on
 the machine can post only one non-winning score on this list.  If
 you score higher than someone else on this list, or better your
 previous score, you will be inserted in the proper place under your
 current name.  How many scores are kept can also be set up when
-{\it NetHack\/} is compiled.
+\textit{NetHack} is compiled.
 
 %.pg
 Your score is chiefly based upon how much experience you gained, how
@@ -6875,7 +6872,7 @@ on most versions.
 \section{Explore mode}
 
 %.pg
-{\it NetHack\/} is an intricate and difficult game.  Novices might falter
+\textit{NetHack} is an intricate and difficult game.  Novices might falter
 in fear, aware of their ignorance of the means to survive.  Well, fear
 not.  Your dungeon comes equipped with an ``explore'' or ``discovery''
 mode that enables you to keep old save files and cheat death, at the
@@ -6883,10 +6880,10 @@ paltry cost of not getting on the high score list.
 
 %.pg
 There are two ways of enabling explore mode.  One is to start the game
-with the {\tt -X}
+with the \texttt{-X}
 command-line switch or with the
-{\it playmode:explore\/}
-option.  The other is to issue the `{\tt \#exploremode}' extended command while
+\textit{playmode:explore}
+option.  The other is to issue the `\texttt{\#exploremode}' extended command while
 already playing the game.  Starting a new game in explore mode provides your
 character with a wand of wishing in initial inventory; switching
 during play does not.  The other benefits of explore mode are left for
@@ -6905,16 +6902,16 @@ program rather than to provide god-like powers to your character, and
 players who attempt debugging are expected to figure out how to use it
 themselves.
 It is initiated by starting the game with the
-{\tt -D}
+\texttt{-D}
 command-line switch or with the
-{\it playmode:debug\/}
+\textit{playmode:debug}
 option.
 
 %.pg
 For some systems, the player must be logged in
 under a particular user name to be allowed to use debug mode; for others,
 the hero must be given a particular character name (but may be any role;
-there's no connection between ``wizard mode'' and the {\it Wizard\/} role).
+there's no connection between ``wizard mode'' and the \textit{Wizard} role).
 Attempting to start a game in debug mode when not allowed
 or not available will result in falling back to explore mode instead.
 
@@ -6922,85 +6919,85 @@ or not available will result in falling back to explore mode instead.
 \section{Credits}
 %.pg
 The original %
-{\it hack\/} game was modeled on the Berkeley
+\textit{hack} game was modeled on the Berkeley
 %.ux
 UNIX
-{\it rogue\/} game.  Large portions of this document were shamelessly
+\textit{rogue} game.  Large portions of this document were shamelessly
 cribbed from %
-{\it A Guide to the Dungeons of Doom}, by Michael C. Toy
+\textit{A Guide to the Dungeons of Doom}, by Michael C. Toy
 and Kenneth C. R. C. Arnold.  Small portions were adapted from
-{\it Further Exploration of the Dungeons of Doom}, by Ken Arromdee.
+\textit{Further Exploration of the Dungeons of Doom}, by Ken Arromdee.
 
 %.pg
-{\it NetHack\/} is the product of literally scores of people's work.
+\textit{NetHack} is the product of literally scores of people's work.
 Main events in the course of the game development are described below:
 
 %.pg
 \bigskip
-\noindent {\it Jay Fenlason\/} wrote the original {\it Hack}, with help from {\it
-Kenny Woodland}, {\it Mike Thome}, and {\it Jon Payne}.
+\noindent \textit{Jay Fenlason} wrote the original \textit{Hack}, with help from {\it
+Kenny Woodland}, \textit{Mike Thome}, and \textit{Jon Payne}.
 
 %.pg
 \medskip
-\noindent {\it Andries Brouwer\/} did a major re-write while at
+\noindent \textit{Andries Brouwer} did a major re-write while at
 Stichting Mathematisch Centrum (now Centrum Wiskunde \& Informatica),
 transforming Hack into a very different game.
 He published the Hack source code for use on UNIX
 systems by posting that to Usenet
-newsgroup {\it net.sources\/} (later renamed {\it comp.sources})
+newsgroup \textit{net.sources} (later renamed \textit{comp.sources})
 releasing version 1.0 in December of 1984, then versions 1.0.1, 1.0.2,
 and finally 1.0.3 in July of 1985.
-Usenet newsgroup {\it net.games.hack\/} (later
-renamed {\it rec.games.hack}, eventually replaced
-by {\it rec.games.roguelike.nethack})
+Usenet newsgroup \textit{net.games.hack} (later
+renamed \textit{rec.games.hack}, eventually replaced
+by \textit{rec.games.roguelike.nethack})
 was created for discussing it.
 
 %.pg
 \medskip
-\noindent {\it Don G. Kneller\/} ported {\it Hack\/} 1.0.3 to Microsoft C and MS-DOS,
-producing {\it PC Hack\/} 1.01e, added support for DEC Rainbow graphics in
+\noindent \textit{Don G. Kneller} ported \textit{Hack} 1.0.3 to Microsoft C and MS-DOS,
+producing \textit{PC Hack} 1.01e, added support for DEC Rainbow graphics in
 version 1.03g, and went on to produce at least four more versions (3.0, 3.2,
 3.51, and 3.6;
-note that these are old {\it Hack\/} version numbers, not contemporary
-{\it NetHack\/} ones).
+note that these are old \textit{Hack} version numbers, not contemporary
+\textit{NetHack} ones).
 
 %.pg
 \medskip
-\noindent {\it R. Black\/} ported {\it PC Hack\/} 3.51 to Lattice C and the Atari
-520/1040ST, producing {\it ST Hack\/} 1.03.
+\noindent \textit{R. Black} ported \textit{PC Hack} 3.51 to Lattice C and the Atari
+520/1040ST, producing \textit{ST Hack} 1.03.
 
 %.pg
 \medskip
-\noindent {\it Mike Stephenson\/} merged these various versions back together,
-incorporating many of the added features, and produced {\it NetHack\/} version
+\noindent \textit{Mike Stephenson} merged these various versions back together,
+incorporating many of the added features, and produced \textit{NetHack} version
 1.4 in 1987.
 He then coordinated a cast of thousands in enhancing and debugging
-{\it NetHack\/} 1.4 and released {\it NetHack\/} versions 2.2 and 2.3.
+\textit{NetHack} 1.4 and released \textit{NetHack} versions 2.2 and 2.3.
 Like Hack, they were released by posting their source code to Usenet where
 they remained available in various archives accessible
-via {\it ftp\/} and {\it uucp\/} after expiring from the newsgroup.
+via \textit{ftp} and \textit{uucp} after expiring from the newsgroup.
 
 %.pg
 \medskip
 \noindent Later, Mike coordinated a major re-write of the game, heading a team which
-included {\it Ken Arromdee}, {\it Jean-Christophe Collet}, {\it Steve Creps},
-{\it Eric Hendrickson}, {\it Izchak Miller}, {\it Eric S. Raymond}, {\it John
-Rupley}, {\it Mike Threepoint}, and {\it Janet Walz}, to produce
-{\it NetHack\/} 3.0c.
+included \textit{Ken Arromdee}, \textit{Jean-Christophe Collet}, \textit{Steve Creps},
+\textit{Eric Hendrickson}, \textit{Izchak Miller}, \textit{Eric S. Raymond}, \textit{John
+Rupley}, \textit{Mike Threepoint}, and \textit{Janet Walz}, to produce
+\textit{NetHack} 3.0c.
 
 %.pg
 \medskip
-\noindent {\it NetHack\/} 3.0 was ported to the Atari by {\it Eric R. Smith}, to OS/2 by
-{\it Timo Hakulinen}, and to VMS by {\it David Gentzel}.  The three of them
-and {\it Kevin Darcy\/} later joined the main {\it NetHack Development Team} to produce
+\noindent \textit{NetHack} 3.0 was ported to the Atari by \textit{Eric R. Smith}, to OS/2 by
+\textit{Timo Hakulinen}, and to VMS by \textit{David Gentzel}.  The three of them
+and \textit{Kevin Darcy} later joined the main \textit{NetHack Development Team} to produce
 subsequent revisions of 3.0.
 
 %.pg
 \medskip
-\noindent {\it Olaf Seibert\/} ported {\it NetHack\/} 2.3 and 3.0 to the Amiga.  {\it
-Norm Meluch}, {\it Stephen Spackman\/} and {\it Pierre Martineau\/} designed
-overlay code for {\it PC NetHack\/} 3.0.  {\it Johnny Lee\/} ported {\it
-NetHack\/} 3.0 to the Macintosh.  Along with various other Dungeoneers, they
+\noindent \textit{Olaf Seibert} ported \textit{NetHack} 2.3 and 3.0 to the Amiga.  {\it
+Norm Meluch}, \textit{Stephen Spackman} and \textit{Pierre Martineau} designed
+overlay code for \textit{PC NetHack} 3.0.  \textit{Johnny Lee} ported {\it
+NetHack} 3.0 to the Macintosh.  Along with various other Dungeoneers, they
 continued to enhance the PC, Macintosh, and Amiga ports through the later
 revisions of 3.0.
 
@@ -7016,92 +7013,92 @@ the three component numbering scheme began to be used with 3.1.0.
 
 %.pg
 \medskip
-\noindent Headed by {\it Mike Stephenson\/} and coordinated by {\it Izchak Miller\/}
-and {\it Janet Walz}, the {\it NetHack Development Team} which now included
-{\it Ken Arromdee},
-{\it David Cohrs}, {\it Jean-Christophe Collet}, {\it Kevin Darcy},
-{\it Matt Day}, {\it Timo Hakulinen}, {\it Steve Linhart}, {\it Dean Luick},
-{\it Pat Rankin}, {\it Eric Raymond}, and {\it Eric Smith\/} undertook a
+\noindent Headed by \textit{Mike Stephenson} and coordinated by \textit{Izchak Miller}
+and \textit{Janet Walz}, the \textit{NetHack Development Team} which now included
+\textit{Ken Arromdee},
+\textit{David Cohrs}, \textit{Jean-Christophe Collet}, \textit{Kevin Darcy},
+\textit{Matt Day}, \textit{Timo Hakulinen}, \textit{Steve Linhart}, \textit{Dean Luick},
+\textit{Pat Rankin}, \textit{Eric Raymond}, and \textit{Eric Smith} undertook a
 radical revision of 3.0.
 They re-structured the game's design, and re-wrote major
 parts of the code.
 They added multiple dungeons, a new display, special
 individual character quests, a new endgame and many other new features, and
-produced {\it NetHack\/} 3.1.
+produced \textit{NetHack} 3.1.
 Version 3.1.0 was released in January of 1993.
 
 %.pg
 \medskip
-\noindent {\it Ken Lorber}, {\it Gregg Wonderly\/} and {\it Greg Olson}, with help
-from {\it Richard Addison}, {\it Mike Passaretti}, and {\it Olaf Seibert},
-developed {\it NetHack\/} 3.1 for the Amiga.
+\noindent \textit{Ken Lorber}, \textit{Gregg Wonderly} and \textit{Greg Olson}, with help
+from \textit{Richard Addison}, \textit{Mike Passaretti}, and \textit{Olaf Seibert},
+developed \textit{NetHack} 3.1 for the Amiga.
 
 %.pg
 \medskip
-\noindent {\it Norm Meluch\/} and {\it Kevin Smolkowski}, with help from
-{\it Carl Schelin}, {\it Stephen Spackman}, {\it Steve VanDevender},
-and {\it Paul Winner}, ported {\it NetHack\/} 3.1 to the PC.
+\noindent \textit{Norm Meluch} and \textit{Kevin Smolkowski}, with help from
+\textit{Carl Schelin}, \textit{Stephen Spackman}, \textit{Steve VanDevender},
+and \textit{Paul Winner}, ported \textit{NetHack} 3.1 to the PC.
 
 %.pg
 \medskip
-\noindent {\it Jon W\{tte} and {\it Hao-yang Wang},
-with help from {\it Ross Brown}, {\it Mike Engber}, {\it David Hairston},
-{\it Michael Hamel}, {\it Jonathan Handler}, {\it Johnny Lee},
-{\it Tim Lennan}, {\it Rob Menke}, and {\it Andy Swanson},
-developed {\it NetHack\/} 3.1 for the Macintosh, porting it for MPW.
-Building on their development, {\it Bart House} added a Think C port.
+\noindent \textit{Jon W\textbraceleft tte} and \textit{Hao-yang Wang},
+with help from \textit{Ross Brown}, \textit{Mike Engber}, \textit{David Hairston},
+\textit{Michael Hamel}, \textit{Jonathan Handler}, \textit{Johnny Lee},
+\textit{Tim Lennan}, \textit{Rob Menke}, and \textit{Andy Swanson},
+developed \textit{NetHack} 3.1 for the Macintosh, porting it for MPW.
+Building on their development, \textit{Bart House} added a Think C port.
 
 %.pg
 \medskip
-\noindent {\it Timo Hakulinen\/} ported {\it NetHack\/} 3.1 to OS/2.
-{\it Eric Smith\/} ported {\it NetHack\/} 3.1 to the Atari.
-{\it Pat Rankin}, with help from {\it Joshua Delahunty},
-was responsible for the VMS version of {\it NetHack\/} 3.1.
-{\it Michael Allison} ported {\it NetHack\/} 3.1 to Windows NT.
+\noindent \textit{Timo Hakulinen} ported \textit{NetHack} 3.1 to OS/2.
+\textit{Eric Smith} ported \textit{NetHack} 3.1 to the Atari.
+\textit{Pat Rankin}, with help from \textit{Joshua Delahunty},
+was responsible for the VMS version of \textit{NetHack} 3.1.
+\textit{Michael Allison} ported \textit{NetHack} 3.1 to Windows NT.
 
 %.pg
 \medskip
-\noindent {\it Dean Luick}, with help from {\it David Cohrs}, developed
-{\it NetHack\/} 3.1 for X11.
+\noindent \textit{Dean Luick}, with help from \textit{David Cohrs}, developed
+\textit{NetHack} 3.1 for X11.
 It drew the map as text rather than graphically but
-included {\tt nh10.bdf}, an optionally used custom X11 font which has
+included \texttt{nh10.bdf}, an optionally used custom X11 font which has
 tiny images in place of letters and punctuation, a precursor of tiles.
 Those images don't extend to individual monster and object types, just
 replacements for monster and object classes (so one custom image for all
-``{\tt a}'' insects and another for all ``{\tt [}'' armor and so
+``\texttt{a}'' insects and another for all ``\texttt{[}'' armor and so
 forth, not separate images for beetles and ants or for cloaks and boots).
 
 %.pg
 \medskip
-\noindent {\it Warwick Allison\/} wrote a graphically displayed version
-of {\it NetHack\/}
+\noindent \textit{Warwick Allison} wrote a graphically displayed version
+of \textit{NetHack}
 for the Atari where the tiny pictures were described as ``icons'' and
 were distinct for specific types of monsters and objects rather than just
 their classes.
-He contributed them to the {\it NetHack Development Team\/} which
+He contributed them to the \textit{NetHack Development Team} which
 rechristened them ``tiles'', original usage which has subsequently been
 picked up by various other games.
-{\it NetHack's\/} tiles support was then implemented on other platforms
+\textit{NetHack's} tiles support was then implemented on other platforms
 (initially MS-DOS but eventually Windows, Qt, and X11 too).
 
 %.pg
 \medskip
-\noindent The 3.2 {\it NetHack Development Team}, comprised of {\it Michael Allison}, {\it Ken
-Arromdee}, {\it David Cohrs}, {\it Jessie Collet}, {\it Steve Creps}, {\it
-Kevin Darcy}, {\it Timo Hakulinen}, {\it Steve Linhart}, {\it Dean Luick},
-{\it Pat Rankin}, {\it Eric Smith}, {\it Mike Stephenson}, {\it Janet Walz},
-and {\it Paul Winner}, released version 3.2.0 in April of 1996.
+\noindent The 3.2 \textit{NetHack Development Team}, comprised of \textit{Michael Allison}, \textit{Ken
+Arromdee}, \textit{David Cohrs}, \textit{Jessie Collet}, \textit{Steve Creps}, {\it
+Kevin Darcy}, \textit{Timo Hakulinen}, \textit{Steve Linhart}, \textit{Dean Luick},
+\textit{Pat Rankin}, \textit{Eric Smith}, \textit{Mike Stephenson}, \textit{Janet Walz},
+and \textit{Paul Winner}, released version 3.2.0 in April of 1996.
 
 %.pg
 \medskip
 \noindent Version 3.2 marked the tenth anniversary of the formation of the
 development team.
 In a testament to their dedication to the game, all thirteen members
-of the original {\it NetHack Development Team} remained on the team at the
+of the original \textit{NetHack Development Team} remained on the team at the
 start of work on that release.
 During the interval between the release of 3.1.3 and 3.2.0,
-one of the founding members of the {\it NetHack Development Team},
-{\it Dr. Izchak Miller}, was diagnosed with cancer and passed away.
+one of the founding members of the \textit{NetHack Development Team},
+\textit{Dr. Izchak Miller}, was diagnosed with cancer and passed away.
 That release of the game was
 dedicated to him by the development and porting teams.
 
@@ -7112,31 +7109,31 @@ better game play.
 
 %.pg
 \medskip
-During the lifespan of {\it NetHack\/} 3.1 and 3.2, several enthusiasts
+During the lifespan of \textit{NetHack} 3.1 and 3.2, several enthusiasts
 of the game added
 their own modifications to the game and made these ``variants'' publicly
 available:
 
 %.pg
 \medskip
-{\it Tom Proudfoot} and {\it Yuval Oren} created {\it NetHack++},
-which was quickly renamed {\it NetHack$--$\/}
+\textit{Tom Proudfoot} and \textit{Yuval Oren} created \textit{NetHack++},
+which was quickly renamed \textit{NetHack$--$}
 when some people incorrectly assumed that it was a conversion of the
-{\it C\/} source code to {\it C++}.
-Working independently, {\it Stephen White} wrote {\it NetHack Plus}.
-{\it Tom Proudfoot} later merged {\it NetHack Plus}
-and his own {\it NetHack$--$} to produce {\it SLASH}.
-{\it Larry Stewart-Zerba} and {\it Warwick Allison} improved the spell
+\textit{C} source code to \textit{C++}.
+Working independently, \textit{Stephen White} wrote \textit{NetHack Plus}.
+\textit{Tom Proudfoot} later merged \textit{NetHack Plus}
+and his own \textit{NetHack$--$} to produce \textit{SLASH}.
+\textit{Larry Stewart-Zerba} and \textit{Warwick Allison} improved the spell
 casting system with the Wizard Patch.
-{\it Warwick Allison} also ported {\it NetHack\/} to use the Qt interface.
+\textit{Warwick Allison} also ported \textit{NetHack} to use the Qt interface.
 
 %.pg
 \medskip
-{\it Warren Cheung} combined {\it SLASH} with the Wizard Patch
-to produce {\it Slash'EM\/}, and
-with the help of {\it Kevin Hugo}, added more features.
-Kevin later joined the {\it NetHack Development Team} and incorporated
-the best of these ideas into {\it NetHack\/} 3.3.
+\textit{Warren Cheung} combined \textit{SLASH} with the Wizard Patch
+to produce \textit{Slash'EM}, and
+with the help of \textit{Kevin Hugo}, added more features.
+Kevin later joined the \textit{NetHack Development Team} and incorporated
+the best of these ideas into \textit{NetHack} 3.3.
 
 %.pg
 \medskip
@@ -7147,7 +7144,7 @@ without any ready-to-play distribution for systems that usually had such.
 
 %.pg
 (To anyone considering resurrecting an old version:  all versions before
-3.2.3 had a {\it Y2K\/} bug.
+3.2.3 had a \textit{Y2K} bug.
 The high scores file and the log file contained
 dates which were formatted using a two-digit year, and 1999's year 99 was
 followed by 2000's year 100.
@@ -7159,11 +7156,11 @@ random ghost and statue names in the current game.)
 
 %.pg
 \medskip
-The 3.3 {\it NetHack Development Team}, consisting of {\it Michael Allison}, {\it Ken Arromdee},
-{\it David Cohrs}, {\it Jessie Collet}, {\it Steve Creps}, {\it Kevin Darcy},
-{\it Timo Hakulinen}, {\it Kevin Hugo}, {\it Steve Linhart}, {\it Ken Lorber},
-{\it Dean Luick}, {\it Pat Rankin}, {\it Eric Smith}, {\it Mike Stephenson},
-{\it Janet Walz}, and {\it Paul Winner}, released 3.3.0 in
+The 3.3 \textit{NetHack Development Team}, consisting of \textit{Michael Allison}, \textit{Ken Arromdee},
+\textit{David Cohrs}, \textit{Jessie Collet}, \textit{Steve Creps}, \textit{Kevin Darcy},
+\textit{Timo Hakulinen}, \textit{Kevin Hugo}, \textit{Steve Linhart}, \textit{Ken Lorber},
+\textit{Dean Luick}, \textit{Pat Rankin}, \textit{Eric Smith}, \textit{Mike Stephenson},
+\textit{Janet Walz}, and \textit{Paul Winner}, released 3.3.0 in
 December 1999 and 3.3.1 in August of 2000.
 
 %.pg
@@ -7181,73 +7178,73 @@ more than a year and a half.
 
 %.pg
 \medskip
-The 3.4 {\it NetHack Development Team} initially consisted of
-{\it Michael Allison}, {\it Ken Arromdee},
-{\it David Cohrs}, {\it Jessie Collet}, {\it Kevin Hugo}, {\it Ken Lorber},
-{\it Dean Luick}, {\it Pat Rankin}, {\it Mike Stephenson},
-{\it Janet Walz}, and {\it Paul Winner}, with {\it  Warwick Allison} joining
-just before the release of {\it NetHack\/} 3.4.0 in March 2002.
+The 3.4 \textit{NetHack Development Team} initially consisted of
+\textit{Michael Allison}, \textit{Ken Arromdee},
+\textit{David Cohrs}, \textit{Jessie Collet}, \textit{Kevin Hugo}, \textit{Ken Lorber},
+\textit{Dean Luick}, \textit{Pat Rankin}, \textit{Mike Stephenson},
+\textit{Janet Walz}, and \textit{Paul Winner}, with \textit{ Warwick Allison} joining
+just before the release of \textit{NetHack} 3.4.0 in March 2002.
 
 %.pg
 \medskip
 As with version 3.3, various people contributed to the game as a whole as
-well as supporting ports on the different platforms that {\it NetHack\/}
+well as supporting ports on the different platforms that \textit{NetHack}
 runs on:
 
 %.pg
 \medskip
-\noindent{\it Pat Rankin} maintained 3.4 for VMS.
+\noindent\textit{Pat Rankin} maintained 3.4 for VMS.
 
 %.pg
 \medskip
-\noindent {\it Michael Allison} maintained {\it NetHack\/} 3.4 for the MS-DOS
+\noindent \textit{Michael Allison} maintained \textit{NetHack} 3.4 for the MS-DOS
 platform.
-{\it Paul Winner} and {\it Yitzhak Sapir} provided encouragement.
+\textit{Paul Winner} and \textit{Yitzhak Sapir} provided encouragement.
 
 %.pg
 \medskip
-\noindent {\it Dean Luick}, {\it Mark Modrall}, and {\it Kevin Hugo} maintained and
+\noindent \textit{Dean Luick}, \textit{Mark Modrall}, and \textit{Kevin Hugo} maintained and
 enhanced the Macintosh port of 3.4.
 
 %.pg
 \medskip
-\noindent {\it Michael Allison}, {\it David Cohrs}, {\it Alex Kompel},
-{\it Dion Nicolaas}, and
-{\it Yitzhak Sapir} maintained and enhanced 3.4 for the Microsoft Windows
+\noindent \textit{Michael Allison}, \textit{David Cohrs}, \textit{Alex Kompel},
+\textit{Dion Nicolaas}, and
+\textit{Yitzhak Sapir} maintained and enhanced 3.4 for the Microsoft Windows
 platform.
-{\it Alex Kompel} contributed a new graphical interface for the Windows port.
-{\it Alex Kompel} also contributed a Windows CE port for 3.4.1.
+\textit{Alex Kompel} contributed a new graphical interface for the Windows port.
+\textit{Alex Kompel} also contributed a Windows CE port for 3.4.1.
 
 %.pg
 \medskip
-\noindent {\it Ron Van Iwaarden} was the sole maintainer of {\it NetHack\/} for
+\noindent \textit{Ron Van Iwaarden} was the sole maintainer of \textit{NetHack} for
 OS/2 the past
 several releases. Unfortunately Ron's last OS/2 machine stopped working in
-early 2006. A great many thanks to Ron for keeping {\it NetHack\/} alive on
+early 2006. A great many thanks to Ron for keeping \textit{NetHack} alive on
 OS/2 all these years.
 
 %.pg
 \medskip
-\noindent {\it Janne Salmij\"{a}rvi} and {\it Teemu Suikki} maintained
-and enhanced the Amiga port of 3.4 after {\it Janne Salmij\"{a}rvi} resurrected
+\noindent \textit{Janne Salmij\"{a}rvi} and \textit{Teemu Suikki} maintained
+and enhanced the Amiga port of 3.4 after \textit{Janne Salmij\"{a}rvi} resurrected
 it for 3.3.1.
 
 %.pg
 \medskip
-\noindent {\it Christian ``Marvin'' Bressler} maintained 3.4 for the Atari after he
+\noindent \textit{Christian ``Marvin'' Bressler} maintained 3.4 for the Atari after he
 resurrected it for 3.3.1.
 
 %.pg
 \medskip
-The release of {\it NetHack\/} 3.4.3 in December 2003 marked the beginning of
+The release of \textit{NetHack} 3.4.3 in December 2003 marked the beginning of
 a long release hiatus. 3.4.3 proved to be a remarkably stable version that
 provided continued enjoyment by the community for more than a decade. The
-{\it NetHack Development Team} slowly and quietly continued to work on the game behind the scenes
+\textit{NetHack Development Team} slowly and quietly continued to work on the game behind the scenes
 during the tenure of 3.4.3. It was during that same period that several new
-variants emerged within the {\it NetHack\/} community. Notably sporkhack by
-Derek S. Ray, {\it unnethack\/} by Patric Mueller, {\it nitrohack\/} and its
+variants emerged within the \textit{NetHack} community. Notably sporkhack by
+Derek S. Ray, \textit{unnethack} by Patric Mueller, \textit{nitrohack} and its
 successors originally by Daniel Thaler and then by Alex Smith, and
-{\it Dynahack\/} by Tung Nguyen.
+\textit{Dynahack} by Tung Nguyen.
 Some of those variants continue to be
 developed, maintained, and enjoyed by the community to this day.
 
@@ -7258,9 +7255,9 @@ released publicly by other parties.
 Since that code was a work-in-progress
 and had not gone through the process of debugging it as a suitable release,
 it was decided that the version numbers present on that code snapshot would
-be retired and never used in an official {\it NetHack\/} release.
-An announcement was posted on the {\it NetHack Development Team}'s official
-{\it nethack.org\/} website
+be retired and never used in an official \textit{NetHack} release.
+An announcement was posted on the \textit{NetHack Development Team}'s official
+\textit{nethack.org} website
 to that effect, stating that there would never be a 3.4.4, 3.5, or 3.5.0
 official release version.
 
@@ -7271,20 +7268,20 @@ In January 2015, preparation began for the release of NetHack 3.6.
 %.pg
 \medskip
 At the beginning of development for what would eventually get released as
-3.6.0, the {\it NetHack Development Team} consisted of {\it Warwick Allison},
-{\it Michael Allison}, {\it Ken Arromdee},
-{\it David Cohrs}, {\it Jessie Collet},
-{\it Ken Lorber}, {\it Dean Luick}, {\it Pat Rankin},
-{\it Mike Stephenson}, {\it Janet Walz}, and {\it Paul Winner}.
+3.6.0, the \textit{NetHack Development Team} consisted of \textit{Warwick Allison},
+\textit{Michael Allison}, \textit{Ken Arromdee},
+\textit{David Cohrs}, \textit{Jessie Collet},
+\textit{Ken Lorber}, \textit{Dean Luick}, \textit{Pat Rankin},
+\textit{Mike Stephenson}, \textit{Janet Walz}, and \textit{Paul Winner}.
 In early 2015, ahead of the release of 3.6.0, new members
-{\it Sean Hunt}, {\it Pasi Kallinen}, and {\it Derek S. Ray}
-joined the {\it NetHack\/} development team.
+\textit{Sean Hunt}, \textit{Pasi Kallinen}, and \textit{Derek S. Ray}
+joined the \textit{NetHack} development team.
 
 %.pg
 \medskip
 Near the end of the development of 3.6.0, one of the significant inspirations
 for many of the humorous and fun features found in the game,
-author Terry Pratchett, passed away. {\it NetHack\/} 3.6.0 introduced
+author Terry Pratchett, passed away. \textit{NetHack} 3.6.0 introduced
 a tribute to him.
 
 %.pg
@@ -7295,46 +7292,46 @@ patches.  Many bugs were fixed and some code was restructured.
 
 %.pg
 \medskip
-The {\it NetHack Development Team}, as well as {\it Steve VanDevender} and
-{\it Kevin Smolkowski}, ensured that {\it NetHack\/} 3.6 continued to
+The \textit{NetHack Development Team}, as well as \textit{Steve VanDevender} and
+\textit{Kevin Smolkowski}, ensured that \textit{NetHack} 3.6 continued to
 operate on various UNIX flavors and maintained the X11 interface.
 
 %.pg
 \medskip
-{\it Ken Lorber}, {\it Haoyang Wang}, {\it Pat Rankin}, and {\it Dean Luick}
-maintained the port of {\it NetHack\/} 3.6 for MacOS.
+\textit{Ken Lorber}, \textit{Haoyang Wang}, \textit{Pat Rankin}, and \textit{Dean Luick}
+maintained the port of \textit{NetHack} 3.6 for MacOS.
 
 %.pg
 \medskip
-{\it Michael Allison}, {\it David Cohrs}, {\it Bart House},
-{\it Pasi Kallinen}, {\it Alex Kompel}, {\it Dion Nicolaas},
-{\it Derek S. Ray} and  {\it Yitzhak Sapir}
-maintained the port of  {\it NetHack\/} 3.6 for Microsoft Windows.
+\textit{Michael Allison}, \textit{David Cohrs}, \textit{Bart House},
+\textit{Pasi Kallinen}, \textit{Alex Kompel}, \textit{Dion Nicolaas},
+\textit{Derek S. Ray} and  \textit{Yitzhak Sapir}
+maintained the port of  \textit{NetHack} 3.6 for Microsoft Windows.
 
 %.pg
 \medskip
-{\it Pat Rankin} attempted to keep the VMS port running for NetHack 3.6,
-hindered by limited access.  {\it Kevin Smolkowski} has updated and tested it
+\textit{Pat Rankin} attempted to keep the VMS port running for NetHack 3.6,
+hindered by limited access.  \textit{Kevin Smolkowski} has updated and tested it
 for the most recent version of OpenVMS (V8.4 as of this writing) on Alpha
 and Integrity (aka Itanium aka IA64) but not VAX.
 
 %.pg
 \medskip
-{\it Ray Chason}  resurrected the MS-DOS port for 3.6 and contributed the
+\textit{Ray Chason}  resurrected the MS-DOS port for 3.6 and contributed the
 necessary updates to the community at large.
 
 %.pg
 \medskip
 In late April 2018, several hundred bug fixes for 3.6.0 and some new features
 were assembled and released as NetHack 3.6.1.
-The {\it NetHack Development Team} at the
+The \textit{NetHack Development Team} at the
 time of release of 3.6.1 consisted of
-{\it Warwick Allison}, {\it Michael Allison}, {\it Ken Arromdee},
-{\it David Cohrs}, {\it Jessie Collet},
-{\it Pasi Kallinen}, {\it Ken Lorber}, {\it Dean Luick},
-{\it Patric Mueller}, {\it Pat Rankin}, {\it Derek S. Ray},
-{\it Alex Smith}, {\it Mike Stephenson}, {\it Janet Walz}, and
-{\it Paul Winner}.
+\textit{Warwick Allison}, \textit{Michael Allison}, \textit{Ken Arromdee},
+\textit{David Cohrs}, \textit{Jessie Collet},
+\textit{Pasi Kallinen}, \textit{Ken Lorber}, \textit{Dean Luick},
+\textit{Patric Mueller}, \textit{Pat Rankin}, \textit{Derek S. Ray},
+\textit{Alex Smith}, \textit{Mike Stephenson}, \textit{Janet Walz}, and
+\textit{Paul Winner}.
 
 %.pg
 \medskip
@@ -7343,8 +7340,8 @@ the adopted curses window port, were released as 3.6.2.
 
 %.pg
 \medskip
-{\it Bart House}, who had contributed to the game as a porting team participant
-for decades, joined the {\it NetHack Development Team} in late May 2019.
+\textit{Bart House}, who had contributed to the game as a porting team participant
+for decades, joined the \textit{NetHack Development Team} in late May 2019.
 
 %.pg
 \medskip
@@ -7373,25 +7370,21 @@ some bug fixes.
 
 %.pg
 \medskip
-\noindent The official {\it NetHack\/} web site is maintained by {\it Ken Lorber} at
-{\catcode`\#=11
-\special{html:<a href="https://www.nethack.org/">}}
-https:{\tt /}{\tt /}www.nethack.org{\tt /}.
-{\catcode`\#=11
-\special{html:</a>}}
+\noindent The official \textit{NetHack} web site is maintained by \textit{Ken Lorber} at
+\url{https://www.nethack.org}.
 
 %.pg
 %.hn 2
 
 \subsection*{Special Thanks}
-\noindent On behalf of the {\it NetHack\/} community, thank you very much once
-again to {\it M. Drew Streib} and {\it Pasi Kallinen} for providing a
-public NetHack server at nethack.alt.org. Thanks to {\it Keith Simpson}
-and {\it Andy Thomson} for hardfought.org. Thanks to all those
+\noindent On behalf of the \textit{NetHack} community, thank you very much once
+again to \textit{M. Drew Streib} and \textit{Pasi Kallinen} for providing a
+public NetHack server at nethack.alt.org. Thanks to \textit{Keith Simpson}
+and \textit{Andy Thomson} for hardfought.org. Thanks to all those
 unnamed dungeoneers who invest their time and effort into annual
-{\it NetHack\/} tournaments such as {\it Junethack},
-{\it The November NetHack Tournament}, and in days past,
-{\it devnull.net\/} (gone for now, but not forgotten).
+\textit{NetHack} tournaments such as \textit{Junethack},
+\textit{The November NetHack Tournament}, and in days past,
+\textit{devnull.net} (gone for now, but not forgotten).
 \clearpage
 
 %.hn 2
@@ -7399,7 +7392,7 @@ unnamed dungeoneers who invest their time and effort into annual
 %.pg
 \noindent From time to time, some depraved individual out there in netland sends a
 particularly intriguing modification to help out with the game.  The
-{\it NetHack Development Team} sometimes makes note of the names of the worst
+\textit{NetHack Development Team} sometimes makes note of the names of the worst
 of these miscreants in this, the list of Dungeoneers:
 \medskip
 %.sd
@@ -7416,7 +7409,7 @@ Andy Thomson & John Kallen & Patric Mueller\\
 Ari Huttunen & John Rupley & Paul Winner\\
 Bart House & John S. Bien & Pierre Martineau\\
 Benson I. Margulies & Johnny Lee & Ralf Brown\\
-Bill Dyer & Jon W\{tte & Ray Chason\\
+Bill Dyer & Jon W\textbraceleft tte & Ray Chason\\
 Boudewijn Waijers & Jonathan Handler & Richard Addison\\
 Bruce Cox & Joshua Delahunty & Richard Beigel\\
 Bruce Holloway & Karl Garrison & Richard P. Hughey\\


### PR DESCRIPTION
This PR is intended to update or modernize the code of the LaTeX guidebook. This mainly consists of moving from documentstyle to documentclass and from the deprecated `it`/`tt` and similar commands to `textit`, `texttt`, and so on. Most uses of `verb` have also been removed in favor of using special characters by commands, e.g. $ as `\textdollar` instead of `\verb|$|`

This builds in pdflatex, xelatex, or lualatex, and the output is similar to the existing code, but I did update one list that seemed clearly misformatted (line 4779 in the original code). I know the diff is large but it is mostly just the same changes over and over.