### PR TITLE
Fix brew CFLAGS for ncurses in macOS.370 hint.

### DIFF
--- a/sys/unix/hints/macOS.370
+++ b/sys/unix/hints/macOS.370
@@ -177,7 +177,7 @@ ifeq "$(HAVE_HOMEBREW_NCURSES)" "1"
 # Newer versions of ncurses are commonly installed via homebrew, but intentionally unlinked.
 HOMEBREW_LFLAGS := -L$(shell brew --prefix)/opt/ncurses/lib
 HOMEBREW_WINLIB := -I$(shell brew --prefix)/opt/ncurses/include
-HOMEBREW_CFLAGS =
+HOMEBREW_CFLAGS := -I$(shell brew --prefix)/opt/ncurses/include
 endif   #HAVE_HOMEBREW_NCURSES
 endif   #HAVE_HOMEBREW
 ifeq "$(HAVE_MACPORTS)" "1"


### PR DESCRIPTION
This fixes a mismatch between macOS system ncurses headers and the brew ncurses library, which do not export the same symbols.