### PR TITLE
themerms: keep Teleportation hub traps off the wall-adjacent gutter

### DIFF
--- a/dat/themerms.lua
+++ b/dat/themerms.lua
@@ -264,8 +264,17 @@ themeroom_fills = {
    {
       name = "Teleportation hub",
       contents = function(rm)
-         local locs = selection.room():filter_mapchar(".");
-         for i = 1, 2 + nh.rn2(3) do
+         -- Only trap the room's interior, never the "gutter" of floor
+         -- tiles next to a wall.  Keeping the gutter clear guarantees a
+         -- trap-free walk around the perimeter between every door, so these
+         -- fixed-destination teleporters can't ring a doorway, seal the
+         -- room, and strand the hero on the wrong side of the level.
+         local floor = selection.room():filter_mapchar(".");
+         local locs = floor - floor:negate():grow("all");
+         -- never ask for more traps than there are interior tiles; a room
+         -- with no interior (smaller than 3x3, which ordinary rooms never
+         -- are) simply gets none
+         for i = 1, math.min(2 + nh.rn2(3), locs:numpoints()) do
             local pos = locs:rndcoord(1);
             if (pos.x > 0) then
                pos.x = pos.x + rm.region.x1 - 1;


### PR DESCRIPTION
A fix for #1640.

The Teleportation hub fill scatters 2-4 "fixed-destination" teleport traps across a room's whole floor. An unlucky room can end up with traps on every tile in front of its only doorway, all teleporting to the far side of the level, leaving no trap-free way through the room. (See #1640 for an example. Level connectivity is built assuming every room is freely passable, so a bad arrangement of fixed-teleport traps can make the level impassable.)

The change places the traps on the room's interior only, never the perimeter "gutter" of floor tiles next to a wall. A clear gutter always leaves a trap-free walk around the room's edge between every door. The trap count is capped at the number of interior tiles, so small rooms place fewer traps and a room with no interior places none.