### PR TITLE
MS-DOS: several fixes for the tiled map

### DIFF
--- a/sys/msdos/pckeys.c
+++ b/sys/msdos/pckeys.c
@@ -14,7 +14,7 @@
 #include "pcvideo.h"
 
 boolean pckeys(unsigned char, unsigned char);
-static void userpan(boolean);
+static void userpan(enum vga_pan_direction pan);
 static void overview(boolean);
 static void traditional(boolean);
 static void refresh(void);
@@ -49,11 +49,25 @@ pckeys(unsigned char scancode, unsigned char shift)
 #endif
     case 0x74: /* Control-right_arrow = scroll horizontal to right */
         if ((shift & CTRL) && iflags.tile_view && !opening_dialog)
-            userpan(1);
+            userpan(pan_right);
         break;
     case 0x73: /* Control-left_arrow = scroll horizontal to left */
         if ((shift & CTRL) && iflags.tile_view && !opening_dialog)
-            userpan(0);
+            userpan(pan_left);
+        break;
+    /* Dosbox reports control-up and down arrows, but VirtualBox and QEMU
+       don't; accept home, end, page up and page down also */
+    case 0x77: /* control-home */
+    case 0x8D: /* control-up_arrow */
+    case 0x84: /* control-page_up */
+        if ((shift & CTRL) && iflags.tile_view && !opening_dialog)
+            userpan(pan_up);
+        break;
+    case 0x75: /* control-end */
+    case 0x91: /* control-down_arrow */
+    case 0x76: /* control-page_down */
+        if ((shift & CTRL) && iflags.tile_view && !opening_dialog)
+            userpan(pan_down);
         break;
     case 0x3E: /* F4 = toggle overview mode */
         if (iflags.tile_view && !opening_dialog && !Is_rogue_level(&u.uz)) {
@@ -76,15 +90,15 @@ pckeys(unsigned char scancode, unsigned char shift)
 }
 
 static void
-userpan(boolean on)
+userpan(enum vga_pan_direction pan)
 {
 #ifdef SCREEN_VGA
     if (iflags.usevga)
-        vga_userpan(on);
+        vga_userpan(pan);
 #endif
 #ifdef SCREEN_VESA
     if (iflags.usevesa)
-        vesa_userpan(on);
+        vesa_userpan(pan);
 #endif
 }
 

--- a/sys/msdos/vidvesa.c
+++ b/sys/msdos/vidvesa.c
@@ -1128,17 +1128,6 @@ vesa_Init(void)
     clipy = 0;
     clipymax = clipy + (viewport_rows - 1);
 
-    /* Set the size of the tiles for the overview mode */
-    vesa_oview_width = vesa_x_res / COLNO;
-    if (vesa_oview_width > (unsigned) iflags.wc_tile_width) {
-        vesa_oview_width = (unsigned) iflags.wc_tile_width;
-    }
-    vesa_oview_height = (vesa_y_res - (TOP_MAP_ROW + 4) * vesa_char_height)
-                      / ROWNO;
-    if (vesa_oview_height > (unsigned) iflags.wc_tile_height) {
-        vesa_oview_height = (unsigned) iflags.wc_tile_height;
-    }
-
     /* Load a font of size appropriate to the screen size */
     if (vesa_x_res >= 1280 && vesa_y_res >= 960)
         font_name = "ter-u32b.psf";
@@ -1180,6 +1169,19 @@ vesa_Init(void)
             vesa_char_height = 64;
         }
         vesa_char_width = vesa_char_height / 2;
+    }
+
+    vesa_SetViewPort();
+
+    /* Set the size of the tiles for the overview mode */
+    vesa_oview_width = vesa_x_res / COLNO;
+    if (vesa_oview_width > (unsigned) iflags.wc_tile_width) {
+        vesa_oview_width = (unsigned) iflags.wc_tile_width;
+    }
+    vesa_oview_height = (vesa_y_res - (TOP_MAP_ROW + 5) * vesa_char_height)
+                      / ROWNO;
+    if (vesa_oview_height > (unsigned) iflags.wc_tile_height) {
+        vesa_oview_height = (unsigned) iflags.wc_tile_height;
     }
 
     /* Process tiles for the current video mode */

--- a/sys/msdos/vidvga.c
+++ b/sys/msdos/vidvga.c
@@ -533,9 +533,9 @@ vga_userpan(enum vga_pan_direction pan)
     /* pline("Into userpan"); */
     if (iflags.over_view || iflags.traditional_view)
         return;
-    if (pan == pan_left)
+    if (pan == pan_right)
         x = min(COLNO - 1, clipxmax + 10);
-    else if (pan == pan_right)
+    else if (pan == pan_left)
         x = max(0, clipx - 10);
     else
         return;


### PR DESCRIPTION
VESA mode: Set the viewport size correctly so the position bar does not overlay the map.

VESA mode: Correctly set the size to which tiles are stretched when overview mode (F4) is selected.

Both VESA and 16 color modes: Pass correct parameters to vga_userpan and vesa_userpan, so the pan keys (CTRL+arrow) work correctly. Some emulations don't report CTRL with up or down arrows, so accept CTRL-home, CTRL-page up, CTRL page down and CTRL-end.

16 color mode: Set the panning direction so CTRL-left and CTRL-right pan in the same direction as 3.4.3.