### PR TITLE
Fixed corridor symbols in Enhanced1

### DIFF
--- a/dat/symbols
+++ b/dat/symbols
@@ -807,6 +807,11 @@ start: Enhanced1
 	Description: Enhanced with Unicode glyphs and 24-bit color
 	Restrictions: primary
 	Handling: UTF8
+	S_corr: U+2591
+	S_litcorr: U+2592
+	S_engrcorr: U+2591
+	S_amulet: U+2299                    # ☉
+	S_cloud: U+2601                     # ☁
 	S_vwall: U+2502                     # BOX DRAWINGS LIGHT VERTICAL
 	S_hwall: U+2500                     # BOX DRAWINGS LIGHT HORIZONTAL
 	S_tlcorn: U+250c                    # BOX DRAWINGS LIGHT DOWN AND RIGHT
@@ -821,8 +826,11 @@ start: Enhanced1
 	S_ndoor: U+00b7                     # MIDDLE DOT
 	S_vodoor: U+2592                    # MEDIUM SHADE
 	S_hodoor: U+2592                    # MEDIUM SHADE
-	S_bars: U+2261                      # IDENTICAL TO
-	S_tree: U+03a8                      # GREEK CAPITAL LETTER PSI
+#	S_bars: U+2261                      # IDENTICAL TO
+	S_bars: U+2551                      # ║
+#	S_tree: U+03a8                      # GREEK CAPITAL LETTER PSI
+#	S_tree: U+1F332                     # 🌲
+	S_tree: U+2660                      # ♠
 	S_room: U+00b7                      # MIDDLE DOT
 	S_engroom: U+03BE                   # Greek Small Letter Xi
 	S_darkroom: U+00b7                  # MIDDLE DOT
@@ -833,6 +841,7 @@ start: Enhanced1
 	G_fountain: U+2320/0-150-255        # TOP HALF INTEGRAL
 	S_pool: U+224b                      # TRIPLE TILDE
 	S_ice: U+00b7                       # MIDDLE DOT
+#	S_ice: U+2744                       # ❄️
 	S_lava: U+224b                      # TRIPLE TILDE
 	S_lavawall: U+2248                  # ALMOST EQUAL TO
 	S_vodbridge: U+00b7                 # MIDDLE DOT

--- a/dat/symbols
+++ b/dat/symbols
@@ -904,6 +904,107 @@ start: Enhanced1
 	G_trwall_mines: U+251C/113-126-142
 finish
 
+start: Enhanced2
+	Description: Enhanced with Unicode glyphs and 24-bit color
+	Restrictions: primary
+	Handling: UTF8
+	S_corr: U+2591
+	S_litcorr: U+2592
+	S_engrcorr: U+2591
+	S_amulet: U+2299                    # ☉
+	S_cloud: U+2601                     # ☁
+	S_vwall: U+2551                     # ║ BOX DRAWINGS DOUBLE VERTICAL
+	S_hwall: U+2550                     # ═ BOX DRAWINGS DOUBLE HORIZONTAL
+	S_tlcorn: U+2554                    # ╔ BOX DRAWINGS DOUBLE DOWN AND RIGHT
+	S_trcorn: U+2557                    # ╗ BOX DRAWINGS DOUBLE DOWN AND LEFT
+	S_blcorn: U+255a                    # ╚ BOX DRAWINGS DOUBLE UP AND RIGHT
+	S_brcorn: U+255d                    # ╝ BOX DRAWINGS DOUBLE UP AND LEFT
+	S_crwall: U+256c                    # ╬ BOX DRAWINGS DOUBLE VERTICAL AND HORIZONTAL
+	S_tuwall: U+2569                    # ╩ BOX DRAWINGS DOUBLE UP AND HORIZONTAL
+	S_tdwall: U+2566                    # ╦ BOX DRAWINGS DOUBLE DOWN AND HORIZONTAL
+	S_tlwall: U+2563                    # ╣ BOX DRAWINGS DOUBLE VERTICAL AND LEFT
+	S_trwall: U+2560                    # ╠ BOX DRAWINGS DOUBLE VERTICAL AND RIGHT
+	S_ndoor: U+00b7                     # MIDDLE DOT
+	S_vodoor: U+2592                    # MEDIUM SHADE
+	S_hodoor: U+2592                    # MEDIUM SHADE
+#	S_bars: U+2261                      # IDENTICAL TO
+	S_bars: U+2980                      # ⦀
+#	S_tree: U+03a8                      # GREEK CAPITAL LETTER PSI
+#	S_tree: U+1F332                     # 🌲
+	S_tree: U+2660                      # ♠
+	S_room: U+00b7                      # MIDDLE DOT
+	S_engroom: U+03BE                   # Greek Small Letter Xi
+	S_darkroom: U+00b7                  # MIDDLE DOT
+	S_upladder: U+2264                  # LESS-THAN OR EQUAL TO
+	S_dnladder: U+2265                  # GREATER-THAN OR EQUAL TO
+	S_altar: U+03A9                     # GREEK CAPITAL LETTER OMEGA
+	S_grave: U+2020                     # DAGGER
+	G_fountain: U+2320/0-150-255        # TOP HALF INTEGRAL
+	S_pool: U+224b                      # TRIPLE TILDE
+	S_ice: U+00b7                       # MIDDLE DOT
+#	S_ice: U+2744                       # ❄️
+	S_lava: U+224b                      # TRIPLE TILDE
+	S_lavawall: U+2248                  # ALMOST EQUAL TO
+	S_vodbridge: U+00b7                 # MIDDLE DOT
+	S_hodbridge: U+00b7                 # MIDDLE DOT
+	S_water: U+2248                     # ALMOST EQUAL TO
+	S_web: U+00A4                       # CURRENCY SIGN
+	S_vbeam: U+2502                     # BOX DRAWINGS LIGHT VERTICAL
+	S_hbeam: U+2500                     # BOX DRAWINGS LIGHT HORIZONTAL
+	S_sw_tc: U+2594                     # UPPER ONE EIGHTH BLOCK
+	S_sw_ml: U+258f                     # LEFT ONE EIGHTH BLOCK
+	S_sw_mr: U+2595                     # RIGHT ONE EIGHTH BLOCK
+	S_sw_bc: U+2581                     # LOWER ONE EIGHTH BLOCK
+	S_expl_tc: U+2594                   # UPPER ONE EIGHTH BLOCK
+	S_expl_ml: U+258f                   # LEFT ONE EIGHTH BLOCK
+	S_expl_mr: U+2595                   # RIGHT ONE EIGHTH BLOCK
+	S_expl_bc: U+2581                   # LOWER ONE EIGHTH BLOCK
+	G_vwall_sokoban:  U+2502/blue
+	G_hwall_sokoban:  U+2500/blue
+	G_tlcorn_sokoban: U+250c/blue
+	G_trcorn_sokoban: U+2510/blue
+	G_blcorn_sokoban: U+2514/blue
+	G_brcorn_sokoban: U+2518/blue
+	G_crwall_sokoban: U+253C/blue
+	G_tuwall_sokoban: U+2534/blue
+	G_tdwall_sokoban: U+252C/blue
+	G_tlwall_sokoban: U+2524/blue
+	G_trwall_sokoban: U+251C/blue
+	G_vwall_gehennom:  U+2502/red
+	G_hwall_gehennom:  U+2500/red
+	G_tlcorn_gehennom: U+250c/red
+	G_trcorn_gehennom: U+2510/red
+	G_blcorn_gehennom: U+2514/red
+	G_brcorn_gehennom: U+2518/red
+	G_crwall_gehennom: U+253C/red
+	G_tuwall_gehennom: U+2534/red
+	G_tdwall_gehennom: U+252C/red
+	G_tlwall_gehennom: U+2524/red
+	G_trwall_gehennom: U+251C/red
+	G_vwall_knox:  U+2502/150-75-0
+	G_hwall_knox:  U+2500/150-75-0
+	G_tlcorn_knox: U+250c/150-75-0
+	G_trcorn_knox: U+2510/150-75-0
+	G_blcorn_knox: U+2514/150-75-0
+	G_brcorn_knox: U+2518/150-75-0
+	G_crwall_knox: U+253C/150-75-0
+	G_tuwall_knox: U+2534/150-75-0
+	G_tdwall_knox: U+252C/150-75-0
+	G_tlwall_knox: U+2524/150-75-0
+	G_trwall_knox: U+251C/150-75-0
+	G_vwall_mines:  U+2502/113-126-142
+	G_hwall_mines:  U+2500/113-126-142
+	G_tlcorn_mines: U+250c/113-126-142
+	G_trcorn_mines: U+2510/113-126-142
+	G_blcorn_mines: U+2514/113-126-142
+	G_brcorn_mines: U+2518/113-126-142
+	G_crwall_mines: U+253C/113-126-142
+	G_tuwall_mines: U+2534/113-126-142
+	G_tdwall_mines: U+252C/113-126-142
+	G_tlwall_mines: U+2524/113-126-142
+	G_trwall_mines: U+251C/113-126-142
+finish
+
 start: AmigaFont
 	Description: Amiga hack.font line-drawing and effect characters
 	# Dungeon features


### PR DESCRIPTION
Also added other Enhanced1 UTF8 symbols for various other items...
        S_corr: U+2591
        S_litcorr: U+2592 
        S_engrcorr: U+2591 
        S_amulet: U+2299                    # ☉
        S_cloud: U+2601                     # ☁
        S_tree: U+2660                      # ♠
        S_bars: U+2551                      # ║