### PR TITLE
Atari: Falcon fixes

### DIFF
--- a/sys/atari/sbrk.c
+++ b/sys/atari/sbrk.c
@@ -1,32 +1,6 @@
-/* sys/atari/sbrk.c — override mintlib's __sbrk so the libc heap is
-   satisfied from TT-RAM when present, with automatic GEMDOS fall-back
-   to ST-RAM.  Mintlib's archive copy in unix/sbrk.c is displaced by
-   this strong definition. */
+/* Atari libc heap tuning. */
 
-#include <errno.h>
-#include <stdint.h>
 #include <malloc.h>           /* _mallocChunkSize (mintlib extension) */
-#include <mint/osbind.h>      /* Mxalloc, Malloc */
-#include <mint/ostruct.h>     /* MX_PREFTTRAM, MX_GLOBAL */
-
-void *
-__sbrk(intptr_t n)
-{
-    void *p;
-
-    if (n < 0)                /* mintlib's malloc never shrinks */
-        return (void *) -1L;
-
-    p = (void *) Mxalloc(n, MX_PREFTTRAM | MX_GLOBAL);
-    if ((long) p == -32L || !p) {  /* pre-0x19 GEMDOS, or pools empty */
-        p = (void *) Malloc(n);
-        if (!p) {
-            __set_errno(ENOMEM);
-            return (void *) -1L;
-        }
-    }
-    return p;
-}
 
 /* Keep __sbrk call counts under the TOS 2.06 ~20-allocation GEMDOS
    cap.  At 256 KB chunks a ~4 MB working set produces ~16 calls. */

--- a/sys/unix/hints/include/cross-pre2.500
+++ b/sys/unix/hints/include/cross-pre2.500
@@ -765,13 +765,8 @@ override TARGET_CFLAGS = -c -O2 $(TOOLARCH) \
 override TARGET_CXXFLAGS = $(TARGET_CFLAGS)
 LUA_TARGET_CFLAGS = $(TARGET_CFLAGS)
 override TARGET_LINK = $(TARGET_CC)
-# Set PRG header flags: bit 0 fastload (skip TPA clear), bit 1 load
-# text/data into TT-RAM.  Bit 2 (Malloc prefers TT-RAM) is intentionally
-# unset — the __sbrk override in sys/atari/sbrk.c steers the libc heap
-# via Mxalloc(_, MX_PREFTTRAM | MX_GLOBAL), so bit 2 has no effect.
-# On ST/STE without TT-RAM the loader still falls back to ST-RAM
-# transparently for bit 1.
-override TARGET_LFLAGS= $(TOOLARCH) -Wl,--mprg-flags=0x03
+# PRG header flags: fastload, load into TT-RAM, Malloc from TT-RAM.
+override TARGET_LFLAGS= $(TOOLARCH) -Wl,--mprg-flags=0x07
 override TARGET_LIBS += $(LIBLM) -le_gem -lgem
 VARDATND += nhtiles.bmp
 override SYSSRC = ../sys/atari/tos.c ../sys/atari/sbrk.c \

--- a/win/gem/wingem1.c
+++ b/win/gem/wingem1.c
@@ -163,24 +163,6 @@ cache_pens(void)
                                          nhclr_rgb[i][2], 1);
 }
 
-/* Set window scrollbar elements to dark grey */
-static void
-set_slider_colors(short whandle)
-{
-    /* Color word (AES OBJECT format):
-       bits 11-8 = border color, bits 6-4 = fill pattern (0=hollow,7=solid),
-       bits 3-0 = fill color */
-    short col = (pen_black << 8) | (7 << 4) | pen_darkgray;
-    wind_set6(whandle, WF_COLOR, W_VBAR, col, col, 0);
-    wind_set6(whandle, WF_COLOR, W_VSLIDE, col, col, 0);
-    wind_set6(whandle, WF_COLOR, W_VELEV, col, col, 0);
-    wind_set6(whandle, WF_COLOR, W_HBAR, col, col, 0);
-    wind_set6(whandle, WF_COLOR, W_HSLIDE, col, col, 0);
-    wind_set6(whandle, WF_COLOR, W_HELEV, col, col, 0);
-    wind_set6(whandle, WF_COLOR, W_UPARROW, col, col, 0);
-    wind_set6(whandle, WF_COLOR, W_DNARROW, col, col, 0);
-}
-
 /* Default STE VDI palette (VDI 0-1000 scale).
    Used to reorder the tile palette so GEM UI elements look correct. */
 static const short default_st_vdi[16][3] = {
@@ -2927,7 +2909,6 @@ mar_display_nhwindow(winid wind)
             WIN *ptr_win = dlg_info->di_win;
 
             ptr_win->scroll = &scroll_menu;
-            set_slider_colors(ptr_win->handle);
             mar_menu_set_slider(ptr_win);
             WindowItems(ptr_win, SCROLL_KEYS, scroll_keys);
             if ((d_exit = X_Form_Do(NULL)) != W_ABANDON) {
@@ -2982,7 +2963,6 @@ mar_display_nhwindow(winid wind)
             WIN *ptr_win = Inv_dialog->di_win;
 
             ptr_win->scroll = &scroll_menu;
-            set_slider_colors(ptr_win->handle);
             mar_menu_set_slider(ptr_win);
             WindowItems(ptr_win, SCROLL_KEYS, scroll_keys);
             do {
@@ -3051,7 +3031,6 @@ mar_display_nhwindow(winid wind)
                 NULL, 0);
             if (p_Gw->gw_window == NULL)
                 break;
-            set_slider_colors(p_Gw->gw_window->handle);
             WindowItems(p_Gw->gw_window, SCROLL_KEYS - 1,
                         scroll_keys); /* ClrHome centers on u */
             mar_clear_map();


### PR DESCRIPTION
I finally got my hands on a real Falcon 030 to run NetHack for Atari natively. 

While the previous version worked fine on FreeMiNT and MagiC, it turns out that it crashed on stock TOS 4.04 and Multitos. This was due to a to small AES stack that got triggered by the setting of the scrollbar color. Also the manual TT-RAM preference that I added without having access to a real machine turned out to be unnecessary and was removed, because the native OS flags take care of that on all tested OS versions:

- TOS 4.04
- FreeMint
- MultiTOS
- MagiC 6.2