### PR TITLE
MS-DOS: Complete highlighting of piles and pets

### DIFF
--- a/sys/msdos/vidvesa.c
+++ b/sys/msdos/vidvesa.c
@@ -120,7 +120,7 @@ static struct map_struct {
 enum { delimdecal, petdecal, piledecal, NUMDECALS };
 static unsigned char *vesa_decals[NUMDECALS] = { 0 };
 static unsigned char *tmptilebuf;
-static unsigned short tilebackground;
+static uint32_t tilebackground;
 
 #define vesa_clearmap()                                         \
     {                                                           \
@@ -726,7 +726,20 @@ vesa_xputg(const glyph_info *glyphinfo, const glyph_info *bkglyphinfo UNUSED)
     if (!vesa_decals[delimdecal]) {
         vesa_decals[delimdecal] = vesa_tile(Tile_delimiter);
         /* The first pixel in Tile_delimiter is the background color */
-        tilebackground = *((unsigned short *)vesa_decals[delimdecal]);
+        switch(vesa_pixel_bytes) {
+        case 1:
+            tilebackground = *((uint8_t *)vesa_decals[delimdecal]);
+            break;
+
+        case 2:
+            tilebackground = *((uint16_t *)vesa_decals[delimdecal]);
+            break;
+
+        case 3:
+        case 4:
+            tilebackground = *((uint32_t *)vesa_decals[delimdecal]) & 0x00FFFFFF;
+            break;
+        }
         if (!vesa_decals[petdecal])
             vesa_decals[petdecal] = vesa_tile(Tile_petmark);
 
@@ -2028,21 +2041,68 @@ tile_with_decal(unsigned char const *tile, unsigned char const *decal)
     dst = tmptilebuf;
     for (tr = 0; tr < iflags.wc_tile_height; ++tr) {
         for (tc = 0; tc < iflags.wc_tile_width; ++tc) {
+            /* 
+             * ignore the "background" pixels in decal,
+             * which is identified by the delim tile in the stock
+             * tile set which is 100% background.
+             */
             switch(vesa_pixel_bytes) {
-                /*
-                 * FIXME: add the other switch cases
-                 */
-                case 2: {
-                        unsigned short *t1 = (unsigned short *) tptr,
-                                       *t2 = (unsigned short *) declptr,
-                                       *t3 = (unsigned short *) dst;
+                case 1: {
+                        uint8_t *t1 = (uint8_t *) tptr,
+                                *t2 = (uint8_t *) declptr,
+                                *t3 = (uint8_t *) dst;
 
-                        /* 
-                        * ignore the "background" pixesl in decal,
-                        * which is identified by the delim tile in the stock
-                        * tile set which is 100% background.
-                        */
-                        *t3 = (!(*t2 == tilebackground)) ? *t2 : *t1;
+                        *t3 = (*t2 != tilebackground) ? *t2 : *t1;
+                    }
+                    break;
+                case 2: {
+                        uint16_t *t1 = (uint16_t *) tptr,
+                                 *t2 = (uint16_t *) declptr,
+                                 *t3 = (uint16_t *) dst;
+
+                        *t3 = (*t2 != tilebackground) ? *t2 : *t1;
+                    }
+                    break;
+                case 3: {
+                        uint16_t *t1a, *t2a, *t3a;
+                        uint8_t *t1b, *t2b, *t3b;
+                        uint32_t pix;
+
+                        if ((tc & 1) == 0) {
+                            /* pixel column is even */
+                            t1a = (uint16_t *) (tptr + 0);
+                            t2a = (uint16_t *) (declptr + 0);
+                            t3a = (uint16_t *) (dst + 0);
+                            t1b = (uint8_t *) (tptr + 2);
+                            t2b = (uint8_t *) (declptr + 2);
+                            t3b = (uint8_t *) (dst + 2);
+                            pix = ((uint32_t) *t2b << 16) | *t2a;
+                        } else {
+                            /* pixel column is odd */
+                            t1b = (uint8_t *) (tptr + 0);
+                            t2b = (uint8_t *) (declptr + 0);
+                            t3b = (uint8_t *) (dst + 0);
+                            t1a = (uint16_t *) (tptr + 1);
+                            t2a = (uint16_t *) (declptr + 1);
+                            t3a = (uint16_t *) (dst + 1);
+                            pix = ((uint32_t) *t2a << 8) | *t2b;
+                        }
+
+                        if (pix != tilebackground) {
+                            *t3a = *t2a;
+                            *t3b = *t2b;
+                        } else {
+                            *t3a = *t1a;
+                            *t3b = *t1b;
+                        }
+                    }
+                    break;
+                case 4: {
+                        uint32_t *t1 = (uint32_t *) tptr,
+                                 *t2 = (uint32_t *) declptr,
+                                 *t3 = (uint32_t *) dst;
+
+                        *t3 = ((*t2 & 0x00FFFFFF) != tilebackground) ? *t2 : *t1;
                     }
                     break;
                 default: {

--- a/sys/msdos/vidvesa.c
+++ b/sys/msdos/vidvesa.c
@@ -2064,36 +2064,21 @@ tile_with_decal(unsigned char const *tile, unsigned char const *decal)
                     }
                     break;
                 case 3: {
-                        uint16_t *t1a, *t2a, *t3a;
-                        uint8_t *t1b, *t2b, *t3b;
-                        uint32_t pix;
-
-                        if ((tc & 1) == 0) {
-                            /* pixel column is even */
-                            t1a = (uint16_t *) (tptr + 0);
-                            t2a = (uint16_t *) (declptr + 0);
-                            t3a = (uint16_t *) (dst + 0);
-                            t1b = (uint8_t *) (tptr + 2);
-                            t2b = (uint8_t *) (declptr + 2);
-                            t3b = (uint8_t *) (dst + 2);
-                            pix = ((uint32_t) *t2b << 16) | *t2a;
-                        } else {
-                            /* pixel column is odd */
-                            t1b = (uint8_t *) (tptr + 0);
-                            t2b = (uint8_t *) (declptr + 0);
-                            t3b = (uint8_t *) (dst + 0);
-                            t1a = (uint16_t *) (tptr + 1);
-                            t2a = (uint16_t *) (declptr + 1);
-                            t3a = (uint16_t *) (dst + 1);
-                            pix = ((uint32_t) *t2a << 8) | *t2b;
-                        }
+                        uint8_t *t1 = (uint8_t *) tptr,
+                                *t2 = (uint8_t *) declptr,
+                                *t3 = (uint8_t *) dst;
+                        uint32_t pix = ((uint32_t) t2[2] << 16)
+                                     | ((uint32_t) t2[1] <<  8)
+                                     | ((uint32_t) t2[0] <<  0);
 
                         if (pix != tilebackground) {
-                            *t3a = *t2a;
-                            *t3b = *t2b;
+                            t3[0] = t2[0];
+                            t3[1] = t2[1];
+                            t3[2] = t2[2];
                         } else {
-                            *t3a = *t1a;
-                            *t3b = *t1b;
+                            t3[0] = t1[0];
+                            t3[1] = t1[1];
+                            t3[2] = t1[2];
                         }
                     }
                     break;

--- a/sys/msdos/vidvesa.c
+++ b/sys/msdos/vidvesa.c
@@ -47,7 +47,9 @@ static unsigned long vesa_ReadPixel32(unsigned x, unsigned y);
 static void vesa_WritePixel32(unsigned x, unsigned y, unsigned long color);
 static void vesa_WritePixel(unsigned x, unsigned y, unsigned color);
 static void vesa_WritePixelRow(unsigned long offset,
-                               unsigned char const *p_row, unsigned p_row_size);
+                               unsigned char const *p_row,
+                               unsigned char const *p_decal_row,
+                               unsigned p_row_size);
 static unsigned long vesa_MakeColor(struct Pixel);
 static void vesa_FillRect(unsigned left, unsigned top, unsigned width,
                           unsigned height, unsigned color);
@@ -66,7 +68,7 @@ static boolean vesa_SetHardPalette(const struct Pixel *);
 static boolean vesa_SetSoftPalette(const struct Pixel *);
 #ifdef TILES_IN_GLYPHMAP
 static void vesa_DisplayCell(int, int, int, uint8_t);
-static unsigned char const *tile_with_decal(unsigned char const *, unsigned char const *);
+static uint8_t *add_transparent_row(uint8_t const *, uint8_t const *, unsigned, uint32_t);
 #endif
 static unsigned vesa_FindMode(unsigned long mode_addr, unsigned bits);
 static void vesa_WriteChar(uint32, int, int, uint32);
@@ -112,13 +114,15 @@ static struct map_struct {
     uint32 ch;
     uint32 attr;
     unsigned special;
-    short int tileidx;
+    uint16_t tileidx;
+    uint16_t decalnum;
     int framecolor;
     int inverse;
 } map[ROWNO][COLNO]; /* track the glyphs */
 
 enum { delimdecal, petdecal, piledecal, NUMDECALS };
 static unsigned char *vesa_decals[NUMDECALS] = { 0 };
+static unsigned char *vesa_oview_decals[NUMDECALS] = { 0 };
 static unsigned char *tmptilebuf;
 static uint32_t tilebackground;
 
@@ -133,6 +137,7 @@ static uint32_t tilebackground;
                 map[y][x].attr = 0;                             \
                 map[y][x].special = 0;                          \
                 map[y][x].tileidx = Tile_unexplored;            \
+                map[y][x].decalnum = 0;                         \
                 map[y][x].inverse = 0;                          \
             }                                                   \
     }
@@ -496,8 +501,22 @@ vesa_WritePixel(unsigned x, unsigned y, unsigned color)
 
 static void
 vesa_WritePixelRow(unsigned long offset,
-                   unsigned char const *p_row, unsigned p_row_size)
+                   unsigned char const *p_row,
+                   unsigned char const *p_decal_row,
+                   unsigned p_row_size)
 {
+#ifdef TILES_IN_GLYPHMAP
+    uint8_t *p_combined_row = NULL; /* custodial */
+
+    if (p_decal_row != NULL) {
+        p_combined_row = add_transparent_row(
+                p_row, p_decal_row, p_row_size, tilebackground);
+        p_row = p_combined_row;
+    }
+#else
+    nhUse(p_decal_row);
+#endif
+
     if (vesa_segment != 0) {
         /* Linear frame buffer in use */
         movedata(_go32_my_ds(), (unsigned)p_row, vesa_segment, offset, p_row_size);
@@ -516,6 +535,10 @@ vesa_WritePixelRow(unsigned long offset,
         }
         dosmemput(p_row + i, p_row_size - i, addr);
     }
+
+#ifdef TILES_IN_GLYPHMAP
+    free(p_combined_row);
+#endif
 }
 
 static unsigned long
@@ -566,7 +589,7 @@ vesa_FillRect(unsigned left, unsigned top, unsigned width,
     }
 
     for (y = 0; y < height; ++y) {
-        vesa_WritePixelRow(offset, p_row, p_row_size);
+        vesa_WritePixelRow(offset, p_row, NULL, p_row_size);
         offset += vesa_scan_line;
     }
 
@@ -745,7 +768,18 @@ vesa_xputg(const glyph_info *glyphinfo, const glyph_info *bkglyphinfo UNUSED)
 
         if (!vesa_decals[piledecal])
             vesa_decals[piledecal] = vesa_tile(Tile_pilemark);
+
+        if (!vesa_oview_decals[petdecal])
+            vesa_oview_decals[petdecal] = vesa_oview_tile(Tile_petmark);
+
+        if (!vesa_oview_decals[piledecal])
+            vesa_oview_decals[piledecal] = vesa_oview_tile(Tile_pilemark);
     }
+
+    unsigned decalnum = ((special & MG_PET) && iflags.hilite_pet)
+                            ? petdecal
+                            : ((special & MG_OBJPILE) && iflags.hilite_pile)
+                                ? piledecal : 0;
  
 #ifdef ENHANCED_SYMBOLS
     if (SYMHANDLING(H_UTF8) && glyphinfo->gm.u && glyphinfo->gm.u->utf8str) {
@@ -775,6 +809,7 @@ vesa_xputg(const glyph_info *glyphinfo, const glyph_info *bkglyphinfo UNUSED)
     map[ry][col].ch = ch;
     map[ry][col].special = special;
     map[ry][col].tileidx = glyphinfo->gm.tileidx;
+    map[ry][col].decalnum = decalnum;
     map[ry][col].attr = attr;
     map[ry][col].inverse = inversed;
 
@@ -791,11 +826,7 @@ vesa_xputg(const glyph_info *glyphinfo, const glyph_info *bkglyphinfo UNUSED)
             if (!iflags.over_view && map[ry][col].special)
                 decal_packed(packcell, special);
 #endif
-            vesa_DisplayCell(glyphinfo->gm.tileidx, col - clipx, ry - clipy,
-                             ((special & MG_PET) && iflags.hilite_pet)
-                                 ? petdecal
-                                 : ((special & MG_OBJPILE) && iflags.hilite_pile)
-                                     ? piledecal : 0);
+            vesa_DisplayCell(glyphinfo->gm.tileidx, col - clipx, ry - clipy, decalnum);
             if (bkglyphinfo->framecolor != NO_COLOR) {
                 int curtypbak = cursor_type;
                 int cclr = cursor_color;
@@ -908,15 +939,20 @@ vesa_redrawmap(void)
         }
     } else if (iflags.over_view) {
         /* Overview mode */
-        const unsigned char *tile;
 
         p_row_width = vesa_oview_width * vesa_pixel_bytes;
         y = y_top;
         for (cy = 0; cy < ROWNO; ++cy) {
             for (py = 0; py < vesa_oview_height; ++py) {
                 for (cx = 0; cx < COLNO; ++cx) {
-                    tile = vesa_oview_tile(map[cy][cx].tileidx);
-                    vesa_WritePixelRow(offset + p_row_width * cx, tile + p_row_width * py, p_row_width);
+                    const uint8_t *tile = vesa_oview_tile(map[cy][cx].tileidx);
+                    const uint8_t *decal = NULL;
+                    unsigned decalnum = map[cy][cx].decalnum;
+                    if (decalnum != 0 && decalnum < NUMDECALS) {
+                        decal = vesa_oview_decals[decalnum];
+                        decal += p_row_width * py;
+                    }
+                    vesa_WritePixelRow(offset + p_row_width * cx, tile + p_row_width * py, decal, p_row_width);
                 }
                 x = COLNO * vesa_oview_width;
                 if (x < vesa_x_res) {
@@ -928,15 +964,20 @@ vesa_redrawmap(void)
         }
     } else {
         /* Normal tiled mode */
-        const unsigned char *tile;
 
         p_row_width = iflags.wc_tile_width * vesa_pixel_bytes;
         y = y_top;
         for (cy = clipy; cy <= (unsigned) clipymax && cy < ROWNO; ++cy) {
             for (py = 0; py < (unsigned) iflags.wc_tile_height; ++py) {
                 for (cx = clipx; cx <= (unsigned) clipxmax && cx < COLNO; ++cx) {
-                    tile = vesa_tile(map[cy][cx].tileidx);
-                    vesa_WritePixelRow(offset + p_row_width * (cx - clipx), tile + p_row_width * py, p_row_width);
+                    const uint8_t *tile = vesa_tile(map[cy][cx].tileidx);
+                    const uint8_t *decal = NULL;
+                    unsigned decalnum = map[cy][cx].decalnum;
+                    if (decalnum != 0 && decalnum < NUMDECALS) {
+                        decal = vesa_decals[decalnum];
+                        decal += p_row_width * py;
+                    }
+                    vesa_WritePixelRow(offset + p_row_width * (cx - clipx), tile + p_row_width * py, decal, p_row_width);
                 }
                 x = (cx - clipx) * iflags.wc_tile_width;
                 if (x < vesa_x_res) {
@@ -1867,7 +1908,7 @@ vesa_WriteTextRow(int pixx, int pixy, struct VesaCharacter const *t_row,
                 }
             }
         }
-        vesa_WritePixelRow(offset, p_row, p_row_width);
+        vesa_WritePixelRow(offset, p_row, NULL, p_row_width);
         offset += vesa_scan_line;
     }
     free(p_row);
@@ -2011,101 +2052,114 @@ vesa_DisplayCell(int tilenum, int col, int row, uint8_t decalnum)
     pixx += vesa_x_center;
     pixy += vesa_y_center;
     offset = pixy * (unsigned long)vesa_scan_line + pixx * vesa_pixel_bytes;
-    decal = (decalnum == petdecal)
-                ? vesa_decals[petdecal]
-                : (decalnum == piledecal)
-                    ? vesa_decals[piledecal]
-                    : NULL;
-    tptr = (decal == NULL) ? tile : tile_with_decal(tile, decal);
+    if (decalnum != 0 && decalnum < NUMDECALS) {
+        if (iflags.over_view) {
+            decal = vesa_oview_decals[decalnum];
+        } else {
+            decal = vesa_decals[decalnum];
+        }
+    } else {
+        decal = NULL;
+    }
+    tptr = tile;
 
     for (py = 0; py < (int) t_height; ++py) {
-        vesa_WritePixelRow(offset, tptr, p_row_width);
+        vesa_WritePixelRow(offset, tptr, decal, p_row_width);
         offset += vesa_scan_line;
         tptr += p_row_width;
+        if (decal != NULL) {
+            decal += p_row_width;
+        }
     }
 }
 
-unsigned char const *
-tile_with_decal(unsigned char const *tile, unsigned char const *decal)
+/* Overlay a transparent row onto the given pixel row */
+/* Return an allocated buffer containing the overlaid row */
+/* The caller is responsible for freeing the returned row */
+static uint8_t *
+add_transparent_row(
+        uint8_t const *p_row,
+        uint8_t const *p_overlay,
+        unsigned p_row_size,
+        uint32_t transparent_pixel)
 {
-    int tr, tc;
-    unsigned char const *tptr, *declptr;
-    unsigned char *dst;
+    /* 
+     * ignore the "background" pixels in decal,
+     * which is identified by the delim tile in the stock
+     * tile set which is 100% background.
+     */
+    uint8_t *p_combined_row = (uint8_t *) alloc(p_row_size);
+    switch(vesa_pixel_bytes) {
+        case 1: {
+                uint8_t *t1 = (uint8_t *) p_row,
+                        *t2 = (uint8_t *) p_overlay,
+                        *t3 = (uint8_t *) p_combined_row;
 
-    if (!tmptilebuf)
-        tmptilebuf = (unsigned char *)
-                        alloc(iflags.wc_tile_width * vesa_pixel_bytes *  iflags.wc_tile_height);
-
-    tptr = tile;
-    declptr = decal;
-    dst = tmptilebuf;
-    for (tr = 0; tr < iflags.wc_tile_height; ++tr) {
-        for (tc = 0; tc < iflags.wc_tile_width; ++tc) {
-            /* 
-             * ignore the "background" pixels in decal,
-             * which is identified by the delim tile in the stock
-             * tile set which is 100% background.
-             */
-            switch(vesa_pixel_bytes) {
-                case 1: {
-                        uint8_t *t1 = (uint8_t *) tptr,
-                                *t2 = (uint8_t *) declptr,
-                                *t3 = (uint8_t *) dst;
-
-                        *t3 = (*t2 != tilebackground) ? *t2 : *t1;
-                    }
-                    break;
-                case 2: {
-                        uint16_t *t1 = (uint16_t *) tptr,
-                                 *t2 = (uint16_t *) declptr,
-                                 *t3 = (uint16_t *) dst;
-
-                        *t3 = (*t2 != tilebackground) ? *t2 : *t1;
-                    }
-                    break;
-                case 3: {
-                        uint8_t *t1 = (uint8_t *) tptr,
-                                *t2 = (uint8_t *) declptr,
-                                *t3 = (uint8_t *) dst;
-                        uint32_t pix = ((uint32_t) t2[2] << 16)
-                                     | ((uint32_t) t2[1] <<  8)
-                                     | ((uint32_t) t2[0] <<  0);
-
-                        if (pix != tilebackground) {
-                            t3[0] = t2[0];
-                            t3[1] = t2[1];
-                            t3[2] = t2[2];
-                        } else {
-                            t3[0] = t1[0];
-                            t3[1] = t1[1];
-                            t3[2] = t1[2];
-                        }
-                    }
-                    break;
-                case 4: {
-                        uint32_t *t1 = (uint32_t *) tptr,
-                                 *t2 = (uint32_t *) declptr,
-                                 *t3 = (uint32_t *) dst;
-
-                        *t3 = ((*t2 & 0x00FFFFFF) != tilebackground) ? *t2 : *t1;
-                    }
-                    break;
-                default: {
-                        unsigned char const *t1 = tptr;
-                        unsigned char *t3 = dst;
-
-                        for (int i = 0; i < vesa_pixel_bytes; ++i) {
-                            *t3 = *t1;
-                        }
-                    }
-                    break;
+                for (unsigned i = 0; i < p_row_size; i += vesa_pixel_bytes) {
+                    *t3 = (*t2 != transparent_pixel) ? *t2 : *t1;
+                    ++t1;
+                    ++t2;
+                    ++t3;
+                }
             }
-            tptr += vesa_pixel_bytes;
-            dst += vesa_pixel_bytes;
-            declptr += vesa_pixel_bytes;
-        }
+            break;
+        case 2: {
+                uint16_t *t1 = (uint16_t *) p_row,
+                         *t2 = (uint16_t *) p_overlay,
+                         *t3 = (uint16_t *) p_combined_row;
+
+                for (unsigned i = 0; i < p_row_size; i += vesa_pixel_bytes) {
+                    *t3 = (*t2 != transparent_pixel) ? *t2 : *t1;
+                    ++t1;
+                    ++t2;
+                    ++t3;
+                }
+            }
+            break;
+        case 3: {
+                uint8_t *t1 = (uint8_t *) p_row,
+                        *t2 = (uint8_t *) p_overlay,
+                        *t3 = (uint8_t *) p_combined_row;
+                for (unsigned i = 0; i < p_row_size; i += vesa_pixel_bytes) {
+                    uint32_t pix = ((uint32_t) t2[2] << 16)
+                                 | ((uint32_t) t2[1] <<  8)
+                                 | ((uint32_t) t2[0] <<  0);
+
+                    if (pix != transparent_pixel) {
+                        t3[0] = t2[0];
+                        t3[1] = t2[1];
+                        t3[2] = t2[2];
+                    } else {
+                        t3[0] = t1[0];
+                        t3[1] = t1[1];
+                        t3[2] = t1[2];
+                    }
+                    t1 += 3;
+                    t2 += 3;
+                    t3 += 3;
+                }
+            }
+            break;
+        case 4: {
+                uint32_t *t1 = (uint32_t *) p_row,
+                         *t2 = (uint32_t *) p_overlay,
+                         *t3 = (uint32_t *) p_combined_row;
+
+                for (unsigned i = 0; i < p_row_size; i += vesa_pixel_bytes) {
+                    *t3 = ((*t2 & 0x00FFFFFF) != transparent_pixel) ? *t2 : *t1;
+                    ++t1;
+                    ++t2;
+                    ++t3;
+                }
+            }
+            break;
+        default:
+            /* This isn't supposed to happen */
+            memcpy(p_combined_row, p_row, p_row_size);
+            break;
     }
-    return tmptilebuf;
+
+    return p_combined_row;
 }
 #endif /* TILES_IN_GLYPHMAP */
 

--- a/sys/msdos/vidvga.c
+++ b/sys/msdos/vidvga.c
@@ -121,6 +121,7 @@ static void vga_scrollmap(boolean);
 static void vga_redrawmap(boolean);
 static void vga_cliparound(int, int);
 static void decal_planar(struct planar_cell_struct *, unsigned);
+static void decal_oview_planar(struct overview_planar_cell_struct *, unsigned);
 #endif
 
 #ifdef POSITIONBAR
@@ -141,6 +142,7 @@ static void vga_WriteStr(char *, int, int, int, int);
 static char __far *vga_FontPtrs(void);
 
 #ifdef TILES_IN_GLYPHMAP
+static int glyph_to_tilenum(unsigned);
 static void read_planar_tile(unsigned, struct planar_cell_struct *);
 static void read_planar_tile_O(unsigned,
                                struct overview_planar_cell_struct *);
@@ -243,6 +245,10 @@ static int vp[SCREENPLANES] = { 8, 4, 2, 1 };
 #ifdef TILES_IN_GLYPHMAP
 static struct planar_cell_struct **cell_cache;
 static struct overview_planar_cell_struct **cell_cache_O;
+
+enum { delimdecal, petdecal, piledecal, NUMDECALS };
+static struct cellplane *decal_alpha[NUMDECALS] = { 0 };
+static struct overview_cellplane *decal_oview_alpha[NUMDECALS] = { 0 };
 #endif
 
 /* static int  g_attribute; */ /* Current attribute to use */
@@ -442,8 +448,8 @@ vga_xputg(const glyph_info *glyphinfo,
     } else if (!iflags.over_view) {
         if ((col >= clipx) && (col <= clipxmax)) {
             struct planar_cell_struct planecell;
-            read_planar_tile(glyphnum, &planecell);
-            if (map[ry][col].special)
+            read_planar_tile(glyph_to_tilenum(glyphnum), &planecell);
+            if (special)
                 decal_planar(&planecell, special);
             vga_DisplayCell(&planecell, col - clipx, row);
             if (bkglyphinfo->framecolor != NO_COLOR) {
@@ -459,7 +465,9 @@ vga_xputg(const glyph_info *glyphinfo,
         }
     } else {
         struct overview_planar_cell_struct planecell_O;
-        read_planar_tile_O(glyphnum, &planecell_O);
+        read_planar_tile_O(glyph_to_tilenum(glyphnum), &planecell_O);
+        if (special)
+            decal_oview_planar(&planecell_O, special);
         vga_DisplayCell_O(&planecell_O, col, row);
     }
     if (col < (CO - 1))
@@ -546,13 +554,15 @@ vga_redrawmap(boolean clearfirst)
                 t = map[y][x].glyph;
                 if (!iflags.over_view) {
                     struct planar_cell_struct planecell;
-                    read_planar_tile(t, &planecell);
+                    read_planar_tile(glyph_to_tilenum(t), &planecell);
                     if (map[y][x].special)
                         decal_planar(&planecell, map[y][x].special);
                     vga_DisplayCell(&planecell, x - clipx, y + TOP_MAP_ROW);
                 } else {
                     struct overview_planar_cell_struct planecell_O;
-                    read_planar_tile_O(t, &planecell_O);
+                    read_planar_tile_O(glyph_to_tilenum(t), &planecell_O);
+                    if (map[y][x].special)
+                        decal_oview_planar(&planecell_O, map[y][x].special);
                     vga_DisplayCell_O(&planecell_O, x, y + TOP_MAP_ROW);
                 }
             }
@@ -684,7 +694,7 @@ boolean left;
         for (x = i; x < j; x += 2) {
             struct planar_cell_struct planecell;
             t = map[y][x].glyph;
-            read_planar_tile(t, &planecell);
+            read_planar_tile(glyph_to_tilenum(t), &planecell);
             if (map[y][x].special)
                 decal_planar(&planecell, map[y][x].special);
             vga_DisplayCell(&planecell, x - clipx, y + TOP_MAP_ROW);
@@ -693,13 +703,23 @@ boolean left;
 }
 #endif /* SCROLLMAP */
 
+static int
+glyph_to_tilenum(unsigned glyph)
+{
+    /* We don't have enough colors to show the statues */
+    if (glyph_is_statue(glyph)) {
+        glyph = GLYPH_OBJ_OFF + STATUE;
+    }
+
+    return glyphmap[glyph].tileidx;
+}
+
 static void
-read_planar_tile(unsigned glyph, struct planar_cell_struct *cell)
+read_planar_tile(unsigned tilenum, struct planar_cell_struct *cell)
 {
     struct planar_cell_struct *pcell;
     unsigned char indexes[TILE_Y][TILE_X];
     unsigned plane, y, byte, bit;
-    int tilenum = glyphmap[glyph].tileidx;
 
     /* Get the processed tile from the cache if we can */
     pcell = cell_cache[tilenum];
@@ -707,7 +727,7 @@ read_planar_tile(unsigned glyph, struct planar_cell_struct *cell)
         /* Process the tile */
         pcell = (struct planar_cell_struct *) alloc(sizeof(*pcell));
         cell_cache[tilenum] = pcell;
-        read_tile_indexes(glyph, indexes);
+        read_tile_indexes(tilenum, indexes);
         /* pcell->plane[0..3].image[0..15][0..1] */
         for (plane = 0; plane < SCREENPLANES; ++plane) {
             for (y = 0; y < TILE_Y; ++y) {
@@ -729,12 +749,11 @@ read_planar_tile(unsigned glyph, struct planar_cell_struct *cell)
 }
 
 static void
-read_planar_tile_O(unsigned glyph, struct overview_planar_cell_struct *cell)
+read_planar_tile_O(unsigned tilenum, struct overview_planar_cell_struct *cell)
 {
     struct overview_planar_cell_struct *pcell;
     unsigned char indexes[TILE_Y][TILE_X];
     unsigned plane, y, bit;
-    int tilenum = glyphmap[glyph].tileidx;
 
     /* Get the processed tile from the cache if we can */
     pcell = cell_cache_O[tilenum];
@@ -742,7 +761,7 @@ read_planar_tile_O(unsigned glyph, struct overview_planar_cell_struct *cell)
         /* Process the tile */
         pcell = (struct overview_planar_cell_struct *) alloc(sizeof(*pcell));
         cell_cache_O[tilenum] = pcell;
-        read_tile_indexes(glyph, indexes);
+        read_tile_indexes(tilenum, indexes);
         /* pcell->plane[0..3].image[0..15][0..0] */
         for (plane = 0; plane < SCREENPLANES; ++plane) {
             for (y = 0; y < TILE_Y; ++y) {
@@ -762,19 +781,12 @@ read_planar_tile_O(unsigned glyph, struct overview_planar_cell_struct *cell)
 }
 
 static void
-read_tile_indexes(unsigned glyph, unsigned char (*indexes)[TILE_X])
+read_tile_indexes(unsigned tilenum, unsigned char (*indexes)[TILE_X])
 {
     const struct TileImage *tile;
     unsigned x, y;
-    int tilenum;
-
-    /* We don't have enough colors to show the statues */
-    if (glyph_is_statue(glyph)) {
-        glyph = GLYPH_OBJ_OFF + STATUE;
-    }
 
     /* Get the tile from the image */
-    tilenum = glyphmap[glyph].tileidx;
     tile = get_tile(tilenum);
 
     /* Map to a 16 bit palette; assume colors laid out as in default tileset */
@@ -792,13 +804,122 @@ read_tile_indexes(unsigned glyph, unsigned char (*indexes)[TILE_X])
 }
 
 static void
-decal_planar(struct planar_cell_struct *gpcs UNUSED, unsigned special)
+decal_planar(struct planar_cell_struct *gpcs, unsigned special)
 {
-    if (special & MG_CORPSE) {
-    } else if (special & MG_INVIS) {
-    } else if (special & MG_DETECT) {
-    } else if (special & MG_PET) {
-    } else if (special & MG_RIDDEN) {
+    int decalnum;   /* indexes decal_alpha */
+    int decal_tile; /* tile index of decal */
+
+    /* Which decal do we use? */
+    if ((special & MG_PET) != 0 && iflags.hilite_pet) {
+        decalnum = petdecal;
+        decal_tile = Tile_petmark;
+    } else if ((special & MG_OBJPILE) != 0 && iflags.hilite_pile) {
+        decalnum = piledecal;
+        decal_tile = Tile_pilemark;
+    } else {
+        /* No decal */
+        return;
+    }
+
+    /* Read the decal */
+    struct planar_cell_struct decal;
+    read_planar_tile(decal_tile, &decal);
+
+    /* Build the alpha channel for the decal */
+    struct cellplane *alpha = decal_alpha[decalnum];
+
+    if (alpha == NULL) {
+        /* Read the delimiter to get the background color */
+        struct planar_cell_struct delim;
+        read_planar_tile(Tile_delimiter, &delim);
+
+        /* Allocate space for the alpha channel */
+        alpha = (struct cellplane *) alloc(sizeof(*alpha));
+        decal_alpha[decalnum] = alpha;
+        memset(alpha, 0x00, sizeof(*alpha));
+
+        /* Alpha channel is 0 where all planes of the decal match the
+           background, and 1 otherwise */
+        for (unsigned i = 0; i < SCREENPLANES; ++i) {
+            uint8_t background = (delim.plane[i].image[0][0] & 0x80) ? 0xFF : 0x00;
+            for (unsigned j = 0; j < MAX_ROWS_PER_CELL; ++j) {
+                for (unsigned k = 0; k < MAX_BYTES_PER_CELL; ++k) {
+                    /* Set alpha to 1 wherever the decal doesn't match the
+                       background */
+                    alpha->image[j][k] |= decal.plane[i].image[j][k] ^ background;
+                }
+            }
+        }
+    }
+
+    /* Apply the decal to the tile */
+    for (unsigned i = 0; i < SCREENPLANES; ++i) {
+        for (unsigned j = 0; j < MAX_ROWS_PER_CELL; ++j) {
+            for (unsigned k = 0; k < MAX_BYTES_PER_CELL; ++k) {
+                uint8_t b1 = gpcs->plane[i].image[j][k];
+                uint8_t b2 = decal.plane[i].image[j][k];
+                uint8_t a = alpha->image[j][k];
+                gpcs->plane[i].image[j][k] = (b1 & ~a) | (b2 & a);
+            }
+        }
+    }
+}
+
+static void
+decal_oview_planar(struct overview_planar_cell_struct *gpcs, unsigned special)
+{
+    int decalnum;   /* indexes decal_alpha */
+    int decal_tile; /* tile index of decal */
+
+    /* Which decal do we use? */
+    if ((special & MG_PET) != 0 && iflags.hilite_pet) {
+        decalnum = petdecal;
+        decal_tile = Tile_petmark;
+    } else if ((special & MG_OBJPILE) != 0 && iflags.hilite_pile) {
+        decalnum = piledecal;
+        decal_tile = Tile_pilemark;
+    } else {
+        /* No decal */
+        return;
+    }
+
+    /* Read the decal */
+    struct overview_planar_cell_struct decal;
+    read_planar_tile_O(decal_tile, &decal);
+
+    /* Build the alpha channel for the decal */
+    struct overview_cellplane *alpha = decal_oview_alpha[decalnum];
+
+    if (alpha == NULL) {
+        /* Read the delimiter to get the background color */
+        struct planar_cell_struct delim; /* not overview_planar_cell_struct */
+        read_planar_tile(Tile_delimiter, &delim);
+
+        /* Allocate space for the alpha channel */
+        alpha = (struct overview_cellplane *) alloc(sizeof(*alpha));
+        decal_oview_alpha[decalnum] = alpha;
+        memset(alpha, 0x00, sizeof(*alpha));
+
+        /* Alpha channel is 0 where all planes of the decal match the
+           background, and 1 otherwise */
+        for (unsigned i = 0; i < SCREENPLANES; ++i) {
+            uint8_t background = (delim.plane[i].image[0][0] & 0x80) ? 0xFF : 0x00;
+            for (unsigned j = 0; j < MAX_ROWS_PER_CELL; ++j) {
+                /* Set alpha to 1 wherever the decal doesn't match the
+                   background */
+                alpha->image[j][0] |= decal.plane[i].image[j][0] ^ background;
+            }
+        }
+    }
+
+    /* Apply the decal to the tile */
+    for (unsigned i = 0; i < SCREENPLANES; ++i) {
+        for (unsigned j = 0; j < MAX_ROWS_PER_CELL; ++j) {
+            uint8_t b1 = gpcs->plane[i].image[j][0];
+            uint8_t b2 = decal.plane[i].image[j][0];
+            uint8_t a = alpha->image[j][0];
+            gpcs->plane[i].image[j][0] = (b1 & ~a) | (b2 & a);
+        }
     }
 }
 #endif /* TILES_IN_GLYPHMAP */

--- a/sys/msdos/vidvga.c
+++ b/sys/msdos/vidvga.c
@@ -136,7 +136,7 @@ static void vga_DisplayCell_O(struct overview_planar_cell_struct *, int,
 #endif
 static void vga_SwitchMode(unsigned int);
 static void vga_SetPalette(const struct Pixel *);
-static void vga_WriteChar(uint32, int, int, int);
+static void vga_WriteChar(uint32, int, int, int, int);
 static void vga_GetBitmap(uint32, unsigned char *);
 static void vga_WriteStr(char *, int, int, int, int);
 static char __far *vga_FontPtrs(void);
@@ -181,6 +181,7 @@ static struct map_struct {
     unsigned special;
     short int tileidx;
     uint32 framecolor;
+    int inverse;
 } map[ROWNO][COLNO]; /* track the glyphs */
 
 extern int total_tiles_used,
@@ -200,6 +201,7 @@ extern int total_tiles_used,
                 map[y][x].attr = 0;                             \
                 map[y][x].special = 0;                          \
                 map[y][x].tileidx = Tile_unexplored;            \
+                map[y][x].inverse = 0;                          \
             }                                                   \
     }
 #endif /* TILES_IN_GLYPHMAP */
@@ -308,7 +310,7 @@ void vga_cl_end(int col, int row)
      * mode 2 methods as did term_clear_screen()
      */
     for (count = col; count < (CO - 1); ++count) {
-        vga_WriteChar(' ', count, row, BACKGROUND_VGA_COLOR);
+        vga_WriteChar(' ', count, row, BACKGROUND_VGA_COLOR, FALSE);
     }
 }
 
@@ -320,7 +322,7 @@ void vga_cl_eos(int cy)
     cl_end();
     while (cy <= LI - 2) {
         for (count = 0; count < (CO - 1); ++count) {
-            vga_WriteChar(' ', count, cy, BACKGROUND_VGA_COLOR);
+            vga_WriteChar(' ', count, cy, BACKGROUND_VGA_COLOR, FALSE);
         }
         cy++;
     }
@@ -392,7 +394,7 @@ void vga_xputc(char ch, int attr)
         ++row;
         break;
     default:
-        vga_WriteChar((unsigned char) ch, col, row, attr);
+        vga_WriteChar((unsigned char) ch, col, row, attr, FALSE);
         if (col < (CO - 1))
             ++col;
         break;
@@ -439,12 +441,13 @@ vga_xputg(const glyph_info *glyphinfo,
     attr = (g_attribute == 0) ? attrib_gr_normal : g_attribute;
     map[ry][col].attr = attr;
     map[ry][col].tileidx = glyphinfo->gm.tileidx;
+    map[ry][col].inverse = inversed;
     if (bkglyphinfo->framecolor != NO_COLOR) {
         map[ry][col].framecolor = bkglyphinfo->framecolor;
     }
 
     if (iflags.traditional_view) {
-        vga_WriteChar(ch, col, row, attr);
+        vga_WriteChar(ch, col, row, attr, inversed);
     } else if (!iflags.over_view) {
         if ((col >= clipx) && (col <= clipxmax)) {
             struct planar_cell_struct planecell;
@@ -549,7 +552,8 @@ vga_redrawmap(boolean clearfirst)
             if (iflags.traditional_view) {
                 if (!(clearfirst && map[y][x].ch == S_stone))
                     vga_WriteChar(map[y][x].ch, x,
-                                  y + TOP_MAP_ROW, map[y][x].attr);
+                                  y + TOP_MAP_ROW, map[y][x].attr,
+                                  map[y][x].inverse);
             } else {
                 t = map[y][x].glyph;
                 if (!iflags.over_view) {
@@ -1162,7 +1166,7 @@ extern int curframecolor;    /* video.c */
  *
  */
 static void
-vga_WriteChar(uint32 chr, int col, int row, int colour)
+vga_WriteChar(uint32 chr, int col, int row, int colour, int inverse)
 {
     int i;
     int x, pixy;
@@ -1182,7 +1186,7 @@ vga_WriteChar(uint32 chr, int col, int row, int colour)
     else
         bgcolor = CLR_BLACK;
 
-    if (inversed) {
+    if (inverse) {
         int tmpc = actual_colour;
         actual_colour = bgcolor;
         bgcolor = tmpc;
@@ -1346,7 +1350,7 @@ vga_WriteStr(char *s, int len, int col, int row, int colour)
     i = 0;
     us = (unsigned char *) s;
     while ((*us != 0) && (i < len) && (col < (CO - 1))) {
-        vga_WriteChar((uchar) *us, col, row, colour);
+        vga_WriteChar((uchar) *us, col, row, colour, FALSE);
         ++us;
         ++i;
         ++col;

--- a/sys/share/NetHack.cnf
+++ b/sys/share/NetHack.cnf
@@ -30,6 +30,8 @@ OPTIONS=rawio,BIOS,symset:IBMGraphics_2,roguesymset:RogueEpyx
 #OPTIONS=video_width:1024
 #OPTIONS=video_height:768
 
+# To show markers for pets and piles if this is supported
+OPTIONS=hilite_pet,hilite_pile
 
 # If your machine is NEC PC-9800, use:
 #OPTIONS=rawio,BIOS,video:default


### PR DESCRIPTION
* Support decals in all VESA modes and in 16 color mode.
* Support decals in the overview modes as well as the normal map mode.
* Provide correct highlighting for vga_redrawmap and vesa_redrawmap.
* Provide the hilite_pet and hilite_pile flags in the default configuration file.