### PR TITLE
glyphs: add piletop_ prefix to piletop-generic-obj canonical names

### DIFF
--- a/src/glyphs.c
+++ b/src/glyphs.c
@@ -975,7 +975,8 @@ parse_id(
                                      ? obj_descr[i].oc_name
                                      : obj_descr[i].oc_descr;
                         Strcpy(buf[0], "G_");
-                        if (glyph_is_normal_piletop_obj(glyph))
+                        if (glyph_is_normal_piletop_obj(glyph)
+                            || glyph_is_piletop_generic_obj(glyph))
                             Strcat(buf[0], "piletop_");
                         Strcat(buf[0], buf2);
                         Strcat(buf[0], buf3);


### PR DESCRIPTION
parse_id's glyph_is_object branch only emitted the "piletop_" prefix when glyph_is_normal_piletop_obj(glyph) was true.  Piletop-generic objects (the GLYPH_OBJ_PILETOP_OFF + 1 .. + LAST_GENERIC range) hit glyph_is_piletop_generic_obj() instead and got no prefix, so they produced the same canonical name as their non-piletop generic counterparts.

For example glyph 3449 (GLYPH_OBJ_OFF + GENERIC_STRANGE) and glyph 7993 (GLYPH_OBJ_PILETOP_OFF + GENERIC_STRANGE) both yielded "G_generic_strange".  14 such pairs exist; the piletop variant is unreachable by name from nethackrc, and the runtime hashtable's "assume no id occurs twice" populate loop silently dropped them.

Emit "piletop_" for both piletop predicates so each glyph gets a distinct canonical name.  --dumpglyphnames now shows the 14 "G_piletop_generic_*" entries (and the count goes from 9577 to 9591; the existing off-by-one in glyph_is_normal_piletop_obj still hides slot GLYPH_OBJ_PILETOP_OFF + FIRST_OBJECT - 1, which is addressed by its own fix).