### PR TITLE
MSDOS: Accept only single character font mappings

### DIFF
--- a/sys/msdos/font.c
+++ b/sys/msdos/font.c
@@ -112,11 +112,27 @@ load_font(const char *filename)
                 bufsize -= strsize;
                 memmove(buf, buf + strsize, bufsize);
             }
-            codepoints = uni_8to32(buf2);
-            for (j = 0; codepoints[j] != 0; ++j) {
-                add_unicode_index(font, codepoints[j], i);
+            /* Split the individual mappings and use only single character
+               mappings */
+            char *start = buf2;
+            while (*start != '\0') {
+                /* Mapping ends with a 0xFE byte */
+                char *end = strchr(start, 0xFE);
+                if (end == NULL) {
+                    end = start + strlen(start);
+                } else {
+                    *end = '\0';
+                    ++end;
+                }
+                /* Convert this mapping */
+                codepoints = uni_8to32(start);
+                /* Accept it if it is a single character */
+                if (codepoints[0] != 0 && codepoints[1] == 0) {
+                    add_unicode_index(font, codepoints[0], i);
+                }
+                free(codepoints);
+                start = end;
             }
-            free(codepoints);
             if (p != NULL)
                 ++i;
         }

--- a/sys/msdos/fonts/makefont.lua
+++ b/sys/msdos/fonts/makefont.lua
@@ -220,6 +220,9 @@ end
 for i = 1, next_pos-1 do
     glyph = font[i]
     for j = 1, #glyph.code do
+        if j ~= 1 then
+            outfile:write("\xFE")
+        end
         outfile:write(utf8.char(glyph.code[j]))
     end
     outfile:write("\xFF")


### PR DESCRIPTION
* makefont.lua generates incorrect PSF fonts. There can be multiple characters mapped to a single glyph, but the mappings should be separated by FE bytes.

* font.c should accept only single character mappings -- not combining sequences. The bundled fonts have no combining sequences, but I am exploring other options that provide more Unicode coverate.