### PR TITLE
wintty: return early if stdout not a tty

### DIFF
--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -766,7 +766,7 @@ getret(void)
 #if defined(MICRO) || defined(WIN32CON)
     getreturn("to continue");
 #else
-    if (!isatty(STDIN_FILENO))
+    if (!isatty(STDIN_FILENO) || !isatty(STDOUT_FILENO))
         return;
     HUPSKIP();
     xputs("\n");


### PR DESCRIPTION
This was already done if stdin wasn't a tty. If stdout isn't either, the user won't be able to see the message asking them to input and so it makes sense to skip prompting them in that circumstance as well.

This fixes Homebrew's automated tests for NetHack, which calls `nethack --showpaths` to check the configured paths. In Homebrew's case, stdout isn't a tty and stdin is, but it's unattended so nothing will ever be available to hit enter.

This adds on to 60d59f4d5574c00cbb391cd58da3ed959de1ba2b, which added the check for stdin. refs #1512