### PR TITLE
Fix: a shopkeeper msg was printed even when deaf

### DIFF
--- a/src/wield.c
+++ b/src/wield.c
@@ -262,8 +262,13 @@ ready_weapon(struct obj *wep)
 
             if ((this_shkp = shop_keeper(inside_shop(u.ux, u.uy)))
                 != (struct monst *) 0) {
-                pline("%s says \"You be careful with my %s!\"",
-                      shkname(this_shkp), xname(wep));
+                /* check msound because we don't have access to muteshk() */
+                if (!Deaf && this_shkp->data->msound > MS_ANIMAL)
+                    pline("%s says \"You be careful with my %s!\"",
+                          shkname(this_shkp), xname(wep));
+                else
+                    pline("%s looks apprehensive about your wielding %s %s.",
+                          shkname(this_shkp), mhis(this_shkp), xname(wep));
             }
         }
     }


### PR DESCRIPTION
The message in question is '[shopkeeper] says "You be careful with my [item]!"' when you wield a shop-owned item, but it was being printed even when the hero is deaf.

Following other examples of shopkeeper dialogue, the correct thing to do here is not to suppress the message if deaf but instead provide some nonverbal feedback, so that is what I did.