### PR TITLE
Atari: Fix performance problems on a real Atari TT

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -7152,8 +7152,13 @@ initoptions_init(void)
     }
 
     /* make any symbol parsing quicker */
+#ifndef CROSS_TO_ATARI
+    /* Skip the ~9600-entry glyph-id prefill on slow m68k Atari hosts;
+       the shipped nethack.cnf doesn't reference any G_glyph names, so
+       a lazy lookup on first use is cheaper than the up-front fill. */
     if (!glyphid_cache_status())
         fill_glyphid_cache();
+#endif
 
     /* set up the command parsing */
     reset_commands(TRUE); /* init */

--- a/sys/atari/sbrk.c
+++ b/sys/atari/sbrk.c
@@ -1,0 +1,37 @@
+/* sys/atari/sbrk.c — override mintlib's __sbrk so the libc heap is
+   satisfied from TT-RAM when present, with automatic GEMDOS fall-back
+   to ST-RAM.  Mintlib's archive copy in unix/sbrk.c is displaced by
+   this strong definition. */
+
+#include <errno.h>
+#include <stdint.h>
+#include <malloc.h>           /* _mallocChunkSize (mintlib extension) */
+#include <mint/osbind.h>      /* Mxalloc, Malloc */
+#include <mint/ostruct.h>     /* MX_PREFTTRAM, MX_GLOBAL */
+
+void *
+__sbrk(intptr_t n)
+{
+    void *p;
+
+    if (n < 0)                /* mintlib's malloc never shrinks */
+        return (void *) -1L;
+
+    p = (void *) Mxalloc(n, MX_PREFTTRAM | MX_GLOBAL);
+    if ((long) p == -32L || !p) {  /* pre-0x19 GEMDOS, or pools empty */
+        p = (void *) Malloc(n);
+        if (!p) {
+            __set_errno(ENOMEM);
+            return (void *) -1L;
+        }
+    }
+    return p;
+}
+
+/* Keep __sbrk call counts under the TOS 2.06 ~20-allocation GEMDOS
+   cap.  At 256 KB chunks a ~4 MB working set produces ~16 calls. */
+static void __attribute__((constructor))
+atari_set_malloc_chunk_size(void)
+{
+    _mallocChunkSize(256L * 1024L);
+}

--- a/sys/unix/hints/include/cross-pre2.500
+++ b/sys/unix/hints/include/cross-pre2.500
@@ -605,7 +605,13 @@ override TARGET_CFLAGS = -c -O2 $(TOOLARCH) \
 override TARGET_CXXFLAGS = $(TARGET_CFLAGS)
 LUA_TARGET_CFLAGS = $(TARGET_CFLAGS)
 override TARGET_LINK = $(TARGET_CC)
-override TARGET_LFLAGS= $(TOOLARCH)
+# Set PRG header flags: bit 0 fastload (skip TPA clear), bit 1 load
+# text/data into TT-RAM.  Bit 2 (Malloc prefers TT-RAM) is intentionally
+# unset — the __sbrk override in sys/atari/sbrk.c steers the libc heap
+# via Mxalloc(_, MX_PREFTTRAM | MX_GLOBAL), so bit 2 has no effect.
+# On ST/STE without TT-RAM the loader still falls back to ST-RAM
+# transparently for bit 1.
+override TARGET_LFLAGS= $(TOOLARCH) -Wl,--mprg-flags=0x03
 override TARGET_LIBS += $(LIBLM) -le_gem -lgem
 VARDATND += nhtiles.bmp
 override SYSSRC = ../sys/atari/tos.c ../sys/atari/sbrk.c \

--- a/sys/unix/hints/include/cross-pre2.500
+++ b/sys/unix/hints/include/cross-pre2.500
@@ -628,6 +628,7 @@ override LUALIBS=
 override TOPLUALIB=
 override DLLIB=
 override WINOBJ=
+override GENTILEOFILE = $(TARGETPFX)tile.o
 override GAMEBIN = $(TARGETPFX)nethack.prg
 override PACKAGE = ataripkg
 override PREGAME += mkdir -p $(TARGETDIR) ;
@@ -638,6 +639,12 @@ $(TARGETPFX)%.o : ../sys/atari/%.c
 	$(TARGET_CC) $(TARGET_CFLAGS) -o$@ $<
 # Rule for files in win/gem
 $(TARGETPFX)%.o : ../win/gem/%.c
+	$(TARGET_CC) $(TARGET_CFLAGS) -o$@ $<
+# Explicit rule for the generated tile.c -> tile.o.  Without this the
+# pattern rule $(TARGETPFX)%.o : %.c picks the wrong source path when
+# tile.c doesn't yet exist on first invocation, breaking -j N builds.
+# SRCDIR isn't defined this early in cross-pre2; spell the path out.
+$(TARGETPFX)tile.o : ../src/tile.c
 	$(TARGET_CC) $(TARGET_CFLAGS) -o$@ $<
 endif  # CROSS_TO_ATARI
 #=================================================================

--- a/sys/unix/hints/include/cross-pre2.500
+++ b/sys/unix/hints/include/cross-pre2.500
@@ -608,14 +608,16 @@ override TARGET_LINK = $(TARGET_CC)
 override TARGET_LFLAGS= $(TOOLARCH)
 override TARGET_LIBS += $(LIBLM) -le_gem -lgem
 VARDATND += nhtiles.bmp
-override SYSSRC = ../sys/atari/tos.c ../sys/share/pcmain.c \
+override SYSSRC = ../sys/atari/tos.c ../sys/atari/sbrk.c \
+		../sys/share/pcmain.c \
 		../sys/share/pcsys.c ../sys/share/pcunix.c \
 		../win/gem/wingem.c ../win/gem/wingem1.c \
 		../win/gem/bitmfile.c ../win/gem/gr_rect.c \
 		../win/gem/load_img.c \
 		../win/share/bmptiles.c ../win/share/giftiles.c \
 		../win/share/tileset.c
-override SYSOBJ = $(TARGETPFX)tos.o $(TARGETPFX)pcmain.o \
+override SYSOBJ = $(TARGETPFX)tos.o $(TARGETPFX)sbrk.o \
+		$(TARGETPFX)pcmain.o \
 		$(TARGETPFX)pcsys.o $(TARGETPFX)pcunix.o \
 		$(TARGETPFX)wingem.o $(TARGETPFX)wingem1.o \
 		$(TARGETPFX)bitmfile.o $(TARGETPFX)gr_rect.o \


### PR DESCRIPTION
## Fix: Atari TT startup performance

I got some feedback from an owner of a real  Atari TT: Startup is very slow (> 8 minutes!). The Atari TT uses two
memory regions of which one (ST-RAM) is very slow. These fixes attempt to address that problem,
but I haven't heard back from the TT owner. It doesn't break existing configurations, so it's worth
doing in any case. Also included is a fix for the build problems that's probably redundant, but not yet 
in m68k-wip.

-  **atari: override __sbrk to prefer TT-RAM with ST-RAM fallback**: strong definition of `__sbrk` in 
  `sys/atari/sbrk.c` displaces mintlib's archive copy. Routes via `Mxalloc(n, MX_PREFTTRAM | MX_GLOBAL)` 
  so the libc heap is satisfied from TT-RAM where available, with GEMDOS-level fallback to ST-RAM when 
  TT-RAM is small (typical of MagiC partitions). 

-  **atari: set PRG flags 0x03 (fastload + TT-RAM load)**: PRG header bit 2 (\`PF_TTRAMMEM\`) is 
  intentionally not set, since the \`__sbrk\` override now steers the libc heap via \`Mxalloc\`. Bit 1 
  (load text/data into TT-RAM) is kept for code-execution speed.

- **atari: skip glyph-id cache prefill**: filling the glyph-id cache on startup is a very expensive operation
on slow computers (it added 2:45 minutes of startup time on the Macintosh SE/30), so also skip it here.