### PR TITLE
Don't print "low buzzing" for bee-less trees when kicked

### DIFF
--- a/src/dokick.c
+++ b/src/dokick.c
@@ -1137,7 +1137,9 @@ kick_nondoor(coordxy x, coordxy y, int avrg_attrib)
 
         /* nothing, fruit or trouble? 75:23.5:1.5% */
         if (rn2(3)) {
-            if (!rn2(6) && !(svm.mvitals[PM_KILLER_BEE].mvflags & G_GONE))
+            if (!rn2(6)
+                && !(svm.mvitals[PM_KILLER_BEE].mvflags & G_GONE)
+                && !(gm.maploc->looted & TREE_SWARM))
                 You_hear("a low buzzing."); /* a warning */
             kick_ouch(x, y, "");
             return ECMD_TIME;


### PR DESCRIPTION
Noticed this when testing a level with some barren trees which were set in the special level to not contain bees; the barren trees are still able to produce a low buzzing. This may convince players that they can get bees from the tree if only they kick it enough times, which will not happen.

To avoid that, only print this message when the tree can release bees, augmenting the existing check for killer bees being non-extinct.