### PR TITLE
Picking up gold pieces can no longer issue a false encumbrance warning.

### DIFF
--- a/src/pickup.c
+++ b/src/pickup.c
@@ -57,7 +57,7 @@ staticfn void tipcontainer(struct obj *);
 #define FOLLOW(curr, flags) \
     (((flags) & BY_NEXTHERE) ? (curr)->nexthere : (curr)->nobj)
 
-#define GOLD_WT(n) (((n) + 50L) / 100L)
+#define GOLD_WT(n) ((n) > 0L ? max(((n) + 50L) / 100L, 1L) : 0L)
 /* if you can figure this out, give yourself a hearty pat on the back... */
 #define GOLD_CAPACITY(w, n) (((w) * -100L) - ((n) + 50L) - 1L)
 


### PR DESCRIPTION
A discrepancy in how the weight of gold pieces were calculated in `pickup.c` caused encumbrance warnings to trigger if the hero picked up less than 50 gold pieces while just being under their carrying capacity. Following through with the pickup would not actually encumber the hero, as that uses the `weight()` function, not the `GOLD_WT` macro.