### PR TITLE
Add secondary effects of different dragon scales for monsters.

### DIFF
--- a/src/eat.c
+++ b/src/eat.c
@@ -639,19 +639,20 @@ eat_brains(
                 make_stoned(5L, (char *) 0, KILLED_BY_AN,
                             pmname(pd, Mgender(mdef)));
         } else {
-            /* no need to check for poly_when_stoned or Stone_resistance;
-               mind flayers don't have those capabilities */
-            if (visflag && canseemon(magr))
-                pline("%s turns to stone!", Monnam(magr));
-            monstone(magr);
-            if (!DEADMONSTER(magr)) {
-                /* life-saved; don't continue eating the brains */
-                return M_ATTK_MISS;
-            } else {
-                if (magr->mtame && !visflag)
-                    /* parallels mhitm.c's brief_feeling */
-                    You("have a sad thought for a moment, then it passes.");
-                return M_ATTK_AGR_DIED;
+            /* mind flayers can wear yellow dragon scales and gain stone resistance */
+            if (!resists_ston(magr)) {
+                if (visflag && canseemon(magr))
+                    pline("%s turns to stone!", Monnam(magr));
+                monstone(magr);
+                if (!DEADMONSTER(magr)) {
+                    /* life-saved; don't continue eating the brains */
+                    return M_ATTK_MISS;
+                } else {
+                    if (magr->mtame && !visflag)
+                        /* parallels mhitm.c's brief_feeling */
+                        You("have a sad thought for a moment, then it passes.");
+                    return M_ATTK_AGR_DIED;
+                }
             }
         }
     }

--- a/src/mhitm.c
+++ b/src/mhitm.c
@@ -1212,6 +1212,13 @@ paralyze_monst(struct monst *mon, int amt)
     if (amt > 127)
         amt = 127;
 
+    /* orange dragon scales confer free action */
+    if (mon != &gy.youmonst && defended(mon, AD_PLYS)) {
+        /* can amt be zero? */
+        if (amt > 0 && canseemon(mon)) pline("%s stiffens momentarily.", Monnam(mon));
+        return;
+    }
+
     mon->mcanmove = 0;
     mon->mfrozen = amt;
     mon->meating = 0; /* terminate any meal-in-progress */

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -191,7 +191,13 @@ Resists_Elem(struct monst *mon, int propindx)
                    we check both so won't need to know which one that is */
                 && o->otyp == ALCHEMY_SMOCK
                 && (propindx == POISON_RES || propindx == ACID_RES))
-            || (o->oartifact && defends_when_carried(damgtype, o)))
+            || (o->oartifact && defends_when_carried(damgtype, o))
+            || ((o->owornmask & W_ARM) != 0L
+                /* similar to aprons, yellow dragon scale (mail) also confers two resistances
+                   so we check stoning resistance here */
+                && propindx == STONE_RES
+                && defends(AD_STON, o)))
+
             return TRUE;
     return FALSE;
 }

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -3909,7 +3909,7 @@ mhitm_ad_halu(
         mhm->damage = 0;
     } else {
         /* mhitm */
-        if (!magr->mcan && haseyes(pd) && mdef->mcansee) {
+        if (!magr->mcan && haseyes(pd) && mdef->mcansee && !defended(mdef, AD_HALU)) {
             if (gv.vis && canseemon(mdef))
                 pline_mon(mdef, "%s looks %sconfused.", Monnam(mdef),
                       mdef->mconf ? "more " : "");
@@ -4901,7 +4901,7 @@ explum(struct monst *mdef, struct attack *mattk)
         }
         break;
     case AD_HALU:
-        if (mdef && haseyes(mdef->data) && mdef->mcansee) {
+        if (mdef && haseyes(mdef->data) && mdef->mcansee && !defended(mdef, AD_HALU)) {
             pline("%s is affected by your flash of light!", Monnam(mdef));
             mdef->mconf = 1;
         }

--- a/src/worn.c
+++ b/src/worn.c
@@ -7,6 +7,7 @@
 
 staticfn void m_lose_armor(struct monst *, struct obj *, boolean) NONNULLPTRS;
 staticfn void clear_bypass(struct obj *) NO_NNARGS;
+staticfn int altprop(struct obj *) NONNULLARG1;
 staticfn void m_dowear_type(struct monst *, long, boolean, boolean)
                                                                   NONNULLARG1;
 staticfn int extra_pref(struct monst *, struct obj *) NONNULLARG1;
@@ -531,9 +532,10 @@ mon_adjust_speed(
     }
 
     for (otmp = mon->minvent; otmp; otmp = otmp->nobj)
-        if (otmp->owornmask && objects[otmp->otyp].oc_oprop == FAST)
+        if (otmp->owornmask && (objects[otmp->otyp].oc_oprop == FAST
+                                || altprop(otmp) == FAST))
             break;
-    if (otmp) /* speed boots */
+    if (otmp) /* speed boots or blue dragon scales */
         mon->mspeed = MFAST;
     else
         mon->mspeed = mon->permspeed;
@@ -568,11 +570,17 @@ mon_adjust_speed(
    if it is poison resistance, alternate property is acid resistance;
    if someone changes it to acid resistance, alt becomes poison resist;
    if someone changes it to hallucination resistance, all bets are off
-   [TODO: handle alternate properties conferred by dragon scales/mail] */
-#define altprop(o) \
-    (((o)->otyp == ALCHEMY_SMOCK)                               \
-     ? (POISON_RES + ACID_RES - objects[(o)->otyp].oc_oprop)    \
-     : 0)
+   [TODO: handle alternate properties conferred by dragon other scales/mail] */
+staticfn int
+altprop(struct obj *o)
+{
+    if (o->otyp == ALCHEMY_SMOCK)
+        return POISON_RES + ACID_RES - objects[o->otyp].oc_oprop;
+    if (o->otyp == BLUE_DRAGON_SCALES || o->otyp == BLUE_DRAGON_SCALE_MAIL)
+        return SHOCK_RES + FAST - objects[o->otyp].oc_oprop;
+    return 0;
+}
+
 
 /* armor put on or taken off; might be magical variety */
 void


### PR DESCRIPTION
Mostly fixes #1555, I'm not sure it is worth implementing the other (unimplemented) dragon scale types.