### PR TITLE
Atari: MiNT performance fixes, small correctness fixes, fix lua build

### DIFF
--- a/sys/atari/tos.c
+++ b/sys/atari/tos.c
@@ -307,10 +307,16 @@ _copyfile(char *from, char *to)
     return (r < 0) ? -1 : 0;
 }
 
+extern short mar_kbhit(void); /* win/gem/wingem1.c */
+
 int
 kbhit(void)
 {
-    return Cconis();
+    /* Use the AES event multiplexer instead of the BIOS console:
+       under MiNT, Cconis() bounces through the kernel console device
+       and the AES console host per call, which is hot during long
+       occupations (eat / dig / travel / run, see src/allmain.c). */
+    return mar_kbhit();
 }
 
 static void

--- a/sys/unix/hints/include/cross-post.500
+++ b/sys/unix/hints/include/cross-post.500
@@ -407,6 +407,10 @@ $(TARGETPFX)giftiles.o : ../win/share/giftiles.c
 endif  # CROSS_SHARED
 #
 ifdef CROSS
+ifdef MAKEFILE_TOP
+# top-level liblua.a is a host-side build; keep TARGET_CC out of it
+LUAMAKEFLAGS = CC='$(CC)' SYSCFLAGS='$(SYSCFLAGS)'
+endif  # MAKEFILE_TOP
 $(TARGETPFX)hacklib.a: $(TARGETPFX)hacklib.o
 	$(TARGET_AR) $(TARGET_ARFLAGS) $@ $(TARGETPFX)hacklib.o
 ifdef MAKEFILE_UTL

--- a/win/gem/gr_rect.c
+++ b/win/gem/gr_rect.c
@@ -51,6 +51,8 @@ add_dirty_rect(dirty_rect *dr, GRECT *area)
     int cheapestmerge2 = -1;
     int merge1;
     int merge2;
+    if (dr == NULL || dr->rects == NULL)
+        return (FALSE);
     for (cursor = 0; cursor < dr->used; cursor++) {
         if (gc_inside(&dr->rects[cursor], area)) {
             /* Wholly contained already. */

--- a/win/gem/wingem.c
+++ b/win/gem/wingem.c
@@ -955,16 +955,17 @@ Gem_raw_print_bold(const char *str)
 }
 
 extern void mar_update_value(void); /* wingem1.c */
+extern short mar_nh_poskey(short *x, short *y, short *mod); /* wingem1.c */
 
 int
 Gem_nhgetch()
 {
-    short i;
+    short i, x, y, mod;
 
     mar_update_value();
-    i = tgetch();
+    i = mar_nh_poskey(&x, &y, &mod);
     if (!i)
-        i = '\033'; /* map NUL to ESC since nethack doesn't expect NUL */
+        i = '\033'; /* mouse click during a getch prompt -> ESC */
 
     return i;
 }

--- a/win/gem/wingem.c
+++ b/win/gem/wingem.c
@@ -749,7 +749,7 @@ Gem_add_menu(winid window, const glyph_info *glyphinfo,
     int glyph = glyphinfo ? glyphinfo->glyph : NO_GLYPH;
     Gem_menu_item *G_item;
     const char *newstr;
-    char buf[QBUFSZ];
+    char buf[4 + BUFSZ];
 
     if (str == (const char *) 0)
         return;

--- a/win/gem/wingem.c
+++ b/win/gem/wingem.c
@@ -164,11 +164,15 @@ Gem_init_nhwindows(int *argcp, char **argv)
     mar_set_tiley(iflags.wc_tile_height);
     mar_set_msg_align(iflags.wc_align_message - ALIGN_BOTTOM);
     mar_set_status_align(iflags.wc_align_status - ALIGN_BOTTOM);
-    if (mar_gem_init() == 0) {
-        bail((char *) 0);
-        /*NOTREACHED*/
+    {
+        extern void Gem_flush_preinit_raw(void);
+        if (mar_gem_init() == 0) {
+            bail((char *) 0);
+            /*NOTREACHED*/
+        }
+        iflags.window_inited = TRUE;
+        Gem_flush_preinit_raw();
     }
-    iflags.window_inited = TRUE;
 
     CO = 80;
     LI = 25;
@@ -932,6 +936,38 @@ mar_print_gl_char(winid window, coordxy x, coordxy y, int ch, int color)
 extern void mar_raw_print(const char *);
 extern void mar_raw_print_bold(const char *);
 
+/* Pre-init raw_print buffer.  Before iflags.window_inited becomes TRUE
+   the only output channel is stdout, which under MiNT bounces through
+   the kernel console device and the AES console host (TosWin2 /
+   N.AES console) per character -- noticeably slow on startup.  Stash
+   such messages here and surface them via xalert() once the AES is
+   up; cap the buffer so a runaway pre-init raw_print storm can't pin
+   the process. */
+#define PREINIT_BUF_SIZE 1024
+static char preinit_raw_buf[PREINIT_BUF_SIZE];
+static int preinit_raw_len = 0;
+static int preinit_raw_overflow = 0;
+
+static void
+preinit_raw_append(const char *str)
+{
+    int n, room;
+    if (!str)
+        return;
+    n = (int) strlen(str);
+    room = PREINIT_BUF_SIZE - 1 - preinit_raw_len;
+    if (n + 1 > room) {
+        preinit_raw_overflow = 1;
+        if (room <= 1)
+            return;
+        n = room - 1;
+    }
+    memcpy(preinit_raw_buf + preinit_raw_len, str, n);
+    preinit_raw_len += n;
+    preinit_raw_buf[preinit_raw_len++] = '\n';
+    preinit_raw_buf[preinit_raw_len] = '\0';
+}
+
 void
 Gem_raw_print(const char *str)
 {
@@ -939,7 +975,7 @@ Gem_raw_print(const char *str)
         if (iflags.window_inited)
             mar_raw_print(str);
         else
-            printf("%s\n", str);
+            preinit_raw_append(str);
     }
 }
 
@@ -950,8 +986,42 @@ Gem_raw_print_bold(const char *str)
         if (iflags.window_inited)
             mar_raw_print_bold(str);
         else
-            printf("%s\n", str);
+            preinit_raw_append(str);
     }
+}
+
+/* Called from Gem_init_nhwindows right after iflags.window_inited
+   becomes TRUE: drop the collected lines into the message window
+   instead of a modal raw_print alert. */
+extern void mar_add_message(const char *); /* wingem1.c */
+extern void mar_display_nhwindow(winid);   /* wingem1.c */
+void
+Gem_flush_preinit_raw(void)
+{
+    char *p, *eol;
+
+    if (preinit_raw_len <= 0)
+        return;
+
+    p = preinit_raw_buf;
+    while (p < preinit_raw_buf + preinit_raw_len) {
+        eol = strchr(p, '\n');
+        if (eol)
+            *eol = '\0';
+        if (*p)
+            mar_add_message(p);
+        if (!eol)
+            break;
+        p = eol + 1;
+    }
+    if (preinit_raw_overflow)
+        mar_add_message("[startup messages truncated]");
+    if (WIN_MESSAGE != WIN_ERR)
+        mar_display_nhwindow(WIN_MESSAGE);
+
+    preinit_raw_len = 0;
+    preinit_raw_overflow = 0;
+    preinit_raw_buf[0] = '\0';
 }
 
 extern void mar_update_value(void); /* wingem1.c */

--- a/win/gem/wingem1.c
+++ b/win/gem/wingem1.c
@@ -3373,6 +3373,41 @@ mar_destroy_nhwindow(int window)
 
 /************************* nh_poskey *******************************/
 
+/* Non-blocking key probe.  AES events don't peek; once an event is
+   returned by evnt_multi it is dequeued.  So mar_kbhit() consumes any
+   pending key event into mar_kbhit_buf_*, and mar_nh_poskey() replays
+   that buffered key on its next call instead of polling the AES queue.
+   This lets src/allmain.c kbhit()-then-pgetchar() interrupt long
+   occupations (eat / dig / travel) without the BIOS Cconis() syscall
+   round-trip per turn under MiNT. */
+static short mar_kbhit_buf_kreturn = 0;
+static short mar_kbhit_buf_kstate = 0;
+static short mar_kbhit_buf_valid = 0;
+
+short
+mar_kbhit(void)
+{
+    XEVENT probe;
+    short ev;
+
+    if (mar_kbhit_buf_valid)
+        return 1;
+
+    memset(&probe, 0, sizeof(probe));
+    probe.ev_mflags = MU_TIMER | MU_KEYBD;
+    probe.ev_mt1locount = 0;
+    probe.ev_mt1hicount = 0;
+    ev = Event_Multi(&probe);
+
+    if (ev & MU_KEYBD) {
+        mar_kbhit_buf_kreturn = probe.ev_mkreturn;
+        mar_kbhit_buf_kstate = probe.ev_mmokstate;
+        mar_kbhit_buf_valid = 1;
+        return 1;
+    }
+    return 0;
+}
+
 void
 mar_set_margin(short m)
 {
@@ -3445,8 +3480,16 @@ mar_nh_poskey(short *x, short *y, short *mod)
     short retval, ev;
 
     do {
-    xev.ev_mflags = Main_Init(&xev, 0xFFFF);
-    ev = Event_Multi(&xev);
+    if (mar_kbhit_buf_valid) {
+        /* Replay key consumed by a prior mar_kbhit() probe. */
+        xev.ev_mkreturn = mar_kbhit_buf_kreturn;
+        xev.ev_mmokstate = mar_kbhit_buf_kstate;
+        mar_kbhit_buf_valid = 0;
+        ev = MU_KEYBD;
+    } else {
+        xev.ev_mflags = Main_Init(&xev, 0xFFFF);
+        ev = Event_Multi(&xev);
+    }
 
     retval = FAIL;
 

--- a/win/gem/xpm2img.c
+++ b/win/gem/xpm2img.c
@@ -138,7 +138,7 @@ fopen_xpm_file(const char *fn, const char *mode)
         if (!ColorMap)
             return FALSE;
         while (ccount++ < (num_colors - 1)) {
-            char index;
+            unsigned char index;
             int r, g, b;
             xb = xpmgetline();
             if (xb == 0)


### PR DESCRIPTION
- fix a build problem for CROSS_TO-targets: host lua build picked up target CC
- fix performance problems on MiNT by routing keyboard input and text output via AES
- some small correctness fixes