### PR TITLE
MS-DOS: Fix custom colors in VESA BIOS mode

### DIFF
--- a/sys/msdos/vidvesa.c
+++ b/sys/msdos/vidvesa.c
@@ -691,9 +691,16 @@ vesa_xputg(const glyph_info *glyphinfo, const glyph_info *bkglyphinfo UNUSED)
     }
 #endif
     if (vesa_pixel_size > 8 && glyphinfo->gm.customcolor != 0) {
-        /* FIXME: won't display black (0,0,0) correctly, but the background
-           is usually black anyway */
-        attr = glyphinfo->gm.customcolor | 0x80000000;
+        attr = glyphinfo->gm.customcolor;
+        if (attr & NH_BASIC_COLOR) {
+            attr &= 0x0F;
+        } else {
+            struct Pixel p;
+            p.r = (unsigned char)(attr >> 16);
+            p.g = (unsigned char)(attr >>  8);
+            p.b = (unsigned char)(attr >>  0);
+            attr = vesa_MakeColor(p) | 0x80000000;
+        }
     }
 
     row = currow;


### PR DESCRIPTION
The basic colors are being displayed as black. Colors specified as RGB are not being converted to the pixel format for the current mode.  This manifests as walls in dungeon branches being drawn in black when the symbol set is IBMgraphics, and in the wrong color when Enhanced1 is in use and the display mode uses 15 or 16 bits per pixel. A particular mode that shows this bug is 1024 by 768 under DOSBox.