### PR TITLE
Nethack-5.0.0: rename MACOS9 to MAC68K to avoid confusion with modern macOS

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -36,7 +36,7 @@
 /* Hint: if you're not developing code, don't define
    ULTRIX_PROTO. */
 
-#include "config1.h" /* should auto-detect MSDOS, MACOS9, AMIGA, and WIN32 */
+#include "config1.h" /* should auto-detect MSDOS, MAC68K, AMIGA, and WIN32 */
 
 /*
  * Consolidated version, patchlevel, development status.
@@ -67,8 +67,8 @@
  *      tty, X11, mac, amii, BeOS, Qt, Gem, Gnome, shim
  */
 
-/* MACOS9 also means MAC windows */
-#ifdef MACOS9
+/* MAC68K also means MAC windows */
+#ifdef MAC68K
 #ifndef AUX
 #define DEFAULT_WINDOW_SYS "mac"
 #endif
@@ -339,7 +339,7 @@
 #define ENTRYMAX 100 /* must be >= 10 */
 #endif
 #ifndef PERS_IS_UID
-#if !defined(MICRO) && !defined(MACOS9) && !defined(WIN32)
+#if !defined(MICRO) && !defined(MAC68K) && !defined(WIN32)
 #define PERS_IS_UID 1 /* delete for PERSMAX per name; now per uid */
 #else
 #define PERS_IS_UID 0
@@ -434,7 +434,7 @@
  */
 #define INSURANCE /* allow crashed game recovery */
 
-#if !defined(MACOS9) && !defined(SHIM_GRAPHICS)
+#if !defined(MAC68K) && !defined(SHIM_GRAPHICS)
 #define CHDIR /* delete if no chdir() available */
 #endif
 
@@ -533,7 +533,7 @@ typedef unsigned char uchar;
 #define MACRO_CPATH /* use clear_path macros instead of functions */
 #endif
 
-#if !defined(MACOS9)
+#if !defined(MAC68K)
 #if !defined(NOCLIPPING)
 #define CLIPPING /* allow smaller screens -- ERS */
 #endif

--- a/include/config1.h
+++ b/include/config1.h
@@ -45,23 +45,23 @@
 #endif
 
 #ifdef macintosh /* Auto-defined symbol for MPW compilers (sc and mrc) */
-#define MACOS9
+#define MAC68K
 #endif
 
 #ifdef THINK_C /* Think C auto-defined symbol */
-#define MACOS9
+#define MAC68K
 #define NEED_VARARGS
 #endif
 
 #ifdef __MWERKS__ /* defined by Metrowerks' Codewarrior compiler */
 #ifndef __BEOS__  /* BeOS */
-#define MACOS9
+#define MAC68K
 #endif
 #define NEED_VARARGS
 #define USE_STDARG
 #endif
 
-#if defined(MACOS9) || defined(__BEOS__)
+#if defined(MAC68K) || defined(__BEOS__)
 #define DLB
 #undef UNIX
 #endif

--- a/include/dlb.h
+++ b/include/dlb.h
@@ -9,7 +9,7 @@
 #ifdef DLB
 
 /* implementations */
-#if defined(MACOS9) && !defined(MACOS9_CROSS)
+#if defined(MAC68K) && !defined(MAC68K_CROSS)
 #define DLBRSRC /* use Mac resources */
 #else
 #define DLBLIB /* use a set of external files */

--- a/include/extern.h
+++ b/include/extern.h
@@ -1461,7 +1461,7 @@ extern boolean stumble_on_door_mimic(coordxy, coordxy);
 extern int doopen_indir(coordxy, coordxy);
 extern int doclose(void);
 
-#ifdef MACOS9
+#ifdef MAC68K
 /* outdated functions removed */
 /* ### macfile.c ### */
 /* ### macmain.c ### */

--- a/include/flag.h
+++ b/include/flag.h
@@ -510,7 +510,7 @@ struct instance_flags {
 #ifdef MAC_GRAPHICS_ENV
 #define large_font obsolete
 #endif
-#ifdef MACOS9
+#ifdef MAC68K
 #define popup_dialog wc_popup_dialog
 #endif
 #define preload_tiles wc_preload_tiles

--- a/include/global.h
+++ b/include/global.h
@@ -185,7 +185,7 @@ typedef uchar nhsym;
 #ifdef AMIGA
 #define PORT_ID "Amiga"
 #endif
-#ifdef MACOS9
+#ifdef MAC68K
 #define PORT_ID "Mac"
 #endif
 #ifdef __APPLE__

--- a/include/optlist.h
+++ b/include/optlist.h
@@ -363,7 +363,7 @@ static int optfn_##a(int, int, boolean, char *, char *);
     NHOPTB(herecmd_menu, Advanced, 0, opt_in, set_in_game,
            Off, Yes, No, No, NoAlias, &iflags.herecmd_menu, Term_False,
            "show commands available in this location")
-#if defined(MACOS9)
+#if defined(MAC68K)
     NHOPTC(hicolor, Advanced, 15, opt_in, set_in_config,
                 No, Yes, No, No, NoAlias,
                 "same as palette, only order is reversed")
@@ -396,7 +396,7 @@ static int optfn_##a(int, int, boolean, char *, char *);
     NHOPTB(idlecheckpoint, Advanced, 0, opt_in, set_in_game,
            Off, Yes, No, No, NoAlias, &iflags.idlecheckpoint, Term_Off,
            "update checkpoint file if input is idle for 10 seconds")
-#ifndef MACOS9
+#ifndef MAC68K
     NHOPTB(ignintr, Advanced, 0, opt_in, set_in_game,
            Off, Yes, No, No, NoAlias, &flags.ignintr, Term_False,
            "ignore interrupt signals")
@@ -548,7 +548,7 @@ static int optfn_##a(int, int, boolean, char *, char *);
                 No, Yes, No, No, NoAlias,
                 "the inventory order of the items in your pack")
 #ifdef CHANGE_COLOR
-#ifndef MACOS9     /* not old Mac OS9 */
+#ifndef MAC68K     /* not old Mac OS9 */
     NHOPTC(palette, Advanced, 15, opt_in, set_gameview,
                 No, Yes, Yes, No, "hicolor",
                 "palette (adjust an RGB color in palette (color/R-G-B)")

--- a/include/tcap.h
+++ b/include/tcap.h
@@ -13,7 +13,7 @@
 #endif
 
 /* might display need graphics code? */
-#if !defined(AMIGA) && !defined(TOS) && !defined(MACOS9)
+#if !defined(AMIGA) && !defined(TOS) && !defined(MAC68K)
 #if defined(TERMLIB) || defined(OS2) || defined(MSDOS)
 #define ASCIIGRAPH
 #endif

--- a/include/winprocs.h
+++ b/include/winprocs.h
@@ -76,7 +76,7 @@ struct window_procs {
     void (*win_delay_output)(void);
 #ifdef CHANGE_COLOR
     void (*win_change_color)(int, long, int);
-#ifdef MACOS9
+#ifdef MAC68K
     void (*win_change_background)(int);
     short (*win_set_font_name)(winid, char *);
 #endif
@@ -162,7 +162,7 @@ extern
 #define nh_delay_output (*windowprocs.win_delay_output)
 #ifdef CHANGE_COLOR
 #define change_color (*windowprocs.win_change_color)
-#ifdef MACOS9
+#ifdef MAC68K
 #define change_background (*windowprocs.win_change_background)
 #define set_font_name (*windowprocs.win_set_font_name)
 #endif
@@ -394,7 +394,7 @@ struct chain_procs {
     void (*win_delay_output)(CARGS);
 #ifdef CHANGE_COLOR
     void (*win_change_color)(CARGS, int, long, int);
-#ifdef MACOS9
+#ifdef MAC68K
     void (*win_change_background)(CARGS, int);
     short (*win_set_font_name)(CARGS, winid, char *);
 #endif

--- a/include/wintty.h
+++ b/include/wintty.h
@@ -280,7 +280,7 @@ extern void tty_number_pad(int);
 extern void tty_delay_output(void);
 #ifdef CHANGE_COLOR
 extern void tty_change_color(int color, long rgb, int reverse);
-#ifdef MACOS9
+#ifdef MAC68K
 extern void tty_change_background(int white_or_black);
 extern short set_tty_font_name(winid, char *);
 #endif
@@ -331,7 +331,7 @@ extern char *tgetstr(const char *, char **);
 extern char *tgoto(const char *, int, int);
 #endif /* NO_TERMCAP_HEADERS */
 #else  /* ?NO_TERMS */
-#ifdef MACOS9
+#ifdef MAC68K
 #ifdef putchar
 #undef putchar
 #undef putc
@@ -342,7 +342,7 @@ extern char *tgoto(const char *, int, int);
 extern int term_putc(int c);
 extern int term_flush(void *desc);
 extern int term_puts(const char *str);
-#endif /* MACOS9 */
+#endif /* MAC68K */
 #if defined(MSDOS) || defined(WIN32)
 #if defined(SCREEN_BIOS) || defined(SCREEN_DJGPPFAST) || defined(WIN32)
 #undef putchar

--- a/outdated/include/mac-carbon.h
+++ b/outdated/include/mac-carbon.h
@@ -21,7 +21,7 @@
  *		set "Prefix File" to include/mac-carbon.h
  */
 
-#define MACOS9
+#define MAC68K
 #define MAC
 #undef UNIX
 

--- a/outdated/include/mac-qt.h
+++ b/outdated/include/mac-qt.h
@@ -22,7 +22,7 @@
  */
 
 #undef MAC
-#undef MACOS9
+#undef MAC68K
 #define UNIX
 #define BSD
 

--- a/outdated/include/mac-term.h
+++ b/outdated/include/mac-term.h
@@ -23,7 +23,7 @@
 
 /* Stuff needed for the core of NetHack */
 #undef MAC
-#undef MACOS9
+#undef MAC68K
 #define UNIX
 #define BSD
 #define __FreeBSD__ /* Darwin is based on FreeBSD */

--- a/outdated/include/macconf.h
+++ b/outdated/include/macconf.h
@@ -3,7 +3,7 @@
 /*-Copyright (c) Kevin Hugo, 2004. */
 /* NetHack may be freely redistributed.  See license for details. */
 
-#ifdef MACOS9
+#ifdef MAC68K
 #ifndef MACCONF_H
 #define MACCONF_H
 
@@ -16,7 +16,7 @@
  *	__MWERKS__		Metrowerks' Codewarrior compiler
  *
  * We use these early in config.h to define some needed symbols,
- * including MACOS9.
+ * including MAC68K.
  #
  # The Metrowerks compiler defines __STDC__ (which sets NHSTC) and uses
  # WIDENED_PROTOTYPES (defined if UNWIDENED_PROTOTYPES is undefined and
@@ -123,4 +123,4 @@ extern void error(const char *, ...);
 #define MAC_GRAPHICS_ENV
 
 #endif /* ! MACCONF_H */
-#endif /* MACOS9 */
+#endif /* MAC68K */

--- a/outdated/include/system.h
+++ b/outdated/include/system.h
@@ -21,7 +21,7 @@
 /* some old <sys/types.h> may not define off_t and size_t; if your system is
  * one of these, define them by hand below
  */
-#if (defined(VMS) && !defined(__GNUC__)) || defined(MACOS9)
+#if (defined(VMS) && !defined(__GNUC__)) || defined(MAC68K)
 #include <types.h>
 #else
 #ifndef AMIGA
@@ -41,7 +41,7 @@ typedef unsigned int size_t;
 #endif
 #endif /* MICRO && !TOS */
 
-#if defined(__TURBOC__) || defined(MACOS9)
+#if defined(__TURBOC__) || defined(MAC68K)
 #include <time.h> /* time_t is not in <sys/types.h> */
 #endif
 #if defined(ULTRIX) && !(defined(ULTRIX_PROTO) || defined(NHSTDC))
@@ -200,7 +200,7 @@ extern int unlink(const char *);
 
 #endif /* AZTEC_50 && __GNUC__ */
 
-#ifdef MACOS9
+#ifdef MAC68K
 #ifndef __CONDITIONALMACROS__          /* universal headers */
 extern int close(int);             /* unistd.h */
 extern int read(int, char *, int); /* unistd.h */
@@ -313,7 +313,7 @@ extern long fork(void);
 /* The POSIX string.h is required to define all the mem* and str* functions */
 #include <string.h>
 #else
-#if defined(SYSV) || defined(VMS) || defined(MACOS9) || defined(SUNOS4)
+#if defined(SYSV) || defined(VMS) || defined(MAC68K) || defined(SUNOS4)
 #if defined(NHSTDC) || (defined(VMS) && !defined(ANCIENT_VAXC))
 #if !defined(_AIX32) && !(defined(SUNOS4) && defined(__STDC__))
 /* Solaris unbundled cc (acc) */
@@ -423,7 +423,7 @@ extern char *strncat(char *, const char *, size_t);
 extern char *strpbrk(const char *, const char *);
 
 #ifdef NOT_C99
-#if defined(SYSV) || defined(MICRO) || defined(MACOS9) || defined(VMS) \
+#if defined(SYSV) || defined(MICRO) || defined(MAC68K) || defined(VMS) \
     || defined(HPUX)
 extern char *strchr(const char *, int);
 extern char *strrchr(const char *, int);
@@ -435,7 +435,7 @@ extern char *rindex(const char *, int);
 
 extern int strcmp(const char *, const char *);
 extern int strncmp(const char *, const char *, size_t);
-#if defined(MICRO) || defined(MACOS9) || defined(VMS)
+#if defined(MICRO) || defined(MAC68K) || defined(VMS)
 extern size_t strlen(const char *);
 #else
 #ifdef HPUX

--- a/outdated/win/gem/wingem.c
+++ b/outdated/win/gem/wingem.c
@@ -63,7 +63,7 @@ struct window_procs Gem_procs = {
     Gem_getlin, Gem_get_ext_cmd, Gem_number_pad, Gem_delay_output,
 #ifdef CHANGE_COLOR /* the Mac uses a palette device */
     Gem_change_color,
-#ifdef MACOS9
+#ifdef MAC68K
     Gem_change_background, Gem_set_font_name,
 #endif
     Gem_get_color_string,
@@ -76,7 +76,7 @@ struct window_procs Gem_procs = {
     genl_can_suspend_no,
 };
 
-#ifdef MACOS9
+#ifdef MAC68K
 void *
 Gem_change_background(dummy)
 int dummy;

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -739,7 +739,7 @@ init_sound_disp_gamewindows(void)
        ever having been used, use it here to pacify the Qt interface */
     start_menu(WIN_INVEN, menu_behavior), end_menu(WIN_INVEN, (char *) 0);
 
-#ifdef MACOS9
+#ifdef MAC68K
     /* This _is_ the right place for this - maybe we will
      * have to split init_sound_disp_gamewindows into
      * create_gamewindows and show_gamewindows to get rid of this ifdef...

--- a/src/cfgfiles.c
+++ b/src/cfgfiles.c
@@ -9,7 +9,7 @@
 #include "dlb.h"
 #include <errno.h>
 
-#if (!defined(MACOS9) && !defined(O_WRONLY) && !defined(AZTEC_C)) \
+#if (!defined(MAC68K) && !defined(O_WRONLY) && !defined(AZTEC_C)) \
     || defined(USE_FCNTL)
 #include <fcntl.h>
 #endif
@@ -131,7 +131,7 @@ static const char *default_configfile =
 #ifdef UNIX
     ".nethackrc";
 #else
-#if defined(MACOS9) || defined(__BEOS__)
+#if defined(MAC68K) || defined(__BEOS__)
     "NetHack Defaults";
 #else
 #if defined(MSDOS) || defined(WIN32)
@@ -280,7 +280,7 @@ fopen_config_file(const char *filename, int src)
     }
     /* fall through to standard names */
 
-#if defined(MICRO) || defined(MACOS9) || defined(__BEOS__) || defined(WIN32)
+#if defined(MICRO) || defined(MAC68K) || defined(__BEOS__) || defined(WIN32)
     set_configfile_name(fqname(default_configfile, CONFIGPREFIX, 0));
     if ((fp = fopen(configfile, "r")) != (FILE *) 0) {
         return fp;
@@ -371,7 +371,7 @@ fopen_config_file(const char *filename, int src)
         wait_synch();
     }
 #endif /* !VMS => Unix */
-#endif /* !(MICRO || MACOS9 || __BEOS__ || WIN32) */
+#endif /* !(MICRO || MAC68K || __BEOS__ || WIN32) */
     return (FILE *) 0;
 }
 

--- a/src/eat.c
+++ b/src/eat.c
@@ -2176,7 +2176,7 @@ fprefx(struct obj *otmp)
         } else if (otmp->otyp == APPLE && otmp->cursed && !Sleep_resistance) {
             ; /* skip core joke; feedback deferred til fpostfx() */
 
-#if defined(MACOS9) || defined(MACOS)
+#if defined(MAC68K) || defined(MACOS)
         /* KMH -- Why should Unix have all the fun?
            We check MACOS before UNIX to get the Apple-specific apple
            message; the '#if UNIX' code will still kick in for pear. */

--- a/src/end.c
+++ b/src/end.c
@@ -1679,7 +1679,7 @@ nh_terminate(int status)
     program_state.in_moveloop = 0; /* won't be returning to normal play */
 
     l_nhcore_call(NHCORE_GAME_EXIT);
-#ifdef MACOS9
+#ifdef MAC68K
     getreturn("to exit");
 #endif
     /* don't bother to try to release memory if we're in panic mode, to

--- a/src/files.c
+++ b/src/files.c
@@ -38,7 +38,7 @@
 #include "wintty.h" /* more() */
 #endif
 
-#if (!defined(MACOS9) && !defined(O_WRONLY) && !defined(AZTEC_C)) \
+#if (!defined(MAC68K) && !defined(O_WRONLY) && !defined(AZTEC_C)) \
     || defined(USE_FCNTL)
 #include <fcntl.h>
 #endif
@@ -133,7 +133,7 @@ extern boolean get_user_home_folder(char *, size_t);
 #endif
 #endif
 
-#ifdef MACOS9
+#ifdef MAC68K
 #undef unlink
 #define unlink macunlink
 #endif
@@ -643,7 +643,7 @@ create_levelfile(int lev, char errbuf[])
         nhfp->fd = open(fq_lock, O_WRONLY | O_CREAT | O_TRUNC | O_BINARY,
                         FCMASK);
 #else
-#ifdef MACOS9
+#ifdef MAC68K
         nhfp->fd = maccreat(fq_lock, LEVL_TYPE);
 #else
         nhfp->fd = creat(fq_lock, FCMASK);
@@ -689,7 +689,7 @@ open_levelfile(int lev, char errbuf[])
         nhfp->fpdef = (FILE *) 0;
     }
     if (nhfp && nhfp->structlevel) {
-#ifdef MACOS9
+#ifdef MAC68K
         nhfp->fd = macopen(fq_lock, O_RDONLY | O_BINARY, LEVL_TYPE);
 #else
         nhfp->fd = open(fq_lock, O_RDONLY | O_BINARY, 0);
@@ -872,12 +872,12 @@ create_bonesfile(d_level *lev, char **bonesid, char errbuf[])
                            O_WRONLY | O_CREAT | O_TRUNC | O_BINARY,
                            _SH_DENYRW, _S_IREAD | _S_IWRITE);
 #else /* ?MICRO || WIN32 */
-/* implies UNIX or MACOS9 (MACOS9 is for OS9 or earlier) */
-#ifdef MACOS9
+/* implies UNIX or MAC68K (MAC68K is for OS9 or earlier) */
+#ifdef MAC68K
             nhfp->fd = maccreat(file, BONE_TYPE);
 #else
             nhfp->fd = creat(file, FCMASK);
-#endif  /* ?MACOS9 */
+#endif  /* ?MAC68K */
 #endif  /* ?MICRO || WIN32 */
             if (nhfp->fd < 0)
                 failed = errno;
@@ -967,7 +967,7 @@ open_bonesfile(d_level *lev, char **bonesid)
 #endif
         }
         if (nhfp->structlevel) {
-#if defined(MACOS9)
+#if defined(MAC68K)
             nhfp->fd = macopen(fq_bones, O_RDONLY | O_BINARY, BONE_TYPE);
 #elif defined(WIN32)
             err = _sopen_s(&nhfp->fd, fq_bones, _O_RDONLY | _O_BINARY,
@@ -1136,7 +1136,7 @@ set_error_savefile(void)
     }
     Strcat(gs.SAVEF, ".e;1");
 #else
-#ifdef MACOS9
+#ifdef MAC68K
     Strcat(gs.SAVEF, "-e");
 #else
     Strcat(gs.SAVEF, ".e");
@@ -1175,8 +1175,8 @@ create_savefile(void)
             nhfp->fd = open(fq_save, O_WRONLY | O_BINARY | O_CREAT | O_TRUNC,
                             FCMASK);
 #else /* !MICRO && !WIN32 */
-/* UNIX || MACOS9 implied (MACOS9 is OS9 or earlier only) */
-#ifdef MACOS9
+/* UNIX || MAC68K implied (MAC68K is OS9 or earlier only) */
+#ifdef MAC68K
             nhfp->fd = maccreat(fq_save, SAVE_TYPE);
 #else
             nhfp->fd = creat(fq_save, FCMASK);
@@ -1231,7 +1231,7 @@ open_savefile(void)
             nhfp->fplog = fopen("open-savefile.log", "w");
 #endif
         }
-#ifdef MACOS9
+#ifdef MAC68K
         nhfp->fd = macopen(fq_save, O_RDONLY | O_BINARY, SAVE_TYPE);
 #else
         nhfp->fd = open(fq_save, O_RDONLY | O_BINARY, 0);
@@ -2496,7 +2496,7 @@ fopen_wizkit_file(void)
 #endif
     }
 
-#if defined(MICRO) || defined(MACOS9) || defined(__BEOS__) || defined(WIN32)
+#if defined(MICRO) || defined(MAC68K) || defined(__BEOS__) || defined(WIN32)
     if ((fp = fopen(fqname(gw.wizkit, CONFIGPREFIX, 0), "r")) != (FILE *) 0)
         return fp;
 #else
@@ -2775,13 +2775,13 @@ check_recordfile(const char *dir UNUSED_if_not_OS2_CODEVIEW)
     }
 #else /* MICRO || WIN32*/
 
-#ifdef MACOS9
+#ifdef MAC68K
     /* Create the "record" file, if necessary */
     fq_record = fqname(RECORD, SCOREPREFIX, 0);
     fd = macopen(fq_record, O_RDWR | O_CREAT, TEXT_TYPE);
     if (fd != -1)
         macclose(fd);
-#endif /* MACOS9 */
+#endif /* MAC68K */
 
 #endif /* MICRO || WIN32*/
 }

--- a/src/getpos.c
+++ b/src/getpos.c
@@ -852,7 +852,7 @@ getpos(coord *ccp, boolean force, const char *goal)
 #endif
     curs(WIN_MAP, cx, cy);
     flush_screen(0);
-#ifdef MACOS9
+#ifdef MAC68K
     lock_mouse_cursor(TRUE);
 #endif
     lock_mouse_buttons(TRUE);
@@ -1149,7 +1149,7 @@ getpos(coord *ccp, boolean force, const char *goal)
         flush_screen(0);
     }
  exitgetpos:
-#ifdef MACOS9
+#ifdef MAC68K
     lock_mouse_cursor(FALSE);
 #endif
     lock_mouse_buttons(FALSE);

--- a/src/mdlib.c
+++ b/src/mdlib.c
@@ -151,7 +151,7 @@ static struct win_information window_opts[] = {
 #ifdef GNOME_GRAPHICS /* unmaintained/defunct */
     { "Gnome", "Gnome", TRUE },
 #endif
-#ifdef MACOS9 /* defunct OS 9 interface */
+#ifdef MAC68K /* defunct OS 9 interface */
     { "mac", "Mac", TRUE },
 #endif
 #ifdef GEM_GRAPHICS /* defunct Atari interface */
@@ -536,7 +536,7 @@ static const char *const build_opts[] = {
     "screen clipping",
 #endif
 #ifdef NO_TERMS
-#ifdef MACOS9
+#ifdef MAC68K
     "screen control via mactty",
 #endif
 #ifdef SCREEN_BIOS

--- a/src/options.c
+++ b/src/options.c
@@ -2731,7 +2731,7 @@ optfn_palette(
 }
 
 #if 0
-/* old MACOS9 OS9 code */
+/* old MAC68K OS9 code */
 staticfn int
 optfn_palette(
     int optidx UNUSED, int req, boolean negated UNUSED,
@@ -5108,7 +5108,7 @@ pfxfn_font(int optidx, int req, boolean negated, char *opts, char *op)
         if (opttype > 0
             && (op = string_for_opt(opts, FALSE)) != empty_optstr) {
             wc_set_font_name(opttype, op);
-#ifdef MACOS9
+#ifdef MAC68K
             set_font_name(opttype, op);
 #endif
             return optn_ok;
@@ -6792,12 +6792,12 @@ complain_about_duplicate(int optidx)
 {
     char buf[BUFSZ];
 
-#ifdef MACOS9
+#ifdef MAC68K
     /* the Mac has trouble dealing with the output of messages while
      * processing the config file.  That should get fixed one day.
      * For now just return.
      */
-#else /* !MACOS9 */
+#else /* !MAC68K */
     buf[0] = '\0';
     if (using_alias)
         Sprintf(buf, " (via alias: %s)", allopt[optidx].alias);
@@ -6805,7 +6805,7 @@ complain_about_duplicate(int optidx)
                      (allopt[optidx].opttyp == CompOpt) ? "compound"
                                                         : "boolean",
                      allopt[optidx].name, buf);
-#endif /* ?MACOS9 */
+#endif /* ?MAC68K */
     return;
 }
 
@@ -9450,7 +9450,7 @@ static const char *opt_intro[] = {
     "                 NetHack Options Help:", "",
 #define CONFIG_SLOT 3 /* fill in next value at run-time */
     (char *) 0,
-#if !defined(MICRO) && !defined(MACOS9)
+#if !defined(MICRO) && !defined(MAC68K)
     "or use `NETHACKOPTIONS=\"<options>\"' in your environment",
 #endif
     "(<options> is a list of options separated by commas)",

--- a/src/shknam.c
+++ b/src/shknam.c
@@ -128,7 +128,7 @@ static const char *const shktools[] = {
 #ifdef WIN32
     "Lexa", "Niod",
 #endif
-#ifdef MACOS9
+#ifdef MAC68K
     "Nhoj-lee", "Evad\'kh", "Ettaw-noj", "Tsew-mot", "Ydna-s", "Yao-hang",
     "Tonbar", "Kivenhoug", "Llardom",
 #endif

--- a/src/windows.c
+++ b/src/windows.c
@@ -22,7 +22,7 @@ extern struct window_procs Qt_procs;
 #ifdef GEM_GRAPHICS
 /*#include "wingem.h"*/
 #endif
-#ifdef MACOS9
+#ifdef MAC68K
 extern struct window_procs mac_procs;
 #endif
 #ifdef BEOS_GRAPHICS
@@ -111,7 +111,7 @@ static struct win_choices {
 #ifdef GEM_GRAPHICS
     { &Gem_procs, win_Gem_init CHAINR(0) },
 #endif
-#ifdef MACOS9
+#ifdef MAC68K
     { &mac_procs, 0 CHAINR(0) },
 #endif
 #ifdef BEOS_GRAPHICS
@@ -543,7 +543,7 @@ staticfn void hup_cliparound(int, int);
 #endif
 #ifdef CHANGE_COLOR
 staticfn void hup_change_color(int, long, int);
-#ifdef MACOS9
+#ifdef MAC68K
 staticfn short hup_set_font_name(winid, char *);
 #endif
 staticfn char *hup_get_color_string(void);
@@ -592,7 +592,7 @@ static struct window_procs hup_procs = {
     hup_void_ndecl,                                   /* nh_delay_output  */
 #ifdef CHANGE_COLOR
     hup_change_color,
-#ifdef MACOS9
+#ifdef MAC68K
     hup_void_fdecl_int,                               /* change_background */
     hup_set_font_name,
 #endif
@@ -795,14 +795,14 @@ hup_change_color(int color UNUSED, long rgb UNUSED, int reverse UNUSED)
     return;
 }
 
-#ifdef MACOS9
+#ifdef MAC68K
 /*ARGSUSED*/
 staticfn short
 hup_set_font_name(winid window UNUSED, char *fontname UNUSED)
 {
     return 0;
 }
-#endif /* MACOS9 */
+#endif /* MAC68K */
 
 staticfn char *
 hup_get_color_string(void)

--- a/util/dlb_main.c
+++ b/util/dlb_main.c
@@ -9,7 +9,7 @@
 #include "dlb.h"
 #include "hacklib.h"
 
-#if !defined(O_WRONLY) && !defined(MACOS9) && !defined(AZTEC_C)
+#if !defined(O_WRONLY) && !defined(MAC68K) && !defined(AZTEC_C)
 #include <fcntl.h>
 #endif
 #if defined(__DJGPP__)

--- a/util/makedefs.c
+++ b/util/makedefs.c
@@ -23,15 +23,15 @@
 #include "dlb.h"
 #include "hacklib.h"
 
-#ifdef MACOS9
+#ifdef MAC68K
 #if defined(__SC__) || defined(__MRC__) /* MPW compilers */
 #define MPWTOOL
 #include <CursorCtl.h>
 #include <string.h>
-#else /* MACOS9 without MPWTOOL */
+#else /* MAC68K without MPWTOOL */
 #define MACsansMPWTOOL
 #endif
-#endif /* MACOS9 */
+#endif /* MAC68K */
 
 #ifndef MPWTOOL
 #define SpinCursor(x)
@@ -78,7 +78,7 @@
 #define DGN_TEMPLATE "NH:dat/%s" /* where dungeon.pdf file goes */
 #endif /* OLD_MAKEDEFS_OPTIONS */
 #else /* not AMIGA */
-#if defined(MACOS9) && !defined(__MACH__)
+#if defined(MAC68K) && !defined(__MACH__)
 /* MacOS 9 or earlier */
 #define SOURCE_TEMPLATE ":src:%s"
 #if __SC__ || __MRC__
@@ -91,7 +91,7 @@
 #define INCLUDE_TEMPLATE ":include:%s"
 #define DGN_TEMPLATE ":dat:%s" /* where dungeon.pdf file goes */
 #endif /* OLD_MAKEDEFS_OPTIONS */
-#else /* neither AMIGA nor MACOS9 */
+#else /* neither AMIGA nor MAC68K */
 #ifdef OS2
 #define SOURCE_TEMPLATE "..\\src\\%s"
 #define DATA_TEMPLATE "..\\dat\\%s"
@@ -100,7 +100,7 @@
 #define INCLUDE_TEMPLATE "..\\include\\%s"
 #define DGN_TEMPLATE "..\\dat\\%s" /* where dungeon.pdf file goes */
 #endif /* OLD_MAKEDEFS_OPTIONS */
-#else /* not AMIGA, MACOS9, or OS2 */
+#else /* not AMIGA, MAC68K, or OS2 */
 #define SOURCE_TEMPLATE "../src/%s"
 #define DATA_TEMPLATE "../dat/%s"
 #define DATA_IN_TEMPLATE "../dat/%s"
@@ -109,7 +109,7 @@
 #define DGN_TEMPLATE "../dat/%s" /* where dungeon.pdf file goes */
 #endif /* OLD_MAKEDEFS_OPTIONS */
 #endif /* else !OS2 */
-#endif /* else !MACOS9 */
+#endif /* else !MAC68K */
 #endif /* else !AMIGA */
 
 static const char
@@ -257,7 +257,7 @@ main(void)
     return 0;
 }
 
-#else /* ! MACOS9 */
+#else /* ! MAC68K */
 
 DISABLE_WARNING_UNREACHABLE_CODE
 
@@ -1551,7 +1551,7 @@ do_oracles(void)
                 break;
             if (!(ok = (fscanf(ofp, "%5lx", &offset) == 1)))
                 break;
-#ifdef MACOS9
+#ifdef MAC68K
 #ifdef __MWERKS__
             /*
             MetroWerks CodeWarrior Pro 1's (AKA CW12) version of MSL

--- a/win/curses/cursmain.c
+++ b/win/curses/cursmain.c
@@ -122,7 +122,7 @@ struct window_procs curses_procs = {
     curses_delay_output,
 #ifdef CHANGE_COLOR
     curses_change_color,
-#ifdef MACOS9 /* old OS 9, not OSX */
+#ifdef MAC68K /* old OS 9, not OSX */
     (void (*)(int)) 0,
     (short (*)(winid, char *)) 0,
 #endif

--- a/win/share/tilemap.c
+++ b/win/share/tilemap.c
@@ -541,7 +541,7 @@ tilename(int set, const int file_entry, int gend UNUSED)
 #define SOURCE_TEMPLATE "NH:src/%s"
 #define INCLUDE_TEMPLATE "NH:include/t.%s"
 #else
-#ifdef MACOS9
+#ifdef MAC68K
 #define SOURCE_TEMPLATE ":src:%s"
 #define INCLUDE_TEMPLATE ":include:%s"
 #else

--- a/win/tty/getline.c
+++ b/win/tty/getline.c
@@ -7,7 +7,7 @@
 
 #ifdef TTY_GRAPHICS
 
-#if !defined(MACOS9)
+#if !defined(MAC68K)
 #define NEWAUTOCOMP
 #endif
 

--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -20,7 +20,7 @@
 /* leave this undefined; it produces bad screen output with rxvt-unicode */
 /*#define DECgraphicsOptimization*/
 
-#ifdef MACOS9
+#ifdef MAC68K
 #define MICRO /* The Mac is a MICRO only for this file, not in general! */
 #ifdef THINK_C
 extern void msmsg(const char *, ...);
@@ -143,7 +143,7 @@ struct window_procs tty_procs = {
     tty_getlin, tty_get_ext_cmd, tty_number_pad, tty_delay_output,
 #ifdef CHANGE_COLOR /* the Mac uses a palette device */
     tty_change_color,
-#ifdef MACOS9
+#ifdef MAC68K
     tty_change_background, set_tty_font_name,
 #endif
     tty_get_color_string,


### PR DESCRIPTION
Nethack-5.0.0 version of the "Rename to mac68k" PR (#1566)