### PR TITLE
add more options to  herecmdmenu

### DIFF
--- a/src/cmd.c
+++ b/src/cmd.c
@@ -4409,6 +4409,7 @@ enum menucmd {
     MCMD_LOOK_AT,
     MCMD_PRAY,
     MCMD_ENGRAVE,
+    MCMD_ATTRIBUTES,
     MCMD_ATTACK_NEXT2U,
     MCMD_UNTRAP_HERE,
     MCMD_OFFER,
@@ -4512,6 +4513,7 @@ there_cmd_menu_self(winid win, coordxy x, coordxy y, int *act UNUSED)
     mcmd_addmenu(win, MCMD_LOOK_HERE, "Look at what is here"), ++K;
     mcmd_addmenu(win, MCMD_PRAY, "Pray here"), ++K;
     mcmd_addmenu(win, MCMD_ENGRAVE, "Engrave here"), ++K;
+    mcmd_addmenu(win, MCMD_ATTRIBUTES, "View attributes"), ++K;
 
     if (num_spells() > 0)
         mcmd_addmenu(win, MCMD_CAST_SPELL, "Cast a spell"), ++K;
@@ -4834,6 +4836,9 @@ act_on_act(
         break;
     case MCMD_ENGRAVE:
         cmdq_add_ec(CQ_CANNED, doengrave);
+        break;
+    case MCMD_ATTRIBUTES:
+        cmdq_add_ec(CQ_CANNED, doattributes);
         break;
     case MCMD_UNTRAP_HERE:
         cmdq_add_ec(CQ_CANNED, dountrap);

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -4414,6 +4414,7 @@ enum menucmd {
     MCMD_OFFER,
     MCMD_INVENTORY,
     MCMD_CAST_SPELL,
+    MCMD_JUMP,
 
     MCMD_THROW_OBJ,
     MCMD_TRAVEL,
@@ -4519,6 +4520,9 @@ there_cmd_menu_self(winid win, coordxy x, coordxy y, int *act UNUSED)
         if (ttmp->ttyp != VIBRATING_SQUARE)
             mcmd_addmenu(win, MCMD_UNTRAP_HERE,
                          "Attempt to disarm trap"), ++K;
+    }
+    if (Jumping) {
+        mcmd_addmenu(win, MCMD_JUMP, "Jump"), ++K;
     }
     return K;
 }
@@ -4842,6 +4846,8 @@ act_on_act(
     case MCMD_CAST_SPELL:
         cmdq_add_ec(CQ_CANNED, docast);
         break;
+    case MCMD_JUMP:
+        cmdq_add_ec(CQ_CANNED, dojump);
     default:
         break;
     }

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -4410,6 +4410,7 @@ enum menucmd {
     MCMD_PRAY,
     MCMD_ENGRAVE,
     MCMD_ATTRIBUTES,
+    MCMD_PREVIOUS_MESSAGES,
     MCMD_ATTACK_NEXT2U,
     MCMD_UNTRAP_HERE,
     MCMD_OFFER,
@@ -4514,6 +4515,7 @@ there_cmd_menu_self(winid win, coordxy x, coordxy y, int *act UNUSED)
     mcmd_addmenu(win, MCMD_PRAY, "Pray here"), ++K;
     mcmd_addmenu(win, MCMD_ENGRAVE, "Engrave here"), ++K;
     mcmd_addmenu(win, MCMD_ATTRIBUTES, "View attributes"), ++K;
+    mcmd_addmenu(win, MCMD_PREVIOUS_MESSAGES, "Access memories"), ++K;
 
     if (num_spells() > 0)
         mcmd_addmenu(win, MCMD_CAST_SPELL, "Cast a spell"), ++K;
@@ -4839,6 +4841,9 @@ act_on_act(
         break;
     case MCMD_ATTRIBUTES:
         cmdq_add_ec(CQ_CANNED, doattributes);
+        break;
+    case MCMD_PREVIOUS_MESSAGES:
+        cmdq_add_key(CQ_CANNED, C('p'));
         break;
     case MCMD_UNTRAP_HERE:
         cmdq_add_ec(CQ_CANNED, dountrap);

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -4805,7 +4805,7 @@ act_on_act(
         cmdq_add_key(CQ_CANNED, 'y'); /* "There is foo here; eat it?" */
         break;
     case MCMD_DROP:
-        cmdq_add_ec(CQ_CANNED, dodrop);
+        cmdq_add_ec(CQ_CANNED, doddrop);
         break;
     case MCMD_INVENTORY:
         cmdq_add_ec(CQ_CANNED, ddoinv);

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -4407,6 +4407,7 @@ enum menucmd {
     MCMD_REST,
     MCMD_LOOK_HERE,
     MCMD_LOOK_AT,
+    MCMD_PRAY,
     MCMD_ATTACK_NEXT2U,
     MCMD_UNTRAP_HERE,
     MCMD_OFFER,
@@ -4507,6 +4508,7 @@ there_cmd_menu_self(winid win, coordxy x, coordxy y, int *act UNUSED)
     mcmd_addmenu(win, MCMD_REST, "Rest one turn"), ++K;
     mcmd_addmenu(win, MCMD_SEARCH, "Search around you"), ++K;
     mcmd_addmenu(win, MCMD_LOOK_HERE, "Look at what is here"), ++K;
+    mcmd_addmenu(win, MCMD_PRAY, "Pray here"), ++K;
 
     if (num_spells() > 0)
         mcmd_addmenu(win, MCMD_CAST_SPELL, "Cast a spell"), ++K;
@@ -4820,6 +4822,9 @@ act_on_act(
         gc.clicklook_cc.x = u.ux + dx;
         gc.clicklook_cc.y = u.uy + dy;
         cmdq_add_ec(CQ_CANNED, doclicklook);
+        break;
+    case MCMD_PRAY:
+        cmdq_add_ec(CQ_CANNED, dopray);
         break;
     case MCMD_UNTRAP_HERE:
         cmdq_add_ec(CQ_CANNED, dountrap);

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -4408,6 +4408,7 @@ enum menucmd {
     MCMD_LOOK_HERE,
     MCMD_LOOK_AT,
     MCMD_PRAY,
+    MCMD_ENGRAVE,
     MCMD_ATTACK_NEXT2U,
     MCMD_UNTRAP_HERE,
     MCMD_OFFER,
@@ -4509,6 +4510,7 @@ there_cmd_menu_self(winid win, coordxy x, coordxy y, int *act UNUSED)
     mcmd_addmenu(win, MCMD_SEARCH, "Search around you"), ++K;
     mcmd_addmenu(win, MCMD_LOOK_HERE, "Look at what is here"), ++K;
     mcmd_addmenu(win, MCMD_PRAY, "Pray here"), ++K;
+    mcmd_addmenu(win, MCMD_ENGRAVE, "Engrave here"), ++K;
 
     if (num_spells() > 0)
         mcmd_addmenu(win, MCMD_CAST_SPELL, "Cast a spell"), ++K;
@@ -4825,6 +4827,9 @@ act_on_act(
         break;
     case MCMD_PRAY:
         cmdq_add_ec(CQ_CANNED, dopray);
+        break;
+    case MCMD_ENGRAVE:
+        cmdq_add_ec(CQ_CANNED, doengrave);
         break;
     case MCMD_UNTRAP_HERE:
         cmdq_add_ec(CQ_CANNED, dountrap);


### PR DESCRIPTION
These are small commits that add:
engraving, jumping, praying, and viewing player attributes to the herecmdmenu. I also made the existing "Drop" button do a multi-drop instead of a single drop.
I wasn't sure if all of these were wanted, but I think at least some of these would be very useful.
I also want to point out that this menu is a new way to test if you have intrinsic/extrinsic jumping since the "Jump" entry only shows up if that is the case. I'm not sure if this is desireable but I cannot imagine it's that big of a deal (you can always use `#jump` to test that without taking a turn anyway).

Another idea I had was to let you eat/loot comestibles/containers that were on the pile you are on but not the top pile. I.e the menu would have an "Eat ..." option for each comestible and a "Loot ..." for each container, but the implementation ended up being too messy so I'll make that a separate PR.