### PR TITLE
mac: drop the obsolete exit getreturn

### DIFF
--- a/src/end.c
+++ b/src/end.c
@@ -1679,9 +1679,6 @@ nh_terminate(int status)
     program_state.in_moveloop = 0; /* won't be returning to normal play */
 
     l_nhcore_call(NHCORE_GAME_EXIT);
-#ifdef MAC68K
-    getreturn("to exit");
-#endif
     /* don't bother to try to release memory if we're in panic mode, to
        avoid trouble in case that happens to be due to memory problems */
     if (!program_state.panicking) {


### PR DESCRIPTION
The revived mac68k port (on the m68k-wip branch) removed it: it runs an event loop after exit_nhwindows() has torn the windowing system down and crashes; the tombstone already pauses.  Removing it here too keeps the block from resurfacing in NetHack-5.0 <-> m68k-wip merges.