### PR TITLE
libnh: fix native build of libnh.a on macOS

### DIFF
--- a/sys/libnh/libnhmain.c
+++ b/sys/libnh/libnhmain.c
@@ -37,7 +37,7 @@ extern struct passwd *getpwnam(const char *);
 #ifdef CHDIR
 static void chdirx(const char *, boolean);
 #endif /* CHDIR */
-static boolean whoami(void);
+boolean whoami(void);
 static void process_options(int, char **);
 
 #ifdef _M_UNIX
@@ -516,7 +516,7 @@ chdirx(const char *dir, boolean wr)
 #endif /* CHDIR */
 
 /* returns True iff we set plname[] to username which contains a hyphen */
-static boolean
+boolean
 whoami(void)
 {
     /*
@@ -805,7 +805,7 @@ get_nhuuid(void)
                              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
     char *uuid = (char *) &stmp[0];
 #ifndef NONHUUID
-#ifdef NHUUID
+#ifdef __EMSCRIPTEN__
     int uuid_available = 0;
 #endif
 #endif
@@ -814,7 +814,7 @@ get_nhuuid(void)
         return;
 
 #ifndef NONHUUID
-#ifdef NHUUID
+#ifdef __EMSCRIPTEN__
     uuid_available = emscripten_run_script_int(
 		    "typeof crypto !== 'undefined'"
 		    " && typeof crypto.randomUUID === 'function'");
@@ -824,7 +824,7 @@ get_nhuuid(void)
             uuid = (char *) &stmp[0];
         }
     }
-#endif  /* NHUUID */
+#endif  /* __EMSCRIPTEN__ */
 #endif  /* NONHUUID */
     Snprintf(svn.nhuuid, sizeof svn.nhuuid, "%s", uuid);
 }

--- a/sys/unix/hints/macOS.500
+++ b/sys/unix/hints/macOS.500
@@ -345,6 +345,12 @@ LIBNHSYSOBJ = $(TARGETPFX)libnhmain.o $(TARGETPFX)ioctl.o \
 #without winshim
 override GAME=
 MOREALL += ( cd src ; $(MAKE) pregame ; $(MAKE) $(TARGETPFX)libnh.a )
+# With $(GAME) empty, the regular `recover: $(GAME)` chain no longer
+# triggers lua_support, but recover.c still pulls in hack.h -> nhlua.h
+# transitively.  Make recover depend on lua_support explicitly.
+ifdef MAKEFILE_TOP
+recover: lua_support
+endif
 endif  # WANT_LIBNH
 
 # Lua
@@ -568,8 +574,20 @@ $(TARGETPFX)macuuid.o: ../sys/unix/macuuid.m
 endif
 
 ifdef WANT_LIBNH
-$(TARGETPFX)libnh.a: $(HOBJ) $(LIBNHSYSOBJ) ../lib/lua/liblua-$(LUA_VERSION).a
-	$(AR) rcs $@ $(HOBJ) $(LIBNHSYSOBJ) ../lib/lua/liblua-$(LUA_VERSION).a
+# Build libnh.a by merging the engine objects, the shim windowport,
+# date.o (separate from $(HOBJ) per Makefile.src), hacklib.a, and Lua's
+# static archive.  Use libtool -static rather than ar so hacklib.a and
+# liblua-$(LUA_VERSION).a have their members merged in -- ar would archive
+# them as opaque .a members and macOS ld can't dereference those.
+# Depending on $(LUALIB) triggers the lua_support build (which generates
+# include/nhlua.h); without it, $(HOBJ) won't compile.
+# filter-out drops $(SYSOBJ) (which carries unixmain.o) and $(WINOBJ) (the
+# tty windowport) from $(HOBJ); $(LIBNHSYSOBJ) supplies libnhmain.o and
+# winshim.o in their place.
+$(TARGETPFX)libnh.a: $(LUALIB) $(HOBJ) $(LIBNHSYSOBJ) $(DATE_O) $(TARGET_HACKLIB)
+	libtool -static -o $@ \
+		$(filter-out $(SYSOBJ) $(WINOBJ),$(HOBJ)) \
+		$(LIBNHSYSOBJ) $(DATE_O) $(TARGET_HACKLIB) $(LUALIB)
 	@echo "$@ built."
 $(TARGETPFX)libnhmain.o : ../sys/libnh/libnhmain.c $(HACK_H)
 	$(CC) $(CFLAGS) -c -o$@ $<


### PR DESCRIPTION
## Summary

Fixes four issues that prevent `make WANT_LIBNH=1 all` from producing a `libnh.a` that links into a host program on macOS. Before these patches, it built without errors but the resulting archive was unusable: macOS `ld` errors on a nested `liblua` archive member, the archive is missing `date.o` and `hacklib` symbols (`populate_nomakedefs`, `eos`, `lcase`, `mungspaces`, ...), and has duplicate definitions of `main`, `whoami`, `sys_random_seed`, etc. coming from both `unixmain.o` and `libnhmain.o`.

I hit these while trying to embed `libnh.a` in a native macOS app. The matching WASM build path is unaffected by any of these changes — emscripten's linker handles nested archives, and the WASM build doesn't link `unixmain.o`.

## Changes

### `sys/libnh/libnhmain.c`

1. **Drop `static` on `whoami()`.** `src/earlyarg.c` declares it `extern` and calls it from `scores_only()`; with the `static` qualifier the reference goes unresolved at link time.

2. **Gate the emscripten-only code in `get_nhuuid` with `#ifdef __EMSCRIPTEN__` instead of `#ifdef NHUUID`.** The macOS hints define `NHUUID` for the libnh build, so on native builds the compiler tries to call `emscripten_run_script_int` / `_string` and fails with `implicit-function-declaration` errors. `__EMSCRIPTEN__` is the right signal for *this is being cross-compiled to WASM*.

### `sys/unix/hints/macOS.500`

3. **Add `recover: lua_support` (gated by `MAKEFILE_TOP`) inside the `WANT_LIBNH` block.** When `$(GAME)` is overridden to empty, the regular `recover: $(GAME)` chain no longer triggers `lua_support`, so `include/nhlua.h` never gets generated and `recover.c`'s transitive `#include` of `hack.h` fails.

4. **Rewrite the `libnh.a` rule.** The previous `ar rcs libnh.a $(HOBJ) $(LIBNHSYSOBJ) liblua-$(LUA_VERSION).a` had four problems:
   - `ar` archives `liblua.a` as a single opaque member that macOS `ld` can't dereference — its members are individually invisible.
   - `date.o` (kept separate from `$(HOBJ)` per `Makefile.src`) is never archived, so `populate_nomakedefs` / `free_nomakedefs` / `nomakedefs` are missing.
   - `hacklib.a` is similarly omitted.
   - `$(HOBJ)` already contains `$(SYSOBJ)` (with `unixmain.o`) and `$(WINOBJ)` (the tty windowport), duplicating symbols already supplied by `libnhmain.o` / `winshim.o`.

   The fix uses `libtool -static` so `hacklib.a` and Lua's archive have their members merged rather than nested, depends on `$(LUALIB)` so `lua_support` runs first, includes `$(DATE_O)` and `$(TARGET_HACKLIB)`, and uses `$(filter-out $(SYSOBJ) $(WINOBJ),$(HOBJ))` to drop the duplicates.

## Verification

Clean rebuild on macOS 26 (arm64, Apple clang 17):

```
make spotless
make fetch-Lua
make WANT_LIBNH=1 all
```

…produces `src/libnh.a` with `_nhmain` and `_shim_graphics_set_callback` exported and no `_main`. Verified link-clean with a minimal harness:

```c
extern int nhmain(int, char *[]);
typedef void (*shim_callback_t)(const char *, void *, const char *, ...);
extern void shim_graphics_set_callback(shim_callback_t);

static void cb(const char *n, void *r, const char *f, ...) { (void)r; (void)f; fprintf(stderr, "[cb] %s\n", n); }

int main(void) { shim_graphics_set_callback(cb); return 0; }
```

```
cc -o nh_link_test nh_link_test.c src/libnh.a -framework Foundation -lm
./nh_link_test  # exits 0
```

I haven't tested the WASM cross-compile path; the changes to `libnhmain.c` should be neutral there (the emscripten code is now guarded by the right macro), and the macOS-only hints file changes don't affect WASM at all. Happy to add `linux.500` companion changes if you want, but I haven't tested on Linux either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)