### PR TITLE
Fix infinite loop on cancel in status_hilite_menu_add

### DIFF
--- a/src/botl.c
+++ b/src/botl.c
@@ -4233,7 +4233,9 @@ status_hilite_menu_add(int origfld)
  choose_color:
     clr = query_color(colorqry, NO_COLOR);
     if (clr == -1) {
-        if (behavior != BL_TH_ALWAYS_HILITE)
+        if (behavior == BL_TH_VAL_PERCENTAGE
+            || behavior == BL_TH_VAL_ABSOLUTE
+            || (behavior == BL_TH_UPDOWN && initblstats[fld].anytype != ANY_STR))
             goto choose_value;
         else
             goto choose_behavior;


### PR DESCRIPTION
When adding a status highlight rule via status_hilite_menu_add(), canceling (ESC / -1) at the color selection dialog (query_color) for non-value fields (e.g. string fields like BL_DUNGEON or BL_TITLE with BL_TH_UPDOWN, BL_TH_CONDITION, BL_TH_TEXTMATCH, or BL_TH_ALWAYS_HILITE) caused a jump to 'goto choose_value;'.

Because those options do not perform any value input prompt in choose_value, execution immediately fell through back to choose_color, creating an infinite loop that prompted for color repeatedly until retry limit was exceeded.

Fix this by jumping to 'goto choose_behavior;' upon color selection cancel when the selected behavior does not prompt for a numeric value, allowing the user to cleanly step back to the behavior selection menu.

## Summary
- **What changed?**
  Modified the cancel handling (`clr == -1`) in `status_hilite_menu_add()` within `src/botl.c`. When color selection is canceled, execution now jumps to `choose_behavior` instead of `choose_value` if the selected rule/field does not prompt for numeric threshold values (specifically: `BL_TH_UPDOWN` on `ANY_STR` fields, `BL_TH_CONDITION`, `BL_TH_TEXTMATCH`, and `BL_TH_ALWAYS_HILITE`).

- **Why is this needed?**
  Fixes an infinite prompt loop when canceling color selection in the `#status_hilite` menu for non-numeric/string fields (e.g. `dungeon level`, `title`, or condition/textmatch rules). Previously, canceling color selection jumped to `goto choose_value;`. Since `choose_value:` performs no user prompts for these field/behavior types, execution immediately fell through back to `choose_color:`, re-opening the color picker continuously until exceeding the retry threshold ("Too many retries.").

## Scope
- [x] Source code (`src/`, `include/`, `sys/`)
- [ ] Translation/text (`dat/`, `docs/`, README)
- [ ] Build/config only
## Validation
- [x] Build succeeds locally
- [x] Relevant runtime behavior checked
- [x] No unintended file changes included

Commands run (if any):
- Build with Visual Studio 2026

## Reproduction & Verification Steps:
1. Open options (O) -> status highlight rules.
2. Select a string status field (e.g., dungeon level or title) -> select value changes (or a condition / textmatch rule).
3. Press ESC / Cancel at the color selection prompt.
4. Before fix: Color selection prompt re-appears immediately 5 times in a loop before failing with "Too many retries.".
5. After fix: ESC cleanly returns to the behavior selection menu (choose_behavior), allowing normal backwards menu navigation.

## Checklist
[x] Security-sensitive changes reviewed
[x] License/notice impact checked
[x] Related issue linked
