### PR TITLE
add WASM/Emscripten build support via shim window port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ Makefile.gcc-orig
 # Win32-specific ignores end
 .DS_Store
 
+# WASM build artifacts
+wasm-data/

--- a/include/config.h
+++ b/include/config.h
@@ -50,6 +50,7 @@
 /* #define QT_GRAPHICS */    /* Qt interface */
 /* #define GNOME_GRAPHICS */ /* Gnome interface */
 /* #define MSWIN_GRAPHICS */ /* Windows NT, CE, Graphics */
+/* #define SHIM_GRAPHICS */  /* WASM/Library shim callback graphics */
 
 /*
  * Define the default window system.  This should be one that is compiled
@@ -113,6 +114,12 @@
 #define DEFAULT_WINDOW_SYS "mswin"
 #endif
 #define HACKDIR "\\nethack"
+#endif
+
+#ifdef SHIM_GRAPHICS
+#ifndef DEFAULT_WINDOW_SYS
+#define DEFAULT_WINDOW_SYS "shim"
+#endif
 #endif
 
 #ifndef DEFAULT_WINDOW_SYS
@@ -261,7 +268,7 @@
  *
  */
 
-#if defined(UNIX) && !defined(ZLIB_COMP) && !defined(COMPRESS)
+#if defined(UNIX) && !defined(ZLIB_COMP) && !defined(COMPRESS) && !defined(SHIM_GRAPHICS)
 /* path and file name extension for compression program */
 #define COMPRESS "/usr/bin/compress" /* Lempel-Ziv compression */
 #define COMPRESS_EXTENSION ".Z"      /* compress's extension */

--- a/include/decl.h
+++ b/include/decl.h
@@ -414,7 +414,7 @@ struct opvar {
     xchar spovartyp; /* one of SPOVAR_foo */
     union {
         char *str;
-        long l;
+        nhdata_long l;
     } vardata;
 };
 

--- a/include/global.h
+++ b/include/global.h
@@ -292,18 +292,37 @@ extern char *FDECL(dupstr, (const char *)); /* ditto */
 
 /* Used for consistency checks of various data files; declare it here so
    that utility programs which include config.h but not hack.h can see it. */
+/*
+ * WASM cross-compilation: binary data files (dungeon, levels, quest text)
+ * are written by native utilities and read by the WASM game. On LP64 hosts
+ * (Linux/macOS x86_64), long/unsigned long is 8 bytes, but on WASM it is
+ * 4 bytes -- causing struct layout mismatches in the binary format.
+ *
+ * These typedefs use int/unsigned int (4 bytes on all NetHack platforms)
+ * when CROSS_TO_WASM is defined, ensuring consistent binary format between
+ * native utilities (CC=cc) and the WASM game (CC=emcc). CROSS_TO_WASM is
+ * set in CFLAGS so both sides see it. On non-WASM builds these are
+ * long/unsigned long, preserving original behavior.
+ */
+#ifdef CROSS_TO_WASM
+typedef int nhdata_long;
+typedef unsigned int version_uint;
+#else
+typedef long nhdata_long;
+typedef unsigned long version_uint;
+#endif
 struct version_info {
-    unsigned long incarnation;   /* actual version number */
-    unsigned long feature_set;   /* bitmask of config settings */
-    unsigned long entity_count;  /* # of monsters and objects */
-    unsigned long struct_sizes1; /* size of key structs */
-    unsigned long struct_sizes2; /* size of more key structs */
+    version_uint incarnation;   /* actual version number */
+    version_uint feature_set;   /* bitmask of config settings */
+    version_uint entity_count;  /* # of monsters and objects */
+    version_uint struct_sizes1; /* size of key structs */
+    version_uint struct_sizes2; /* size of more key structs */
 };
 
 struct savefile_info {
-    unsigned long sfi1; /* compression etc. */
-    unsigned long sfi2; /* miscellaneous */
-    unsigned long sfi3; /* thirdparty */
+    version_uint sfi1; /* compression etc. */
+    version_uint sfi2; /* miscellaneous */
+    version_uint sfi3; /* thirdparty */
 };
 #ifdef NHSTDC
 #define SFI1_EXTERNALCOMP (1UL)

--- a/include/qtext.h
+++ b/include/qtext.h
@@ -12,7 +12,7 @@
 struct qtmsg {
     int msgnum;
     char delivery;
-    long offset, size, summary_size;
+    nhdata_long offset, size, summary_size;
 };
 
 #ifdef MAKEDEFS_C /***** MAKEDEFS *****/
@@ -27,7 +27,7 @@ struct msghdr {
 struct qthdr {
     int n_hdr;
     char id[N_HDR][LEN_HDR];
-    long offset[N_HDR];
+    nhdata_long offset[N_HDR];
 };
 
 /* Error message macros */

--- a/include/sp_lev.h
+++ b/include/sp_lev.h
@@ -444,7 +444,7 @@ typedef struct {
 
 typedef struct {
     _opcode *opcodes;
-    long n_opcodes;
+    nhdata_long n_opcodes;
 } sp_lev;
 
 typedef struct {

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -15,3 +15,8 @@ nhdat*
 #address san
 *.exp
 *.lib
+
+# WASM build artifacts
+nethack.js
+nethack.wasm
+test-objects-layout.c

--- a/src/questpgr.c
+++ b/src/questpgr.c
@@ -20,7 +20,7 @@ extern char *lev_message;
 
 static void NDECL(dump_qtlist);
 static void FDECL(Fread, (genericptr_t, int, int, dlb *));
-STATIC_DCL struct qtmsg *FDECL(construct_qtlist, (long));
+STATIC_DCL struct qtmsg *FDECL(construct_qtlist, (nhdata_long));
 STATIC_DCL const char *NDECL(intermed);
 STATIC_DCL struct obj *FDECL(find_qarti, (struct obj *));
 STATIC_DCL const char *NDECL(neminame);
@@ -76,7 +76,7 @@ dlb *stream;
 
 STATIC_OVL struct qtmsg *
 construct_qtlist(hdr_offset)
-long hdr_offset;
+nhdata_long hdr_offset;
 {
     struct qtmsg *msg_list;
     int n_msgs;
@@ -101,7 +101,7 @@ load_qtlist()
 {
     int n_classes, i;
     char qt_classes[N_HDR][LEN_HDR];
-    long qt_offsets[N_HDR];
+    nhdata_long qt_offsets[N_HDR];
 
     msg_file = dlb_fopen(QTEXT_FILE, RDBMODE);
     if (!msg_file)
@@ -114,7 +114,7 @@ load_qtlist()
 
     Fread(&n_classes, sizeof (int), 1, msg_file);
     Fread(&qt_classes[0][0], sizeof (char) * LEN_HDR, n_classes, msg_file);
-    Fread(qt_offsets, sizeof (long), n_classes, msg_file);
+    Fread(qt_offsets, sizeof (nhdata_long), n_classes, msg_file);
 
     /*
      * Now construct the message lists for quick reference later

--- a/src/windows.c
+++ b/src/windows.c
@@ -44,6 +44,9 @@ extern struct window_procs Gnome_procs;
 #ifdef MSWIN_GRAPHICS
 extern struct window_procs mswin_procs;
 #endif
+#ifdef SHIM_GRAPHICS
+extern struct window_procs shim_procs;
+#endif
 #ifdef WINCHAIN
 extern struct window_procs chainin_procs;
 extern void FDECL(chainin_procs_init, (int));
@@ -127,6 +130,9 @@ static struct win_choices {
 #endif
 #ifdef MSWIN_GRAPHICS
     { &mswin_procs, 0 CHAINR(0) },
+#endif
+#ifdef SHIM_GRAPHICS
+    { &shim_procs, 0 CHAINR(0) },
 #endif
 #ifdef WINCHAIN
     { &chainin_procs, chainin_procs_init, chainin_procs_chain },

--- a/sys/libnh/README.md
+++ b/sys/libnh/README.md
@@ -123,6 +123,7 @@ The `Module` object provides Emscripten runtime methods:
 |----------|-------------|
 | `_main(argc, argv)` | Start the game. Call with `(0, 0)` for defaults. |
 | `shim_graphics_set_callback(name)` | Register a callback by name. Must be called before `_main`. |
+| `_glyph_to_tile(glyph)` | Return the tile index for a glyph. See [Tile System](#tile-system). |
 | `_malloc(size)` | Allocate WASM heap memory (for advanced use). |
 
 ### Pointer Helpers
@@ -284,6 +285,71 @@ Common cmap symbols (glyph = symbol index + 2359):
 | `S_dnstair` | 24 | `>` | Downstairs |
 | `S_fountain` | 31 | `{` | Fountain |
 
+### Tile System
+
+When rendering with graphical tiles instead of ASCII, you need to map each glyph to a tile index in your tileset. The WASM build exposes NetHack's internal `glyph2tile[]` array through a helper function.
+
+#### Why not compute tile indices from offsets?
+
+The glyph offset constants (`GLYPH_MON_OFF`, `GLYPH_OBJ_OFF`, etc.) identify *what* a glyph represents, but they do not map directly to tile indices. NetHack's tilesets include conditional extra tiles for variant monsters (Cerberus, vampire mage, etc.) that shift the tile numbering. For example, the first 28 monster glyphs map to these tile indices:
+
+```
+glyph  0 -> tile  0    glyph 14 -> tile 14
+glyph  1 -> tile  1    glyph 15 -> tile 15
+...                     ...
+glyph 26 -> tile 26    glyph 27 -> tile 28  (tile 27 is a conditional monster)
+```
+
+The only reliable way to get the correct tile index is to use NetHack's precomputed `glyph2tile[]` lookup, which accounts for all conditional tiles.
+
+#### tileIndexForGlyph(glyph)
+
+After the game initializes (once `_main` is called and helpers are registered), use:
+
+```js
+const helpers = globalThis.nethackGlobal.helpers;
+const tileIndex = helpers.tileIndexForGlyph(glyph);
+```
+
+This is equivalent to `glyph2tile[glyph]` in C -- a direct lookup into NetHack's authoritative glyph-to-tile mapping. Returns `-1` for out-of-range glyphs.
+
+#### Example: rendering tiles in shim_print_glyph
+
+```js
+const TILE_WIDTH = 16;
+const TILE_HEIGHT = 16;
+const TILES_PER_ROW = 40; // depends on your tileset image layout
+
+globalThis.nethackCallback = async (name, ...args) => {
+    if (name === "shim_print_glyph") {
+        const [winid, x, y, glyph, bkglyph] = args;
+        const helpers = globalThis.nethackGlobal.helpers;
+
+        const tileIndex = helpers.tileIndexForGlyph(glyph);
+        const srcX = (tileIndex % TILES_PER_ROW) * TILE_WIDTH;
+        const srcY = Math.floor(tileIndex / TILES_PER_ROW) * TILE_HEIGHT;
+
+        // Draw from tileset image at (srcX, srcY) to map position (x, y)
+        ctx.drawImage(tilesetImage, srcX, srcY, TILE_WIDTH, TILE_HEIGHT,
+                      x * TILE_WIDTH, y * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
+        return;
+    }
+    // ... other callbacks
+};
+```
+
+#### mapglyphHelper
+
+The `mapglyphHelper` also returns a `tileIdx` field alongside the ASCII character and color:
+
+```js
+const helpers = globalThis.nethackGlobal.helpers;
+const info = helpers.mapglyphHelper(glyph, x, y, 0);
+// info = { glyph, ch, color, special, tileIdx, x, y, mgflags }
+```
+
+This is useful when you need both tile and ASCII information for the same glyph in a single call.
+
 ### Status Fields
 
 `shim_status_update` receives a field index and a pointer. For most fields, the pointer is a `char *` to a pre-formatted string. Read it with `Module.UTF8ToString(ptr)`.
@@ -342,4 +408,5 @@ If you're porting a 3.7 client to 3.6:
 | `shim_get_nh_event` | Called periodically | Not present |
 | `shim_display_file` | Called for NEWS | Not present |
 | `shim_update_inventory` | No-op in WASM (reentrancy) | Has parameter |
+| Tile lookup | `tileIndexForGlyph(glyph)` returns `int` | `mapGlyphInfoHelper(glyph, x, y, mgflags).tileidx` |
 | Global variables | Direct (`plname`) | Prefixed (`g.plname`) |

--- a/sys/libnh/README.md
+++ b/sys/libnh/README.md
@@ -1,0 +1,345 @@
+# NetHack 3.6 WASM Library
+
+A WebAssembly build of NetHack 3.6.7 that exposes all window system operations through a single JavaScript callback. Your JavaScript code receives rendering events (draw map, show menu, get input) and controls the game by returning values from the callback.
+
+## Quick Start
+
+```bash
+# Prerequisites: Emscripten SDK (https://emscripten.org/docs/getting_started/downloads.html)
+
+# From the repository root:
+./build-wasm.sh
+
+# Run the test:
+node sys/libnh/test/test.mjs
+```
+
+Build outputs:
+- `src/nethack.js` (~93KB) — ES6 module factory
+- `src/nethack.wasm` (~4.8MB) — Game binary with embedded data files
+
+## Minimal Example
+
+```js
+import createModule from "./nethack.js";
+
+const Module = await createModule({ noInitialRun: true });
+
+// 1. Install pointer helpers (required by the callback bridge)
+globalThis.nethackGlobal = { helpers: {
+    getPointerValue: (name, ptr, type) => {
+        switch (type) {
+            case "i": case "2": return Module.getValue(ptr, "i32");
+            case "s": return Module.UTF8ToString(ptr);
+            case "b": return Module.getValue(ptr, "i8") !== 0;
+            case "c": return String.fromCharCode(Module.getValue(ptr, "i8"));
+            case "0": return Module.getValue(ptr, "i8");
+            case "1": return Module.getValue(ptr, "i16");
+            case "p": return ptr;
+            default:  return ptr;
+        }
+    },
+    setPointerValue: (name, ptr, type, val) => {
+        if (!ptr) return;
+        switch (type) {
+            case "i": case "2": Module.setValue(ptr, val | 0, "i32"); break;
+            case "b": Module.setValue(ptr, val ? 1 : 0, "i8"); break;
+            case "c": Module.setValue(ptr, typeof val === "string"
+                          ? val.charCodeAt(0) : (val | 0), "i8"); break;
+            case "0": Module.setValue(ptr, val | 0, "i8"); break;
+            case "1": Module.setValue(ptr, val | 0, "i16"); break;
+            case "v": break;
+            default:  Module.setValue(ptr, val | 0, "i32"); break;
+        }
+    },
+}};
+
+// 2. Register your callback
+globalThis.nethackCallback = async (name, ...args) => {
+    switch (name) {
+        case "shim_create_nhwindow": return 1;  // return a window ID
+        case "shim_nhgetch":         return 32;  // return a keycode
+        case "shim_yn_function":     return 121; // 'y'
+        case "shim_putstr":
+            console.log(args[2]); // args = [winid, attr, text]
+            return;
+        // ... handle other callbacks
+        default: return 0;
+    }
+};
+
+// 3. Set the callback name and start the game
+const setCallback = Module.cwrap("shim_graphics_set_callback", null, ["string"]);
+setCallback("nethackCallback");
+Module._main(0, 0);
+```
+
+## Build
+
+The build uses a three-phase process because NetHack 3.6 requires native utilities (`makedefs`, `lev_comp`, `dgn_comp`) to generate data files, but the game itself must be compiled to WASM.
+
+```bash
+./build-wasm.sh
+```
+
+The script handles all three phases:
+1. **Phase 1** — Build native utilities with `cc`, using WASM hints for consistent `-D` flags
+2. **Phase 2** — Copy generated data files into `wasm-data/` for embedding
+3. **Phase 3** — Build the game with `emcc`, embedding data files into the WASM binary
+
+See `nethack-3.6.7-wasm-backport.md` in the repository root for the full build system documentation.
+
+## API
+
+### Module Loading
+
+The build produces an ES6 module factory. Load it and create an instance:
+
+```js
+import createModule from "./nethack.js";
+
+const Module = await createModule({
+    noInitialRun: true,  // required — we call _main() manually after setup
+    print: (text) => {}, // optional stdout handler
+    printErr: (text) => {}, // optional stderr handler
+});
+```
+
+The `Module` object provides Emscripten runtime methods:
+
+| Method | Purpose |
+|--------|---------|
+| `Module.cwrap(name, ret, args)` | Wrap a C function for calling from JS |
+| `Module.getValue(ptr, type)` | Read a value from WASM memory |
+| `Module.setValue(ptr, val, type)` | Write a value to WASM memory |
+| `Module.UTF8ToString(ptr)` | Read a C string from WASM memory |
+| `Module.stringToUTF8(str, ptr, len)` | Write a JS string to WASM memory |
+| `Module.addFunction(fn, sig)` | Register a JS function as a C callback |
+| `Module.FS` | Emscripten virtual filesystem |
+
+### Exported C Functions
+
+| Function | Description |
+|----------|-------------|
+| `_main(argc, argv)` | Start the game. Call with `(0, 0)` for defaults. |
+| `shim_graphics_set_callback(name)` | Register a callback by name. Must be called before `_main`. |
+| `_malloc(size)` | Allocate WASM heap memory (for advanced use). |
+
+### Pointer Helpers
+
+Before calling `_main`, you must install two helper functions on `globalThis.nethackGlobal.helpers`. The C-to-JS bridge (`local_callback` in `winshim.c`) calls these to convert between WASM memory pointers and JavaScript values:
+
+- **`getPointerValue(name, ptr, type)`** — Read a value from a WASM pointer. Called once per callback argument.
+- **`setPointerValue(name, ptr, type, val)`** — Write a return value to a WASM pointer. Called once per callback return.
+
+Type codes (shared with the format string system):
+
+| Code | C Type | JS Read (`getValue`) | JS Write (`setValue`) |
+|------|--------|---------------------|----------------------|
+| `i` | `int` (4 bytes) | `"i32"` | `"i32"` |
+| `s` | `char *` (string) | `UTF8ToString(ptr)` | N/A (strings are read-only) |
+| `p` | `void *` (pointer) | raw pointer value | `"i32"` |
+| `b` | `boolean` (1 byte) | `"i8"`, convert to bool | `"i8"`, 1 or 0 |
+| `c` | `char` (1 byte) | `"i8"`, convert to char | `"i8"`, charCode |
+| `0` | 1-byte int | `"i8"` | `"i8"` |
+| `1` | 2-byte int | `"i16"` | `"i16"` |
+| `2` | 4-byte int | `"i32"` | `"i32"` |
+| `v` | `void` | N/A | no-op |
+
+### The Callback
+
+All game-to-UI communication goes through a single async callback:
+
+```js
+globalThis.yourCallbackName = async (name, ...args) => {
+    // name: string — which window function is being called
+    // args: mixed[] — arguments already decoded by getPointerValue
+    // return: the value expected by the game (decoded by setPointerValue)
+};
+```
+
+Register it before calling `_main`:
+
+```js
+const setCallback = Module.cwrap("shim_graphics_set_callback", null, ["string"]);
+setCallback("yourCallbackName");
+Module._main(0, 0);  // starts the game; callbacks begin firing via Asyncify
+```
+
+### Callback Reference
+
+Each callback corresponds to a function in NetHack's `window_procs` interface. The format string column shows the return type (first character) followed by parameter types.
+
+#### Lifecycle
+
+| Callback | Format | Args | Return | Description |
+|----------|--------|------|--------|-------------|
+| `shim_init_nhwindows` | `vpp` | `(argcp, argv)` | void | Initialize the window system |
+| `shim_player_selection` | `v` | `()` | void | Select character role/race/etc. Set `flags.initrole` et al. via exported globals, or leave unset for random |
+| `shim_askname` | `v` | `()` | void | Prompt for player name. Write to exported `plname` global |
+| `shim_exit_nhwindows` | `vs` | `(str)` | void | Shut down the window system |
+| `shim_start_screen` | `v` | `()` | void | Called before first output (3.6 only) |
+| `shim_end_screen` | `v` | `()` | void | Called after last output (3.6 only) |
+
+#### Windows
+
+| Callback | Format | Args | Return | Description |
+|----------|--------|------|--------|-------------|
+| `shim_create_nhwindow` | `ii` | `(type)` | `winid` | Create a window. Types: 1=MESSAGE, 2=STATUS, 3=MAP, 4=MENU, 5=TEXT |
+| `shim_clear_nhwindow` | `vi` | `(winid)` | void | Clear window contents |
+| `shim_display_nhwindow` | `vib` | `(winid, blocking)` | void | Display/refresh a window |
+| `shim_destroy_nhwindow` | `vi` | `(winid)` | void | Destroy a window |
+| `shim_curs` | `viii` | `(winid, x, y)` | void | Position the cursor |
+
+#### Text Output
+
+| Callback | Format | Args | Return | Description |
+|----------|--------|------|--------|-------------|
+| `shim_putstr` | `viis` | `(winid, attr, str)` | void | Write a string to a window |
+| `shim_raw_print` | `vs` | `(str)` | void | Print a string (no window context) |
+| `shim_raw_print_bold` | `vs` | `(str)` | void | Print a bold string |
+| `shim_display_file` | `vsb` | `(name, complain)` | void | Display a text file (e.g., NEWS) |
+
+#### Map
+
+| Callback | Format | Args | Return | Description |
+|----------|--------|------|--------|-------------|
+| `shim_print_glyph` | `vi00ii` | `(winid, x, y, glyph, bkglyph)` | void | Draw a glyph on the map. `x`/`y` are 1-byte ints. See [Glyph System](#glyph-system) |
+| `shim_cliparound` | `vii` | `(x, y)` | void | Center the viewport around a position |
+
+#### Input
+
+| Callback | Format | Args | Return | Description |
+|----------|--------|------|--------|-------------|
+| `shim_nhgetch` | `i` | `()` | `int` (keycode) | Get a single keypress |
+| `shim_nh_poskey` | `ippp` | `(x_ptr, y_ptr, mod_ptr)` | `int` (keycode) | Get a keypress or mouse click. Write x/y/mod to pointers for mouse events |
+| `shim_yn_function` | `css0` | `(query, resp, def)` | `char` (charcode) | Ask a yes/no/other question |
+| `shim_getlin` | `vsp` | `(query, bufp)` | void | Get a line of text input. Write response to `bufp` |
+| `shim_get_ext_cmd` | `iv` | `()` | `int` | Get an extended command index. Return -1 for none |
+
+#### Menus
+
+| Callback | Format | Args | Return | Description |
+|----------|--------|------|--------|-------------|
+| `shim_start_menu` | `vi` | `(winid)` | void | Begin building a menu |
+| `shim_add_menu` | `viip00isb` | `(winid, glyph, identifier, ch, gch, attr, str, preselected)` | void | Add a menu item |
+| `shim_end_menu` | `vis` | `(winid, prompt)` | void | Finish building a menu |
+| `shim_select_menu` | `iiip` | `(winid, how, menu_list_ptr)` | `int` (count) | Display menu and get selection. `how`: 0=PICK_NONE, 1=PICK_ONE, 2=PICK_ANY |
+| `shim_message_menu` | `ciis` | `(let, how, mesg)` | `char` | Display a message with menu-style selection |
+
+#### Status
+
+| Callback | Format | Args | Return | Description |
+|----------|--------|------|--------|-------------|
+| `shim_status_init` | `v` | `()` | void | Initialize the status display |
+| `shim_status_update` | `vipiiip` | `(fldidx, ptr, chg, percent, color, colormasks)` | void | Update a status field. See [Status Fields](#status-fields) |
+
+#### Miscellaneous
+
+| Callback | Format | Args | Return | Description |
+|----------|--------|------|--------|-------------|
+| `shim_nhbell` | `v` | `()` | void | Ring the bell |
+| `shim_delay_output` | `v` | `()` | void | Pause briefly for animation |
+| `shim_mark_synch` | `v` | `()` | void | Synchronize display output |
+| `shim_wait_synch` | `v` | `()` | void | Wait for display sync to complete |
+| `shim_get_nh_event` | `v` | `()` | void | Poll for asynchronous events |
+| `shim_number_pad` | `vi` | `(state)` | void | Notify of number pad mode change |
+| `shim_doprev_message` | `iv` | `()` | `int` | Scroll back through message history |
+| `shim_preference_update` | `vp` | `(pref)` | void | Notify of a preference change |
+| `shim_getmsghistory` | `sb` | `(init)` | `string` | Get a message from history. Return `""` when done |
+| `shim_putmsghistory` | `vsb` | `(msg, restoring)` | void | Store a message in history |
+| `shim_outrip` | `viii` | `(winid, how, when)` | void | Display the tombstone (3.6 only) |
+| `shim_update_positionbar` | `vs` | `(posbar)` | void | Update position indicator |
+| `shim_suspend_nhwindows` | `vs` | `(str)` | void | Suspend the window system |
+| `shim_resume_nhwindows` | `v` | `()` | void | Resume the window system |
+
+### Glyph System
+
+`shim_print_glyph` receives integer glyph IDs. Decode them using these offset ranges (for this build: NUMMONS=381, NUM_OBJECTS=453):
+
+| Range | Category | Offset Constant | How to decode |
+|-------|----------|----------------|---------------|
+| 0–380 | Monster | `GLYPH_MON_OFF` (0) | `glyph - 0` = monster index into `mons[]` |
+| 381–761 | Pet | `GLYPH_PET_OFF` (381) | `glyph - 381` = monster index (tame) |
+| 762 | Invisible | `GLYPH_INVIS_OFF` | Single glyph for "remembered invisible monster" |
+| 763–1143 | Detected | `GLYPH_DETECT_OFF` (763) | `glyph - 763` = monster index (detected) |
+| 1144–1524 | Corpse | `GLYPH_BODY_OFF` (1144) | `glyph - 1144` = monster index (corpse) |
+| 1525–1905 | Ridden | `GLYPH_RIDDEN_OFF` (1525) | `glyph - 1525` = monster index (ridden) |
+| 1906–2358 | Object | `GLYPH_OBJ_OFF` (1906) | `glyph - 1906` = object index into `objects[]` |
+| 2359–2454 | Cmap | `GLYPH_CMAP_OFF` (2359) | `glyph - 2359` = dungeon symbol (see `S_` constants in `rm.h`) |
+| 2455+ | Explosions, zaps, swallows, warnings, statues | Higher offsets | See `display.h` for exact ranges |
+| 5976 | No glyph | `NO_GLYPH` / `MAX_GLYPH` | Sentinel value meaning "no glyph" (used as `bkglyph`) |
+
+Common cmap symbols (glyph = symbol index + 2359):
+
+| Symbol | Index | ASCII | Description |
+|--------|-------|-------|-------------|
+| `S_stone` | 0 | ` ` | Unexplored/dark area |
+| `S_vwall` | 1 | `\|` | Vertical wall |
+| `S_hwall` | 2 | `-` | Horizontal wall |
+| `S_ndoor` | 12 | `.` | Doorway (no door) |
+| `S_room` | 19 | `.` | Room floor |
+| `S_corr` | 21 | `#` | Corridor |
+| `S_upstair` | 23 | `<` | Upstairs |
+| `S_dnstair` | 24 | `>` | Downstairs |
+| `S_fountain` | 31 | `{` | Fountain |
+
+### Status Fields
+
+`shim_status_update` receives a field index and a pointer. For most fields, the pointer is a `char *` to a pre-formatted string. Read it with `Module.UTF8ToString(ptr)`.
+
+| Field Index | Name | Example Value |
+|-------------|------|---------------|
+| 0 | `BL_TITLE` | `"Web_user the Gallant"` |
+| 1 | `BL_STR` | `"18/07"` |
+| 2 | `BL_DX` | `"12"` |
+| 3 | `BL_CO` | `"15"` |
+| 4 | `BL_IN` | `"9"` |
+| 5 | `BL_WI` | `"11"` |
+| 6 | `BL_CH` | `"17"` |
+| 7 | `BL_ALIGN` | `"Lawful"` |
+| 9 | `BL_CAP` | `""` (empty when not encumbered) |
+| 10 | `BL_GOLD` | `"\GXXXXNNNN:42"` (encoded — see note) |
+| 11 | `BL_ENE` | `"5"` |
+| 12 | `BL_ENEMAX` | `"5"` |
+| 13 | `BL_XP` | `"1"` |
+| 14 | `BL_AC` | `"3"` |
+| 17 | `BL_HUNGER` | `""` (empty when not hungry) |
+| 18 | `BL_HP` | `"16"` |
+| 19 | `BL_HPMAX` | `"16"` |
+| 20 | `BL_LEVELDESC` | `"Dlvl:1"` |
+| 22 | `BL_CONDITION` | `""` (bitmask of conditions) |
+| -2 | `BL_FLUSH` | N/A — signal to flush/redraw status |
+
+**Gold encoding:** The `BL_GOLD` field uses `\GXXXXNNNN:amount` format where `XXXXXXXX` is a hex-encoded glyph for the gold symbol. Strip the `\G________:` prefix to get the numeric amount.
+
+### Exported Globals
+
+`js_globals_init()` (called automatically during `_main`) exports pointers to key game variables on `globalThis.nethackGlobal.globals`:
+
+| Global | Type | Description |
+|--------|------|-------------|
+| `plname` | `string` | Player name (writable — set during `shim_askname`) |
+| `WIN_MAP` | `int` | Map window ID |
+| `WIN_MESSAGE` | `int` | Message window ID |
+| `WIN_STATUS` | `int` | Status window ID |
+| `WIN_INVEN` | `int` | Inventory window ID |
+| `flags.initrole` | `int` | Role selection (-1=none, -2=random, 0+=specific role) |
+| `flags.initrace` | `int` | Race selection |
+| `flags.initgend` | `int` | Gender selection |
+| `flags.initalign` | `int` | Alignment selection |
+
+### Differences from 3.7
+
+If you're porting a 3.7 client to 3.6:
+
+| Aspect | 3.6 | 3.7 |
+|--------|-----|-----|
+| Player selection callback | `shim_player_selection` (void) | `shim_player_selection_or_tty` (returns boolean) |
+| `shim_start_menu` | 1 arg (winid) | 2 args (winid, mbehavior) |
+| `shim_print_glyph` | int glyph, int bkglyph | glyph_info*, glyph_info* |
+| `shim_start_screen` / `shim_end_screen` | Present | Removed |
+| `shim_get_nh_event` | Called periodically | Not present |
+| `shim_display_file` | Called for NEWS | Not present |
+| `shim_update_inventory` | No-op in WASM (reentrancy) | Has parameter |
+| Global variables | Direct (`plname`) | Prefixed (`g.plname`) |

--- a/sys/libnh/libnhmain.c
+++ b/sys/libnh/libnhmain.c
@@ -493,12 +493,8 @@ port_help(void)
 boolean
 authorize_wizard_mode(void)
 {
-    struct passwd *pw = get_unix_pw();
-
-    if (pw && sysopt.wizards && sysopt.wizards[0]) {
-        if (check_user_string(sysopt.wizards))
-            return TRUE;
-    }
+    if (sysopt.wizards && sysopt.wizards[0] && check_user_string(sysopt.wizards))
+        return TRUE;
     wiz_error_flag = TRUE;
     return FALSE;
 }

--- a/sys/libnh/libnhmain.c
+++ b/sys/libnh/libnhmain.c
@@ -1,0 +1,1016 @@
+/* NetHack 3.6  libnhmain.c */
+/* Copyright (c) Stichting Mathematisch Centrum, Amsterdam, 1985. */
+/*-Copyright (c) Robert Patrick Rankin, 2011. */
+/* NetHack may be freely redistributed.  See license for details. */
+
+/* main.c - WASM/Library NetHack entry point for 3.6
+ * Adapted from sys/unix/unixmain.c and NetHack 3.7's sys/libnh/libnhmain.c.
+ */
+
+#include "hack.h"
+#include "dlb.h"
+#include "patchlevel.h"
+#include "date.h"
+#include "func_tab.h"
+
+#include <ctype.h>
+#include <sys/stat.h>
+#include <signal.h>
+#include <pwd.h>
+#ifndef O_RDONLY
+#include <fcntl.h>
+#endif
+
+/* for cross-compiling to WebAssembly (WASM) */
+#ifdef __EMSCRIPTEN__
+#include <emscripten/emscripten.h>
+void js_helpers_init();
+void js_constants_init();
+void js_globals_init();
+#endif
+
+#if !defined(_BULL_SOURCE) && !defined(__sgi) && !defined(_M_UNIX)
+#if !defined(SUNOS4) && !(defined(ULTRIX) && defined(__GNUC__))
+#if defined(POSIX_TYPES) || defined(SVR4) || defined(HPUX)
+extern struct passwd *getpwuid(uid_t);
+#else
+extern struct passwd *getpwuid(int);
+#endif
+#endif
+#endif
+extern struct passwd *getpwnam(const char *);
+#ifdef CHDIR
+static void chdirx(const char *, boolean);
+#endif /* CHDIR */
+static boolean whoami(void);
+static void process_options(int, char **);
+
+static void wd_message(void);
+static boolean wiz_error_flag = FALSE;
+static struct passwd *get_unix_pw(void);
+
+#ifdef __EMSCRIPTEN__
+/* if WebAssembly, export this API and don't optimize it out */
+EMSCRIPTEN_KEEPALIVE
+#endif
+int
+main(int argc, char *argv[])
+{
+    register int fd;
+#ifdef CHDIR
+    register char *dir;
+#endif
+    boolean exact_username;
+    boolean resuming = FALSE; /* assume new game */
+    boolean plsel_once = FALSE;
+
+    sys_early_init();
+
+    hname = argv[0];
+    hackpid = getpid();
+    (void) umask(0777 & ~FCMASK);
+
+    choose_windows(DEFAULT_WINDOW_SYS);
+
+#ifdef CHDIR /* otherwise no chdir() */
+    dir = nh_getenv("NETHACKDIR");
+    if (!dir)
+        dir = nh_getenv("HACKDIR");
+
+    if (argc > 1) {
+        if (argcheck(argc, argv, ARG_VERSION) == 2)
+            exit(EXIT_SUCCESS);
+
+        if (argcheck(argc, argv, ARG_SHOWPATHS) == 2) {
+#ifdef CHDIR
+            chdirx((char *) 0, 0);
+#endif
+            iflags.initoptions_noterminate = TRUE;
+            initoptions();
+            iflags.initoptions_noterminate = FALSE;
+            reveal_paths(EXIT_SUCCESS);
+            exit(EXIT_SUCCESS);
+        }
+        if (argcheck(argc, argv, ARG_DEBUG) == 1) {
+            argc--;
+            argv++;
+        }
+        if (argc > 1 && !strncmp(argv[1], "-d", 2) && argv[1][2] != 'e') {
+            argc--;
+            argv++;
+            dir = argv[0] + 2;
+            if (*dir == '=' || *dir == ':')
+                dir++;
+            if (!*dir && argc > 1) {
+                argc--;
+                argv++;
+                dir = argv[0];
+            }
+            if (!*dir)
+                error("Flag -d must be followed by a directory name.");
+        }
+    }
+#endif /* CHDIR */
+
+    if (argc > 1) {
+        if (!strncmp(argv[1], "-s", 2) && strncmp(argv[1], "-style", 6)) {
+#ifdef CHDIR
+            chdirx(dir, 0);
+#endif
+#ifdef SYSCF
+            initoptions();
+#endif
+#ifdef PANICTRACE
+            ARGV0 = hname;
+#ifndef NO_SIGNAL
+            panictrace_setsignals(TRUE);
+#endif
+#endif
+            prscore(argc, argv);
+            exit(EXIT_SUCCESS);
+        }
+    }
+
+#ifdef CHDIR
+    chdirx(dir, 1);
+#endif
+
+#ifdef __EMSCRIPTEN__
+    js_helpers_init();
+    js_constants_init();
+    js_globals_init();
+#endif
+
+    initoptions();
+#ifdef PANICTRACE
+    ARGV0 = hname;
+#ifndef NO_SIGNAL
+    panictrace_setsignals(TRUE);
+#endif
+#endif
+    exact_username = whoami();
+
+    u.uhp = 1; /* prevent RIP on early quits */
+    program_state.preserve_locks = 1;
+#ifndef NO_SIGNAL
+    sethanguphandler((SIG_RET_TYPE) hangup);
+#endif
+
+    process_options(argc, argv);
+#ifdef WINCHAIN
+    commit_windowchain();
+#endif
+    init_nhwindows(&argc, argv);
+
+#ifdef DEF_PAGER
+    if (!(catmore = nh_getenv("HACKPAGER"))
+        && !(catmore = nh_getenv("PAGER")))
+        catmore = DEF_PAGER;
+#endif
+#ifdef MAIL
+    getmailstatus();
+#endif
+
+    /* wizard mode access is deferred until here */
+    set_playmode(); /* sets plname to "wizard" for wizard mode */
+    if (exact_username) {
+        int len = (int) strlen(plname);
+        if (++len < (int) sizeof plname)
+            (void) strncat(strcat(plname, "-"), pl_character,
+                           sizeof plname - len - 1);
+    }
+    plnamesuffix();
+
+    if (wizard) {
+        locknum = 0;
+    } else {
+#ifndef NO_SIGNAL
+        (void) signal(SIGQUIT, SIG_IGN);
+        (void) signal(SIGINT, SIG_IGN);
+#endif
+    }
+
+    dlb_init(); /* must be before newgame() */
+
+    vision_init();
+
+    display_gamewindows();
+
+ attempt_restore:
+
+    if (*plname) {
+        getlock();
+        program_state.preserve_locks = 0;
+    }
+
+    if (*plname && (fd = restore_saved_game()) >= 0) {
+        const char *fq_save = fqname(SAVEF, SAVEPREFIX, 1);
+
+        (void) chmod(fq_save, 0);
+#ifndef NO_SIGNAL
+        (void) signal(SIGINT, (SIG_RET_TYPE) done1);
+#endif
+#ifdef NEWS
+        if (iflags.news) {
+            display_file(NEWS, FALSE);
+            iflags.news = FALSE;
+        }
+#endif
+        pline("Restoring save file...");
+        mark_synch();
+        if (dorecover(fd)) {
+            resuming = TRUE;
+            wd_message();
+            if (discover || wizard) {
+                if (yn("Do you want to keep the save file?") == 'n') {
+                    (void) delete_savefile();
+                } else {
+                    (void) chmod(fq_save, FCMASK);
+                    nh_compress(fq_save);
+                }
+            }
+        }
+    }
+
+    if (!resuming) {
+        boolean neednewlock = (!*plname);
+        if (!iflags.renameinprogress || iflags.defer_plname || neednewlock) {
+            if (!plsel_once)
+                player_selection();
+            plsel_once = TRUE;
+            if (neednewlock && *plname)
+                goto attempt_restore;
+            if (iflags.renameinprogress) {
+                if (!locknum) {
+                    delete_levelfile(0);
+                    getlock();
+                }
+                goto attempt_restore;
+            }
+        }
+        newgame();
+        wd_message();
+    }
+
+    moveloop(resuming);
+
+    exit(EXIT_SUCCESS);
+    /*NOTREACHED*/
+    return 0;
+}
+
+/* caveat: argv elements might be arbitrary long */
+static void
+process_options(int argc, char *argv[])
+{
+    int i, l;
+
+    while (argc > 1 && argv[1][0] == '-') {
+        argv++;
+        argc--;
+        l = (int) strlen(*argv);
+        if (l < 4)
+            l = 4;
+
+        switch (argv[0][1]) {
+        case 'D':
+        case 'd':
+            if ((argv[0][1] == 'D' && !argv[0][2])
+                || !strcmpi(*argv, "-debug")) {
+                wizard = TRUE, discover = FALSE;
+            } else if (!strncmpi(*argv, "-DECgraphics", l)) {
+                load_symset("DECGraphics", PRIMARY);
+                switch_symbols(TRUE);
+            } else {
+                raw_printf("Unknown option: %.60s", *argv);
+            }
+            break;
+        case 'X':
+            discover = TRUE, wizard = FALSE;
+            break;
+#ifdef NEWS
+        case 'n':
+            iflags.news = FALSE;
+            break;
+#endif
+        case 'u':
+            if (argv[0][2]) {
+                (void) strncpy(plname, argv[0] + 2, sizeof plname - 1);
+            } else if (argc > 1) {
+                argc--;
+                argv++;
+                (void) strncpy(plname, argv[0], sizeof plname - 1);
+            } else {
+                raw_print("Player name expected after -u");
+            }
+            break;
+        case 'I':
+        case 'i':
+            if (!strncmpi(*argv, "-IBMgraphics", l)) {
+                load_symset("IBMGraphics", PRIMARY);
+                load_symset("RogueIBM", ROGUESET);
+                switch_symbols(TRUE);
+            } else {
+                raw_printf("Unknown option: %.60s", *argv);
+            }
+            break;
+        case 'p':
+            if (argv[0][2]) {
+                if ((i = str2role(&argv[0][2])) >= 0)
+                    flags.initrole = i;
+            } else if (argc > 1) {
+                argc--;
+                argv++;
+                if ((i = str2role(argv[0])) >= 0)
+                    flags.initrole = i;
+            }
+            break;
+        case 'r':
+            if (argv[0][2]) {
+                if ((i = str2race(&argv[0][2])) >= 0)
+                    flags.initrace = i;
+            } else if (argc > 1) {
+                argc--;
+                argv++;
+                if ((i = str2race(argv[0])) >= 0)
+                    flags.initrace = i;
+            }
+            break;
+        case 'w':
+            config_error_init(FALSE, "command line", FALSE);
+            choose_windows(&argv[0][2]);
+            config_error_done();
+            break;
+        case '@':
+            flags.randomall = 1;
+            break;
+        default:
+            if ((i = str2role(&argv[0][1])) >= 0) {
+                flags.initrole = i;
+                break;
+            }
+        }
+    }
+
+#ifdef SYSCF
+    if (argc > 1)
+        raw_printf("MAXPLAYERS are set in sysconf file.\n");
+#else
+    if (argc > 1)
+        locknum = atoi(argv[1]);
+#endif
+#ifdef MAX_NR_OF_PLAYERS
+    if (!locknum || locknum > MAX_NR_OF_PLAYERS)
+        locknum = MAX_NR_OF_PLAYERS;
+#endif
+#ifdef SYSCF
+    if (!locknum || (sysopt.maxplayers && locknum > sysopt.maxplayers))
+        locknum = sysopt.maxplayers;
+#endif
+}
+
+#ifdef CHDIR
+static void
+chdirx(const char *dir, boolean wr)
+{
+    if (dir
+#ifdef HACKDIR
+        && strcmp(dir, HACKDIR)
+#endif
+        ) {
+#ifdef SECURE
+        (void) setgid(getgid());
+        (void) setuid(getuid());
+#endif
+    } else {
+#ifdef VAR_PLAYGROUND
+        int len = strlen(VAR_PLAYGROUND);
+
+        fqn_prefix[SCOREPREFIX] = (char *) alloc(len + 2);
+        Strcpy(fqn_prefix[SCOREPREFIX], VAR_PLAYGROUND);
+        if (fqn_prefix[SCOREPREFIX][len - 1] != '/') {
+            fqn_prefix[SCOREPREFIX][len] = '/';
+            fqn_prefix[SCOREPREFIX][len + 1] = '\0';
+        }
+#endif
+    }
+
+#ifdef HACKDIR
+    if (dir == (const char *) 0)
+        dir = HACKDIR;
+#endif
+
+    if (dir && chdir(dir) < 0) {
+        perror(dir);
+        error("Cannot chdir to %s.", dir);
+    }
+
+    if (wr) {
+#ifdef VAR_PLAYGROUND
+        fqn_prefix[LEVELPREFIX] = fqn_prefix[SCOREPREFIX];
+        fqn_prefix[SAVEPREFIX] = fqn_prefix[SCOREPREFIX];
+        fqn_prefix[BONESPREFIX] = fqn_prefix[SCOREPREFIX];
+        fqn_prefix[LOCKPREFIX] = fqn_prefix[SCOREPREFIX];
+        fqn_prefix[TROUBLEPREFIX] = fqn_prefix[SCOREPREFIX];
+#endif
+        check_recordfile(dir);
+    }
+}
+#endif /* CHDIR */
+
+void
+after_opt_showpaths(dir)
+const char *dir UNUSED;
+{
+#ifdef CHDIR
+    chdirx((char *) 0, 0);
+#else
+    nhUse(dir);
+#endif
+    nh_terminate(EXIT_SUCCESS);
+}
+
+static boolean
+whoami(void)
+{
+    if (!*plname) {
+        register const char *s;
+
+        s = nh_getenv("USER");
+        if (!s || !*s)
+            s = nh_getenv("LOGNAME");
+        if (!s || !*s)
+            s = getlogin();
+
+        if (s && *s) {
+            (void) strncpy(plname, s, sizeof plname - 1);
+            if (index(plname, '-'))
+                return TRUE;
+        }
+    }
+    return FALSE;
+}
+
+#ifndef NO_SIGNAL
+void
+sethanguphandler(void (*handler)(int))
+{
+#ifdef SA_RESTART
+    struct sigaction sact;
+
+    (void) memset((genericptr_t) &sact, 0, sizeof sact);
+    sact.sa_handler = (SIG_RET_TYPE) handler;
+    (void) sigaction(SIGHUP, &sact, (struct sigaction *) 0);
+#ifdef SIGXCPU
+    (void) sigaction(SIGXCPU, &sact, (struct sigaction *) 0);
+#endif
+#else /* !SA_RESTART */
+    (void) signal(SIGHUP, (SIG_RET_TYPE) handler);
+#ifdef SIGXCPU
+    (void) signal(SIGXCPU, (SIG_RET_TYPE) handler);
+#endif
+#endif /* ?SA_RESTART */
+}
+#else /* NO_SIGNAL */
+/* Stub for WASM builds where signals are not available.
+ * Referenced by various parts of the codebase but never functional. */
+void
+sethanguphandler(void (*handler)(int))
+{
+    /* no-op: signals not supported in WASM */
+    nhUse(handler);
+}
+#endif /* !NO_SIGNAL */
+
+#ifdef PORT_HELP
+void
+port_help(void)
+{
+    display_file(PORT_HELP, TRUE);
+}
+#endif
+
+boolean
+authorize_wizard_mode(void)
+{
+    struct passwd *pw = get_unix_pw();
+
+    if (pw && sysopt.wizards && sysopt.wizards[0]) {
+        if (check_user_string(sysopt.wizards))
+            return TRUE;
+    }
+    wiz_error_flag = TRUE;
+    return FALSE;
+}
+
+static void
+wd_message(void)
+{
+    if (wiz_error_flag) {
+        if (sysopt.wizards && sysopt.wizards[0]) {
+            char *tmp = build_english_list(sysopt.wizards);
+            pline("Only user%s %s may access debug (wizard) mode.",
+                  index(sysopt.wizards, ' ') ? "s" : "", tmp);
+            free(tmp);
+        } else
+            pline("Entering explore/discovery mode instead.");
+        wizard = 0, discover = 1;
+    } else if (discover)
+        You("are in non-scoring explore/discovery mode.");
+}
+
+void
+append_slash(char *name)
+{
+    char *ptr;
+
+    if (!*name)
+        return;
+    ptr = name + (strlen(name) - 1);
+    if (*ptr != '/') {
+        *++ptr = '/';
+        *++ptr = '\0';
+    }
+    return;
+}
+
+boolean
+check_user_string(char *optstr)
+{
+    struct passwd *pw;
+    int pwlen;
+    char *eop, *w;
+    char *pwname = 0;
+
+    if (optstr[0] == '*')
+        return TRUE;
+    if (sysopt.check_plname)
+        pwname = plname;
+    else if ((pw = get_unix_pw()) != 0)
+        pwname = pw->pw_name;
+    if (!pwname || !*pwname)
+        return FALSE;
+    pwlen = (int) strlen(pwname);
+    eop = eos(optstr);
+    w = optstr;
+    while (w + pwlen <= eop) {
+        if (!*w)
+            break;
+        if (isspace(*w)) {
+            w++;
+            continue;
+        }
+        if (!strncmp(w, pwname, pwlen)) {
+            if (!w[pwlen] || isspace(w[pwlen]))
+                return TRUE;
+        }
+        while (*w && !isspace(*w))
+            w++;
+    }
+    return FALSE;
+}
+
+static struct passwd *
+get_unix_pw(void)
+{
+    char *user;
+    unsigned uid;
+    static struct passwd *pw = (struct passwd *) 0;
+
+    if (pw)
+        return pw;
+
+    uid = (unsigned) getuid();
+    user = getlogin();
+    if (user) {
+        pw = getpwnam(user);
+        if (pw && ((unsigned) pw->pw_uid != uid))
+            pw = 0;
+    }
+    if (pw == 0) {
+        user = nh_getenv("USER");
+        if (user) {
+            pw = getpwnam(user);
+            if (pw && ((unsigned) pw->pw_uid != uid))
+                pw = 0;
+        }
+        if (pw == 0) {
+            pw = getpwuid(uid);
+        }
+    }
+    return pw;
+}
+
+char *
+get_login_name(void)
+{
+    static char buf[BUFSZ];
+    struct passwd *pw = get_unix_pw();
+
+    buf[0] = '\0';
+    if (pw)
+        (void)strcpy(buf, pw->pw_name);
+
+    return buf;
+}
+
+unsigned long
+sys_random_seed(void)
+{
+    unsigned long seed = 0L;
+    unsigned long pid = (unsigned long) getpid();
+    boolean no_seed = TRUE;
+#ifdef DEV_RANDOM
+    FILE *fptr;
+
+    fptr = fopen(DEV_RANDOM, "r");
+    if (fptr) {
+        fread(&seed, sizeof (long), 1, fptr);
+        has_strong_rngseed = TRUE;
+        no_seed = FALSE;
+        (void) fclose(fptr);
+    } else {
+        paniclog("sys_random_seed", "falling back to weak seed");
+    }
+#endif
+    if (no_seed) {
+        seed = (unsigned long) getnow();
+        if (pid) {
+            if (!(pid & 3L))
+                pid -= 1L;
+            seed *= pid;
+        }
+    }
+    return seed;
+}
+
+
+#ifdef __EMSCRIPTEN__
+/***
+ * Helpers
+ ***/
+EM_JS(void, js_helpers_init, (), {
+    globalThis.nethackGlobal = globalThis.nethackGlobal || {};
+    globalThis.nethackGlobal.helpers = globalThis.nethackGlobal.helpers || {};
+
+    installHelper(getPointerValue, "getPointerValue");
+    installHelper(setPointerValue, "setPointerValue");
+    installHelper(mapglyphHelper, "mapglyphHelper");
+
+    function mapglyphHelper(glyph, x, y, mgflags) {
+        let ochar = _malloc(4);
+        let ocolor = _malloc(4);
+        let ospecial = _malloc(4);
+        _mapglyph(glyph, ochar, ocolor, ospecial, x, y, mgflags);
+        let ch = getValue(ochar, "i32");
+        let color = getValue(ocolor, "i32");
+        let special = getValue(ospecial, "i32");
+        _free(ochar);
+        _free(ocolor);
+        _free(ospecial);
+        return { glyph, ch, color, special, x, y, mgflags };
+    }
+
+    // convert 'ptr' to the type indicated by 'type'
+    function getPointerValue(name, ptr, type) {
+        switch(type) {
+        case "s": // string
+            return UTF8ToString(ptr);
+        case "p": // pointer
+            if(!ptr) return 0;
+            return getValue(ptr, "*");
+        case "c": // char
+            return String.fromCharCode(getValue(ptr, "i8"));
+        case "b":
+            return getValue(ptr, "i8") == 1;
+        case "0": /* 2^0 = 1 byte */
+            return getValue(ptr, "i8");
+        case "1": /* 2^1 = 2 bytes */
+            return getValue(ptr, "i16");
+        case "2": /* 2^2 = 4 bytes */
+        case "i": // integer
+        case "n": // number
+            return getValue(ptr, "i32");
+        case "f": // float
+            return getValue(ptr, "float");
+        case "d": // double
+            return getValue(ptr, "double");
+        case "v": // void
+            return undefined;
+        default:
+            throw new TypeError ("unknown type:" + type);
+        }
+    }
+
+    // sets the return value of the function to the type expected
+    function setPointerValue(name, ptr, type, value = 0) {
+        switch (type) {
+        case "p":
+            setValue(ptr, value, "*");
+            break;
+        case "s":
+            if(typeof value !== "string")
+                throw new TypeError(`expected ${name} return type to be string`);
+            stringToUTF8(value, ptr, 256);
+            break;
+        case "i":
+            if(typeof value !== "number" || !Number.isInteger(value))
+                throw new TypeError(`expected ${name} return type to be integer`);
+            setValue(ptr, value, "i32");
+            break;
+        case "1":
+            if(typeof value !== "number" || !Number.isInteger(value))
+                throw new TypeError(`expected ${name} return type to be integer`);
+            setValue(ptr, value, "i16");
+            break;
+        case "c":
+            if(typeof value !== "number" || value < 0 || value > 128)
+                throw new TypeError(`expected ${name} return type to be integer representing an ASCII character`);
+            setValue(ptr, value, "i8");
+            break;
+        case "f":
+        case "d":
+            if(typeof value !== "number")
+                throw new TypeError(`expected ${name} return type to be number`);
+            setValue(ptr, value, "double");
+            break;
+        case "b":
+            if (typeof value !== "boolean")
+                throw new TypeError(`expected ${name} return type to be boolean`);
+            setValue(ptr, value ? 1 : 0, "i8");
+            break;
+        case "v":
+            break;
+        default:
+            throw new Error("unknown type");
+        }
+    }
+
+    function installHelper(fn, name) {
+        name = name || fn.name;
+        globalThis.nethackGlobal.helpers[name] = fn;
+    }
+})
+
+/***
+ * Constants
+ ***/
+#define SET_CONSTANT(scope, name) set_const(scope, #name, name);
+EM_JS(void, set_const, (char *scope_str, char *name_str, int num), {
+    let scope = UTF8ToString(scope_str);
+    let name = UTF8ToString(name_str);
+
+    globalThis.nethackGlobal.constants[scope] = globalThis.nethackGlobal.constants[scope] || {};
+    globalThis.nethackGlobal.constants[scope][name] = num;
+    globalThis.nethackGlobal.constants[scope][num] = name;
+});
+#define SET_CONSTANT_STRING(scope, name) set_const_str(scope, #name, name);
+EM_JS(void, set_const_str, (char *scope_str, char *name_str, char *input_str), {
+    let scope = UTF8ToString(scope_str);
+    let name = UTF8ToString(name_str);
+    let str = UTF8ToString(input_str);
+
+    globalThis.nethackGlobal.constants[scope] = globalThis.nethackGlobal.constants[scope] || {};
+    globalThis.nethackGlobal.constants[scope][name] = str;
+});
+#define SET_POINTER(name) set_const_ptr(#name, (void *)&name);
+EM_JS(void, set_const_ptr, (char *name_str, void* ptr), {
+    let name = UTF8ToString(name_str);
+
+    globalThis.nethackGlobal.pointers = globalThis.nethackGlobal.pointers || {};
+    globalThis.nethackGlobal.pointers[name] = ptr;
+});
+
+void js_constants_init() {
+    EM_ASM({
+        globalThis.nethackGlobal = globalThis.nethackGlobal || {};
+        globalThis.nethackGlobal.constants = globalThis.nethackGlobal.constants || {};
+        globalThis.nethackGlobal.pointers = globalThis.nethackGlobal.pointers || {};
+    });
+
+    /* create_nhwindow */
+    SET_CONSTANT("WIN_TYPE", NHW_MESSAGE)
+    SET_CONSTANT("WIN_TYPE", NHW_STATUS)
+    SET_CONSTANT("WIN_TYPE", NHW_MAP)
+    SET_CONSTANT("WIN_TYPE", NHW_MENU)
+    SET_CONSTANT("WIN_TYPE", NHW_TEXT)
+
+    /* status_update */
+    SET_CONSTANT("STATUS_FIELD", BL_CHARACTERISTICS)
+    SET_CONSTANT("STATUS_FIELD", BL_RESET)
+    SET_CONSTANT("STATUS_FIELD", BL_FLUSH)
+    SET_CONSTANT("STATUS_FIELD", BL_TITLE)
+    SET_CONSTANT("STATUS_FIELD", BL_STR)
+    SET_CONSTANT("STATUS_FIELD", BL_DX)
+    SET_CONSTANT("STATUS_FIELD", BL_CO)
+    SET_CONSTANT("STATUS_FIELD", BL_IN)
+    SET_CONSTANT("STATUS_FIELD", BL_WI)
+    SET_CONSTANT("STATUS_FIELD", BL_CH)
+    SET_CONSTANT("STATUS_FIELD", BL_ALIGN)
+    SET_CONSTANT("STATUS_FIELD", BL_SCORE)
+    SET_CONSTANT("STATUS_FIELD", BL_CAP)
+    SET_CONSTANT("STATUS_FIELD", BL_GOLD)
+    SET_CONSTANT("STATUS_FIELD", BL_ENE)
+    SET_CONSTANT("STATUS_FIELD", BL_ENEMAX)
+    SET_CONSTANT("STATUS_FIELD", BL_XP)
+    SET_CONSTANT("STATUS_FIELD", BL_AC)
+    SET_CONSTANT("STATUS_FIELD", BL_HD)
+    SET_CONSTANT("STATUS_FIELD", BL_TIME)
+    SET_CONSTANT("STATUS_FIELD", BL_HUNGER)
+    SET_CONSTANT("STATUS_FIELD", BL_HP)
+    SET_CONSTANT("STATUS_FIELD", BL_HPMAX)
+    SET_CONSTANT("STATUS_FIELD", BL_LEVELDESC)
+    SET_CONSTANT("STATUS_FIELD", BL_EXP)
+    SET_CONSTANT("STATUS_FIELD", BL_CONDITION)
+    SET_CONSTANT("STATUS_FIELD", MAXBLSTATS)
+
+    /* text attributes */
+    SET_CONSTANT("ATTR", ATR_NONE);
+    SET_CONSTANT("ATTR", ATR_BOLD);
+    SET_CONSTANT("ATTR", ATR_DIM);
+    SET_CONSTANT("ATTR", ATR_ULINE);
+    SET_CONSTANT("ATTR", ATR_BLINK);
+    SET_CONSTANT("ATTR", ATR_INVERSE);
+
+    /* conditions (3.6 has 13 conditions) */
+    SET_CONSTANT("CONDITION", BL_MASK_STONE);
+    SET_CONSTANT("CONDITION", BL_MASK_SLIME);
+    SET_CONSTANT("CONDITION", BL_MASK_STRNGL);
+    SET_CONSTANT("CONDITION", BL_MASK_FOODPOIS);
+    SET_CONSTANT("CONDITION", BL_MASK_TERMILL);
+    SET_CONSTANT("CONDITION", BL_MASK_BLIND);
+    SET_CONSTANT("CONDITION", BL_MASK_DEAF);
+    SET_CONSTANT("CONDITION", BL_MASK_STUN);
+    SET_CONSTANT("CONDITION", BL_MASK_CONF);
+    SET_CONSTANT("CONDITION", BL_MASK_HALLU);
+    SET_CONSTANT("CONDITION", BL_MASK_LEV);
+    SET_CONSTANT("CONDITION", BL_MASK_FLY);
+    SET_CONSTANT("CONDITION", BL_MASK_RIDE);
+
+    /* menu */
+    SET_CONSTANT("MENU_SELECT", PICK_NONE);
+    SET_CONSTANT("MENU_SELECT", PICK_ONE);
+    SET_CONSTANT("MENU_SELECT", PICK_ANY);
+
+    /* copyright */
+    SET_CONSTANT_STRING("COPYRIGHT", COPYRIGHT_BANNER_A);
+    SET_CONSTANT_STRING("COPYRIGHT", COPYRIGHT_BANNER_B);
+    set_const_str("COPYRIGHT", "COPYRIGHT_BANNER_C", (char*) COPYRIGHT_BANNER_C);
+    SET_CONSTANT_STRING("COPYRIGHT", COPYRIGHT_BANNER_D);
+
+    /* glyphs */
+    SET_CONSTANT("GLYPH", GLYPH_MON_OFF);
+    SET_CONSTANT("GLYPH", GLYPH_PET_OFF);
+    SET_CONSTANT("GLYPH", GLYPH_INVIS_OFF);
+    SET_CONSTANT("GLYPH", GLYPH_DETECT_OFF);
+    SET_CONSTANT("GLYPH", GLYPH_BODY_OFF);
+    SET_CONSTANT("GLYPH", GLYPH_RIDDEN_OFF);
+    SET_CONSTANT("GLYPH", GLYPH_OBJ_OFF);
+    SET_CONSTANT("GLYPH", GLYPH_CMAP_OFF);
+    SET_CONSTANT("GLYPH", GLYPH_EXPLODE_OFF);
+    SET_CONSTANT("GLYPH", GLYPH_ZAP_OFF);
+    SET_CONSTANT("GLYPH", GLYPH_SWALLOW_OFF);
+    SET_CONSTANT("GLYPH", GLYPH_WARNING_OFF);
+    SET_CONSTANT("GLYPH", GLYPH_STATUE_OFF);
+    SET_CONSTANT("GLYPH", MAX_GLYPH);
+    SET_CONSTANT("GLYPH", NO_GLYPH);
+    SET_CONSTANT("GLYPH", GLYPH_INVISIBLE);
+
+    /* colors */
+    SET_CONSTANT("COLORS", CLR_BLACK);
+    SET_CONSTANT("COLORS", CLR_RED);
+    SET_CONSTANT("COLORS", CLR_GREEN);
+    SET_CONSTANT("COLORS", CLR_BROWN);
+    SET_CONSTANT("COLORS", CLR_BLUE);
+    SET_CONSTANT("COLORS", CLR_MAGENTA);
+    SET_CONSTANT("COLORS", CLR_CYAN);
+    SET_CONSTANT("COLORS", CLR_GRAY);
+    SET_CONSTANT("COLORS", NO_COLOR);
+    SET_CONSTANT("COLORS", CLR_ORANGE);
+    SET_CONSTANT("COLORS", CLR_BRIGHT_GREEN);
+    SET_CONSTANT("COLORS", CLR_YELLOW);
+    SET_CONSTANT("COLORS", CLR_BRIGHT_BLUE);
+    SET_CONSTANT("COLORS", CLR_BRIGHT_MAGENTA);
+    SET_CONSTANT("COLORS", CLR_BRIGHT_CYAN);
+    SET_CONSTANT("COLORS", CLR_WHITE);
+    SET_CONSTANT("COLORS", CLR_MAX);
+
+    /* color attributes */
+    SET_CONSTANT("COLOR_ATTR", HL_ATTCLR_DIM);
+    SET_CONSTANT("COLOR_ATTR", HL_ATTCLR_BLINK);
+    SET_CONSTANT("COLOR_ATTR", HL_ATTCLR_ULINE);
+    SET_CONSTANT("COLOR_ATTR", HL_ATTCLR_INVERSE);
+    SET_CONSTANT("COLOR_ATTR", HL_ATTCLR_BOLD);
+    SET_CONSTANT("COLOR_ATTR", BL_ATTCLR_MAX);
+
+    SET_CONSTANT("ROLE_RACEMASK", MH_HUMAN);
+    SET_CONSTANT("ROLE_RACEMASK", MH_ELF);
+    SET_CONSTANT("ROLE_RACEMASK", MH_DWARF);
+    SET_CONSTANT("ROLE_RACEMASK", MH_GNOME);
+    SET_CONSTANT("ROLE_RACEMASK", MH_ORC);
+
+    SET_CONSTANT("ROLE_GENDMASK", ROLE_MALE);
+    SET_CONSTANT("ROLE_GENDMASK", ROLE_FEMALE);
+    SET_CONSTANT("ROLE_GENDMASK", ROLE_NEUTER);
+
+    SET_CONSTANT("ROLE_ALIGNMASK", ROLE_LAWFUL);
+    SET_CONSTANT("ROLE_ALIGNMASK", ROLE_NEUTRAL);
+    SET_CONSTANT("ROLE_ALIGNMASK", ROLE_CHAOTIC);
+
+    SET_CONSTANT("HL", HL_UNDEF);
+    SET_CONSTANT("HL", HL_NONE);
+    SET_CONSTANT("HL", HL_BOLD);
+    SET_CONSTANT("HL", HL_DIM);
+    SET_CONSTANT("HL", HL_ULINE);
+    SET_CONSTANT("HL", HL_BLINK);
+    SET_CONSTANT("HL", HL_INVERSE);
+
+    /* monster glyph flags (3.6 subset) */
+    SET_CONSTANT("MG", MG_CORPSE);
+    SET_CONSTANT("MG", MG_INVIS);
+    SET_CONSTANT("MG", MG_DETECT);
+    SET_CONSTANT("MG", MG_PET);
+    SET_CONSTANT("MG", MG_RIDDEN);
+    SET_CONSTANT("MG", MG_STATUE);
+    SET_CONSTANT("MG", MG_OBJPILE);
+    SET_CONSTANT("MG", MG_BW_LAVA);
+
+    SET_POINTER(extcmdlist);
+
+    /* roles/races/genders/alignments */
+    SET_POINTER(roles);
+    SET_POINTER(races);
+    SET_POINTER(genders);
+    SET_POINTER(aligns);
+}
+
+/***
+ * Globals
+ ***/
+#define CREATE_GLOBAL(var, type) create_global(#var, (void *)&var, type);
+
+void create_global (char *name, void *ptr, char *type);
+
+void js_globals_init() {
+    EM_ASM({
+        globalThis.nethackGlobal = globalThis.nethackGlobal || {};
+        globalThis.nethackGlobal.globals = globalThis.nethackGlobal.globals || {};
+    });
+
+    /* globals — 3.6 uses direct globals (no svp./gh. prefix) */
+    CREATE_GLOBAL(plname, "s");
+
+    /* window globals */
+    CREATE_GLOBAL(WIN_MAP, "i");
+    CREATE_GLOBAL(WIN_MESSAGE, "i");
+    CREATE_GLOBAL(WIN_INVEN, "i");
+    CREATE_GLOBAL(WIN_STATUS, "i");
+
+    /* instance flags */
+    CREATE_GLOBAL(iflags.window_inited, "b");
+    CREATE_GLOBAL(iflags.wc2_hitpointbar, "b");
+    CREATE_GLOBAL(iflags.wc_hilite_pet, "b");
+    CREATE_GLOBAL(iflags.hilite_pile, "b");
+
+    /* flags */
+    CREATE_GLOBAL(flags.initrole, "i");
+    CREATE_GLOBAL(flags.initrace, "i");
+    CREATE_GLOBAL(flags.initgend, "i");
+    CREATE_GLOBAL(flags.initalign, "i");
+    CREATE_GLOBAL(flags.showexp, "b");
+    CREATE_GLOBAL(flags.time, "b");
+}
+
+EM_JS(void, create_global, (char *name_str, void *ptr, char *type_str), {
+    let name = UTF8ToString(name_str);
+    let type = UTF8ToString(type_str);
+
+    let getPointerValue = globalThis.nethackGlobal.helpers.getPointerValue;
+    let setPointerValue = globalThis.nethackGlobal.helpers.setPointerValue;
+
+    let { obj, prop } = createPath(globalThis.nethackGlobal.globals, name);
+
+    Object.defineProperty(obj, prop, {
+        get: getPointerValue.bind(null, name, ptr, type),
+        set: setPointerValue.bind(null, name, ptr, type),
+        configurable: true,
+        enumerable: true
+    });
+
+    function createPath(obj, path) {
+        path = path.split(".");
+        let i;
+        for (i = 0; i < path.length - 1; i++) {
+            if (obj[path[i]] === undefined) {
+                obj[path[i]] = {};
+            }
+            obj = obj[path[i]];
+        }
+
+        return { obj, prop: path[i] };
+    }
+})
+
+#endif /* __EMSCRIPTEN__ */
+
+/*libnhmain.c*/

--- a/sys/libnh/libnhmain.c
+++ b/sys/libnh/libnhmain.c
@@ -646,6 +646,20 @@ sys_random_seed(void)
 
 
 #ifdef __EMSCRIPTEN__
+
+#ifdef USE_TILES
+extern short glyph2tile[];
+
+int
+glyph_to_tile(glyph)
+int glyph;
+{
+    if (glyph < 0 || glyph >= MAX_GLYPH)
+        return -1;
+    return (int)glyph2tile[glyph];
+}
+#endif /* USE_TILES */
+
 /***
  * Helpers
  ***/
@@ -656,6 +670,7 @@ EM_JS(void, js_helpers_init, (), {
     installHelper(getPointerValue, "getPointerValue");
     installHelper(setPointerValue, "setPointerValue");
     installHelper(mapglyphHelper, "mapglyphHelper");
+    installHelper(tileIndexForGlyph, "tileIndexForGlyph");
 
     function mapglyphHelper(glyph, x, y, mgflags) {
         let ochar = _malloc(4);
@@ -668,7 +683,11 @@ EM_JS(void, js_helpers_init, (), {
         _free(ochar);
         _free(ocolor);
         _free(ospecial);
-        return { glyph, ch, color, special, x, y, mgflags };
+        return { glyph, ch, color, special, tileIdx: _glyph_to_tile(glyph), x, y, mgflags };
+    }
+
+    function tileIndexForGlyph(glyph) {
+        return _glyph_to_tile(glyph);
     }
 
     // convert 'ptr' to the type indicated by 'type'

--- a/sys/libnh/sysconf
+++ b/sys/libnh/sysconf
@@ -1,0 +1,22 @@
+# NetHack 3.6 sysconf - WASM/Library build
+# Copyright (c) Adam Powers, 2020.
+# NetHack may be freely redistributed.  See license for details.
+#
+# Minimal sysconf for WASM builds.
+
+# Allow anyone to use wizard/debug mode
+WIZARDS=*
+
+# Allow anyone to use explore mode
+EXPLORERS=*
+
+# Prompt for username for generic users
+GENERICUSERS=play player game games nethack nethacker
+
+# Maximum simultaneous games
+MAXPLAYERS=0
+
+# Disable panic tracing (not available in WASM)
+PANICTRACE_GDB=0
+PANICTRACE_LIBC=0
+

--- a/sys/libnh/test/test.mjs
+++ b/sys/libnh/test/test.mjs
@@ -1,0 +1,424 @@
+#!/usr/bin/env node
+
+// Integration test for the NetHack 3.6 WASM build.
+// Verifies that the module loads, callbacks fire correctly, and the game
+// produces valid rendering data (map glyphs, status fields, text output).
+//
+// Usage:
+//   node sys/libnh/test/test.mjs              # from the NetHack-3.6 directory
+//   node NetHack-3.6/sys/libnh/test/test.mjs  # from the repository root
+
+import { fileURLToPath } from "url";
+import { dirname, join, resolve } from "path";
+import { existsSync } from "fs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Find nethack.js — try relative to this file first, then cwd
+const candidates = [
+    join(__dirname, "..", "..", "..", "src", "nethack.js"),   // from NetHack-3.6/sys/libnh/test/
+    join(process.cwd(), "src", "nethack.js"),                // from NetHack-3.6/
+    join(process.cwd(), "NetHack-3.6", "src", "nethack.js"), // from repository root
+];
+const nethackPath = candidates.find(p => existsSync(p));
+if (!nethackPath) {
+    console.error("ERROR: Cannot find src/nethack.js. Run build-wasm.sh first.");
+    console.error("Searched:", candidates.map(p => resolve(p)).join("\n  "));
+    process.exit(1);
+}
+
+// ── Glyph offset constants (NUMMONS=381, NUM_OBJECTS=453, MAXPCHARS=96) ──
+const NUMMONS = 381;
+const NUM_OBJECTS = 453;
+const GLYPH_MON_OFF = 0;
+const GLYPH_PET_OFF = NUMMONS;
+const GLYPH_INVIS_OFF = NUMMONS + GLYPH_PET_OFF;
+const GLYPH_DETECT_OFF = 1 + GLYPH_INVIS_OFF;
+const GLYPH_BODY_OFF = NUMMONS + GLYPH_DETECT_OFF;
+const GLYPH_RIDDEN_OFF = NUMMONS + GLYPH_BODY_OFF;
+const GLYPH_OBJ_OFF = NUMMONS + GLYPH_RIDDEN_OFF;
+const GLYPH_CMAP_OFF = NUM_OBJECTS + GLYPH_OBJ_OFF;
+// NO_GLYPH = MAX_GLYPH = 5976 for this build
+const NO_GLYPH = 5976;
+
+// S_ cmap symbols -> ASCII (from include/rm.h + src/drawing.c)
+const CMAP_CHARS = {
+    0: " ", 1: "|", 2: "-", 3: "-", 4: "-", 5: "-", 6: "-", 7: "-",
+    8: "-", 9: "-", 10: "|", 11: "|", 12: ".", 13: "|", 14: "-",
+    15: "+", 16: "+", 17: "#", 18: "#", 19: ".", 20: ".", 21: "#",
+    22: "#", 23: "<", 24: ">", 25: "<", 26: ">", 27: "_", 28: "|",
+    29: "\\", 30: "{", 31: "{", 32: "}", 33: ".", 34: "}", 35: ".",
+    36: ".", 37: "#", 38: "#", 39: " ", 40: "#", 41: "}",
+};
+
+function glyphToChar(g) {
+    if (g >= GLYPH_CMAP_OFF) return CMAP_CHARS[g - GLYPH_CMAP_OFF] || "?";
+    if (g >= GLYPH_OBJ_OFF) return ")";
+    if (g >= GLYPH_RIDDEN_OFF) return "u";
+    if (g >= GLYPH_BODY_OFF) return "%";
+    if (g >= GLYPH_DETECT_OFF) return "M";
+    if (g === GLYPH_INVIS_OFF) return "I";
+    if (g >= GLYPH_PET_OFF) return "d";
+    if (g >= GLYPH_MON_OFF) return "@";
+    return "?";
+}
+
+function glyphCategory(g) {
+    if (g === NO_GLYPH) return "NO_GLYPH";
+    if (g >= GLYPH_CMAP_OFF) return `CMAP(${g - GLYPH_CMAP_OFF})`;
+    if (g >= GLYPH_OBJ_OFF) return `OBJ(${g - GLYPH_OBJ_OFF})`;
+    if (g >= GLYPH_RIDDEN_OFF) return `RIDDEN(${g - GLYPH_RIDDEN_OFF})`;
+    if (g >= GLYPH_BODY_OFF) return `BODY(${g - GLYPH_BODY_OFF})`;
+    if (g >= GLYPH_DETECT_OFF) return `DETECT(${g - GLYPH_DETECT_OFF})`;
+    if (g === GLYPH_INVIS_OFF) return "INVISIBLE";
+    if (g >= GLYPH_PET_OFF) return `PET(${g - GLYPH_PET_OFF})`;
+    return `MON(${g})`;
+}
+
+// ── Test harness ──
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, label) {
+    if (condition) {
+        passed++;
+    } else {
+        failed++;
+        console.log(`  FAIL: ${label}`);
+    }
+}
+
+// ── Data collectors ──
+
+const windows = {};
+const glyphs = [];
+const statusFields = {};
+const putstrCalls = [];
+const rawPrints = [];
+const callbackNames = new Set();
+let cmdCount = 0;
+let nextWinId = 1;
+let cursorX = -1, cursorY = -1;
+let Module;
+
+// ── Main ──
+
+async function main() {
+    console.log("NetHack 3.6 WASM — Integration Test\n");
+
+    // ── Load module ──
+    console.log("Loading module...");
+    const createModule = (await import(nethackPath)).default;
+    Module = await createModule({
+        noInitialRun: true,
+        print: () => {},
+        printErr: () => {},
+    });
+
+    // ── Install helpers ──
+    globalThis.nethackGlobal = globalThis.nethackGlobal || {};
+    globalThis.nethackGlobal.helpers = {
+        getPointerValue: (name, ptr, type) => {
+            switch (type) {
+                case "i": case "2": return Module.getValue(ptr, "i32");
+                case "0": return Module.getValue(ptr, "i8");
+                case "1": return Module.getValue(ptr, "i16");
+                case "s": return Module.UTF8ToString(ptr);
+                case "p": return ptr;
+                case "b": return Module.getValue(ptr, "i8") !== 0;
+                case "c": return String.fromCharCode(Module.getValue(ptr, "i8"));
+                default:  return ptr;
+            }
+        },
+        setPointerValue: (name, ptr, type, val) => {
+            if (!ptr) return;
+            switch (type) {
+                case "i": case "2": Module.setValue(ptr, val | 0, "i32"); break;
+                case "0": Module.setValue(ptr, val | 0, "i8"); break;
+                case "1": Module.setValue(ptr, val | 0, "i16"); break;
+                case "b": Module.setValue(ptr, val ? 1 : 0, "i8"); break;
+                case "c": Module.setValue(ptr, typeof val === "string"
+                              ? val.charCodeAt(0) : (val | 0), "i8"); break;
+                case "v": break;
+                default:  Module.setValue(ptr, val | 0, "i32"); break;
+            }
+        },
+    };
+
+    // ── Install callback ──
+    globalThis.nethackCallback = async (name, ...args) => {
+        callbackNames.add(name);
+        switch (name) {
+            case "shim_init_nhwindows": return;
+            case "shim_askname": return;
+            case "shim_player_selection": return;
+            case "shim_create_nhwindow": {
+                const type = args[0];
+                const winid = nextWinId++;
+                const names = { 1: "MESSAGE", 2: "STATUS", 3: "MAP", 4: "MENU", 5: "TEXT" };
+                windows[winid] = { type: names[type] || `TYPE${type}`, typeNum: type };
+                return winid;
+            }
+            case "shim_display_nhwindow": return;
+            case "shim_clear_nhwindow": return;
+            case "shim_putstr":
+                putstrCalls.push({ winid: args[0], attr: args[1], text: args[2] });
+                return;
+            case "shim_print_glyph":
+                glyphs.push({ winid: args[0], x: args[1], y: args[2],
+                              glyph: args[3], bkglyph: args[4] });
+                return;
+            case "shim_curs":
+                cursorX = args[1]; cursorY = args[2];
+                return;
+            case "shim_status_init": return;
+            case "shim_status_enablefield": return;
+            case "shim_status_update": {
+                const fldidx = args[0];
+                const ptr = args[1];
+                let strVal = "";
+                if (ptr && typeof ptr === "number" && ptr > 0) {
+                    try { strVal = Module.UTF8ToString(ptr); } catch (e) { strVal = ""; }
+                }
+                statusFields[fldidx] = { strVal, chg: args[2], percent: args[3] };
+                return;
+            }
+            case "shim_start_menu": return;
+            case "shim_add_menu": return;
+            case "shim_end_menu": return;
+            case "shim_select_menu": return 0;
+            case "shim_nhgetch":
+            case "shim_nh_poskey":
+                cmdCount++;
+                if (cmdCount > 5) { runTests(); process.exit(failed > 0 ? 1 : 0); }
+                return 32;
+            case "shim_yn_function": return 121; // 'y'
+            case "shim_raw_print":
+            case "shim_raw_print_bold":
+                rawPrints.push(String(args[0] || ""));
+                return;
+            case "shim_getmsghistory": return "";
+            case "shim_putmsghistory": return;
+            case "shim_getlin": return;
+            case "shim_message_menu": return 0;
+            case "shim_nhbell": return;
+            case "shim_delay_output": return;
+            case "shim_mark_synch": return;
+            case "shim_wait_synch": return;
+            case "shim_start_screen": return;
+            case "shim_end_screen": return;
+            case "shim_get_nh_event": return;
+            case "shim_number_pad": return;
+            case "shim_exit_nhwindows": return;
+            case "shim_cliparound": return;
+            case "shim_preference_update": return;
+            case "shim_destroy_nhwindow": return;
+            case "shim_doprev_message": return 0;
+            case "shim_update_positionbar": return;
+            case "shim_outrip": return;
+            case "shim_display_file": return;
+            case "shim_get_ext_cmd": return -1;
+            case "shim_suspend_nhwindows": return;
+            case "shim_resume_nhwindows": return;
+            default: return 0;
+        }
+    };
+
+    const setCallback = Module.cwrap("shim_graphics_set_callback", null, ["string"]);
+    setCallback("nethackCallback");
+    try { Module._main(0, 0); } catch (e) {}
+}
+
+// ── Tests ──
+
+function runTests() {
+    console.log(""); // blank line after any raw_print output
+
+    // 1. Module exports
+    testSection("Module Exports");
+    assert(typeof Module._main === "function", "_main is exported");
+    assert(typeof Module._malloc === "function", "_malloc is exported");
+    assert(typeof Module.cwrap === "function", "cwrap is available");
+    assert(typeof Module.getValue === "function", "getValue is available");
+    assert(typeof Module.setValue === "function", "setValue is available");
+    assert(typeof Module.UTF8ToString === "function", "UTF8ToString is available");
+    assert(typeof Module.FS === "object", "FS is available");
+
+    // 2. Embedded filesystem
+    testSection("Filesystem");
+    const rootFiles = Module.FS.readdir("/").filter(f => f !== "." && f !== "..");
+    assert(rootFiles.includes("nhdat"), "nhdat exists in virtual FS");
+    assert(rootFiles.includes("sysconf"), "sysconf exists in virtual FS");
+    const nhdat = Module.FS.stat("/nhdat");
+    assert(nhdat.size > 1000000, `nhdat is large enough (${nhdat.size} bytes)`);
+
+    // 3. Callbacks fired
+    testSection("Callbacks");
+    assert(callbackNames.has("shim_init_nhwindows"), "shim_init_nhwindows was called");
+    assert(callbackNames.has("shim_player_selection"), "shim_player_selection was called");
+    assert(callbackNames.has("shim_create_nhwindow"), "shim_create_nhwindow was called");
+    assert(callbackNames.has("shim_print_glyph"), "shim_print_glyph was called");
+    assert(callbackNames.has("shim_status_update"), "shim_status_update was called");
+    assert(callbackNames.has("shim_nh_poskey") || callbackNames.has("shim_nhgetch"),
+        "input callback (nh_poskey or nhgetch) was called");
+    assert(callbackNames.size >= 10, `at least 10 unique callbacks (got ${callbackNames.size})`);
+
+    // 4. Windows
+    testSection("Windows");
+    const winTypes = Object.values(windows).map(w => w.type);
+    assert(winTypes.includes("MESSAGE"), "MESSAGE window was created");
+    assert(winTypes.includes("MAP"), "MAP window was created");
+    assert(Object.keys(windows).length >= 2, `at least 2 windows created (got ${Object.keys(windows).length})`);
+
+    // 5. Map / glyph data
+    testSection("Map");
+    assert(glyphs.length > 20, `enough glyphs received (got ${glyphs.length})`);
+
+    const mapWinId = Object.entries(windows).find(([, w]) => w.type === "MAP")?.[0];
+    const mapGlyphs = mapWinId ? glyphs.filter(g => g.winid === parseInt(mapWinId)) : [];
+    assert(mapGlyphs.length > 20, `glyphs sent to MAP window (got ${mapGlyphs.length})`);
+
+    // Check coordinate ranges are plausible (NetHack map is 80x21)
+    const xs = mapGlyphs.map(g => g.x);
+    const ys = mapGlyphs.map(g => g.y);
+    assert(Math.min(...xs) >= 0 && Math.max(...xs) < 80, `x range valid (${Math.min(...xs)}-${Math.max(...xs)})`);
+    assert(Math.min(...ys) >= 0 && Math.max(...ys) < 21, `y range valid (${Math.min(...ys)}-${Math.max(...ys)})`);
+
+    // Check glyph values are in valid range
+    const allGlyphVals = mapGlyphs.map(g => g.glyph);
+    assert(allGlyphVals.every(g => g >= 0 && g <= NO_GLYPH), "all glyphs in valid range");
+
+    // Check background glyphs
+    const bkgs = [...new Set(mapGlyphs.map(g => g.bkglyph))];
+    assert(bkgs.every(g => g >= 0 && g <= NO_GLYPH), "background glyphs in valid range");
+
+    // Should have a mix of cmap (walls/floors) and at least one monster/object
+    const hasCmap = allGlyphVals.some(g => g >= GLYPH_CMAP_OFF && g < GLYPH_CMAP_OFF + 96);
+    const hasNonCmap = allGlyphVals.some(g => g < GLYPH_CMAP_OFF);
+    assert(hasCmap, "map contains cmap glyphs (walls, floors)");
+    assert(hasNonCmap, "map contains non-cmap glyphs (monsters, objects, pets)");
+
+    // Check that room floor (S_room=19) is the most common glyph
+    const roomGlyph = GLYPH_CMAP_OFF + 19;
+    const roomCount = allGlyphVals.filter(g => g === roomGlyph).length;
+    assert(roomCount >= 5, `room floor glyph is common (${roomCount} cells)`);
+
+    // Cursor position should be on the map
+    assert(cursorX >= 0 && cursorX < 80, `cursor X on map (${cursorX})`);
+    assert(cursorY >= 0 && cursorY < 21, `cursor Y on map (${cursorY})`);
+
+    // 6. Status
+    testSection("Status");
+    assert(Object.keys(statusFields).length >= 10, `enough status fields (got ${Object.keys(statusFields).length})`);
+
+    // TITLE (field 0) should be a non-empty string
+    const title = statusFields[0];
+    assert(title && title.strVal.length > 0, `BL_TITLE has text ("${title?.strVal}")`);
+
+    // HP (field 18) should be a positive number
+    const hp = statusFields[18];
+    assert(hp && parseInt(hp.strVal) > 0, `BL_HP is positive (${hp?.strVal})`);
+
+    // HPMAX (field 19) should match or exceed HP
+    const hpmax = statusFields[19];
+    assert(hpmax && parseInt(hpmax.strVal) >= parseInt(hp?.strVal || "0"),
+        `BL_HPMAX >= BL_HP (${hpmax?.strVal} >= ${hp?.strVal})`);
+
+    // LEVELDESC (field 20) should say Dlvl:1
+    const level = statusFields[20];
+    assert(level && level.strVal.includes("Dlvl:1"), `BL_LEVELDESC is Dlvl:1 ("${level?.strVal.trim()}")`);
+
+    // AC (field 14) should be a number
+    const ac = statusFields[14];
+    assert(ac && !isNaN(parseInt(ac.strVal)), `BL_AC is numeric (${ac?.strVal})`);
+
+    // 7. Text output
+    testSection("Text Output");
+    assert(putstrCalls.length > 0, `putstr was called (${putstrCalls.length} times)`);
+
+    // Quest intro text should be present
+    const introLine = putstrCalls.find(p => p.text && p.text.includes("It is written"));
+    assert(introLine, "quest intro text was displayed");
+
+    const molochLine = putstrCalls.find(p => p.text && p.text.includes("Moloch"));
+    assert(molochLine, "creation story mentions Moloch");
+
+    // 8. Welcome message
+    testSection("Welcome");
+    const welcomeMsg = rawPrints.find(m => m.includes("welcome to NetHack"));
+    assert(welcomeMsg, "welcome message received");
+    assert(welcomeMsg && !welcomeMsg.includes("(null)"), "welcome message has no (null) role");
+
+    // 9. No errors
+    testSection("No Errors");
+    const errors = rawPrints.filter(m =>
+        m.includes("Program in disorder") ||
+        m.includes("init-prob error") ||
+        m.includes("Configuration incompatibility") ||
+        m.includes("Dungeon description not valid") ||
+        m.includes("CANNOT OPEN")
+    );
+    assert(errors.length === 0, `no fatal errors in raw_print (${errors.length > 0 ? errors[0] : "ok"})`);
+
+    const qtError = rawPrints.find(m => m.includes("load_qtlist"));
+    assert(!qtError, "no quest text loading errors");
+
+    // ── Render the ASCII map ──
+    console.log("\n── ASCII Map ──\n");
+    if (mapGlyphs.length > 0) {
+        const grid = {};
+        for (const g of mapGlyphs) grid[`${g.y},${g.x}`] = glyphToChar(g.glyph);
+        const minY = Math.min(...ys), maxY = Math.max(...ys);
+        const minX = Math.min(...xs), maxX = Math.max(...xs);
+        for (let y = minY; y <= maxY; y++) {
+            let row = "";
+            for (let x = minX; x <= maxX; x++) {
+                if (y === cursorY && x === cursorX) row += "@";
+                else row += grid[`${y},${x}`] || " ";
+            }
+            console.log(`  ${row}`);
+        }
+
+        console.log(`\n  Cursor: (${cursorX}, ${cursorY})`);
+        const glyphFreq = {};
+        for (const g of mapGlyphs) {
+            const cat = glyphCategory(g.glyph);
+            glyphFreq[cat] = (glyphFreq[cat] || 0) + 1;
+        }
+        console.log("  Glyphs:", Object.entries(glyphFreq)
+            .sort((a, b) => b[1] - a[1])
+            .map(([cat, n]) => `${cat}:${n}`)
+            .join("  "));
+    }
+
+    // ── Status line ──
+    console.log("\n── Status ──\n");
+    const fieldNames = {
+        0: "Title", 1: "Str", 2: "Dx", 3: "Co", 4: "In", 5: "Wi", 6: "Ch",
+        7: "Align", 9: "Cap", 10: "Gold", 11: "Ene", 12: "EneMax",
+        13: "XP", 14: "AC", 17: "Hunger", 18: "HP", 19: "HPmax",
+        20: "Dlvl", 22: "Cond",
+    };
+    const statusLine = [];
+    for (const [idx, name] of Object.entries(fieldNames)) {
+        const f = statusFields[idx];
+        if (f && f.strVal) statusLine.push(`${name}:${f.strVal.trim()}`);
+    }
+    console.log(`  ${statusLine.join("  ")}`);
+
+    // ── Summary ──
+    console.log(`\n── Results: ${passed} passed, ${failed} failed ──\n`);
+    if (failed > 0) console.log("FAIL");
+    else console.log("OK");
+}
+
+function testSection(name) {
+    console.log(`  ${name}`);
+}
+
+main().catch(e => {
+    console.error("FATAL:", e);
+    process.exit(1);
+});

--- a/sys/unix/hints/linux-wasm
+++ b/sys/unix/hints/linux-wasm
@@ -1,0 +1,83 @@
+#
+# NetHack 3.6  linux-wasm
+# Copyright (c) Adam Powers, 2020.
+# NetHack may be freely redistributed.  See license for details.
+#
+#-PRE
+# WASM cross-compilation hints file for NetHack 3.6
+# Builds nethack.js + nethack.wasm using Emscripten (emcc).
+#
+# Single hints file for the entire build. Native utilities are built
+# with CC=cc overrides; the game is built with CC=emcc (the default).
+# This ensures makedefs sees the same -D flags as the game, preventing
+# index mismatches in generated headers (onames.h, pm.h).
+# See build-wasm.sh for the full build process.
+
+HACKDIR=/
+
+CC=emcc
+AR=emar
+LINK=emcc
+
+CFLAGS=-O3 -I../include -DNOTPARMDECL
+CFLAGS+=-Wall
+CFLAGS+=-DDLB
+CFLAGS+=-DNO_SIGNAL
+CFLAGS+=-DNOMAIL
+CFLAGS+=-DSYSCF -DSYSCF_FILE=\"/sysconf\" -DSECURE
+CFLAGS+=-DHACKDIR=\"$(HACKDIR)\"
+CFLAGS+=-DDEFAULT_WINDOW_SYS=\"shim\"
+CFLAGS+=-DNOTTYGRAPHICS -DSHIM_GRAPHICS
+CFLAGS+=-DCONFIG_ERROR_SECURE=FALSE
+CFLAGS+=-DCROSS_TO_WASM
+CFLAGS+=-DSCORE_ON_BOTL
+
+LFLAGS=-s WASM=1
+LFLAGS+=-s ALLOW_TABLE_GROWTH
+LFLAGS+=-s ASYNCIFY -s ASYNCIFY_IMPORTS='["local_callback"]'
+LFLAGS+=-O3
+LFLAGS+=-s MODULARIZE
+LFLAGS+=-s EXPORTED_FUNCTIONS='["_main", "_shim_graphics_set_callback", "_malloc", "_free", "_mapglyph"]'
+LFLAGS+=-s EXPORTED_RUNTIME_METHODS='["cwrap", "ccall", "addFunction", "removeFunction", "UTF8ToString", "stringToUTF8", "getValue", "setValue", "ENV", "FS", "IDBFS"]'
+LFLAGS+=-s ERROR_ON_UNDEFINED_SYMBOLS=0
+# ^^^ Required: EM_JS functions (js_helpers_init, create_global, local_callback) are
+# resolved during JS generation, not at wasm-ld link time. Emscripten 3.1.x treats
+# them as undefined symbols without this flag.
+LFLAGS+=-s EXPORT_ES6=1
+LFLAGS+=-lidbfs.js
+LFLAGS+=--embed-file ../wasm-data@/
+
+WINSRC = ../win/shim/winshim.c
+WINOBJ = winshim.o
+WINLIB =
+
+CHOWN=true
+CHGRP=true
+
+VARDIRPERM = 0755
+VARFILEPERM = 0600
+GAMEPERM = 0755
+
+#-POST
+# Override GAME to produce .js output (emcc uses extension to determine format)
+GAME = nethack.js
+
+# Override SYSSRC and SYSOBJ to use libnhmain.c instead of unixmain.c
+SYSSRC = ../sys/libnh/libnhmain.c \
+	../sys/share/ioctl.c ../sys/share/unixtty.c \
+	../sys/unix/unixunix.c ../sys/unix/unixres.c
+SYSOBJ = libnhmain.o ioctl.o unixtty.o unixunix.o unixres.o
+
+# NOTE: No-op rules for preventing utility rebuilds are NOT included here
+# because the #-POST section is appended to ALL Makefiles (src, util, dat, top).
+# The build script (build-wasm.sh) appends them only to src/Makefile, where
+# they prevent the game build from trying to rebuild utilities with emcc.
+
+# Compile rules for source files in non-standard locations.
+Sysunix: libnhmain.o winshim.o
+
+libnhmain.o: ../sys/libnh/libnhmain.c $(HACK_H)
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+winshim.o: ../win/shim/winshim.c $(HACK_H)
+	$(CC) $(CFLAGS) -c -o $@ $<

--- a/sys/unix/hints/linux-wasm
+++ b/sys/unix/hints/linux-wasm
@@ -31,13 +31,15 @@ CFLAGS+=-DNOTTYGRAPHICS -DSHIM_GRAPHICS
 CFLAGS+=-DCONFIG_ERROR_SECURE=FALSE
 CFLAGS+=-DCROSS_TO_WASM
 CFLAGS+=-DSCORE_ON_BOTL
+CFLAGS+=-DUSE_TILES
+CFLAGS+=-DSTATUES_LOOK_LIKE_MONSTERS
 
 LFLAGS=-s WASM=1
 LFLAGS+=-s ALLOW_TABLE_GROWTH
 LFLAGS+=-s ASYNCIFY -s ASYNCIFY_IMPORTS='["local_callback"]'
 LFLAGS+=-O3
 LFLAGS+=-s MODULARIZE
-LFLAGS+=-s EXPORTED_FUNCTIONS='["_main", "_shim_graphics_set_callback", "_malloc", "_free", "_mapglyph"]'
+LFLAGS+=-s EXPORTED_FUNCTIONS='["_main", "_shim_graphics_set_callback", "_malloc", "_free", "_mapglyph", "_glyph_to_tile"]'
 LFLAGS+=-s EXPORTED_RUNTIME_METHODS='["cwrap", "ccall", "addFunction", "removeFunction", "UTF8ToString", "stringToUTF8", "getValue", "setValue", "ENV", "FS", "IDBFS"]'
 LFLAGS+=-s ERROR_ON_UNDEFINED_SYMBOLS=0
 # ^^^ Required: EM_JS functions (js_helpers_init, create_global, local_callback) are
@@ -47,8 +49,8 @@ LFLAGS+=-s EXPORT_ES6=1
 LFLAGS+=-lidbfs.js
 LFLAGS+=--embed-file ../wasm-data@/
 
-WINSRC = ../win/shim/winshim.c
-WINOBJ = winshim.o
+WINSRC = ../win/shim/winshim.c tile.c
+WINOBJ = winshim.o tile.o
 WINLIB =
 
 CHOWN=true

--- a/util/.gitignore
+++ b/util/.gitignore
@@ -27,3 +27,7 @@ heaputil.c
 #address san
 *.exp
 *.lib
+
+# WASM build artifacts
+makedefs-nomail
+makedefs.wasm

--- a/util/makedefs.c
+++ b/util/makedefs.c
@@ -1432,20 +1432,20 @@ do_date()
         Fprintf(ofp, "#define BUILD_TIME (%lu%s)\n",
                 (unsigned long) clocktim, ul_sfx);
     Fprintf(ofp, "\n");
-    Fprintf(ofp, "#define VERSION_NUMBER 0x%08lx%s\n", version.incarnation,
-            ul_sfx);
-    Fprintf(ofp, "#define VERSION_FEATURES 0x%08lx%s\n", version.feature_set,
-            ul_sfx);
+    Fprintf(ofp, "#define VERSION_NUMBER 0x%08lx%s\n",
+            (unsigned long) version.incarnation, ul_sfx);
+    Fprintf(ofp, "#define VERSION_FEATURES 0x%08lx%s\n",
+            (unsigned long) version.feature_set, ul_sfx);
 #ifdef IGNORED_FEATURES
     Fprintf(ofp, "#define IGNORED_FEATURES 0x%08lx%s\n",
             (unsigned long) IGNORED_FEATURES, ul_sfx);
 #endif
-    Fprintf(ofp, "#define VERSION_SANITY1 0x%08lx%s\n", version.entity_count,
-            ul_sfx);
-    Fprintf(ofp, "#define VERSION_SANITY2 0x%08lx%s\n", version.struct_sizes1,
-            ul_sfx);
-    Fprintf(ofp, "#define VERSION_SANITY3 0x%08lx%s\n", version.struct_sizes2,
-            ul_sfx);
+    Fprintf(ofp, "#define VERSION_SANITY1 0x%08lx%s\n",
+            (unsigned long) version.entity_count, ul_sfx);
+    Fprintf(ofp, "#define VERSION_SANITY2 0x%08lx%s\n",
+            (unsigned long) version.struct_sizes1, ul_sfx);
+    Fprintf(ofp, "#define VERSION_SANITY3 0x%08lx%s\n",
+            (unsigned long) version.struct_sizes2, ul_sfx);
     Fprintf(ofp, "\n");
     Fprintf(ofp, "#define VERSION_STRING \"%s\"\n", version_string(buf, "."));
     Fprintf(ofp, "#define VERSION_ID \\\n \"%s\"\n",
@@ -1801,6 +1801,9 @@ static struct win_info window_opts[] = {
 #endif
 #ifdef BEOS_GRAPHICS /* unmaintained/defunct */
     { "BeOS", "BeOS InterfaceKit" },
+#endif
+#ifdef SHIM_GRAPHICS
+    { "shim", "shim callback graphics" },
 #endif
     { 0, 0 }
 };
@@ -2655,7 +2658,7 @@ adjust_qt_hdrs()
 {
     int i, j;
     long count = 0L, hdr_offset = sizeof(int)
-                                  + (sizeof(char) * LEN_HDR + sizeof(long))
+                                  + (sizeof(char) * LEN_HDR + sizeof(nhdata_long))
                                         * qt_hdr.n_hdr;
 
     for (i = 0; i < qt_hdr.n_hdr; i++) {
@@ -2685,7 +2688,7 @@ put_qt_hdrs()
     (void) fwrite((genericptr_t) & (qt_hdr.n_hdr), sizeof(int), 1, ofp);
     (void) fwrite((genericptr_t) & (qt_hdr.id[0][0]), sizeof(char) * LEN_HDR,
                   qt_hdr.n_hdr, ofp);
-    (void) fwrite((genericptr_t) & (qt_hdr.offset[0]), sizeof(long),
+    (void) fwrite((genericptr_t) & (qt_hdr.offset[0]), sizeof(nhdata_long),
                   qt_hdr.n_hdr, ofp);
     if (debug) {
         for (i = 0; i < qt_hdr.n_hdr; i++)

--- a/win/shim/winshim.c
+++ b/win/shim/winshim.c
@@ -1,0 +1,374 @@
+/* NetHack 3.6  winshim.c */
+/* Copyright (c) Adam Powers, 2020 */
+/* NetHack may be freely redistributed.  See license for details. */
+
+/* Shim window port for NetHack 3.6 WASM builds.
+ * Adapted from the NetHack 3.7 winshim.c by Adam Powers.
+ * All window system operations are routed through a single JavaScript
+ * callback via Emscripten's Asyncify mechanism.
+ */
+
+#include "hack.h"
+#include <string.h>
+
+#ifdef SHIM_GRAPHICS
+#include <stdarg.h>
+/* for cross-compiling to WebAssembly (WASM) */
+#ifdef __EMSCRIPTEN__
+#include <emscripten/emscripten.h>
+#endif
+
+#undef SHIM_DEBUG
+
+#ifdef SHIM_DEBUG
+#define debugf printf
+#else /* !SHIM_DEBUG */
+#define debugf(...)
+#endif /* SHIM_DEBUG */
+
+
+/* shim_graphics_callback is the primary interface to shim graphics,
+ * call this function with your declared callback function
+ * and you will receive all the windowing calls
+ */
+#ifdef __EMSCRIPTEN__
+/************
+ * WASM interface
+ ************/
+static char *shim_callback_name = NULL;
+void shim_graphics_set_callback(char *cbName);
+
+void shim_graphics_set_callback(char *cbName) {
+    if (shim_callback_name != NULL) free(shim_callback_name);
+    if(cbName && strlen(cbName) > 0) {
+        debugf("setting shim_callback_name: %s\n", cbName);
+        shim_callback_name = strdup(cbName);
+    } else {
+        debugf("un-setting shim_callback_name\n");
+        shim_callback_name = NULL;
+    }
+}
+void local_callback (const char *cb_name, const char *shim_name, void *ret_ptr, const char *fmt_str, void *args);
+
+/* A2P = Argument to Pointer */
+#define A2P &
+/* P2V = Pointer to Void */
+#define P2V (void *)
+#define DECLCB(ret_type, name, fn_args, fmt, ...) \
+ret_type name fn_args; \
+\
+ret_type name fn_args { \
+    void *args[] = { __VA_ARGS__ }; \
+    ret_type ret = (ret_type) 0; \
+    debugf("SHIM GRAPHICS: " #name "\n"); \
+    if (!shim_callback_name) return ret; \
+    local_callback(shim_callback_name, #name, (void *)&ret, fmt, args); \
+    debugf("SHIM GRAPHICS: " #name " done.\n"); \
+    return ret; \
+}
+
+#define VDECLCB(name, fn_args, fmt, ...) \
+void name fn_args; \
+\
+void name fn_args { \
+    void *args[] = { __VA_ARGS__ }; \
+    debugf("SHIM GRAPHICS: " #name "\n"); \
+    if (!shim_callback_name) return; \
+    local_callback(shim_callback_name, #name, NULL, fmt, args); \
+    debugf("SHIM GRAPHICS: " #name " done.\n"); \
+}
+
+#else /* !__EMSCRIPTEN__ */
+
+/************
+ * libnethack.a interface
+ ************/
+typedef void(*shim_callback_t)(const char *name, void *ret_ptr, const char *fmt, ...);
+static shim_callback_t shim_graphics_callback = NULL;
+void shim_graphics_set_callback(shim_callback_t cb);
+
+void shim_graphics_set_callback(shim_callback_t cb) {
+    shim_graphics_callback = cb;
+}
+
+#define A2P
+#define P2V
+#define DECLCB(ret_type, name, fn_args, fmt, ...) \
+ret_type name fn_args;\
+\
+ret_type name fn_args { \
+    ret_type ret = (ret_type) 0; \
+    debugf("SHIM GRAPHICS: " #name "\n"); \
+    if (!shim_graphics_callback) return ret; \
+    shim_graphics_callback(#name, (void *)&ret, fmt, ## __VA_ARGS__); \
+    debugf("SHIM GRAPHICS: " #name " done.\n"); \
+    return ret; \
+}
+
+#define VDECLCB(name, fn_args, fmt, ...) \
+void name fn_args;\
+\
+void name fn_args { \
+    debugf("SHIM GRAPHICS: " #name "\n"); \
+    if (!shim_graphics_callback) return; \
+    shim_graphics_callback(#name, NULL, fmt, ## __VA_ARGS__); \
+    debugf("SHIM GRAPHICS: " #name " done.\n"); \
+}
+#endif /* __EMSCRIPTEN__ */
+
+/*
+ * Callback declarations for all window_procs functions.
+ * Adapted from 3.7 to match 3.6 window_procs signatures.
+ *
+ * Format string: first char = return type, remaining = parameter types.
+ * Types: v=void, i=int, s=string, p=pointer, c=char, b=boolean,
+ *        0=1-byte int, 1=2-byte int, 2=4-byte int
+ */
+
+VDECLCB(shim_init_nhwindows,(int *argcp, char **argv), "vpp", P2V argcp, P2V argv)
+/* 3.6: player_selection is void(void), not boolean(void) as in 3.7 */
+VDECLCB(shim_player_selection,(void), "v")
+VDECLCB(shim_askname,(void), "v")
+VDECLCB(shim_get_nh_event,(void), "v")
+VDECLCB(shim_exit_nhwindows,(const char *str), "vs", P2V str)
+VDECLCB(shim_suspend_nhwindows,(const char *str), "vs", P2V str)
+VDECLCB(shim_resume_nhwindows,(void), "v")
+DECLCB(winid, shim_create_nhwindow, (int type), "ii", A2P type)
+VDECLCB(shim_clear_nhwindow,(winid window), "vi", A2P window)
+VDECLCB(shim_display_nhwindow,(winid window, BOOLEAN_P blocking), "vib", A2P window, A2P blocking)
+VDECLCB(shim_destroy_nhwindow,(winid window), "vi", A2P window)
+VDECLCB(shim_curs,(winid a, int x, int y), "viii", A2P a, A2P x, A2P y)
+VDECLCB(shim_putstr,(winid w, int attr, const char *str), "viis", A2P w, A2P attr, P2V str)
+VDECLCB(shim_display_file,(const char *name, BOOLEAN_P complain), "vsb", P2V name, A2P complain)
+/* 3.6: start_menu takes only winid, no mbehavior */
+VDECLCB(shim_start_menu,(winid window), "vi", A2P window)
+/* 3.6: add_menu uses int glyph (not glyph_info*), BOOLEAN_P preselected (not unsigned int itemflags), no clr param */
+VDECLCB(shim_add_menu,
+    (winid window, int glyph, const ANY_P *identifier, CHAR_P ch, CHAR_P gch, int attr, const char *str, BOOLEAN_P preselected),
+    "viip00isb",
+    A2P window, A2P glyph, P2V identifier, A2P ch, A2P gch, A2P attr, P2V str, A2P preselected)
+VDECLCB(shim_end_menu,(winid window, const char *prompt), "vis", A2P window, P2V prompt)
+/* XXX: shim_select_menu menu_list is an output */
+DECLCB(int, shim_select_menu,(winid window, int how, MENU_ITEM_P **menu_list), "iiip", A2P window, A2P how, P2V menu_list)
+DECLCB(char, shim_message_menu,(CHAR_P let, int how, const char *mesg), "ciis", A2P let, A2P how, P2V mesg)
+VDECLCB(shim_mark_synch,(void), "v")
+VDECLCB(shim_wait_synch,(void), "v")
+VDECLCB(shim_cliparound,(int x, int y), "vii", A2P x, A2P y)
+VDECLCB(shim_update_positionbar,(char *posbar), "vs", P2V posbar)
+/* 3.6: print_glyph uses int glyph + int bkglyph (not glyph_info*), xchar x/y (1-byte) */
+VDECLCB(shim_print_glyph,(winid w, XCHAR_P x, XCHAR_P y, int glyph, int bkglyph), "vi00ii", A2P w, A2P x, A2P y, A2P glyph, A2P bkglyph)
+VDECLCB(shim_raw_print,(const char *str), "vs", P2V str)
+VDECLCB(shim_raw_print_bold,(const char *str), "vs", P2V str)
+DECLCB(int, shim_nhgetch,(void), "i")
+/* 3.6: nh_poskey uses int* (not coordxy*) */
+DECLCB(int, shim_nh_poskey,(int *x, int *y, int *mod), "ippp", P2V x, P2V y, P2V mod)
+VDECLCB(shim_nhbell,(void), "v")
+DECLCB(int, shim_doprev_message,(void),"iv")
+DECLCB(char, shim_yn_function,(const char *query, const char *resp, CHAR_P def), "css0", P2V query, P2V resp, A2P def)
+VDECLCB(shim_getlin,(const char *query, char *bufp), "vsp", P2V query, P2V bufp)
+DECLCB(int,shim_get_ext_cmd,(void),"iv")
+VDECLCB(shim_number_pad,(int state), "vi", A2P state)
+VDECLCB(shim_delay_output,(void), "v")
+VDECLCB(shim_change_color,(int color, long rgb, int reverse), "viii", A2P color, A2P rgb, A2P reverse)
+VDECLCB(shim_change_background,(int white_or_black), "vi", A2P white_or_black)
+DECLCB(short, set_shim_font_name,(winid window_type, char *font_name),"2is", A2P window_type, P2V font_name)
+DECLCB(char *,shim_get_color_string,(void),"sv")
+
+/* 3.6-only functions */
+VDECLCB(shim_start_screen,(void), "v")
+VDECLCB(shim_end_screen,(void), "v")
+VDECLCB(shim_outrip,(winid tmpwin, int how, time_t when), "viii", A2P tmpwin, A2P how, A2P when)
+
+VDECLCB(shim_preference_update, (const char *pref), "vp", P2V pref)
+DECLCB(char *,shim_getmsghistory, (BOOLEAN_P init), "sb", A2P init)
+VDECLCB(shim_putmsghistory, (const char *msg, BOOLEAN_P restoring_msghist), "vsb", P2V msg, A2P restoring_msghist)
+VDECLCB(shim_status_init, (void), "v")
+VDECLCB(shim_status_enablefield,
+    (int fieldidx, const char *nm, const char *fmt, BOOLEAN_P enable),
+    "vippb",
+    A2P fieldidx, P2V nm, P2V fmt, A2P enable)
+/* XXX: the second argument to shim_status_update is sometimes an integer and sometimes a pointer */
+VDECLCB(shim_status_update,
+    (int fldidx, genericptr_t ptr, int chg, int percent, int color, unsigned long *colormasks),
+    "vipiiip",
+    A2P fldidx, P2V ptr, A2P chg, A2P percent, A2P color, P2V colormasks)
+
+#ifdef __EMSCRIPTEN__
+/* update_inventory is called by the game engine during command processing,
+ * while the shim callback is still on the Asyncify stack. Calling
+ * local_callback here would cause Asyncify reentrancy, which crashes.
+ * Instead, set a JavaScript flag that local_callback checks on its next
+ * entry and delivers as a non-blocking notification. */
+void shim_update_inventory() {
+    EM_ASM({
+        globalThis.nethackGlobal = globalThis.nethackGlobal || {};
+        globalThis.nethackGlobal.pendingInventoryUpdate = true;
+    });
+}
+#else /* !__EMSCRIPTEN__ */
+VDECLCB(shim_update_inventory,(void), "v")
+#endif
+
+/* Interface definition used in windows.c
+ * Must match the order in 3.6 struct window_procs (include/winprocs.h)
+ */
+struct window_procs shim_procs = {
+    "shim",
+    (0
+     | WC_ASCII_MAP
+     | WC_MOUSE_SUPPORT
+     | WC_COLOR | WC_HILITE_PET | WC_INVERSE | WC_EIGHT_BIT_IN),
+    (0
+#if defined(SELECTSAVED)
+     | WC2_SELECTSAVED
+#endif
+#if defined(STATUS_HILITES)
+     | WC2_HILITE_STATUS | WC2_HITPOINTBAR | WC2_FLUSH_STATUS
+     | WC2_RESET_STATUS
+#endif
+     | WC2_DARKGRAY | WC2_SUPPRESS_HIST | WC2_STATUSLINES),
+    {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},   /* color availability */
+    shim_init_nhwindows,
+    shim_player_selection,
+    shim_askname,
+    shim_get_nh_event,
+    shim_exit_nhwindows,
+    shim_suspend_nhwindows,
+    shim_resume_nhwindows,
+    shim_create_nhwindow,
+    shim_clear_nhwindow,
+    shim_display_nhwindow,
+    shim_destroy_nhwindow,
+    shim_curs,
+    shim_putstr,
+    genl_putmixed,          /* putmixed */
+    shim_display_file,
+    shim_start_menu,
+    shim_add_menu,
+    shim_end_menu,
+    shim_select_menu,
+    shim_message_menu,
+    shim_update_inventory,
+    shim_mark_synch,
+    shim_wait_synch,
+#ifdef CLIPPING
+    shim_cliparound,
+#endif
+#ifdef POSITIONBAR
+    shim_update_positionbar,
+#endif
+    shim_print_glyph,
+    shim_raw_print,
+    shim_raw_print_bold,
+    shim_nhgetch,
+    shim_nh_poskey,
+    shim_nhbell,
+    shim_doprev_message,
+    shim_yn_function,
+    shim_getlin,
+    shim_get_ext_cmd,
+    shim_number_pad,
+    shim_delay_output,
+#ifdef CHANGE_COLOR
+    shim_change_color,
+#ifdef MAC
+    shim_change_background,
+    set_shim_font_name,
+#endif
+    shim_get_color_string,
+#endif
+    /* 3.6-only: start_screen, end_screen */
+    shim_start_screen,
+    shim_end_screen,
+    shim_outrip,
+    shim_preference_update,
+    shim_getmsghistory,
+    shim_putmsghistory,
+    shim_status_init,
+    genl_status_finish,
+    genl_status_enablefield,
+#ifdef STATUS_HILITES
+    shim_status_update,
+#else
+    genl_status_update,
+#endif
+    genl_can_suspend_no,
+};
+
+#ifdef __EMSCRIPTEN__
+/* convert the C callback to a JavaScript callback */
+EM_JS(void, local_callback, (const char *cb_name, const char *shim_name, void *ret_ptr, const char *fmt_str, void *args), {
+    /* Dispatch any inventory update that was queued since the last callback.
+     * This runs synchronously before handleSleep, so there is no Asyncify
+     * stack to re-enter. The user callback's returned Promise is intentionally
+     * not awaited -- the notification will resolve after handleSleep suspends. */
+    if (globalThis.nethackGlobal && globalThis.nethackGlobal.pendingInventoryUpdate) {
+        globalThis.nethackGlobal.pendingInventoryUpdate = false;
+        let pendingCbName = UTF8ToString(cb_name);
+        let pendingCb = globalThis[pendingCbName];
+        if (pendingCb) {
+            pendingCb.call(null, 'shim_update_inventory');
+        }
+    }
+
+    // Asyncify.handleAsync() is the more logical choice here; however, the stack unrolling in Asyncify is performed by
+    // function call analysis during compilation. Since we are using an indirect callback (cb_name), it can't predict the stack
+    // unrolling and it crashes. Thus we use Asyncify.handleSleep() and wakeUp() to make sure that async doesn't break
+    // Asyncify. For details, see: https://emscripten.org/docs/porting/asyncify.html#optimizing
+    Asyncify.handleSleep(wakeUp => {
+        // convert callback arguments to proper JavaScript variadic arguments
+        let name = UTF8ToString(shim_name);
+        let fmt = UTF8ToString(fmt_str);
+        let cbName = UTF8ToString(cb_name);
+        // console.log("local_callback:", cbName, fmt, name);
+
+        // get pointer / type conversion helpers
+        let getPointerValue = globalThis.nethackGlobal.helpers.getPointerValue;
+        let setPointerValue = globalThis.nethackGlobal.helpers.setPointerValue;
+
+        reentryGuardEnter(name);
+
+        let argTypes = fmt.split("");
+        let retType = argTypes.shift();
+
+        // build array of JavaScript args from WASM parameters
+        let jsArgs = [];
+        for (let i = 0; i < argTypes.length; i++) {
+            let ptr = args + (4*i);
+            let val = getArg(name, ptr, argTypes[i]);
+            jsArgs.push(val);
+        }
+
+        // do the callback
+        let userCallback = globalThis[cbName];
+        userCallback.call(this, name, ... jsArgs).then((retVal) => {
+            // save the return value
+            setPointerValue(name, ret_ptr, retType, retVal);
+            reentryGuardExit();
+            try {
+                wakeUp();
+            } catch (e) {
+                console.error("Asyncify wakeUp failed:", e);
+            }
+        });
+
+        function getArg(name, ptr, type) {
+            return (type === "p") ? getValue(ptr, "*") : getPointerValue(name, getValue(ptr, "*"), type);
+        }
+
+        function reentryGuardEnter(name) {
+            globalThis.nethackGlobal = globalThis.nethackGlobal || {};
+            if(globalThis.nethackGlobal.shimFunctionRunning) {
+                console.error(`'${name}' attempting second call to 'local_callback' before '${globalThis.nethackGlobal.shimFunctionRunning}' has finished, will crash emscripten Asyncify. For details see: emscripten.org/docs/porting/asyncify.html#reentrancy`);
+            }
+            globalThis.nethackGlobal.shimFunctionRunning = name;
+        }
+
+        function reentryGuardExit() {
+            globalThis.nethackGlobal.shimFunctionRunning = null;
+        }
+    });
+})
+#endif /* __EMSCRIPTEN__ */
+
+#endif /* SHIM_GRAPHICS */


### PR DESCRIPTION
Backport of the WASM/Emscripten cross-compilation support from 3.7
(#385, #1331, #1328) to the 3.6 branch so the current production
release can run in the browser or Node.js.

Same approach as 3.7: a shim window port (win/shim/winshim.c) bridges
the C engine to JavaScript via an async callback, and a library main
(sys/libnh/libnhmain.c) replaces unixmain.c. A hints file
(sys/unix/hints/linux-wasm) wires up the Emscripten flags.

The one wrinkle specific to 3.6 is a cross-compilation data mismatch.
On LP64 hosts (Linux/macOS x86_64) unsigned long is 8 bytes, but in
WASM it's 4. The binary data files (dungeon, levels, quest text) are
written by native utilities and read by the WASM game, so the struct
layouts have to agree. A CROSS_TO_WASM guard in include/global.h
typedefs the relevant types to int/unsigned int when building for WASM
and leaves them as long/unsigned long otherwise. This doesn't come up
in 3.7 because the data file format was reworked there.

Build instructions and API docs are in sys/libnh/README.md.

I've also published this as npm packages for anyone who wants to embed
NetHack in a JS project without setting up the C toolchain:

  @neth4ck/wasm-367 -- https://www.npmjs.com/package/@neth4ck/wasm-367
  @neth4ck/neth4ck  -- https://www.npmjs.com/package/@neth4ck/neth4ck