### PR TITLE
atari: move tile.o rule to cross-post so it isn't the default goal

### DIFF
--- a/sys/unix/hints/include/cross-post.500
+++ b/sys/unix/hints/include/cross-post.500
@@ -525,6 +525,12 @@ $(TARGETPFX)wingem1.o : ../win/gem/wingem1.c $(HACK_H)
 $(TARGETPFX)bitmfile.o : ../win/gem/bitmfile.c $(HACK_H)
 $(TARGETPFX)gr_rect.o : ../win/gem/gr_rect.c $(HACK_H)
 $(TARGETPFX)load_img.o : ../win/gem/load_img.c $(HACK_H)
+# Explicit rule for the generated tile.c -> tile.o so make's pattern rule
+# $(TARGETPFX)%.o : %.c doesn't pick the wrong path before tile.c exists
+# (breaks -j N builds).  Kept here in cross-post -- after 'all' -- so it
+# never becomes the default goal, matching the amiga/msdos placement.
+$(TARGETPFX)tile.o : $(SRCDIR)/tile.c
+	$(TARGET_CC) $(TARGET_CFLAGS) -o$@ $<
 $(GAMEBIN) : $(HOBJ) $(LUACROSSLIB)
 	$(TARGET_LINK) $(TARGET_LFLAGS) -o $(GAMEBIN) \
 	$(HOBJ) $(WINLIB) $(TARGET_LIBS)

--- a/sys/unix/hints/include/cross-pre2.500
+++ b/sys/unix/hints/include/cross-pre2.500
@@ -726,12 +726,6 @@ $(TARGETPFX)%.o : ../sys/atari/%.c
 # Rule for files in win/gem
 $(TARGETPFX)%.o : ../win/gem/%.c
 	$(TARGET_CC) $(TARGET_CFLAGS) -o$@ $<
-# Explicit rule for the generated tile.c -> tile.o.  Without this the
-# pattern rule $(TARGETPFX)%.o : %.c picks the wrong source path when
-# tile.c doesn't yet exist on first invocation, breaking -j N builds.
-# SRCDIR isn't defined this early in cross-pre2; spell the path out.
-$(TARGETPFX)tile.o : ../src/tile.c
-	$(TARGET_CC) $(TARGET_CFLAGS) -o$@ $<
 endif  # CROSS_TO_ATARI
 #=================================================================
 


### PR DESCRIPTION
move tile.o rule from pre2 to post so all becomes the default rule again for the top Makefile.