### PR TITLE
Atari: win/gem: tab-completing extended-command prompt

### DIFF
--- a/win/gem/wingem.c
+++ b/win/gem/wingem.c
@@ -1100,12 +1100,54 @@ static const struct {
     { "?",          '?' },
 };
 
-/* Get an extended command in windowport-specific way.  Returns the
-   extcmdlist index of the chosen command or -1.  Called after '#'.
-   The curated `?` entry opens a second menu listing every available
-   command in extcmdlist as a selectable item. */
+/* extcmdlist index of the which-th prefix match, ordering AUTOCOMPLETE
+   commands before the rest and wrapping modulo the match count (so a
+   negative which cycles backward).  -1 if there is no match. */
+static int
+extcmds_match_cycle(const char *prefix, int which)
+{
+    int *all;
+    int i, o, k, n_ac = 0;
+    int n_all = extcmds_match(prefix, ECM_IGNOREAC, &all);
+
+    if (n_all <= 0)
+        return -1;
+    for (i = 0; i < n_all; i++)
+        if (extcmdlist[all[i]].flags & AUTOCOMPLETE)
+            n_ac++;
+    o = ((which % n_all) + n_all) % n_all;
+    if (o < n_ac) {
+        for (i = 0, k = 0; i < n_all; i++)
+            if ((extcmdlist[all[i]].flags & AUTOCOMPLETE) && k++ == o)
+                return all[i];
+    } else {
+        o -= n_ac;
+        for (i = 0, k = 0; i < n_all; i++)
+            if (!(extcmdlist[all[i]].flags & AUTOCOMPLETE) && k++ == o)
+                return all[i];
+    }
+    return -1; /* not reached */
+}
+
+/* fill out[] with the which-th tab-completion of prefix (AUTOCOMPLETE
+   commands first, wrapping); returns 0 on success, -1 if no match.
+   bridges extcmd data to the GEM-side prompt in wingem1.c. */
 int
-Gem_get_ext_cmd()
+gem_ext_complete_next(const char *prefix, int which, char *out, int outsz)
+{
+    int idx = extcmds_match_cycle(prefix, which);
+
+    if (idx < 0)
+        return -1;
+    (void) strncpy(out, extcmdlist[idx].ef_txt, outsz - 1);
+    out[outsz - 1] = '\0';
+    return 0;
+}
+
+/* the curated menu picker, reached from Gem_get_ext_cmd when the player
+   types '?' at the text prompt */
+static int
+gem_ext_cmd_menu(void)
 {
     winid wind;
     int i, idx, count, what = -1;
@@ -1126,11 +1168,14 @@ Gem_get_ext_cmd()
                          MENU_ITEMFLAGS_NONE);
             continue;
         }
-        for (idx = 0; extcmdlist[idx].ef_txt; idx++)
-            if (!strcmp(extcmdlist[idx].ef_txt, gem_ext_menu[i].name))
-                break;
-        if (!extcmdlist[idx].ef_txt)
-            continue; /* command not present in this build */
+        {
+            int *m;
+
+            if (extcmds_match(gem_ext_menu[i].name,
+                              ECM_IGNOREAC | ECM_EXACTMATCH, &m) != 1)
+                continue; /* not present / not available in this build */
+            idx = m[0];
+        }
         any.a_int = idx + 1; /* +1 so identifier is non-zero */
         Gem_add_menu(wind, &nul_glyphinfo, &any,
                      gem_ext_menu[i].accelerator, 0, ATR_NONE, NO_COLOR,
@@ -1138,7 +1183,7 @@ Gem_get_ext_cmd()
     }
     Gem_end_menu(wind, "What extended command?");
     count = Gem_select_menu(wind, PICK_ONE, &selected);
-    if (count) {
+    if (count > 0) { /* -1 means cancelled, selected stays NULL */
         if (selected->item.a_int == -1)
             show_all = TRUE;
         else
@@ -1182,7 +1227,7 @@ Gem_get_ext_cmd()
         }
         Gem_end_menu(wind, "Pick a command:");
         count = Gem_select_menu(wind, PICK_ONE, &selected);
-        if (count) {
+        if (count > 0) {
             what = selected->item.a_int - 1;
             free((genericptr_t) selected);
         }
@@ -1190,6 +1235,34 @@ Gem_get_ext_cmd()
     }
 
     return what;
+}
+
+/* Get an extended command.  Runs a text prompt with TAB completion; the
+   player can type '?' to fall back to the curated menu. */
+int
+Gem_get_ext_cmd(void)
+{
+    char buf[BUFSZ];
+    int *m;
+
+    switch (gem_ext_cmd_getlin(buf)) {
+    case 1:
+        return gem_ext_cmd_menu();
+    case -1:
+        return -1;
+    default:
+        break;
+    }
+
+    (void) mungspaces(buf);
+    if (buf[0] == '\0')
+        return -1;
+    if (extcmds_match(buf, ECM_IGNOREAC | ECM_EXACTMATCH, &m) == 1)
+        return m[0];
+    if (extcmds_match(buf, ECM_NOFLAGS, &m) == 1)
+        return m[0];
+    pline("#%.60s: unknown extended command.", buf);
+    return -1;
 }
 
 void

--- a/win/gem/wingem.h
+++ b/win/gem/wingem.h
@@ -91,6 +91,11 @@ extern int Gem_doprev_message(void);
 extern char Gem_yn_function(const char *, const char *, char);
 extern void Gem_getlin(const char *, char *);
 extern int Gem_get_ext_cmd(void);
+/* returns 0 = buf holds the typed reply, 1 = user requested the menu,
+   -1 = cancelled */
+extern int gem_ext_cmd_getlin(char *buf);
+extern int gem_ext_complete_next(const char *prefix, int which, char *out,
+                                 int outsz);
 extern void Gem_number_pad(int);
 extern void Gem_delay_output(void);
 

--- a/win/gem/wingem1.c
+++ b/win/gem/wingem1.c
@@ -3848,6 +3848,163 @@ Gem_getlin(const char *ques, char *input)
 
 #define Dia_Init K_Init
 
+/* state shared between gem_ext_cmd_getlin() and gem_ext_handler() for one
+   invocation of the extended-command prompt */
+static char gem_ext_base[BUFSZ];  /* prefix currently being cycled */
+static char gem_ext_last[BUFSZ];  /* last completion we wrote to the field */
+static int gem_ext_tabi;          /* index of the last completion shown */
+static boolean gem_ext_started;   /* a cycle is in progress for gem_ext_base */
+static boolean gem_ext_want_menu; /* set when '?' is typed on an empty field */
+
+/* step the TAB cycle (dir +1 forward, -1 backward) and rewrite the LGREPLY
+   edit field */
+static void
+gem_ext_complete(DIAINFO *dinf, int dir)
+{
+    OBJECT *tree = dinf->di_tree;
+    char *field = ob_get_text(tree, LGREPLY, 0);
+    short txtlen = tree[LGREPLY].ob_spec.tedinfo->te_txtlen;
+    char snap[BUFSZ];
+
+    if (!field)
+        return;
+
+    /* snapshot the live field text (its own te_ptext buffer, distinct from
+       gem_ext_last); if it differs from the last completion we offered, the
+       player typed something since the last TAB, so start a new cycle */
+    (void) strncpy(snap, field, sizeof snap - 1);
+    snap[sizeof snap - 1] = '\0';
+    if (!gem_ext_started || strcmp(snap, gem_ext_last) != 0) {
+        (void) strncpy(gem_ext_base, snap, sizeof gem_ext_base - 1);
+        gem_ext_base[sizeof gem_ext_base - 1] = '\0';
+        gem_ext_tabi = (dir < 0) ? -1 : 0;
+        gem_ext_started = TRUE;
+    } else {
+        gem_ext_tabi += dir;
+    }
+
+    if (gem_ext_complete_next(gem_ext_base, gem_ext_tabi, gem_ext_last,
+                              sizeof gem_ext_last) < 0) {
+        Gem_nhbell();
+        return;
+    }
+
+    /* copy the completion INTO the field's edit buffer.  ob_set_text would
+       only repoint te_ptext at gem_ext_last (E_GEM assigns the pointer),
+       aliasing our state and breaking further editing. */
+    if (txtlen > 0) {
+        (void) strncpy(field, gem_ext_last, txtlen - 1);
+        field[txtlen - 1] = '\0';
+    }
+    ob_draw(dinf, LGREPLY);
+    ob_set_cursor(dinf, LGREPLY, 0x1000, FAIL); /* 0x1000 = end of text */
+}
+
+/* keyboard handler installed around the extended-command prompt dialog.
+   TAB cycles completions; '?' on an empty field opens the menu; every other
+   key passes through to the AES edit field (clear MU_KEYBD to pass through,
+   leave it set to consume -- same convention as Dia_Handler). */
+static short
+gem_ext_handler(XEVENT *xev)
+{
+    short ev = xev->ev_mwich;
+
+    if (ev & MU_KEYBD) {
+        char ch = (char) (xev->ev_mkreturn & 0x00FF);
+        short scan = (short) (((unsigned short) xev->ev_mkreturn) >> 8);
+        WIN *w = get_top_window();
+        DIAINFO *dinf = w ? (DIAINFO *) w->dialog : 0;
+
+        /* match TAB by scancode; AES doesn't deliver a reliable ascii byte
+           for it the way E_GEM's own key handling assumes.  Shift reverses
+           the cycle direction. */
+        if (dinf && scan == SCANTAB) {
+            gem_ext_complete(dinf,
+                             (xev->ev_mmokstate & K_SHIFT) ? -1 : 1);
+            return ev; /* consume */
+        }
+        if (dinf && ch == '?') {
+            char *cur = ob_get_text(dinf->di_tree, LGREPLY, 0);
+
+            if (!cur || !cur[0]) {
+                gem_ext_want_menu = TRUE;
+                my_close_dialog(dinf, FALSE);
+                return ev; /* consume */
+            }
+        }
+        ev &= ~MU_KEYBD; /* pass through to the edit field */
+    }
+    return ev;
+}
+
+/* extended-command text prompt with TAB completion.  Mirrors Gem_getlin's
+   dialog setup but installs gem_ext_handler for TAB/'?' interception. */
+int
+gem_ext_cmd_getlin(char *buf)
+{
+    OBJECT *z_ob = zz_oblist[LINEGET];
+    short d_exit, length;
+    char *pr[2], *tmp;
+    char ques_buf[128];
+    static const char ques[] = "Enter extended command (TAB=autocomplete, ?=list)";
+
+    if (WIN_MESSAGE != WIN_ERR && Gem_nhwindow[WIN_MESSAGE].gw_window)
+        mar_display_nhwindow(WIN_MESSAGE);
+
+    gem_ext_base[0] = '\0';
+    gem_ext_last[0] = '\0';
+    gem_ext_tabi = 0;
+    gem_ext_started = FALSE;
+    gem_ext_want_menu = FALSE;
+
+    z_ob[LGPROMPT].ob_type = G_USERDEF;
+    z_ob[LGPROMPT].ob_spec.userblk = &ub_prompt;
+    z_ob[LGPROMPT].ob_height = 2 * gr_ch;
+
+    (void) strncpy(ques_buf, ques, sizeof(ques_buf) - 1);
+    ques_buf[sizeof(ques_buf) - 1] = '\0';
+
+    length = z_ob[LGPROMPT].ob_width / gr_cw;
+    if ((short) strlen(ques_buf) > length) {
+        tmp = ques_buf + length;
+        while (tmp >= ques_buf && *tmp != ' ')
+            tmp--;
+        if (tmp <= ques_buf)
+            tmp = ques_buf + length;
+        pr[0] = ques_buf;
+        *tmp = 0;
+        pr[1] = ++tmp;
+    } else {
+        pr[0] = ques_buf;
+        pr[1] = NULL;
+    }
+    ub_prompt.ub_parm = (long) pr;
+
+    ob_clear_edit(z_ob);
+    Event_Handler(Dia_Init, gem_ext_handler);
+    /* give our handler first crack at keys so it sees TAB/'?'; the editable
+       field otherwise consumes them (port default keys arg is TRUE, see the
+       dial_options call in mar_gem_init).  restore it afterwards. */
+    dial_options(TRUE, TRUE, FALSE, TRUE, TRUE, TRUE,
+                 KEY_FIRST, FALSE, TRUE, 0);
+    d_exit = xdialog(z_ob, nullstr, NULL, NULL, mar_ob_mapcenter(z_ob), FALSE,
+                     DIALOG_MODE);
+    dial_options(TRUE, TRUE, FALSE, TRUE, TRUE, TRUE,
+                 TRUE, FALSE, TRUE, 0);
+    Event_Timer(0, 0, TRUE);
+    Event_Handler(NULL, NULL);
+
+    if (gem_ext_want_menu)
+        return 1;
+    if (d_exit == W_CLOSED || d_exit == W_ABANDON
+        || (d_exit & NO_CLICK) == QLG) {
+        return -1;
+    }
+    strncpy(buf, ob_get_text(z_ob, LGREPLY, 0), BUFSZ - 1);
+    buf[BUFSZ - 1] = '\0';
+    return 0;
+}
+
 short
 Dia_Handler(XEVENT *xev)
 {


### PR DESCRIPTION
Replace the '#' menu picker with a text field: TAB cycles prefix matches (AUTOCOMPLETE commands first, Shift-TAB reverses), '?' on an empty field opens the menu. 