### PR TITLE
MS-DOS: Support no-tiles, no-graphics and Curses-only builds

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1986,9 +1986,6 @@ extern void mplayer_talk(struct monst *) NONNULLARG1;
 #ifndef WIN32
 extern int tgetch(void);
 #endif
-#ifndef TOS
-extern char switchar(void);
-#endif
 #ifndef __GO32__
 extern long freediskspace(char *);
 #ifdef MSDOS
@@ -2424,6 +2421,9 @@ extern void gettty(void);
 extern void settty(const char *);
 extern void setftty(void);
 ATTRNORETURN extern void error(const char *, ...) PRINTF_F(1, 2) NORETURN;
+#ifdef ENHANCED_SYMBOLS
+extern void tty_utf8graphics_fixup(void);
+#endif
 #if defined(TIMED_DELAY) && defined(_MSC_VER)
 extern void msleep(unsigned);
 #endif

--- a/include/optlist.h
+++ b/include/optlist.h
@@ -825,7 +825,7 @@ static int optfn_##a(int, int, boolean, char *, char *);
            (char *)0)
     NHOPTC(versinfo, Advanced, 80, opt_out, set_in_game,
            No, Yes, No, Yes, NoAlias, "extra information for 'showvers'")
-#ifdef MSDOS
+#if defined(MSDOS) && defined(NO_TERMS)
     NHOPTC(video, Advanced, 20, opt_in, set_in_config,
                 No, Yes, No, No, NoAlias, "method of video updating")
 #endif

--- a/include/pcconf.h
+++ b/include/pcconf.h
@@ -75,7 +75,7 @@
  */
 #ifndef SUPPRESS_GRAPHICS
 #if (defined(SCREEN_BIOS) || defined(SCREEN_DJGPPFAST)) && !defined(PC9800)
-#ifdef TILES_IN_GLYPHMAP
+#if defined(TILES_IN_GLYPHMAP) || defined(ENHANCED_SYMBOLS)
 #define SCREEN_VGA /* Include VGA graphics routines in the build */
 #define SCREEN_VESA
 #endif
@@ -287,6 +287,10 @@
 #define SMALL_MAP
 #endif
 #endif /* End of sanity check block */
+
+#if defined(MSDOS) && defined(SUPPRESS_GRAPHICS)
+#define NO_TERMCAP_HEADERS
+#endif
 
 #if defined(MSDOS) && defined(DLB)
 #define FILENAME_CMP stricmp /* case insensitive */

--- a/include/pcconf.h
+++ b/include/pcconf.h
@@ -73,7 +73,7 @@
  * You may uncomment any/all of the options below.
  *
  */
-#ifndef SUPPRESS_GRAPHICS
+#if defined(TTY_GRAPHICS) && !defined(SUPPRESS_GRAPHICS)
 #if (defined(SCREEN_BIOS) || defined(SCREEN_DJGPPFAST)) && !defined(PC9800)
 #if defined(TILES_IN_GLYPHMAP) || defined(ENHANCED_SYMBOLS)
 #define SCREEN_VGA /* Include VGA graphics routines in the build */

--- a/src/glyphs.c
+++ b/src/glyphs.c
@@ -711,8 +711,10 @@ apply_customizations(
     struct customization_detail *details;
     struct symset_customization *sc;
     boolean at_least_one = FALSE,
-            do_colors = ((docustomize & do_custom_colors) != 0),
-            do_symbols = ((docustomize & do_custom_symbols) != 0);
+            do_colors = ((docustomize & do_custom_colors) != 0);
+#ifdef ENHANCED_SYMBOLS
+    boolean do_symbols = ((docustomize & do_custom_symbols) != 0);
+#endif
     int custs;
 
     for (custs = 0; custs < (int) custom_count; ++custs) {

--- a/src/wizcmds.c
+++ b/src/wizcmds.c
@@ -1990,10 +1990,8 @@ wizcustom_callback(winid win, int glyphnum, char *id)
     extern glyph_map glyphmap[MAX_GLYPH];
     glyph_map *cgm;
     int clr = NO_COLOR;
-    char buf[BUFSZ], bufa[BUFSZ], bufb[BUFSZ], bufc[BUFSZ], bufd[BUFSZ],
-        bufu[BUFSZ];
+    char buf[BUFSZ], bufa[BUFSZ], bufb[BUFSZ], bufc[BUFSZ], bufu[BUFSZ];
     anything any;
-    uint8 *cp;
 
     if (win && id) {
         cgm = &glyphmap[glyphnum];
@@ -2009,9 +2007,11 @@ wizcustom_callback(winid win, int glyphnum, char *id)
             bufu[0] = '\0';
 #ifdef ENHANCED_SYMBOLS
             if (cgm->u && cgm->u->utf8str) {
+                uint8 *cp;
                 Sprintf(bufu, "U+%04lx", (unsigned long) cgm->u->utf32ch);
                 cp = cgm->u->utf8str;
                 while (*cp) {
+                    char bufd[BUFSZ];
                     Sprintf(bufd, " <%d>", (int) *cp);
                     Strcat(bufu, bufd);
                     cp++;

--- a/sys/msdos/Install.dos
+++ b/sys/msdos/Install.dos
@@ -96,11 +96,22 @@ II. There once was a time when people built NetHack right on their DOS machine.
 
         make WANT_WIN_TTY=1 WANT_WIN_CURSES=1 CROSS_TO_MSDOS=1 WANT_DOSVGA=1 package
 
+    For the TTY interface, use NO_TILES=1 to drop support for tiles. The
+    resulting TTY interface can still support Unicode if that is enabled
+    in include/config.h.
+
+    For the TTY interface, use NO_GRAPHICS=1 to drop all graphics support, and
+    build a NetHack that outputs through the standard output channel.  This
+    configuration requires ANSI.SYS, or an equivalent driver such as NANSI.SYS.
+    The curses interface will still use graphics if WANT_DOSVGA=1 is set.
+
+    NO_GRAPHICS=1 takes priority of NO_TILES=1.
+
     Result: The "make package" target will bundle all of the necessary
             components to run NetHack on msdos into a folder:
                 targets/msdos/pkg
             and then it zips the contents of that folder into:
-                targets/msdos/nh370dos.zip
+                targets/msdos/NH500DOS.ZIP
 
     Also note that building the msdos targets using the make command
     above, does not preclude you from building local linux or macOS

--- a/sys/msdos/msdos.c
+++ b/sys/msdos/msdos.c
@@ -57,7 +57,7 @@ unsigned long sys_random_seed(void);
 static char *getdta(void);
 #endif
 static unsigned int dos_ioctl(int, int, unsigned);
-#ifdef TILES_IN_GLYPHMAP
+#ifdef NO_TERMS
 extern boolean pckeys(unsigned char, unsigned char); /* pckeys.c */
 #endif
 
@@ -280,7 +280,7 @@ BIOSgetch(void)
             else
                 ch = kpad[scan - KEYPADLO].normal;
         }
-#ifdef TILES_IN_GLYPHMAP
+#ifdef NO_TERMS
         /* Check for special interface manipulation keys */
         if (pckeys(scan, shift)) {
             ch = 0xFF;
@@ -347,16 +347,6 @@ DOSgetch(void)
     }
 #endif
     return (ch);
-}
-
-char
-switchar(void)
-{
-    union REGS regs;
-
-    regs.x.ax = GETSWITCHAR;
-    intdos(&regs, &regs);
-    return regs.h.dl;
 }
 
 #if 0

--- a/sys/msdos/msdos.c
+++ b/sys/msdos/msdos.c
@@ -61,6 +61,7 @@ static unsigned int dos_ioctl(int, int, unsigned);
 extern boolean pckeys(unsigned char, unsigned char); /* pckeys.c */
 #endif
 
+#ifdef TTY_GRAPHICS
 int
 tgetch(void)
 {
@@ -86,6 +87,7 @@ tgetch(void)
 #endif
     return ((ch == '\r') ? '\n' : ch);
 }
+#endif /* TTY_GRAPHICS */
 
 /*
  *  Keyboard translation tables.

--- a/sys/msdos/pckeys.c
+++ b/sys/msdos/pckeys.c
@@ -8,16 +8,17 @@
 
 #include "hack.h"
 
-#ifdef MSDOS
-#ifdef TILES_IN_GLYPHMAP
+#if defined(MSDOS) && defined(NO_TERMS)
 #include "wintty.h"
 #include "pcvideo.h"
 
 boolean pckeys(unsigned char, unsigned char);
+#ifdef TILES_IN_GLYPHMAP
 static void userpan(enum vga_pan_direction pan);
 static void overview(boolean);
 static void traditional(boolean);
 static void refresh(void);
+#endif
 
 extern struct WinDesc *wins[MAXWIN]; /* from wintty.c */
 extern boolean inmap;                /* from video.c */
@@ -34,9 +35,15 @@ extern boolean inmap;                /* from video.c */
 boolean
 pckeys(unsigned char scancode, unsigned char shift)
 {
+#ifdef TILES_IN_GLYPHMAP
     boolean opening_dialog;
 
     opening_dialog = svp.pl_character[0] ? FALSE : TRUE;
+#endif
+
+#ifndef TILES_IN_GLYPHMAP
+    nhUse(shift);
+#endif
     switch (scancode) {
 #ifdef SIMULATE_CURSOR
     case 0x3d: /* F3 = toggle cursor type */
@@ -47,6 +54,7 @@ pckeys(unsigned char scancode, unsigned char shift)
         DrawCursor();
         break;
 #endif
+#ifdef TILES_IN_GLYPHMAP
     case 0x74: /* Control-right_arrow = scroll horizontal to right */
         if ((shift & CTRL) && iflags.tile_view && !opening_dialog)
             userpan(pan_right);
@@ -83,12 +91,14 @@ pckeys(unsigned char scancode, unsigned char shift)
             refresh();
         }
         break;
+#endif /* TILES_IN_GLYPHMAP */
     default:
         return FALSE;
     }
     return TRUE;
 }
 
+#ifdef TILES_IN_GLYPHMAP
 static void
 userpan(enum vga_pan_direction pan)
 {
@@ -141,6 +151,6 @@ refresh(void)
 #endif
 }
 #endif /* TILES_IN_GLYPHMAP */
-#endif /* MSDOS */
+#endif /* MSDOS && NO_TERMS */
 
 /*pckeys.c*/

--- a/sys/msdos/pcvideo.h
+++ b/sys/msdos/pcvideo.h
@@ -237,12 +237,12 @@ extern void HideCursor(void);
 
 /* ### vidtxt.c ### */
 
+extern void txt_get_scr_size(void);
 #ifdef NO_TERMS
 extern void txt_backsp(void);
 extern void txt_clear_screen(void);
 extern void txt_cl_end(int, int);
 extern void txt_cl_eos(void);
-extern void txt_get_scr_size(void);
 extern void txt_gotoxy(int, int);
 extern int txt_monoadapt_check(void);
 extern void txt_nhbell(void);
@@ -267,7 +267,6 @@ extern void vga_show_cursor(void);
 extern void vga_DrawCursor(void);
 #endif
 extern void vga_Finish(void);
-extern char __far *vga_FontPtrs(void);
 extern void vga_get_scr_size(void);
 extern void vga_gotoloc(int, int);
 #ifdef POSITIONBAR

--- a/sys/msdos/video.c
+++ b/sys/msdos/video.c
@@ -89,7 +89,7 @@ get_scr_size(void)
         txt_get_scr_size();
 }
 
-#ifdef ENHANCED_SYMBOLS
+#if defined(TTY_GRAPHICS) && defined(ENHANCED_SYMBOLS)
 void g_pututf8(uint8 *utf8str)
 {
     /* not implemented for msdos (yet) */

--- a/sys/msdos/video.c
+++ b/sys/msdos/video.c
@@ -132,17 +132,17 @@ void cmov(int, int);
 void nocmov(int, int);
 static void init_ttycolor(void);
 
-int savevmode;               /* store the original video mode in here */
+#if defined(SCREEN_VGA) || defined(SCREEN_VESA)
 int curcol, currow;          /* graphics mode current cursor locations */
+#endif
 int g_attribute;             /* Current attribute to use */
-int monoflag;                /* 0 = not monochrome, else monochrome */
+static int monoflag;         /* 0 = not monochrome, else monochrome */
 int inversed;
 int attrib_text_normal;      /* text mode normal attribute */
 int attrib_gr_normal;        /* graphics mode normal attribute */
 int attrib_text_intense;     /* text mode intense attribute */
 int attrib_gr_intense;       /* graphics mode intense attribute */
 uint32 curframecolor = NO_COLOR;   /* current background text color */
-boolean traditional = FALSE; /* traditional TTY character mode */
 boolean inmap = FALSE;       /* in the map window */
 char ttycolors[CLR_MAX]; /* also used/set in options.c */
 
@@ -183,8 +183,8 @@ term_curs_set(int visibility)
 #ifdef SCREEN_VESA
         } else if (iflags.usevesa) {
             vesa_hide_cursor();
-        }
 #endif
+        }
     } else if (visibility) {
         if (!iflags.grmode) {
             txt_show_cursor();
@@ -195,8 +195,8 @@ term_curs_set(int visibility)
 #ifdef SCREEN_VESA
         } else if (iflags.usevesa) {
             vesa_show_cursor();
-        }
 #endif
+        }
     }
     vis = visibility;
 }
@@ -255,16 +255,16 @@ void cl_end(void) /* clear to end of line */
 
 void cl_eos(void) /* clear to end of screen */
 {
-    int cy = (int) ttyDisplay->cury + 1;
-
     if (!iflags.grmode) {
         txt_cl_eos();
 #ifdef SCREEN_VGA
     } else if (iflags.usevga) {
+        int cy = (int) ttyDisplay->cury + 1;
         vga_cl_eos(cy);
 #endif
 #ifdef SCREEN_VESA
     } else if (iflags.usevesa) {
+        int cy = (int) ttyDisplay->cury + 1;
         vesa_cl_eos(cy);
 #endif
     }
@@ -683,6 +683,7 @@ xputc(int ch) /* write out character (and attribute) */
 }
 
 /* write out a glyph picture at current location */
+#ifdef TILES_IN_GLYPHMAP
 void xputg(const glyph_info *glyphinfo, const glyph_info *bkglyphinfo)
 {
     if (!iflags.grmode || !iflags.tile_view) {
@@ -697,6 +698,7 @@ void xputg(const glyph_info *glyphinfo, const glyph_info *bkglyphinfo)
 #endif
     }
 }
+#endif /* TILES_IN_GLYPHMAP */
 
 #ifdef POSITIONBAR
 void
@@ -731,6 +733,8 @@ adjust_cursor_flags(struct WinDesc *cw)
         cursor_flag = 1;
     }
 #endif /* 0 */
+#else
+    nhUse(cw);
 #endif /* SIMULATE_CURSOR */
 }
 
@@ -796,9 +800,9 @@ HideCursor(void)
 /* assign_videocolors() is prototyped in extern.h */
 /* assign_video()       is prototyped in extern.h */
 
-int shadeflag; /* shades are initialized */
-int colorflag; /* colors are initialized */
-const char *schoice[3] = { "dark", "normal", "light" };
+static int shadeflag; /* shades are initialized */
+static int colorflag; /* colors are initialized */
+static const char *schoice[3] = { "dark", "normal", "light" };
 const char *shade[3];
 #endif /* VIDEOSHADES */
 
@@ -1068,6 +1072,7 @@ assign_video(char *sopt)
     return 1;
 }
 
+#ifdef TILES_IN_GLYPHMAP
 void
 tileview(boolean enable)
 {
@@ -1080,6 +1085,7 @@ tileview(boolean enable)
         vesa_traditional(enable ? FALSE : TRUE);
 #endif
 }
+#endif /* TILES_IN_GLYPHMAP */
 #endif /* NO_TERMS  */
 
 #else  /* STUBVIDEO */

--- a/sys/msdos/vidtxt.c
+++ b/sys/msdos/vidtxt.c
@@ -109,7 +109,7 @@ txt_get_scr_size(void)
 void txt_gotoxy(int, int);
 
 #if defined(SCREEN_BIOS) && !defined(PC9800)
-void txt_get_cursor(int *, int *);
+static void txt_get_cursor(int *, int *);
 #endif
 
 #ifdef SCREEN_DJGPPFAST
@@ -401,7 +401,7 @@ void txt_xputc(char ch, int attr)
  *
  * This is implemented as a macro under DJGPPFAST.
  */
-void txt_get_cursor(int *x, int *y)
+static void txt_get_cursor(int *x, int *y)
 {
     union REGS regs;
 

--- a/sys/msdos/vidvesa.c
+++ b/sys/msdos/vidvesa.c
@@ -15,12 +15,22 @@
 #include "pctiles.h"
 #include "vesa.h"
 #include "wintty.h"
-#include "tileset.h"
 #include "font.h"
+
+#ifdef TILES_IN_GLYPHMAP
+#include "tileset.h"
+#else
+/* For the palette */
+struct Pixel {
+    unsigned char r, g, b, a;
+};
+#endif
 
 #define FIRST_TEXT_COLOR 240
 
+#ifdef TILES_IN_GLYPHMAP
 extern int total_tiles_used, Tile_corr, Tile_unexplored;  /* from tile.c */
+#endif
 struct VesaCharacter {
     uint32 colour, bgcolour;
     uint32 chr;
@@ -37,8 +47,10 @@ static unsigned long vesa_MakeColor(struct Pixel);
 static void vesa_FillRect(unsigned left, unsigned top, unsigned width,
                           unsigned height, unsigned color);
 
+#ifdef TILES_IN_GLYPHMAP
 static void vesa_redrawmap(void);
 static void vesa_cliparound(int, int);
+#endif
 #if 0
 static void decal_packed(const struct TileImage *tile, unsigned special);
 #endif
@@ -47,7 +59,9 @@ static void vesa_SetViewPort(void);
 static boolean vesa_SetPalette(const struct Pixel *);
 static boolean vesa_SetHardPalette(const struct Pixel *);
 static boolean vesa_SetSoftPalette(const struct Pixel *);
+#ifdef TILES_IN_GLYPHMAP
 static void vesa_DisplayCell(int, int, int);
+#endif
 static unsigned vesa_FindMode(unsigned long mode_addr, unsigned bits);
 static void vesa_WriteChar(uint32, int, int, uint32);
 static void vesa_WriteCharXY(uint32, int, int, uint32);
@@ -60,8 +74,10 @@ static unsigned long vesa_DoublePixels(unsigned long);
 static unsigned long vesa_TriplePixels(unsigned long);
 static void vesa_WriteStr(const char *, int, int, int, int);
 static unsigned char __far *vesa_FontPtrs(void);
+#ifdef TILES_IN_GLYPHMAP
 static unsigned char *vesa_tile(unsigned);
 static unsigned char *vesa_oview_tile(unsigned);
+#endif
 /* static void vesa_process_tile(struct TileImage *tile); */
 
 #ifdef POSITIONBAR
@@ -84,6 +100,7 @@ extern boolean inmap;           /* in the map window */
 
 static unsigned char __far *font;
 
+#ifdef TILES_IN_GLYPHMAP
 static struct map_struct {
     int glyph;
     uint32 ch;
@@ -108,10 +125,13 @@ static struct map_struct {
                 map[y][x].inverse = 0;                          \
             }                                                   \
     }
+#endif /* TILES_IN_GLYPHMAP */
 #define TOP_MAP_ROW 1
 
+#ifdef TILES_IN_GLYPHMAP
 static int viewport_cols = 40;
 static int viewport_rows = ROWNO;
+#endif
 
 static const struct Pixel defpalette[] = {    /* Colors for text and the position bar */
         { 0x00, 0x00, 0x00, 0xff }, /* CLR_BLACK */
@@ -158,8 +178,10 @@ static unsigned char vesa_blue_shift;
 static unsigned long vesa_palette[256];
 static unsigned vesa_char_width = 8, vesa_char_height = 16;
 static unsigned vesa_oview_width, vesa_oview_height;
+#ifdef TILES_IN_GLYPHMAP
 static unsigned char **vesa_tiles;
 static unsigned char **vesa_oview_tiles;
+#endif
 static struct BitmapFont *vesa_font;
 
 #ifdef SIMULATE_CURSOR
@@ -564,8 +586,10 @@ void
 vesa_clear_screen(int colour)
 {
     vesa_FillRect(0, 0, vesa_x_res, vesa_y_res, colour);
+#ifdef TILES_IN_GLYPHMAP
     if (iflags.tile_view)
         vesa_clearmap();
+#endif
     vesa_gotoloc(0, 0); /* is this needed? */
 }
 
@@ -893,6 +917,7 @@ vesa_redrawmap(void)
 #endif /* TILES_IN_GLYPHMAP && CLIPPING */
 
 
+#ifdef TILES_IN_GLYPHMAP
 void
 vesa_userpan(enum vga_pan_direction pan)
 {
@@ -1040,6 +1065,7 @@ decal_packed(const struct TileImage *gp, unsigned special)
     }
 }
 #endif
+#endif /* TILES_IN_GLYPHMAP */
 
 DISABLE_WARNING_FORMAT_NONLITERAL
 
@@ -1055,7 +1081,9 @@ vesa_Init(void)
 {
     static boolean inited = FALSE;
     const struct Pixel *paletteptr;
+#ifdef TILES_IN_GLYPHMAP
     const char *tile_file;
+#endif
     const char *font_name;
     int tilefailure = 0;
 
@@ -1089,11 +1117,16 @@ vesa_Init(void)
         /* term_clear_screen() */ /* not vesa_clear_screen() */
         return;
     }
+    paletteptr = get_palette();
+#else
+    /* This isn't actually used; it just keeps paletteptr from being NULL,
+     * so an 8 bit color mode will work */
+    paletteptr = defpalette;
 #endif
 
     vesa_mode = 0xFFFF; /* might want an 8 bit mode after loading tiles */
     vesa_detect();
-    if (vesa_mode == 0xFFFF || (vesa_pixel_size == 8 && get_palette() == NULL)) {
+    if (vesa_mode == 0xFFFF || (vesa_pixel_size == 8 && paletteptr == NULL)) {
         raw_printf("%s (%d)", "Reverting to TTY mode, no VESA mode available.",
                    tilefailure);
         wait_synch();
@@ -1108,25 +1141,26 @@ vesa_Init(void)
 
     vesa_SwitchMode(vesa_mode);
     vesa_SetViewPort();
+#ifdef TILES_IN_GLYPHMAP
     windowprocs.win_cliparound = vesa_cliparound;
+#endif
     if (vesa_pixel_size > 8) {
         windowprocs.wincap2 |= WC2_EXTRACOLORS;
     }
 #ifdef TILES_IN_GLYPHMAP
-    paletteptr = get_palette();
     iflags.tile_view = TRUE;
     iflags.over_view = FALSE;
-#else
-    paletteptr = defpalette;
 #endif
     vesa_SetPalette(paletteptr);
     g_attribute = attrib_gr_normal;
     font = vesa_FontPtrs();
     term_clear_screen();
+#ifdef TILES_IN_GLYPHMAP
     clipx = 0;
     clipxmax = clipx + (viewport_cols - 1);
     clipy = 0;
     clipymax = clipy + (viewport_rows - 1);
+#endif
 
     /* Load a font of size appropriate to the screen size */
     if (vesa_x_res >= 1280 && vesa_y_res >= 960)
@@ -1185,15 +1219,18 @@ vesa_Init(void)
     }
 
     /* Process tiles for the current video mode */
+#ifdef TILES_IN_GLYPHMAP
     vesa_tiles = (unsigned char **) alloc(total_tiles_used * sizeof(void *));
     memset(vesa_tiles, 0, total_tiles_used * sizeof(void *));
     vesa_oview_tiles = (unsigned char **) alloc(total_tiles_used * sizeof(void *));
     memset(vesa_oview_tiles, 0, total_tiles_used * sizeof(void *));
     set_tile_type(vesa_pixel_size > 8);
+#endif
 }
 
 RESTORE_WARNING_FORMAT_NONLITERAL
 
+#ifdef TILES_IN_GLYPHMAP
 /* Return processed pixels for a normal tile */
 static unsigned char *
 vesa_tile(unsigned index)
@@ -1277,11 +1314,13 @@ vesa_oview_tile(unsigned index)
 
     return vesa_oview_tiles[index];
 }
+#endif /* TILES_IN_GLYPHMAP */
 
 /* Set the size of the map viewport */
 static void
 vesa_SetViewPort(void)
 {
+#ifdef TILES_IN_GLYPHMAP
     unsigned y_reserved = (TOP_MAP_ROW + 5) * vesa_char_height;
     unsigned y_map = vesa_y_res - y_reserved;
 
@@ -1289,6 +1328,7 @@ vesa_SetViewPort(void)
     viewport_rows = y_map / iflags.wc_tile_height;
     if (viewport_cols > COLNO) viewport_cols = COLNO;
     if (viewport_rows > ROWNO) viewport_rows = ROWNO;
+#endif
 }
 
 /*
@@ -1340,6 +1380,7 @@ vesa_SwitchMode(unsigned mode)
 void
 vesa_Finish(void)
 {
+#ifdef TILES_IN_GLYPHMAP
     int i;
 
     for (i = 0; i < total_tiles_used; ++i) {
@@ -1349,6 +1390,7 @@ vesa_Finish(void)
     free(vesa_tiles);
     free(vesa_oview_tiles);
     free_tiles();
+#endif
     vesa_SwitchMode(MODETEXT);
     windowprocs.win_cliparound = tty_cliparound;
     g_attribute = attrib_text_normal;
@@ -1897,6 +1939,7 @@ vesa_TriplePixels(unsigned long fnt)
  * not the x,y pixel location.
  *
  */
+#ifdef TILES_IN_GLYPHMAP
 static void
 vesa_DisplayCell(int tilenum, int col, int row)
 {
@@ -1932,6 +1975,7 @@ vesa_DisplayCell(int tilenum, int col, int row)
         tptr += p_row_width;
     }
 }
+#endif /* TILES_IN_GLYPHMAP */
 
 /*
  * Write the character string pointed to by 's', whose maximum length
@@ -2009,6 +2053,8 @@ vesa_SetHardPalette(const struct Pixel *palette)
         p2[i*4 + 1] = palette[i].g >> shift;
         p2[i*4 + 2] = palette[i].r >> shift;
     }
+#else
+    nhUse(palette);
 #endif
     for (i = FIRST_TEXT_COLOR; i < 256; ++i) {
         p2[i*4 + 0] = defpalette[i-FIRST_TEXT_COLOR].b >> shift;
@@ -2077,6 +2123,8 @@ vesa_SetSoftPalette(const struct Pixel *palette)
             ++p;
         }
     }
+#else
+    nhUse(palette);
 #endif
     p = defpalette;
     for (i = FIRST_TEXT_COLOR; i < 256; ++i) {
@@ -2199,17 +2247,25 @@ positionbar(void)
 void
 vesa_DrawCursor(void)
 {
+#ifdef TILES_IN_GLYPHMAP
     static boolean last_inmap = FALSE;
+#endif
     unsigned x, y, left, top, right, bottom, width, height;
+#ifdef TILES_IN_GLYPHMAP
     boolean isrogue = Is_rogue_level(&u.uz);
     boolean halfwidth =
         (isrogue || iflags.over_view || iflags.traditional_view || !inmap);
+#else
+    const boolean halfwidth = TRUE;
+#endif
     int curtyp;
 
+#ifdef TILES_IN_GLYPHMAP
     if (inmap && !last_inmap) {
         vesa_redrawmap();
     }
     last_inmap = inmap;
+#endif
 
     if (!cursor_type && inmap)
         return; /* CURSOR_INVIS - nothing to do */
@@ -2232,9 +2288,12 @@ vesa_DrawCursor(void)
         y -= clipy;
     }
     /* convert to pixels */
+#ifdef TILES_IN_GLYPHMAP
     if (!inmap || iflags.traditional_view) {
+#endif
         width = vesa_char_width;
         height = vesa_char_height;
+#ifdef TILES_IN_GLYPHMAP
     } else if (iflags.over_view) {
         width = vesa_oview_width;
         height = vesa_oview_height;
@@ -2242,6 +2301,7 @@ vesa_DrawCursor(void)
         width = iflags.wc_tile_width;
         height = iflags.wc_tile_height;
     }
+#endif
     left = x * width  + vesa_x_center;
     top  = y * height + vesa_y_center;
     if (y >= TOP_MAP_ROW) {
@@ -2315,9 +2375,13 @@ void
 vesa_HideCursor(void)
 {
     unsigned x, y, left, top, width, height;
+#ifdef TILES_IN_GLYPHMAP
     boolean isrogue = Is_rogue_level(&u.uz);
     boolean halfwidth =
         (isrogue || iflags.over_view || iflags.traditional_view || !inmap);
+#else
+    const boolean halfwidth = TRUE;
+#endif
 
     if (!cursor_type && inmap)
         return; /* CURSOR_INVIS - nothing to do */
@@ -2336,9 +2400,12 @@ vesa_HideCursor(void)
         y -= clipy;
     }
     /* convert to pixels */
+#ifdef TILES_IN_GLYPHMAP
     if (!inmap || iflags.traditional_view) {
+#endif
         width = vesa_char_width;
         height = vesa_char_height;
+#ifdef TILES_IN_GLYPHMAP
     } else if (iflags.over_view) {
         width = vesa_oview_width;
         height = vesa_oview_height;
@@ -2346,6 +2413,7 @@ vesa_HideCursor(void)
         width = iflags.wc_tile_width;
         height = iflags.wc_tile_height;
     }
+#endif
     left = x * width  + vesa_x_center;
     top  = y * height + vesa_y_center;
     if (y >= TOP_MAP_ROW) {

--- a/sys/msdos/vidvga.c
+++ b/sys/msdos/vidvga.c
@@ -10,8 +10,16 @@
 #ifdef SCREEN_VGA /* this file is for SCREEN_VGA only    */
 #include "pcvideo.h"
 #include "tile.h"
-#include "tileset.h"
 #include "font.h"
+
+#ifdef TILES_IN_GLYPHMAP
+#include "tileset.h"
+#else
+/* For the palette */
+struct Pixel {
+    unsigned char r, g, b, a;
+};
+#endif
 
 #include <dos.h>
 #include "wintty.h"
@@ -109,28 +117,35 @@ void vga_backsp(void);
 #ifdef SCROLLMAP
 static void vga_scrollmap(boolean);
 #endif
+#ifdef TILES_IN_GLYPHMAP
 static void vga_redrawmap(boolean);
 static void vga_cliparound(int, int);
 static void decal_planar(struct planar_cell_struct *, unsigned);
+#endif
 
 #ifdef POSITIONBAR
 static void positionbar(void);
 static void vga_special(int, int, int);
 #endif
 
+#ifdef TILES_IN_GLYPHMAP
 static void vga_DisplayCell(struct planar_cell_struct *, int, int);
 static void vga_DisplayCell_O(struct overview_planar_cell_struct *, int,
                               int);
+#endif
 static void vga_SwitchMode(unsigned int);
 static void vga_SetPalette(const struct Pixel *);
 static void vga_WriteChar(uint32, int, int, int);
 static void vga_GetBitmap(uint32, unsigned char *);
 static void vga_WriteStr(char *, int, int, int, int);
+static char __far *vga_FontPtrs(void);
 
+#ifdef TILES_IN_GLYPHMAP
 static void read_planar_tile(unsigned, struct planar_cell_struct *);
 static void read_planar_tile_O(unsigned,
                                struct overview_planar_cell_struct *);
 static void read_tile_indexes(unsigned, unsigned char (*)[TILE_X]);
+#endif
 
 extern int clipx, clipxmax; /* current clipping column from wintty.c */
 extern boolean clipping;    /* clipping on? from wintty.c */
@@ -156,6 +171,7 @@ static struct BitmapFont *psf_font;
 static char *screentable[SCREENHEIGHT];
 
 static const struct Pixel *paletteptr;
+#ifdef TILES_IN_GLYPHMAP
 static struct map_struct {
     int glyph;
     uint32 ch;
@@ -180,11 +196,14 @@ extern int total_tiles_used, Tile_corr, Tile_unexplored;  /* from tile.c */
                 map[y][x].tileidx = Tile_unexplored;            \
             }                                                   \
     }
+#endif /* TILES_IN_GLYPHMAP */
 #define TOP_MAP_ROW 1
 
+#ifdef TILES_IN_GLYPHMAP
 static const int vgacmap[CLR_MAX] = {
     1, 4, 6, 10, 5, 9, 0, 15,
     12, 3, 7, 8, 2, 9, 0, 14 };
+#endif
 static const int textcmap[CLR_MAX] = {
     1, 4, 6, 10, 5, 9, 0, 15,
     12, 3, 7, 8, 2, 11, 13, 14 };
@@ -214,12 +233,13 @@ static const struct Pixel text_palette[] = {
         };
 
 #ifndef ALTERNATE_VIDEO_METHOD
-int vp[SCREENPLANES] = { 8, 4, 2, 1 };
+static int vp[SCREENPLANES] = { 8, 4, 2, 1 };
 #endif
-int vp2[SCREENPLANES] = { 1, 2, 4, 8 };
 
+#ifdef TILES_IN_GLYPHMAP
 static struct planar_cell_struct **cell_cache;
 static struct overview_planar_cell_struct **cell_cache_O;
+#endif
 
 /* static int  g_attribute; */ /* Current attribute to use */
 
@@ -260,8 +280,10 @@ vga_clear_screen(int colour)
         WRITE_ABSOLUTE_DWORD(&pch[j], 0x00000000);
     }
     egawriteplane(15);
+#ifdef TILES_IN_GLYPHMAP
     if (iflags.tile_view)
         vga_clearmap();
+#endif
     vga_gotoloc(0, 0); /* is this needed? */
 }
 
@@ -534,6 +556,7 @@ vga_redrawmap(boolean clearfirst)
 }
 #endif /* TILES_IN_GLYPHMAP && CLIPPING */
 
+#ifdef TILES_IN_GLYPHMAP
 void
 vga_userpan(enum vga_pan_direction pan)
 {
@@ -774,6 +797,7 @@ decal_planar(struct planar_cell_struct *gpcs UNUSED, unsigned special)
     } else if (special & MG_RIDDEN) {
     }
 }
+#endif /* TILES_IN_GLYPHMAP */
 
 /*
  * Open tile files,
@@ -834,7 +858,9 @@ vga_Init(void)
         }
     }
     vga_SwitchMode(MODE640x480);
+#ifdef TILES_IN_GLYPHMAP
     windowprocs.win_cliparound = vga_cliparound;
+#endif
     /*     vga_NoBorder(BACKGROUND_VGA_COLOR); */ /* Not needed after palette
                                                      mod */
 #ifdef TILES_IN_GLYPHMAP
@@ -904,6 +930,7 @@ vga_SwitchMode(unsigned int mode)
 void
 vga_Finish(void)
 {
+#ifdef TILES_IN_GLYPHMAP
     int i;
 
     free_tiles();
@@ -915,6 +942,7 @@ vga_Finish(void)
     cell_cache = NULL;
     free(cell_cache_O);
     cell_cache_O = NULL;
+#endif
     vga_SwitchMode(MODETEXT);
     windowprocs.win_cliparound = tty_cliparound;
     g_attribute = attrib_text_normal;
@@ -954,7 +982,7 @@ vga_NoBorder(int bc)
  * address of the appropriate character definition table for
  * the current graphics mode into interrupt vector 0x43 (0000:010C).
  */
-char __far *
+static char __far *
 vga_FontPtrs(void)
 {
     USHORT __far *tmp;
@@ -1109,6 +1137,7 @@ vga_GetBitmap(uint32 chr, unsigned char *bitmap)
     }
 }
 
+#ifdef TILES_IN_GLYPHMAP
 /*
  * This is the routine that displays a high-res "cell" pointed to by 'gp'
  * at the desired location (col,row).
@@ -1172,6 +1201,7 @@ vga_DisplayCell_O(struct overview_planar_cell_struct *gpcs, int col, int row)
     }
     egawriteplane(15);
 }
+#endif /* TILES_IN_GLYPHMAP */
 
 /*
  * Write the character string pointed to by 's', whose maximum length
@@ -1421,9 +1451,13 @@ vga_DrawCursor(void)
     unsigned char first, second;
     /* char on[2] =  {0xFF,0xFF}; */
     /* char off[2] = {0x00,0x00}; */
+#ifdef TILES_IN_GLYPHMAP
     boolean isrogue = Is_rogue_level(&u.uz);
     boolean singlebyte =
         (isrogue || iflags.over_view || iflags.traditional_view || !inmap);
+#else
+    const boolean singlebyte = TRUE;
+#endif
     int curtyp;
 
     if (!cursor_type && inmap)
@@ -1633,9 +1667,13 @@ vga_HideCursor(void)
     int i, pixx, pixy, x, y;
     char __far *tmp1;
     char __far *tmp2;
+#ifdef TILES_IN_GLYPHMAP
     boolean isrogue = Is_rogue_level(&u.uz);
     boolean singlebyte =
         (isrogue || iflags.over_view || iflags.traditional_view || !inmap);
+#else
+    const boolean singlebyte = TRUE;
+#endif
     int curtyp;
 
     if (inmap && !cursor_type)

--- a/sys/share/pcsys.c
+++ b/sys/share/pcsys.c
@@ -271,7 +271,9 @@ msexit(void)
         restore_colors();
 #endif
     wait_synch();
+#if !(defined(MSDOS) && !defined(TTY_GRAPHICS))
     term_curs_set(1);
+#endif
     return;
 }
 #endif /* MICRO || OS2 */

--- a/sys/share/pctty.c
+++ b/sys/share/pctty.c
@@ -38,7 +38,9 @@ settty(const char *s)
 #if defined(MSDOS) && defined(NO_TERMS)
     gr_finish();
 #endif
+#if !(defined(MSDOS) && !defined(TTY_GRAPHICS))
     term_end_screen();
+#endif
     if (s)
         raw_print(s);
 #if !defined(TOS)
@@ -50,7 +52,9 @@ settty(const char *s)
 void
 setftty(void)
 {
+#if !(defined(MSDOS) && !defined(TTY_GRAPHICS))
     term_start_screen();
+#endif
 }
 
 #ifdef ENHANCED_SYMBOLS
@@ -83,8 +87,10 @@ VA_DECL(const char *, s)
     VA_START(s);
     VA_INIT(s, const char *);
     /* error() may get called before tty is initialized */
+#if !(defined(MSDOS) && !defined(TTY_GRAPHICS))
     if (iflags.window_inited)
         term_end_screen();
+#endif
     putchar('\n');
     Vprintf(s, VA_ARGS);
     putchar('\n');

--- a/sys/share/pctty.c
+++ b/sys/share/pctty.c
@@ -53,6 +53,13 @@ setftty(void)
     term_start_screen();
 }
 
+#ifdef ENHANCED_SYMBOLS
+void
+tty_utf8graphics_fixup(void)
+{
+}
+#endif
+
 #if defined(TIMED_DELAY) && defined(_MSC_VER)
 void
 msleep(unsigned mseconds)

--- a/sys/unix/hints/include/cross-post.500
+++ b/sys/unix/hints/include/cross-post.500
@@ -50,7 +50,7 @@ $(DOSFONT)/ter-u32b.psf: $(FONTTOP)/ter-u32b.bdf $(DOSFONT)/nh-u32b.bdf $(DOSFON
 #
 .PHONY: dodata dospkg dosfonts
 dosfonts: $(FONTTARGETS)
-dospkg: dodata dosfonts $(GAMEBIN) $(TARGETPFX)recover.exe ../dat/nhtiles.bmp
+dospkg: dodata dosfonts $(GAMEBIN) $(TARGETPFX)recover.exe $(NHTILES)
 	$(TARGET_STUBEDIT) $(GAMEBIN) minstack=2048K
 	mkdir -p $(TARGETPFX)pkg
 	cp $(GAMEBIN) $(TARGETPFX)pkg/NETHACK.EXE
@@ -58,7 +58,7 @@ dospkg: dodata dosfonts $(GAMEBIN) $(TARGETPFX)recover.exe ../dat/nhtiles.bmp
 	-cp $(SFCTOOLBIN) $(TARGETPFX)pkg/SFCTOOL.EXE
 	cp ../dat/nhdat $(TARGETPFX)pkg/NHDAT
 	cp ../dat/license $(TARGETPFX)pkg/LICENSE
-	cp ../dat/nhtiles.bmp $(TARGETPFX)pkg/NHTILES.BMP
+	-cp ../dat/nhtiles.bmp $(TARGETPFX)pkg/NHTILES.BMP
 	cp ../dat/symbols $(TARGETPFX)pkg/SYMBOLS
 	cp ../sys/share/NetHack.cnf $(TARGETPFX)pkg/NETHACK.CNF
 	cp ../sys/msdos/sysconf $(TARGETPFX)pkg/SYSCONF

--- a/sys/unix/hints/include/cross-pre2.500
+++ b/sys/unix/hints/include/cross-pre2.500
@@ -177,7 +177,15 @@ MSDOS_GPP_CFLAGS = -Wall -Wextra -Wno-missing-field-initializers -Wreturn-type \
 	-Wunused -Wformat -Wswitch -Wshadow -Wwrite-strings -pedantic \
 	-Wmissing-declarations -Wformat-nonliteral -Wunreachable-code \
 	-Wno-maybe-uninitialized
-ifdef NO_GRAPHICS
+ifndef WANT_WIN_TTY
+    # A Curses-only configuration
+    MSDOS_GRAPH_CONFIG = -DNOTTYGRAPHICS
+    SKIP_TILES = 1
+    ifndef WANT_DOSVGA
+        SKIP_FONTS = 1
+    endif
+    SKIP_FONT_C = 1
+else ifdef NO_GRAPHICS
     MSDOS_GRAPH_CONFIG = -DSUPPRESS_GRAPHICS
     # Curses will need the fonts, but not font.c
     ifndef WANT_DOSVGA

--- a/sys/unix/hints/include/cross-pre2.500
+++ b/sys/unix/hints/include/cross-pre2.500
@@ -177,8 +177,23 @@ MSDOS_GPP_CFLAGS = -Wall -Wextra -Wno-missing-field-initializers -Wreturn-type \
 	-Wunused -Wformat -Wswitch -Wshadow -Wwrite-strings -pedantic \
 	-Wmissing-declarations -Wformat-nonliteral -Wunreachable-code \
 	-Wno-maybe-uninitialized
+ifdef NO_GRAPHICS
+    MSDOS_GRAPH_CONFIG = -DSUPPRESS_GRAPHICS
+    # Curses will need the fonts, but not font.c
+    ifndef WANT_DOSVGA
+        SKIP_FONTS = 1
+    endif
+    SKIP_FONT_C = 1
+    SKIP_TILES = 1
+else ifdef NO_TILES
+    MSDOS_GRAPH_CONFIG =
+    # without SKIP_FONT_C; if ENHANCED_SYMBOLS is set, we'll need the fonts
+    SKIP_TILES = 1
+else
+    MSDOS_GRAPH_CONFIG = -DTILES_IN_GLYPHMAP
+endif
 MSDOS_TARGET_CFLAGS = -c -O $(DBGFLAGS) -I../include -I../sys/msdos -I../win/share \
-	$(LUAINCL) -DDLB $(PDCURSESDEF) -DTILES_IN_GLYPHMAP \
+	$(LUAINCL) -DDLB $(PDCURSESDEF) $(MSDOS_GRAPH_CONFIG) \
 	-DCROSSCOMPILE -DCROSSCOMPILE_TARGET -DCROSS_TO_MSDOS \
 	-D_NAIVE_DOS_REGS \
 	$(MSDOS_GCC_CFLAGS) $(SNDCFLAGS)
@@ -190,7 +205,11 @@ MSDOS_TARGET_CXXFLAGS = -c -O $(DBGFLAGS) -I../include -I../sys/msdos -I../win/s
 PDCINCL += -I$(PDCPORT)
 PDC_TARGET_CFLAGS = $(MSDOS_TARGET_CFLAGS) -Wno-unused-parameter \
 			-Wno-missing-prototypes
-ifndef SKIP_FONTS_IN_CI
+ifdef SKIP_FONTS_IN_CI
+FONTTARGETS=
+else ifdef SKIP_FONTS
+FONTTARGETS=
+else
 FONTVER = terminus-font-4.49.1
 FONTTOP = ../lib/$(FONTVER)
 DOSFONT = ../sys/msdos/fonts
@@ -198,8 +217,6 @@ FONTTARGETS = $(DOSFONT)/ter-u16b.psf $(DOSFONT)/ter-u16v.psf \
 		$(DOSFONT)/ter-u18b.psf $(DOSFONT)/ter-u20b.psf \
 		$(DOSFONT)/ter-u22b.psf $(DOSFONT)/ter-u24b.psf \
 		$(DOSFONT)/ter-u28b.psf $(DOSFONT)/ter-u32b.psf
-else
-FONTTARGETS=
 endif
 LUABIN = ../lib/lua-$(LUA_VERSION)/src/lua
 LUA_TARGET_CFLAGS = $(MSDOS_TARGET_CFLAGS)
@@ -216,18 +233,22 @@ override SYSSRC = ../sys/share/pcmain.c ../sys/msdos/msdos.c \
 		../sys/share/pcsys.c ../sys/share/pctty.c \
 		../sys/share/pcunix.c ../sys/msdos/video.c \
 		../sys/msdos/vidtxt.c ../sys/msdos/pckeys.c \
-		../sys/msdos/vidvga.c ../sys/msdos/vidvesa.c \
-		../sys/msdos/font.c \
-		../win/share/bmptiles.c ../win/share/giftiles.c \
-		../win/share/tileset.c
+		../sys/msdos/vidvga.c ../sys/msdos/vidvesa.c
 override SYSOBJ= $(TARGETPFX)pcmain.o $(TARGETPFX)msdos.o \
 		$(TARGETPFX)pcsys.o $(TARGETPFX)pctty.o \
 		$(TARGETPFX)pcunix.o $(TARGETPFX)video.o \
 		$(TARGETPFX)vidtxt.o $(TARGETPFX)pckeys.o \
-		$(TARGETPFX)vidvga.o $(TARGETPFX)vidvesa.o \
-		$(TARGETPFX)font.o \
-		$(TARGETPFX)bmptiles.o $(TARGETPFX)giftiles.o \
+		$(TARGETPFX)vidvga.o $(TARGETPFX)vidvesa.o
+ifndef SKIP_FONT_C
+override SYSSRC += ../sys/msdos/font.c
+override SYSOBJ += $(TARGETPFX)font.o
+endif
+ifndef SKIP_TILES
+override SYSSRC += ../win/share/bmptiles.c ../win/share/giftiles.c \
+		../win/share/tileset.c
+override SYSOBJ += $(TARGETPFX)bmptiles.o $(TARGETPFX)giftiles.o \
 		$(TARGETPFX)tileset.o
+endif
 override WINLIB=
 override LUALIB=
 override LUALIBS=
@@ -250,7 +271,12 @@ GDBEXE=
 GDBBAT=
 GDBCMDLINE=
 endif
+ifndef SKIP_TILES
 VARDATND += nhtiles.bmp
+NHTILES = ../dat/nhtiles.bmp
+else
+NHTILES =
+endif
 #
 ifdef WANT_WIN_CURSES
 # rules for pdcurses dos-specific files

--- a/win/share/bmptiles.c
+++ b/win/share/bmptiles.c
@@ -3,6 +3,9 @@
 /* NetHack may be freely redistributed.  See license for details. */
 
 #include "config.h"
+
+#ifdef TILES_IN_GLYPHMAP
+
 #include "tileset.h"
 
 /* First BMP file header */
@@ -592,3 +595,5 @@ pixel_element(uint32 mask, uint32 color)
     color &= mask;
     return color * 255 / mask;
 }
+
+#endif /* TILES_IN_GLYPHMAP */

--- a/win/share/giftiles.c
+++ b/win/share/giftiles.c
@@ -7,6 +7,9 @@
  * http://www.w3.org/Graphics/GIF/spec-gif89a.txt */
 
 #include "config.h"
+
+#ifdef TILES_IN_GLYPHMAP
+
 #include "tileset.h"
 
 #define MIN_LZW_BITS 3
@@ -497,3 +500,5 @@ free_data_block(struct DataBlock *block)
     block->size = 0;
     block->data = NULL;
 }
+
+#endif /* TILES_IN_GLYPHMAP */

--- a/win/share/tileset.c
+++ b/win/share/tileset.c
@@ -3,6 +3,9 @@
 /* NetHack may be freely redistributed.  See license for details. */
 
 #include "config.h"
+
+#ifdef TILES_IN_GLYPHMAP
+
 #include "objclass.h"
 #include "flag.h"
 #include "tileset.h"
@@ -348,3 +351,5 @@ read_png_tiles(const char *filename UNUSED, struct TileSetImage *image UNUSED)
     /* stub */
     return FALSE;
 }
+
+#endif /* TILES_IN_GLYPHMAP */

--- a/win/tty/termcap.c
+++ b/win/tty/termcap.c
@@ -27,11 +27,13 @@ void term_end_extracolor(void);
 #if (!defined(UNIX) || !defined(TERMINFO)) && !defined(TOS)
 static void analyze_seq(char *, int *, int *);
 #endif
+#if defined(UNIX) && defined(TERMINFO)
+static int indexed_color_count(void);
+#endif
 #endif
 #if (defined(TERMLIB) || defined(ANSI_DEFAULT))
 static void init_hilite(void);
 static void kill_hilite(void);
-static int indexed_color_count(void);
 #endif
 
 /* (see tcap.h) -- nh_CM, nh_ND, nh_CD, nh_HI,nh_HE, nh_US,nh_UE, ul_hack */
@@ -40,11 +42,15 @@ struct tc_lcl_data tc_lcl_data = { 0, 0, 0, 0, 0, 0, 0, FALSE };
 static char *nh_VI = (char *) 0; /* cursor_invisible */
 static char *nh_VE = (char *) 0; /* cursor_normal */
 /*static char *nh_VS = (char *) 0;*/ /* cursor_visible (highlighted cursor) */
+#if defined(TERMLIB) || defined(CHANGE_COLOR)
 static char *nh_Ic = (char *) 0; /* initialize_color */
+#endif
 
 #if !defined(__NetBSD__)
 static char *UP, *BC;
+#ifdef TERMLIB
 static char PC = '\0';
+#endif
 #endif
 
 static char *HO, *CL, *CE, *XD, *SO, *SE, *TI, *TE;
@@ -1580,13 +1586,7 @@ tty_change_color(int color, long rgb, int reverse UNUSED)
 
 #ifndef SEP2
 #define tcfmtstr "\033[38;2;%ld;%ld;%ldm"
-#ifdef UNIX
-#define tcfmtstr24bit "\033[38;2;%u;%u;%um"
 #define tcfmtstr256 "\033[38;5;%dm"
-#else
-#define tcfmtstr24bit "\033[38;2;%lu;%lu;%lum"
-#define tcfmtstr256 "\033[38:5:%lum"
-#endif
 #endif
 
 static void emit24bit(long mcolor);

--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -182,7 +182,7 @@ static const char winpanicstr[] = "Bad window Id %d (%s)";
 char defmorestr[] = "--More--";
 
 #ifdef CLIPPING
-#if defined(TILES_IN_GLYPHMAP) && defined(MSDOS)
+#if (defined(TILES_IN_GLYPHMAP) || defined(ENHANCED_SYMBOLS)) && defined(MSDOS)
 boolean clipping = FALSE; /* clipping on? */
 int clipx = 0, clipxmax = 0;
 int clipy = 0, clipymax = 0;
@@ -193,7 +193,7 @@ static int clipy = 0, clipymax = 0;
 #endif
 #endif /* CLIPPING */
 
-#if defined(TILES_IN_GLYPHMAP) && defined(MSDOS)
+#if defined(NO_TERMS) && defined(MSDOS)
 extern void adjust_cursor_flags(struct WinDesc *);
 #endif
 
@@ -2072,7 +2072,7 @@ tty_curs(
 
     print_vt_code2(AVTC_SELECT_WINDOW, window);
 
-#if defined(TILES_IN_GLYPHMAP) && defined(MSDOS)
+#if defined(NO_TERMS) && defined(MSDOS)
     adjust_cursor_flags(cw);
 #endif
 


### PR DESCRIPTION
In previous versions of NetHack, setting -DUSE_TILES enabled the tile support, while setting -DSUPPRESS_GRAPHICS produced a NetHack that would write its TTY output to standard output, and rely on ANSI.SYS or similar to do screen control. (USE_TILES is now TILES_IN_GLYPHMAP.)

This change ensures that the current NetHack can be built the same ways. NO_TILES=1 gives an untiled NetHack, while NO_GRAPHICS=1 gives a NetHack that uses ANSI.SYS.

One twist is that previous NetHacks would drop all support for graphical modes when tiles were not supported. Thus sys/msdos/vid{vga,vesa}.c have very disordered use of TILES_IN_GLYPHMAP. There was no need to check this. But now, the graphical modes also support Unicode. A non-tiled build should have the graphical modes, with only the text functions present, provided that ENHANCED_SYMBOLS is defined.

A build with WANT_WIN_CURSES=1 but not WANT_WIN_TTY=1 now does the expected thing.

Some unused and locally used symbols were cleaned up along the way.