### PR TITLE
Add paranoid_confirmation:genocide option

### DIFF
--- a/include/flag.h
+++ b/include/flag.h
@@ -90,6 +90,7 @@ struct flag {
 #define PARANOID_SWIM       0x0400
 #define PARANOID_TRAP       0x0800
 #define PARANOID_AUTOALL    0x1000
+#define PARANOID_GENOCIDE   0x2000
     unsigned versinfo; /* flag mask for 'showvers' option */
     /* mask bits for 'versinfo'; numeric order does not match display order
        which is "name branch number" */
@@ -565,6 +566,8 @@ enum runmode_types {
 #define ParanoidTrap ((flags.paranoia_bits & PARANOID_TRAP) != 0)
 /* Require confirmation for choosing 'A' in class menu for menustyle:Full */
 #define ParanoidAutoAll ((flags.paranoia_bits & PARANOID_AUTOALL) != 0U)
+/* Require confirmation to genocide a monster */
+#define ParanoidGenocide ((flags.paranoia_bits & PARANOID_GENOCIDE) != 0U)
 
 /* command parsing, mainly dealing with number_pad handling;
    not saved and restored */

--- a/src/options.c
+++ b/src/options.c
@@ -194,6 +194,8 @@ static const struct paranoia_opts {
     { PARANOID_REMOVE, "Remove", 1, "Takeoff", 1,
       /* normally when there is only 1 candidate it's chosen automatically */
       "always pick from inventory for Remove and Takeoff" },
+    { PARANOID_GENOCIDE, "genocide", 1, NULL, 0,
+      "y required to genocide monsters" },
     /* for config file parsing; interactive menu skips these */
     { 0, "none", 4, 0, 0, 0 }, /* require full word match */
     { ~0, "all", 3, 0, 0, 0 }, /* ditto */

--- a/src/read.c
+++ b/src/read.c
@@ -2661,6 +2661,7 @@ do_class_genocide(void)
             snprintf(promptbuf, sizeof promptbuf,
                     "Are you sure you want to genocide all '%c' monsters?",
                     def_monsyms[class].sym);
+            promptbuf[sizeof promptbuf - 1] = 0;
             ok = paranoid_query(ParanoidGenocide, promptbuf);
             if (!ok) {
                 continue;
@@ -2863,6 +2864,17 @@ do_genocide(
                 continue;
             }
             ptr = &mons[mndx];
+            if (ParanoidGenocide) {
+                boolean ok;
+                snprintf(promptbuf, sizeof promptbuf,
+                        "Are you sure you want to genocide all %s?",
+                        makeplural(ptr->pmnames[NEUTRAL]));
+                promptbuf[sizeof promptbuf - 1] = 0;
+                ok = paranoid_query(ParanoidGenocide, promptbuf);
+                if (!ok) {
+                    continue;
+                }
+            }
             /* first revert if current shifted form or base vampire form */
             if (Upolyd && vampshifted(&gy.youmonst)
                 && (mndx == u.umonnum || mndx == gy.youmonst.cham))

--- a/src/read.c
+++ b/src/read.c
@@ -2637,6 +2637,7 @@ do_class_genocide(void)
         class = name_to_monclass(buf, (int *) 0);
         if (class == 0 && (i = name_to_mon(buf, (int *) 0)) != NON_PM)
             class = mons[i].mlet;
+
         immunecnt = gonecnt = goodcnt = 0;
         for (i = LOW_PM; i < NUMMONS; i++) {
             if (mons[i].mlet == class) {
@@ -2648,6 +2649,24 @@ do_class_genocide(void)
                     goodcnt++;
             }
         }
+
+        if (immunecnt + gonecnt + goodcnt == 0) {
+            pline("That %s does not represent any monster.",
+                  strlen(buf) == 1 ? "symbol" : "response");
+            continue;
+        }
+
+        if (ParanoidGenocide) {
+            boolean ok;
+            snprintf(promptbuf, sizeof promptbuf,
+                    "Are you sure you want to genocide all '%c' monsters?",
+                    def_monsyms[class].sym);
+            ok = paranoid_query(ParanoidGenocide, promptbuf);
+            if (!ok) {
+                continue;
+            }
+        }
+
         if (!goodcnt && class != mons[gu.urole.mnum].mlet
             && class != mons[gu.urace.mnum].mlet) {
             if (gonecnt)
@@ -2667,9 +2686,7 @@ do_class_genocide(void)
                 }
                 pline("Eliminated %d monster%s.", gonecnt, plur(gonecnt));
                 return;
-            } else
-                pline("That %s does not represent any monster.",
-                      strlen(buf) == 1 ? "symbol" : "response");
+            }
             continue;
         }
 

--- a/src/read.c
+++ b/src/read.c
@@ -2659,8 +2659,8 @@ do_class_genocide(void)
         if (ParanoidGenocide) {
             boolean ok;
             snprintf(promptbuf, sizeof promptbuf,
-                    "Are you sure you want to genocide all '%c' monsters?",
-                    def_monsyms[class].sym);
+                     "Are you sure you want to genocide all '%c' monsters?",
+                     def_monsyms[class].sym);
             promptbuf[sizeof promptbuf - 1] = 0;
             ok = paranoid_query(ParanoidGenocide, promptbuf);
             if (!ok) {
@@ -2867,8 +2867,8 @@ do_genocide(
             if (ParanoidGenocide) {
                 boolean ok;
                 snprintf(promptbuf, sizeof promptbuf,
-                        "Are you sure you want to genocide all %s?",
-                        makeplural(ptr->pmnames[NEUTRAL]));
+                         "Are you sure you want to genocide all %s?",
+                         makeplural(ptr->pmnames[NEUTRAL]));
                 promptbuf[sizeof promptbuf - 1] = 0;
                 ok = paranoid_query(ParanoidGenocide, promptbuf);
                 if (!ok) {


### PR DESCRIPTION
Addresses issue #1474, adds the `paranoid_confirmation:genocide` config option, which asks to confirm the chosen creature whenever you read a scroll of genocide. Here's a quick excerpt from running with a blessed scroll of genocide. I copy-pasted from `^P` so the messages are read bottom-up:

```
Wiped out all liches.  Wiped out all demiliches.  Wiped out all master liches.  Wiped out all arch-liches.
Are you sure you want to genocide all 'L' monsters? [yes|no] yes
What class of monsters do you want to genocide? [enter the symbol or name representing a class, or '?'] L
Are you sure you want to genocide all '@' monsters? [yes|no] no
What class of monsters do you want to genocide? master mnd flayer # note the typo
As you read the scroll, it disappears.
```

Here's another with an uncursed scroll of genocide:

```
Wiped out all master mind flayers.
Are you sure you want to genocide all master mind flayers? [yes|no] yes
What type of monster do you want to genocide? [enter the name of a type of monster, or '?'] master mind flayer
Are you sure you want to genocide all monks? [yes|no] no
What type of monster do you want to genocide? master mnd flayer
As you read the scroll, it disappears.
```