### PR TITLE
sfstruct: buffered stdio writes on amiga and atari st

### DIFF
--- a/include/amiconf.h
+++ b/include/amiconf.h
@@ -73,6 +73,7 @@ extern void ami_wininit_data(int);
 #define HACKFONT  /* Use special hack.font */
 #define MAIL      /* Get mail at unexpected occasions */
 #define AMIFLUSH /* toss typeahead (select flush in .cnf) */
+#define SFSTRUCT_BUFFERING /* buffered stdio writes for structlevel files */
 
 /* new window system options */
 /* WRONG - AMIGA_INTUITION should go away */

--- a/include/tosconf.h
+++ b/include/tosconf.h
@@ -42,6 +42,7 @@
 #define TERMLIB   /* use termcap			*/
 #endif
 #define MAIL      /* enable the fake maildemon */
+#define SFSTRUCT_BUFFERING /* buffered stdio writes for structlevel files */
 
 /* Skip the ~9600-entry glyph-id prefill on slow m68k Atari hosts;
    the shipped nethack.cnf doesn't reference any G_glyph names, so

--- a/src/sfstruct.c
+++ b/src/sfstruct.c
@@ -320,7 +320,7 @@ static long floc = 0L;
 
 staticfn int getidx(int, int);
 
-#if defined(UNIX) || defined(WIN32)
+#if defined(UNIX) || defined(WIN32) || defined(SFSTRUCT_BUFFERING)
 #define USE_BUFFERING
 #endif
 
@@ -329,6 +329,9 @@ struct restore_info restoreinfo = {
 };
 
 #define MAXFD 5
+#ifdef SFSTRUCT_BUFFERING
+#define BWBUFSZ 16384
+#endif
 enum {NOFLG = 0, NOSLOT = 1};
 static int bw_sticky[MAXFD] = {-1,-1,-1,-1,-1};
 static int bw_buffered[MAXFD] = {0,0,0,0,0};
@@ -431,6 +434,10 @@ bufon(int fd)
         if (!bw_FILE[idx]) {
             if ((bw_FILE[idx] = fdopen(fd, "w")) == 0)
                 panic("buffering of file %d failed", fd);
+#ifdef SFSTRUCT_BUFFERING
+            (void) setvbuf(bw_FILE[idx], (char *) 0, _IOFBF,
+                           (size_t) BWBUFSZ);
+#endif
         }
         bw_buffered[idx] = (bw_FILE[idx] != 0);
 #else


### PR DESCRIPTION
Enable USE_BUFFERING for the structlevel savefile write path on AMIGA and TOS via a new SFSTRUCT_BUFFERING config define, with a 16 KB setvbuf on the fdopen'd write stream so many small bwrite()s coalesce into few dos.library Write() packets.  Leaves mread() unbuffered.
