### PR TITLE
Amiga 5.0.0 startup fixes

### DIFF
--- a/include/amiconf.h
+++ b/include/amiconf.h
@@ -212,4 +212,7 @@ struct ami_sysflags {
 };
 extern struct ami_sysflags sysflags;
 
+#undef SYSCF
+#undef SYSCF_FILE
+
 #endif /* AMICONF_H */

--- a/sys/amiga/amistack.c
+++ b/sys/amiga/amistack.c
@@ -22,6 +22,10 @@
 #ifdef __SASC_60
 long __stack = 256 * 1024;
 #else
-/* For GCC with -noixemul (libnix), __stack is also recognized */
+/* libnix needs __stkinit referenced to pull swapstack.o from libnix.a */
 unsigned long __stack = 256 * 1024;
+#ifdef CROSS_TO_AMIGA
+extern void __stkinit(void);
+void *__nh_force_stkinit = __stkinit;
+#endif
 #endif

--- a/sys/amiga/nethack.cnf
+++ b/sys/amiga/nethack.cnf
@@ -5,7 +5,10 @@
 
 # *** DISPLAY MODE ***
 #
-# Tile mode (graphical tiles, recommended):
+# Tile mode (graphical tiles, recommended).  Needs >=384 KB free chip
+# RAM and a display mode that can open at 4 bitplanes (16 colours); on
+# machines that can't, NetHack will automatically fall back to text
+# mode at startup.
 OPTIONS=windowtype:amiv
 #
 # Text mode (uses hack.font line-drawing characters):

--- a/sys/amiga/winfuncs.c
+++ b/sys/amiga/winfuncs.c
@@ -886,6 +886,49 @@ int
     return 0;
 }
 
+/* Fall back from AMIV (tile) to AMII (text) if this machine can't
+ * run tile mode.  Probes in order of reliability. */
+static void
+amii_fall_back(const char *why1, const char *why2)
+{
+    extern struct window_procs amii_procs;
+
+    raw_print(why1);
+    raw_print(why2);
+    raw_print("Falling back to text mode.  Set windowtype:amiv in");
+    raw_print("nethack.cnf to override.");
+    windowprocs = amii_procs;
+    ami_wininit_data(WININIT);
+}
+
+static void
+amii_maybe_fall_back_to_text(void)
+{
+    if (!WINVERS_AMIV)
+        return;
+
+    if (IntuitionBase->LibNode.lib_Version >= 37) {
+        struct Screen *wbscr;
+        int wb_depth = -1;
+
+        if ((wbscr = LockPubScreen("Workbench")) != NULL) {
+            wb_depth = wbscr->BitMap.Depth;
+            UnlockPubScreen(NULL, wbscr);
+        }
+        if (wb_depth >= 0 && wb_depth < 4) {
+            amii_fall_back("Workbench screen is shallower than 16 colours",
+                           "(tile mode requires depth >= 4).");
+            return;
+        }
+    }
+
+    if (AvailMem(MEMF_CHIP) < 384L * 1024L) {
+        amii_fall_back("Not enough chip RAM available for tile mode",
+                       "(< 384 KB free).");
+        return;
+    }
+}
+
 /* Initialize the windowing environment */
 
 void
@@ -950,6 +993,8 @@ amii_init_nhwindows(int *argcp, char **argv)
     if ((AslBase = OpenLibrary("asl.library", amii_libvers)) == NULL) {
         Abort(AG_OpenLib);
     }
+
+    amii_maybe_fall_back_to_text();
 
     amiIDisplay =
         (struct amii_DisplayDesc *) alloc(sizeof(struct amii_DisplayDesc));

--- a/sys/unix/hints/include/cross-post.500
+++ b/sys/unix/hints/include/cross-post.500
@@ -318,7 +318,6 @@ amigapkg: $(AMITILES) ../util/uudecode
 	cp $(TARGETPFX)tiles16.iff $(TARGETPFX)pkg/tiles/tiles16.iff
 	cp $(TARGETPFX)tiles32.iff $(TARGETPFX)pkg/tiles/tiles32.iff
 	cp $(TARGETPFX)tomb.iff $(TARGETPFX)pkg/tomb.iff
-	cp ../sys/msdos/sysconf $(TARGETPFX)pkg/sysconf
 	cp ../doc/nethack.txt $(TARGETPFX)pkg/nethack.txt
 	( cd $(TARGETPFX)pkg && ../../../util/uudecode ../../../sys/amiga/amifont8.uu && mv 8 hack/8 )
 	( cd $(TARGETPFX)pkg && ../../../util/uudecode ../../../sys/amiga/amifont.uu )


### PR DESCRIPTION
When I tested the release version on an Amiga 1000, I noticed some problems in the startup code:

- the stack setup code wasn't properly setup for libnix, so it relied on the user having a rather large stack-setting in their environment.
- we don't need SYSCF on Amiga and the code caused the startup to fail with "sysconfig not found" when the sysconfig file wasn't in the current directory
- the shipped nethack.cnf wants to use tile mode by default. That failed with an Oops (bad openwin) if the current screenmode doesn't allow for at least 16 colors or not enough chipmem is available. It now prints a warning and falls back to text mode.

The release binary works fine if you make sure that the window-type is set up correctly for your machine in nethack.cnf, you have enough stack space ("stack 262144") and start from the nethack directory:

```
> assign nethack: Games:NH500AMI
> stack 262144
> cd nethack:
> nethack
```