### PR TITLE
MS-DOS: Check font pointer for null

### DIFF
--- a/sys/msdos/vidvga.c
+++ b/sys/msdos/vidvga.c
@@ -811,7 +811,7 @@ vga_Init(void)
     }
     free_font(psf_font);
     psf_font = load_font(font_name);
-    if (psf_font != NULL && psf_font->width != 8 || psf_font->height != 16) {
+    if (psf_font != NULL && (psf_font->width != 8 || psf_font->height != 16)) {
         raw_printf("VGA mode only supports 8x16 fonts");
         free_font(psf_font);
         psf_font = NULL;

--- a/sys/msdos/vidvga.c
+++ b/sys/msdos/vidvga.c
@@ -811,7 +811,7 @@ vga_Init(void)
     }
     free_font(psf_font);
     psf_font = load_font(font_name);
-    if (psf_font->width != 8 || psf_font->height != 16) {
+    if (psf_font != NULL && psf_font->width != 8 || psf_font->height != 16) {
         raw_printf("VGA mode only supports 8x16 fonts");
         free_font(psf_font);
         psf_font = NULL;


### PR DESCRIPTION
The 16 color mode loads the font specified in font_map, and accepts it only if its size is 8 by 16 pixels. This change avoids a null dereference if the font is not found.