### PR TITLE
lua: read coordxy fields with the right width (big-endian fix)

### DIFF
--- a/include/wintype.h
+++ b/include/wintype.h
@@ -58,6 +58,7 @@ enum any_types {
     ANY_STR,         /* pointer to null-terminated char string */
     ANY_NFUNC,       /* pointer to function taking no args, returning int */
     ANY_MASK32,      /* 32-bit mask (stored as unsigned long) */
+    ANY_INT16,      /* xint16 / coordxy (16-bit signed) */
 
     ANY_INVALID      /* leave this last */
 };

--- a/src/nhlua.c
+++ b/src/nhlua.c
@@ -1954,6 +1954,10 @@ nhl_push_anything(lua_State *L, int anytype, void *src)
         any.a_schar = *(schar *) src;
         lua_pushinteger(L, any.a_schar);
         break;
+    case ANY_INT16:
+        any.a_int = *(xint16 *) src;
+        lua_pushinteger(L, any.a_int);
+        break;
     }
     return 1;
 }
@@ -1968,13 +1972,13 @@ nhl_meta_u_index(lua_State *L)
         void *ptr;
         int type;
     } ustruct[] = {
-        { "ux", &(u.ux), ANY_UCHAR },
-        { "uy", &(u.uy), ANY_UCHAR },
+        { "ux", &(u.ux), ANY_INT16 },
+        { "uy", &(u.uy), ANY_INT16 },
         { "dx", &(u.dx), ANY_SCHAR },
         { "dy", &(u.dy), ANY_SCHAR },
         { "dz", &(u.dz), ANY_SCHAR },
-        { "tx", &(u.tx), ANY_UCHAR },
-        { "ty", &(u.ty), ANY_UCHAR },
+        { "tx", &(u.tx), ANY_INT16 },
+        { "ty", &(u.ty), ANY_INT16 },
         { "ulevel", &(u.ulevel), ANY_INT },
         { "ulevelmax", &(u.ulevelmax), ANY_INT },
         { "uhunger", &(u.uhunger), ANY_INT },
@@ -1985,8 +1989,8 @@ nhl_meta_u_index(lua_State *L)
         { "mh", &(u.mh), ANY_INT },
         { "mhmax", &(u.mhmax), ANY_INT },
         { "mtimedone", &(u.mtimedone), ANY_INT },
-        { "dlevel", &(u.uz.dlevel), ANY_SCHAR }, /* actually coordxy */
-        { "dnum", &(u.uz.dnum), ANY_SCHAR },     /* actually coordxy */
+        { "dlevel", &(u.uz.dlevel), ANY_INT16 },
+        { "dnum", &(u.uz.dnum), ANY_INT16 },
         { "uluck", &(u.uluck), ANY_SCHAR },
         { "uhp", &(u.uhp), ANY_INT },
         { "uhpmax", &(u.uhpmax), ANY_INT },


### PR DESCRIPTION
Add ANY_INT16 to any_types and use it for u.ux/uy/tx/ty and uz dlevel/dnum.  These are coordxy (int16_t) but the Lua bindings were treating them as 1-byte fields, so on big-endian m68k Lua read the high byte (0) instead of the actual value.  Symptom: place_object off map <0,0> in the tutorial.