### PR TITLE
m68k: TT-RAM PRG flags, big-endian Lua coord fix, startup speedup, tile-alloc fallback

### DIFF
--- a/include/wintype.h
+++ b/include/wintype.h
@@ -58,6 +58,7 @@ enum any_types {
     ANY_STR,         /* pointer to null-terminated char string */
     ANY_NFUNC,       /* pointer to function taking no args, returning int */
     ANY_MASK32,      /* 32-bit mask (stored as unsigned long) */
+    ANY_INT16,      /* xint16 / coordxy (16-bit signed) */
 
     ANY_INVALID      /* leave this last */
 };

--- a/src/nhlua.c
+++ b/src/nhlua.c
@@ -1954,6 +1954,10 @@ nhl_push_anything(lua_State *L, int anytype, void *src)
         any.a_schar = *(schar *) src;
         lua_pushinteger(L, any.a_schar);
         break;
+    case ANY_INT16:
+        any.a_int = *(xint16 *) src;
+        lua_pushinteger(L, any.a_int);
+        break;
     }
     return 1;
 }
@@ -1968,13 +1972,13 @@ nhl_meta_u_index(lua_State *L)
         void *ptr;
         int type;
     } ustruct[] = {
-        { "ux", &(u.ux), ANY_UCHAR },
-        { "uy", &(u.uy), ANY_UCHAR },
+        { "ux", &(u.ux), ANY_INT16 },
+        { "uy", &(u.uy), ANY_INT16 },
         { "dx", &(u.dx), ANY_SCHAR },
         { "dy", &(u.dy), ANY_SCHAR },
         { "dz", &(u.dz), ANY_SCHAR },
-        { "tx", &(u.tx), ANY_UCHAR },
-        { "ty", &(u.ty), ANY_UCHAR },
+        { "tx", &(u.tx), ANY_INT16 },
+        { "ty", &(u.ty), ANY_INT16 },
         { "ulevel", &(u.ulevel), ANY_INT },
         { "ulevelmax", &(u.ulevelmax), ANY_INT },
         { "uhunger", &(u.uhunger), ANY_INT },
@@ -1985,8 +1989,8 @@ nhl_meta_u_index(lua_State *L)
         { "mh", &(u.mh), ANY_INT },
         { "mhmax", &(u.mhmax), ANY_INT },
         { "mtimedone", &(u.mtimedone), ANY_INT },
-        { "dlevel", &(u.uz.dlevel), ANY_SCHAR }, /* actually coordxy */
-        { "dnum", &(u.uz.dnum), ANY_SCHAR },     /* actually coordxy */
+        { "dlevel", &(u.uz.dlevel), ANY_INT16 },
+        { "dnum", &(u.uz.dnum), ANY_INT16 },
         { "uluck", &(u.uluck), ANY_SCHAR },
         { "uhp", &(u.uhp), ANY_INT },
         { "uhpmax", &(u.uhpmax), ANY_INT },

--- a/src/options.c
+++ b/src/options.c
@@ -7152,8 +7152,13 @@ initoptions_init(void)
     }
 
     /* make any symbol parsing quicker */
+#ifndef CROSS_TO_ATARI
+    /* Skip the ~9600-entry glyph-id prefill on slow m68k Atari hosts;
+       the shipped nethack.cnf doesn't reference any G_glyph names, so
+       a lazy lookup on first use is cheaper than the up-front fill. */
     if (!glyphid_cache_status())
         fill_glyphid_cache();
+#endif
 
     /* set up the command parsing */
     reset_commands(TRUE); /* init */

--- a/sys/unix/hints/include/cross-pre2.500
+++ b/sys/unix/hints/include/cross-pre2.500
@@ -612,7 +612,10 @@ override TARGET_CFLAGS = -c -O2 $(TOOLARCH) \
 override TARGET_CXXFLAGS = $(TARGET_CFLAGS)
 LUA_TARGET_CFLAGS = $(TARGET_CFLAGS)
 override TARGET_LINK = $(TARGET_CC)
-override TARGET_LFLAGS= $(TOOLARCH)
+# Set PRG header flags: bit 0 fastload (skip TPA clear), bit 1 load
+# text/data into TT-RAM, bit 2 malloc()/Malloc() prefers TT-RAM.  On
+# ST/STE without TT-RAM the loader falls back to ST-RAM transparently.
+override TARGET_LFLAGS= $(TOOLARCH) -Wl,--mprg-flags=0x07
 override TARGET_LIBS += $(LIBLM) -le_gem -lgem
 VARDATND += nhtiles.bmp
 override SYSSRC = ../sys/atari/tos.c ../sys/share/pcmain.c \

--- a/win/gem/wingem1.c
+++ b/win/gem/wingem1.c
@@ -20,6 +20,7 @@
 #include <unistd.h>
 #include <ctype.h>
 #include <e_gem.h>
+#include <mint/osbind.h>
 #include <string.h>
 
 #include "gem_rsc.h"
@@ -489,7 +490,16 @@ build_truecolor_mfdb(IMG_header *img, MFDB *out, int scr_planes)
         return FALSE;
     if (scr_planes != 16 && scr_planes != 24 && scr_planes != 32)
         return FALSE;
+    /* PF_TTRAMMEM steers malloc to TT-RAM by default.  If MagiC's
+       configured TT-RAM is too small for this multi-MB pixel buffer
+       and Mxalloc's mode-3 (prefer-alt) didn't transparently fall back
+       to ST-RAM, retry explicitly with Mxalloc mode 0 (ST-RAM). */
     buf = (unsigned char *) calloc(1, (size_t) total);
+    if (!buf) {
+        buf = (unsigned char *) Mxalloc(total, 0);
+        if (buf)
+            memset(buf, 0, (size_t) total);
+    }
     if (!buf) return FALSE;
 
     for (y = 0; y < h; y++) {
@@ -1769,12 +1779,15 @@ loadimg:
            copies device-format pixels straight to screen with no
            palette involvement. */
         MFDB new_mfdb;
-        if (build_truecolor_mfdb(&tile_image, &new_mfdb, planes)) {
-            free(tile_image.addr);
-            tile_image.addr = (char *) new_mfdb.fd_addr;
-            tile_image.planes = planes;
-            Tile_bilder = new_mfdb;
-        }
+        if (!build_truecolor_mfdb(&tile_image, &new_mfdb, planes))
+            panic("Out of memory building tile image (need %ld bytes); "
+                  "increase TT-RAM or run at 4/8 planes.",
+                  (long) tile_image.img_w * (long) tile_image.img_h
+                  * (long) ((planes + 7) >> 3));
+        free(tile_image.addr);
+        tile_image.addr = (char *) new_mfdb.fd_addr;
+        tile_image.planes = planes;
+        Tile_bilder = new_mfdb;
     } else {
         mfdb(&Tile_bilder, (short *) tile_image.addr, tile_image.img_w,
              tile_image.img_h, 1, tile_image.planes);


### PR DESCRIPTION
Four small m68k port fixes from feedback on the WIP Atari ST/TT/Falcon builds.

--- problems with memory fix found, retracting for now ---
