### PR TITLE
Nhuuid dedup m68k, add nhuuid to MSDOS port

### DIFF
--- a/sys/amiga/amidos.c
+++ b/sys/amiga/amidos.c
@@ -45,44 +45,6 @@ amiga_self_assign(void)
         UnLock(dup);
 }
 
-/* Generate an RFC 4122 v4 UUID for this game.  Draw bytes from the
-   core's ISAAC64 RNG, which init_random() seeded before we get here. */
-void
-get_nhuuid(void)
-{
-    uchar bytes[16];
-    int i;
-
-    if (svn.nhuuid[0])
-        return;
-
-    for (i = 0; i < 16; i++)
-        bytes[i] = (uchar) rn2(256);
-    /* RFC 4122: version=4 (random), variant=10. */
-    bytes[6] = (bytes[6] & 0x0F) | 0x40;
-    bytes[8] = (bytes[8] & 0x3F) | 0x80;
-
-    Snprintf(svn.nhuuid, sizeof svn.nhuuid,
-             "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-"
-             "%02x%02x%02x%02x%02x%02x",
-             bytes[0], bytes[1], bytes[2], bytes[3],
-             bytes[4], bytes[5],
-             bytes[6], bytes[7],
-             bytes[8], bytes[9],
-             bytes[10], bytes[11], bytes[12], bytes[13],
-             bytes[14], bytes[15]);
-}
-
-void
-free_nhuuid(void)
-{
-    int i;
-
-    for (i = 0; i < SIZE(svn.nhuuid); i++) {
-        svn.nhuuid[i] = 0;
-    }
-}
-
 #include "winext.h"
 #include "winproto.h"
 

--- a/sys/share/pcmain.c
+++ b/sys/share/pcmain.c
@@ -745,34 +745,8 @@ exepath(char *str)
 }
 #endif /* EXEPATH */
 
-#if defined(CROSS_TO_MSDOS)
-
-void
-get_nhuuid(void)
-{
-    unsigned char stmp[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-
-    if (svn.nhuuid[0])
-        return;
-
-    /* FIXME: fill in a useful valid UUID somehow */
-    Snprintf(svn.nhuuid, sizeof svn.nhuuid, "%s", (char *) stmp);
-}
-
-void
-free_nhuuid(void)
-{
-    int i;
-
-    for (i = 0; i < SIZE(svn.nhuuid); i++) {
-        svn.nhuuid[i] = 0;
-    }
-}
-#endif
-
-#if defined(CROSS_TO_ATARI) || defined(CROSS_TO_AMIGA)
+#if defined(CROSS_TO_ATARI) || defined(CROSS_TO_AMIGA) \
+    || defined(CROSS_TO_MSDOS)
 /* Generate an RFC 4122 v4 UUID for this game.  Draw bytes from the
    core's ISAAC64 RNG, which init_random() seeded before we get here. */
 void

--- a/sys/share/pcmain.c
+++ b/sys/share/pcmain.c
@@ -772,7 +772,7 @@ free_nhuuid(void)
 }
 #endif
 
-#if defined(CROSS_TO_ATARI)
+#if defined(CROSS_TO_ATARI) || defined(CROSS_TO_AMIGA)
 /* Generate an RFC 4122 v4 UUID for this game.  Draw bytes from the
    core's ISAAC64 RNG, which init_random() seeded before we get here. */
 void


### PR DESCRIPTION
We don't need multiple copies of the nh_uuid code for Amiga, Atari  and later MACOS9. This code should work on any platform, so why not enable it for MSDOS which is currently missing an implementation.
