### PR TITLE
glyphs: rotate-5 in glyph_hash eliminates all current collisions

### DIFF
--- a/src/glyphs.c
+++ b/src/glyphs.c
@@ -442,7 +442,7 @@ glyph_hash(const char *id)
         if ('A' <= ch && ch <= 'Z') {
             ch += 'a' - 'A';
         }
-        hash = (hash << 1) | (hash >> 31);
+        hash = (hash << 5) | (hash >> 27);
         hash ^= ch;
     }
     return hash;


### PR DESCRIPTION
The previous rotate-1-xor put consecutive characters' bits in adjacent positions, so short similar names like fox/bat or jaguar/lichen collided -- 164 colliding buckets across the 9577 named glyphs.  Rotate-5 spreads each character across a 5-bit window: zero collisions.