### PR TITLE
mac68k: change opt flag to -Os, keep Lua interpreter at -O2

### DIFF
--- a/include/mac68kconf.h
+++ b/include/mac68kconf.h
@@ -14,9 +14,6 @@
 /* No system-wide config file on classic Mac OS */
 /* STATUS_HILITES supported via the native renderer in sys/mac68k/macstat.c */
 
-/* NB: Lua's default 64-bit integers/floats are software-emulated and slow on
-   68k.  Lua's LUA_32BITS would help, but lua-5.4 luaconf.h hardcodes it to 0,
-   so it cannot be enabled by -D/#define without patching luaconf.h itself. */
 #ifndef TARGET_API_MAC_OS8
 #define TARGET_API_MAC_OS8 1
 #endif

--- a/sys/unix/hints/include/cross-pre2.500
+++ b/sys/unix/hints/include/cross-pre2.500
@@ -592,7 +592,8 @@ MAC68K_COMMON_FLAGS = -std=gnu17 -m68020 -msoft-float \
 	-Wall -Wno-missing-field-initializers \
 	-Wno-unused-parameter -Wno-unused-variable -Wno-four-char-constants \
 	-ffunction-sections -fdata-sections
-override TARGET_CFLAGS = -c -O2 $(MAC68K_COMMON_FLAGS)
+# -Os for size on RAM-tight 68k; the Lua interpreter stays at -O2.
+override TARGET_CFLAGS = -c -Os $(MAC68K_COMMON_FLAGS)
 LUA_TARGET_CFLAGS = -c -O2 $(MAC68K_COMMON_FLAGS)
 override TARGET_LFLAGS = -Wl,--gc-sections \
 	-Wl,--wrap=malloc -Wl,--wrap=free -Wl,--wrap=realloc   # macalloc.c pool


### PR DESCRIPTION
After a benchmark heavy evening: Drop the comment that 64 Bit Lua data types are a major performance problem (it's only 10% in both speed and memory footprint when running actual NetHack scripts).

Switching to from -O2 to -Os is a much bigger win on m68k: It shrinks code size by over 20% (600KB) and doesn't hurt performance. Only the Lua interpreter stays at -O2 because that speeds up parsing by about 30%.