### PR TITLE
Avoid redundant punctuation in engraving message

### DIFF
--- a/include/engrave.h
+++ b/include/engrave.h
@@ -13,6 +13,8 @@ enum engraving_texts {
     text_states
 };
 
+#define engr_text_space(ep) ((char *) ((ep) + 1))
+
 struct engr {
     struct engr *nxt_engr;
     char *engr_txt[text_states];

--- a/src/engrave.c
+++ b/src/engrave.c
@@ -370,18 +370,26 @@ read_engr_at(coordxy x, coordxy y)
 
         if (sensed) {
             char *et, buf[BUFSZ];
+            const char *endpunct;
             int maxelen = (int) (sizeof buf
                                  /* sizeof "literal" counts terminating \0 */
-                                 - sizeof "You feel the words: \"\".");
+                                 - sizeof "You feel the words: \"\"."),
+                elen = (int) strlen(ep->engr_txt[actual_text]);
 
-            if ((int) strlen(ep->engr_txt[actual_text]) > maxelen) {
+            if (elen > maxelen) {
                 (void) strncpy(buf, ep->engr_txt[actual_text], maxelen);
                 buf[maxelen] = '\0';
                 et = buf;
+                elen = maxelen;
             } else {
                 et = ep->engr_txt[actual_text];
             }
-            You("%s: \"%s\".", (Blind) ? "feel the words" : "read", et);
+            endpunct = "";
+            if (elen > 0 && !strchr(".!?", et[elen - 1])) {
+                endpunct = ".";
+            }
+            You("%s: \"%s\"%s", (Blind) ? "feel the words" : "read", et,
+                endpunct);
             Strcpy(ep->engr_txt[remembered_text], ep->engr_txt[actual_text]);
             ep->eread = 1;
             ep->erevealed = 1;

--- a/src/engrave.c
+++ b/src/engrave.c
@@ -374,7 +374,8 @@ read_engr_at(coordxy x, coordxy y)
             int maxelen = (int) (sizeof buf
                                  /* sizeof "literal" counts terminating \0 */
                                  - sizeof "You feel the words: \"\"."),
-                elen = (int) strlen(ep->engr_txt[actual_text]);
+                elen = (int) strlen(ep->engr_txt[actual_text]),
+                off = (int) (ep->engr_txt[actual_text] - engr_text_space(ep));
 
             if (elen > maxelen) {
                 (void) strncpy(buf, ep->engr_txt[actual_text], maxelen);
@@ -385,7 +386,11 @@ read_engr_at(coordxy x, coordxy y)
                 et = ep->engr_txt[actual_text];
             }
             endpunct = "";
-            if (elen > 0 && !strchr(".!?", et[elen - 1])) {
+            if (elen < 2
+                /* only skip if punctuation is original, not degraded char */
+                || !((ep->engr_txt[pristine_text][off + elen - 1]
+                      == et[elen - 1])
+                     && strchr(".!?", et[elen - 1]))) {
                 endpunct = ".";
             }
             You("%s: \"%s\"%s", (Blind) ? "feel the words" : "read", et,
@@ -427,7 +432,7 @@ make_engr_at(
     head_engr = ep;
     ep->engr_x = x;
     ep->engr_y = y;
-    ep->engr_txt[actual_text] = (char *) (ep + 1);
+    ep->engr_txt[actual_text] = engr_text_space(ep);
     ep->engr_txt[remembered_text] = ep->engr_txt[actual_text] + smem;
     ep->engr_txt[pristine_text] = ep->engr_txt[remembered_text] + smem;
     for(i = 0; i < text_states; ++i)
@@ -1556,7 +1561,7 @@ save_engravings(NHFILE *nhfp)
             szeach = ep->engr_szeach;
             Sfo_unsigned(nhfp, &engr_alloc, "engraving-engr_alloc");
             Sfo_engr(nhfp, ep, "engraving");
-            ep->engr_txt[actual_text] = (char *)(ep + 1);
+            ep->engr_txt[actual_text] = engr_text_space(ep);
             ep->engr_txt[remembered_text] = ep->engr_txt[actual_text] + szeach;
             ep->engr_txt[pristine_text] = ep->engr_txt[remembered_text] + szeach;
             Sfo_char(nhfp, ep->engr_txt[actual_text], "engraving-actual_text", szeach);
@@ -1591,7 +1596,7 @@ rest_engravings(NHFILE *nhfp)
         szeach = ep->engr_szeach;
         ep->nxt_engr = head_engr;
         head_engr = ep;
-        ep->engr_txt[actual_text] = (char *) (ep + 1); /* Andreas Bormann */
+        ep->engr_txt[actual_text] = engr_text_space(ep); /* Andreas Bormann */
         ep->engr_txt[remembered_text] = ep->engr_txt[actual_text] + szeach;
         ep->engr_txt[pristine_text] = ep->engr_txt[remembered_text] + szeach;
         Sfi_char(nhfp, ep->engr_txt[actual_text],


### PR DESCRIPTION
Change the formatting of reading an engraving to include a terminal period
only if the engraving does not already include punctuation, to avoid
messages like:

    You feel the words: "Please don't feed the animals.".

This is an approach like that used by doread().

Because engravings tend to degrade, it is much more likely than with
doread() to encounter a message like `".? o |     ?"`.  These should probably
still retain the final period even though it is "punctuated," because the
question mark represents an unreadable character instead of an actual
question.  The second commit tacks a whack at that, but is a bit weird as
part of working around how engravings are allocated/structured in memory.
It could be dropped if the conclusion is that the added complexity is not
worth it (or if there's a better approach I missed, being out of practice!).

