### PR TITLE
Fix windows-port crash on startup when showvers option is enabled

### DIFF
--- a/sys/windows/windmain.c
+++ b/sys/windows/windmain.c
@@ -197,11 +197,11 @@ _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);*/
 #endif
 #endif
 
-    gh.hname = "NetHack"; /* used for syntax messages */
     set_emergency_io();
 #ifndef MSWIN_GRAPHICS
     early_init(argc, argv); /* already in WinMain for MSWIN_GRAPHICS */
 #endif
+    gh.hname = "NetHack"; /* used for syntax messages */
     set_default_prefix_locations(
         argv[0]); /* must be re-done after initoptions_init()
                    * which clears out gp.fqn_prefix[] */


### PR DESCRIPTION
In windmain.c, `gh.hname` was assigned before the `gh` struct was initialized by `early_init`.

This resulted in `gh.hname` becoming NULL.

https://github.com/NetHack/NetHack/blob/3d5b3e35ea0e18ee1be1506608bedcac54678562/sys/windows/windmain.c#L200-L208

This ultimately triggered a null pointer dereference in the `nh_basename` function when calling `strrchr`.

https://github.com/NetHack/NetHack/blob/3d5b3e35ea0e18ee1be1506608bedcac54678562/src/version.c#L97-L106

https://github.com/NetHack/NetHack/blob/3d5b3e35ea0e18ee1be1506608bedcac54678562/src/files.c#L197-L205

Moving the assignment `gh.hname = "NetHack";` to after `early_init(argc, argv);` fixes the issue.