### PR TITLE
Fix Clang detection in unix hints

### DIFF
--- a/sys/unix/hints/linux.370
+++ b/sys/unix/hints/linux.370
@@ -192,7 +192,7 @@ endif   #WANT_WIN_CURSES
 #-INCLUDE multisnd1-pre.370
 #
 
-ifeq "$(CCISCLANG)" "1"
+ifneq "$(CCISCLANG)" ""
 # clang-specific starts
 # clang-specific ends
 else

--- a/sys/unix/hints/macOS.370
+++ b/sys/unix/hints/macOS.370
@@ -221,7 +221,7 @@ endif
 
 # although not currently doing anything for macOS, this is
 # kept in for consistency with layout of linux.370
-ifeq "$(CCISCLANG)" "1"
+ifneq "$(CCISCLANG)" ""
 # clang-specific starts
 # clang-specific ends
 else


### PR DESCRIPTION
When trying to detect if the compiler is Clang or not, the users of `$(CCISCLANG)` expect it to be the exit status of the `grep` command, when in fact it is just the result of the grep command (an empty string if no match and the version information if it did match). 
```
CCISCLANG := $(shell echo `$(CC) --version` | grep clang)
```