### PR TITLE
Mac68k: permanent inventory and map overview windows, window management

### DIFF
--- a/include/macwin.h
+++ b/include/macwin.h
@@ -188,6 +188,9 @@ extern void macprefs_note_perminv(Boolean); /* persist windoid open/closed */
 
 /* macwin.c: update-event dispatch for movable-modal dialog filters */
 extern void mac_handle_update_event(EventRecord *);
+
+/* macwin.c: Game > Save Window Positions */
+extern void mac_save_window_positions(void);
 extern Boolean RetrieveWinPos(WindowPtr, short *, short *);
 
 /* ### macerrs.c ### */

--- a/include/macwin.h
+++ b/include/macwin.h
@@ -57,7 +57,9 @@ extern MacFlags macFlags;
 #define kTextWindow 3
 #define kMenuWindow 4
 #define kMapTileWindow 5
-#define kLastWindowKind kMapTileWindow
+#define kInvenWindow 6 /* perm-invent windoid; separate from kMenuWindow
+                          so dragging it doesn't move future menus */
+#define kLastWindowKind kInvenWindow
 
 /* WIND resource IDs (templates in sys/mac68k/nhmapwind.r) */
 #define kWindMapDocument      200 /* map, decorated (scrollbars + grow box) */
@@ -158,7 +160,8 @@ extern void SaveSizeForKind(short kind, short height, short width);
    and applied at startup AFTER initoptions(), so they override the
    NetHack Defaults file.  valid==0 (never saved / "Forget Settings")
    leaves the config-file values alone. */
-#define UIPREFS_VERSION 2 /* v2: added menutiles */
+#define UIPREFS_VERSION 3 /* v2: menutiles; v3: perminv_open + the
+                             kInvenWindow position slot */
 enum uiprefs_fonts {
     uiFontMap = 0, uiFontStatus, uiFontMessage, uiFontMenu, uiFontText,
     UIPREFS_NFONTS
@@ -170,7 +173,7 @@ typedef struct UiPrefs {
     char hitpointbar;
     char statuslines;            /* 2 or 3 */
     char menutiles;              /* item tiles in menu rows */
-    char pad_;                   /* keep the shorts word-aligned */
+    char perminv_open;           /* windoid was open at last save */
     Str31 fonts[UIPREFS_NFONTS]; /* fonts[i][0]==0 => port default */
     short sizes[UIPREFS_NFONTS]; /* 0 => port default */
 } UiPrefs;
@@ -181,6 +184,7 @@ extern void StoreUiPrefs(const UiPrefs *);
 
 extern void macprefs_dialog(void);
 extern void macprefs_apply_startup(void);
+extern void macprefs_note_perminv(Boolean); /* persist windoid open/closed */
 
 /* macwin.c: update-event dispatch for movable-modal dialog filters */
 extern void mac_handle_update_event(EventRecord *);

--- a/include/macwin.h
+++ b/include/macwin.h
@@ -59,7 +59,8 @@ extern MacFlags macFlags;
 #define kMapTileWindow 5
 #define kInvenWindow 6 /* perm-invent windoid; separate from kMenuWindow
                           so dragging it doesn't move future menus */
-#define kLastWindowKind kInvenWindow
+#define kOverviewWindow 7 /* map overview windoid (macmap.c) */
+#define kLastWindowKind kOverviewWindow
 
 /* WIND resource IDs (templates in sys/mac68k/nhmapwind.r) */
 #define kWindMapDocument      200 /* map, decorated (scrollbars + grow box) */
@@ -122,6 +123,8 @@ typedef struct NhWindow {
     long windowTextLen;
     short scrollPos;
     ControlHandle scrollBar;
+    ControlHandle hScrollBar; /* perm-invent windoid only: horizontal */
+    short hScrollPos;         /* pixels scrolled left */
 
     Boolean tile_mode;        /* tile rendering enabled (map window only) */
 } NhWindow;
@@ -160,8 +163,10 @@ extern void SaveSizeForKind(short kind, short height, short width);
    and applied at startup AFTER initoptions(), so they override the
    NetHack Defaults file.  valid==0 (never saved / "Forget Settings")
    leaves the config-file values alone. */
-#define UIPREFS_VERSION 3 /* v2: menutiles; v3: perminv_open + the
-                             kInvenWindow position slot */
+/* Bumped whenever UiPrefs or the savePos[] layout changes; a stored
+   record with any other version is discarded (maccurs.c InitWinFile),
+   so there is no migration path. */
+#define UIPREFS_VERSION 4
 enum uiprefs_fonts {
     uiFontMap = 0, uiFontStatus, uiFontMessage, uiFontMenu, uiFontText,
     UIPREFS_NFONTS
@@ -174,6 +179,8 @@ typedef struct UiPrefs {
     char statuslines;            /* 2 or 3 */
     char menutiles;              /* item tiles in menu rows */
     char perminv_open;           /* windoid was open at last save */
+    char sounds;                 /* soundlib on/off (iflags.sounds) */
+    char overview_open;          /* map overview windoid open at last save */
     Str31 fonts[UIPREFS_NFONTS]; /* fonts[i][0]==0 => port default */
     short sizes[UIPREFS_NFONTS]; /* 0 => port default */
 } UiPrefs;
@@ -185,6 +192,7 @@ extern void StoreUiPrefs(const UiPrefs *);
 extern void macprefs_dialog(void);
 extern void macprefs_apply_startup(void);
 extern void macprefs_note_perminv(Boolean); /* persist windoid open/closed */
+extern void macprefs_note_overview(Boolean); /* ditto, overview windoid */
 
 /* macwin.c: update-event dispatch for movable-modal dialog filters */
 extern void mac_handle_update_event(EventRecord *);
@@ -275,6 +283,8 @@ E void mac_delay_output(void);
 /* macwin.c: palette-safe text color, shared by menus and status */
 extern void mac_set_text_color(int);
 extern short mac_main_depth(void); /* main-device pixel depth (1 = B&W) */
+extern WindowPtr FrontGameWindow(void); /* FrontWindow() minus the
+                                           floating overview windoid */
 
 /* macstat.c: native status renderer */
 extern void mac_status_init(void);

--- a/sys/mac68k/NHDeflts
+++ b/sys/mac68k/NHDeflts
@@ -41,6 +41,11 @@ OPTIONS=hitpointbar
 # costs a status row of screen space, so leave at 2 on an SE/30):
 #OPTIONS=statuslines:3
 
+# The persistent inventory window: '|' (or #perminv) opens it, it stays
+# open and updates itself while you play, and its close box puts it away.
+# 'i' remains the normal inventory (pick an item for its action menu).
+OPTIONS=perm_invent
+
 # Sound (handled separately in 3.7)
 #OPTIONS=soundlib:macsound
 

--- a/sys/mac68k/NHDeflts
+++ b/sys/mac68k/NHDeflts
@@ -192,6 +192,9 @@ OPTIONS=hilite_status:carrying-capacity/Stressed/orange
 OPTIONS=hilite_status:carrying-capacity/Strained/red&bold
 OPTIONS=hilite_status:carrying-capacity/Overtaxed/red&inverse
 OPTIONS=hilite_status:carrying-capacity/Overloaded/red&inverse
+# Conditions: deadly ones inverse red, nuisances yellow.
+OPTIONS=hilite_status:condition/major_troubles/red&inverse
+OPTIONS=hilite_status:condition/minor_troubles/yellow
 
 # Hunger: flag both dangerous ends.
 OPTIONS=hilite_status:hunger/Satiated/brown

--- a/sys/mac68k/maccurs.c
+++ b/sys/mac68k/maccurs.c
@@ -205,6 +205,8 @@ GetWinKind(WindowPtr win)
     short kind;
     extern WindowPtr _mt_window;
 
+    if (win && GetWRefCon(win) == MACOVERVIEW_REFCON)
+        return kOverviewWindow;             /* not an NhWindow; check first */
     if (!CheckNhWin(win)) {
         return -1;
     }

--- a/sys/mac68k/maccurs.c
+++ b/sys/mac68k/maccurs.c
@@ -212,6 +212,8 @@ GetWinKind(WindowPtr win)
         return kMapWindow;
     if (win == _mt_window)                  /* shared base/status tty window */
         return kStatusWindow;
+    if (WIN_INVEN != WIN_ERR && win == theWindows[WIN_INVEN].its_window)
+        return kInvenWindow;                /* perm-invent windoid */
     kind = GetWindowKind(win) - WIN_BASE_KIND;
     if (kind < 0 || kind > NHW_TEXT) {
         return -1;

--- a/sys/mac68k/macmap.c
+++ b/sys/mac68k/macmap.c
@@ -11,6 +11,7 @@
 #include <QDOffscreen.h>
 #include <Palettes.h>
 #include <Controls.h>
+#include <Menus.h> /* GetMBarHeight, for the overview default spot */
 
 /* src/tile.c reserves a tile slot per statue-monster, but our PICT sheet has
    only the one generic statue tile; remap any out-of-sheet index to it. */
@@ -76,6 +77,15 @@ static void scroll_viewport_to(short new_col, short new_row);
 static void draw_cursor_border(int col, int row);
 static void queue_cell(int x, int y);
 static void flush_pending_cells(void);
+
+/* Overview windoid; see the block above its implementation below. */
+#define OV_SCALE 3
+#define OV_COLS (COLNO - 1) /* col 0 is unused, so it gets no pixels */
+static WindowPtr gOvWindow = NULL;
+static void ov_draw_cell(short x, short y);
+static void ov_repaint_range(short c0, short r0, short c1, short r1);
+static void ov_repaint_all(void);
+static void ov_mirror_pending(void);
 
 /* Union a backing-local cell rect into the pending dirty region. */
 static void
@@ -370,6 +380,11 @@ void
 macmap_destroy(NhWindow *map)
 {
     if (!map || gMap.owner != map) return;
+    if (gOvWindow) { /* before the shared palette goes away */
+        SetPalette(gOvWindow, (PaletteHandle) 0, false);
+        DisposeWindow(gOvWindow);
+        gOvWindow = NULL;
+    }
     if (gMap.backing) { DisposeGWorld(gMap.backing); gMap.backing = NULL; }
     if (gMap.palette) { DisposePalette(gMap.palette); gMap.palette = NULL; }
     if (map->its_window) {
@@ -773,6 +788,19 @@ void
 macmap_flush(void)
 {
     if (!gMap.owner || !gMap.owner->its_window) return;
+    {
+        /* reopen the overview at the first frame if it was open last
+           launch (game windows don't exist yet at prefs-apply time) */
+        static Boolean ov_startup_checked = false;
+
+        if (!ov_startup_checked) {
+            UiPrefs up;
+
+            ov_startup_checked = true;
+            if (RetrieveUiPrefs(&up) && up.overview_open)
+                macmap_overview_show();
+        }
+    }
     flush_pending_cells(); /* paint queued print_glyph cells (batched) */
     if (gMap.has_dirty && gMap.backing) {
         Rect r = gMap.dirty, b;
@@ -1101,6 +1129,7 @@ flush_pending_cells(void)
         if (batched)
             end_cell_batch();
     }
+    ov_mirror_pending(); /* pend fields are still intact here */
 }
 
 /* Move the viewport to (new_col,new_row), clamped, repainting via soft-scroll
@@ -1328,4 +1357,195 @@ macmap_pixel_to_cell(NhWindow *map, Point pt, int *col, int *row)
     if (col) *col = (pt.h / gMap.cell_w) + gMap.scroll_col;
     if (row) *row = (pt.v / gMap.cell_h) + gMap.scroll_row;
     (void) map;
+}
+
+/**********************************************************************
+ * Overview windoid: the whole level at OV_SCALE px per cell.
+ * Rendered from the text_cache/text_color caches (mode-independent),
+ * so it works in both text and tile map display.  Toggled from the
+ * Game menu; the close box hides it (both persist through
+ * UiPrefs.overview_open); position persists as kOverviewWindow.
+ */
+
+/* Color scheme depends on the live screen depth, not macFlags.color:
+   Color QD stays present when the monitor is switched to B&W, but the
+   black-background scheme would paint black on black there.  Refreshed
+   at the start of every repaint pass. */
+static Boolean gOvUseColor = false;
+
+/* caller has set the port to gOvWindow */
+static void
+ov_draw_cell(short x, short y)
+{
+    Rect r;
+    unsigned char ch = gMap.text_cache[y][x];
+    Boolean is_hero = ((int) x == (int) u.ux && (int) y == (int) u.uy);
+
+    SetRect(&r, (x - 1) * OV_SCALE, y * OV_SCALE,
+            x * OV_SCALE, (y + 1) * OV_SCALE);
+    if (gOvUseColor) {
+        if (ch == ' ' || ch == '\0') {
+            ForeColor(blackColor); /* unexplored: matches the map bg */
+        } else if (is_hero) {
+            ForeColor(whiteColor);
+        } else {
+            set_nh_color(gMap.text_color[y][x]);
+        }
+        PaintRect(&r);
+        ForeColor(blackColor);
+    } else {
+        /* B&W / low depth: white background, explored cells black */
+        if (ch == ' ' || ch == '\0')
+            EraseRect(&r);
+        else
+            PaintRect(&r);
+    }
+}
+
+/* end-exclusive cell range */
+static void
+ov_repaint_range(short c0, short r0, short c1, short r1)
+{
+    short x, y;
+
+    gOvUseColor = macFlags.color && mac_main_depth() >= 4;
+    if (c0 < 1) c0 = 1; /* col 0 unused, and not part of the content */
+    if (r0 < 0) r0 = 0;
+    if (c1 > COLNO) c1 = COLNO;
+    if (r1 > ROWNO) r1 = ROWNO;
+    for (y = r0; y < r1; y++)
+        for (x = c0; x < c1; x++)
+            ov_draw_cell(x, y);
+}
+
+static void
+ov_repaint_all(void)
+{
+    ov_repaint_range(0, 0, COLNO, ROWNO);
+}
+
+/* mirror the cells flush_pending_cells just repainted; called at the
+   per-frame flush boundary, so it's one port switch per frame */
+static void
+ov_mirror_pending(void)
+{
+    GrafPtr saveP;
+
+    if (!gOvWindow || !IsWindowVisible(gOvWindow))
+        return;
+    GetPort(&saveP);
+    SetPortWindowPort(gOvWindow);
+    if (gMap.pend_overflow) {
+        ov_repaint_range(gMap.pend_c0, gMap.pend_r0,
+                         gMap.pend_c1, gMap.pend_r1);
+    } else {
+        short i;
+
+        gOvUseColor = macFlags.color && mac_main_depth() >= 4;
+        for (i = 0; i < gMap.pend_n; i++)
+            ov_draw_cell(gMap.pend_x[i], gMap.pend_y[i]);
+    }
+    SetPort(saveP);
+}
+
+void
+macmap_overview_show(void)
+{
+    if (!gOvWindow) {
+        Rect b;
+        Str255 title;
+        short top = 0, left = 0;
+
+        if (!RetrievePosition(kOverviewWindow, &top, &left)) {
+            /* default: the screen's top-right corner (same spot the
+               Reposition Windows layout uses) */
+            left = qd.screenBits.bounds.right - OV_COLS * OV_SCALE - 4;
+            if (left < 0)
+                left = 0;
+            top = GetMBarHeight() + 24; /* menu bar + our title bar */
+        }
+        SetRect(&b, left, top,
+                left + OV_COLS * OV_SCALE, top + ROWNO * OV_SCALE);
+        C2P("Overview", title);
+        gOvWindow = macFlags.color
+            ? (WindowPtr) NewCWindow(0L, &b, title, false, noGrowDocProc,
+                                     (WindowPtr) -1L, true,
+                                     MACOVERVIEW_REFCON)
+            : NewWindow(0L, &b, title, false, noGrowDocProc,
+                        (WindowPtr) -1L, true, MACOVERVIEW_REFCON);
+        if (!gOvWindow)
+            return;
+        if (macFlags.color && gMap.palette)
+            NSetPalette(gOvWindow, gMap.palette, pmNoUpdates);
+    }
+    ShowWindow(gOvWindow);
+    {
+        GrafPtr saveP;
+
+        GetPort(&saveP);
+        SetPortWindowPort(gOvWindow);
+        ov_repaint_all();
+        SetPort(saveP);
+    }
+}
+
+void
+macmap_overview_hide(void)
+{
+    if (gOvWindow)
+        HideWindow(gOvWindow);
+}
+
+Boolean
+macmap_overview_visible(void)
+{
+    return gOvWindow && IsWindowVisible(gOvWindow);
+}
+
+WindowPtr
+macmap_overview_window(void)
+{
+    return gOvWindow;
+}
+
+/* content size, valid whether or not the window exists yet; the
+   default window layout reserves the right column from it */
+short
+macmap_overview_width(void)
+{
+    return OV_COLS * OV_SCALE;
+}
+
+short
+macmap_overview_height(void)
+{
+    return ROWNO * OV_SCALE;
+}
+
+/* Floating layer, which System 7 does not provide: whenever another
+   window got in front of the overview, put it back on top, hilited
+   active.  Called after every event (macwin.c HandleEvent), so a
+   SelectWindow elsewhere is undone on the next tick. */
+void
+macmap_overview_float(void)
+{
+    if (gOvWindow && IsWindowVisible(gOvWindow)
+        && FrontWindow() != gOvWindow) {
+        BringToFront(gOvWindow);
+        HiliteWindow(gOvWindow, true);
+    }
+}
+
+/* called from HandleUpdate inside BeginUpdate/EndUpdate */
+void
+macmap_overview_update_event(WindowPtr w)
+{
+    GrafPtr saveP;
+
+    if (!gOvWindow || w != gOvWindow)
+        return;
+    GetPort(&saveP);
+    SetPortWindowPort(gOvWindow);
+    ov_repaint_all();
+    SetPort(saveP);
 }

--- a/sys/mac68k/macmap.c
+++ b/sys/mac68k/macmap.c
@@ -1212,15 +1212,26 @@ macmap_grow_event(NhWindow *map, long newSize)
 
 /* Size the map window to fit as much map as fits in avail_w x avail_h, snapped
    to whole cells and never larger than the full map. Placement stays with
-   SanePositions(). */
+   SanePositions(). honor_saved caps the fit at the size saved in the prefs
+   file (per display mode), so a manual resize survives a restart; reset and
+   small screens pass false for the plain max-fit. */
 void
-macmap_fit(short avail_w, short avail_h)
+macmap_fit(short avail_w, short avail_h, Boolean honor_saved)
 {
     long full_w, full_h;
     short w, h, cols, rows;
     short map_cols = COLNO - 1;   /* col 0 unused */
     if (!gMap.owner || !gMap.owner->its_window) return;
     if (gMap.cell_w < 1 || gMap.cell_h < 1) return;
+    if (honor_saved) {
+        Rect b; short sh, sw;
+        GetWindowPortBounds(gMap.owner->its_window, &b);
+        if (RetrieveSize(gMap.tile_mode ? kMapTileWindow : kMapWindow,
+                         b.top, b.left, &sh, &sw)) {
+            if (sw < avail_w) avail_w = sw;
+            if (sh < avail_h) avail_h = sh;
+        }
+    }
     if (avail_w < gMap.cell_w + gMap.inset_r) avail_w = gMap.cell_w + gMap.inset_r;
     if (avail_h < gMap.cell_h + gMap.inset_b) avail_h = gMap.cell_h + gMap.inset_b;
     full_w = (long) map_cols * gMap.cell_w + gMap.inset_r;

--- a/sys/mac68k/macmap.c
+++ b/sys/mac68k/macmap.c
@@ -82,6 +82,7 @@ static void flush_pending_cells(void);
 #define OV_SCALE 3
 #define OV_COLS (COLNO - 1) /* col 0 is unused, so it gets no pixels */
 static WindowPtr gOvWindow = NULL;
+static Boolean gOvHasPalette = false; /* tile palette attached to it */
 static void ov_draw_cell(short x, short y);
 static void ov_repaint_range(short c0, short r0, short c1, short r1);
 static void ov_repaint_all(void);
@@ -177,14 +178,62 @@ static const RGBColor gNhColorRGB[16] = {
     {R16(0xFF), R16(0xFF), R16(0xFF)}    /* 15 CLR_WHITE   */
 };
 
+/* The effective RGB set_nh_color draws a NetHack color in: color 0
+   (black) would be invisible on the black map bg, so it shows as dark
+   gray. */
+static void
+nh_color_rgb(int color, RGBColor *out)
+{
+    *out = gNhColorRGB[color];
+    if (color == 0)
+        out->red = out->green = out->blue = R16(0x55);
+}
+
 static void
 set_nh_color(int color)
 {
+    RGBColor c;
+
     if (color < 0 || color >= 16) color = 8;   /* NO_COLOR */
-    RGBColor c = gNhColorRGB[color];
-    /* color 0 (black) would be invisible on the black map bg; show it as dark gray */
-    if (color == 0) { c.red = c.green = c.blue = R16(0x55); }
+    nh_color_rgb(color, &c);
     RGBForeColor(&c);
+}
+
+/* Nearest tile-palette entry for each NetHack color, resolved once when
+   the palette is built.  Drawing by index (PmForeColor) never asks the
+   Palette Manager to match an RGB, so it can never reassign a
+   pmTolerant entry out from under the tiles. */
+static short gNhColorIdx[16];
+
+static void
+build_nh_color_index(PaletteHandle pal)
+{
+    int c, j;
+
+    for (c = 0; c < 16; c++) {
+        RGBColor want;
+        long best = 0x7FFFFFFFL;
+        short bestj = 0;
+
+        nh_color_rgb(c, &want);
+        for (j = 0; j < TILE_PALETTE_ENTRIES; j++) {
+            RGBColor e;
+            long dr, dg, db, d;
+
+            GetEntryColor(pal, (short) j, &e);
+            /* compare at 8-bit precision: squaring three full 16-bit
+               deltas would overflow a signed long */
+            dr = ((long) e.red - want.red) / 256;
+            dg = ((long) e.green - want.green) / 256;
+            db = ((long) e.blue - want.blue) / 256;
+            d = dr * dr + dg * dg + db * db;
+            if (d < best) {
+                best = d;
+                bestj = (short) j;
+            }
+        }
+        gNhColorIdx[c] = bestj;
+    }
 }
 
 static Boolean
@@ -384,6 +433,7 @@ macmap_destroy(NhWindow *map)
         SetPalette(gOvWindow, (PaletteHandle) 0, false);
         DisposeWindow(gOvWindow);
         gOvWindow = NULL;
+        gOvHasPalette = false;
     }
     if (gMap.backing) { DisposeGWorld(gMap.backing); gMap.backing = NULL; }
     if (gMap.palette) { DisposePalette(gMap.palette); gMap.palette = NULL; }
@@ -441,6 +491,8 @@ macmap_set_mode(NhWindow *map, Boolean tile_mode)
                     gMap.palette = NewPalette(TILE_PALETTE_ENTRIES, ct,
                                               pmTolerant,
                                               TILE_PALETTE_TOLERANCE);
+                if (gMap.palette)
+                    build_nh_color_index(gMap.palette);
             }
             if (gMap.palette) {
                 SetPalette(map->its_window, gMap.palette, true);
@@ -1373,6 +1425,36 @@ macmap_pixel_to_cell(NhWindow *map, Point pt, int *col, int *row)
    at the start of every repaint pass. */
 static Boolean gOvUseColor = false;
 
+/* The tile palette outlives any one display mode, but it may not exist
+   yet when the overview is first shown (text mode builds none).  Attach
+   it on the first repaint pass that finds one, so PmForeColor below
+   always indexes a palette this window owns. */
+static void
+ov_sync_palette(void)
+{
+    if (gOvHasPalette || !gOvWindow || !gMap.palette || !macFlags.color)
+        return;
+    NSetPalette(gOvWindow, gMap.palette, pmNoUpdates);
+    gOvHasPalette = true;
+}
+
+/* Color select for the overview, which unlike the map draws straight
+   into an on-screen window carrying the tile palette.  Name the entry
+   by index so the Palette Manager is never asked to match an RGB and
+   can never reassign a pmTolerant slot.  Without a palette (text mode,
+   or a sheet that isn't 8bpp) there is nothing to protect and the RGB
+   path applies. */
+static void
+ov_set_color(int color)
+{
+    if (color < 0 || color >= 16)
+        color = 8; /* NO_COLOR, same fallback as set_nh_color */
+    if (gOvHasPalette)
+        PmForeColor(gNhColorIdx[color]);
+    else
+        set_nh_color(color);
+}
+
 /* caller has set the port to gOvWindow */
 static void
 ov_draw_cell(short x, short y)
@@ -1389,7 +1471,7 @@ ov_draw_cell(short x, short y)
         } else if (is_hero) {
             ForeColor(whiteColor);
         } else {
-            set_nh_color(gMap.text_color[y][x]);
+            ov_set_color(gMap.text_color[y][x]);
         }
         PaintRect(&r);
         ForeColor(blackColor);
@@ -1408,6 +1490,7 @@ ov_repaint_range(short c0, short r0, short c1, short r1)
 {
     short x, y;
 
+    ov_sync_palette();
     gOvUseColor = macFlags.color && mac_main_depth() >= 4;
     if (c0 < 1) c0 = 1; /* col 0 unused, and not part of the content */
     if (r0 < 0) r0 = 0;
@@ -1441,6 +1524,7 @@ ov_mirror_pending(void)
     } else {
         short i;
 
+        ov_sync_palette();
         gOvUseColor = macFlags.color && mac_main_depth() >= 4;
         for (i = 0; i < gMap.pend_n; i++)
             ov_draw_cell(gMap.pend_x[i], gMap.pend_y[i]);
@@ -1475,8 +1559,7 @@ macmap_overview_show(void)
                         (WindowPtr) -1L, true, MACOVERVIEW_REFCON);
         if (!gOvWindow)
             return;
-        if (macFlags.color && gMap.palette)
-            NSetPalette(gOvWindow, gMap.palette, pmNoUpdates);
+        ov_sync_palette();
     }
     ShowWindow(gOvWindow);
     {

--- a/sys/mac68k/macmap.c
+++ b/sys/mac68k/macmap.c
@@ -1189,11 +1189,8 @@ macmap_grow_event(NhWindow *map, long newSize)
     gMap.vis_rows = (cr.bottom - cr.top) / gMap.cell_h;
     if (gMap.vis_cols < 1) gMap.vis_cols = 1;
     if (gMap.vis_rows < 1) gMap.vis_rows = 1;
-    /* persist per display mode in the prefs file (text and tile sizes
-       are independent) */
-    SaveSizeForKind(gMap.tile_mode ? kMapTileWindow : kMapWindow,
-                    (short)(full.bottom - full.top),
-                    (short)(full.right - full.left));
+    /* not persisted here: Game > Save Window Positions snapshots the
+       per-mode size (text and tile sizes are independent there) */
     if (!allocate_backing()) {
         mac_dprintf("macmap: backing realloc failed on grow\n");
     }

--- a/sys/mac68k/macmap.h
+++ b/sys/mac68k/macmap.h
@@ -33,7 +33,7 @@ extern short   remap_tile_idx(int idx);
 /* Mac event callbacks. */
 extern void    macmap_update_event(NhWindow *map);
 extern void    macmap_grow_event(NhWindow *map, long newSize);
-extern void    macmap_fit(short avail_w, short avail_h);
+extern void    macmap_fit(short avail_w, short avail_h, Boolean honor_saved);
 extern Boolean macmap_click(NhWindow *map, Point pt, UInt32 modifiers);
 
 /* Viewport queries. */

--- a/sys/mac68k/macmap.h
+++ b/sys/mac68k/macmap.h
@@ -40,7 +40,21 @@ extern Boolean macmap_click(NhWindow *map, Point pt, UInt32 modifiers);
 extern void    macmap_pixel_to_cell(NhWindow *map, Point pt,
                                     int *col, int *row);
 
-/* WRefCon sentinel for identifying the map window in event dispatch. */
+/* Overview windoid: the whole level, a few pixels per cell.
+   Show/hide are pure UI; persisting UiPrefs.overview_open is the
+   caller's job (Game menu toggle / close box). */
+extern void    macmap_overview_show(void);
+extern void    macmap_overview_hide(void);
+extern Boolean macmap_overview_visible(void);
+extern WindowPtr macmap_overview_window(void); /* NULL until first shown */
+/* content size in pixels; both are valid before the first show */
+extern short   macmap_overview_width(void);
+extern short   macmap_overview_height(void);
+extern void    macmap_overview_update_event(WindowPtr w);
+extern void    macmap_overview_float(void); /* keep it the frontmost window */
+
+/* WRefCon sentinels for identifying our windows in event dispatch. */
 #define MACMAP_REFCON  ((long) 0x4E486D70)  /* 'NHmp' */
+#define MACOVERVIEW_REFCON ((long) 0x4E486F76)  /* 'NHov' */
 
 #endif /* MACMAP_H */

--- a/sys/mac68k/macmenu.c
+++ b/sys/mac68k/macmenu.c
@@ -106,6 +106,7 @@ enum {
     menuGameReposition,
     menuGameSavePositions,
     menuGameTileMode,
+    menuGameOverview,
     ____Game___1,
     menuGamePlayMode,
 
@@ -811,7 +812,7 @@ void
 AdjustMenus(short dimMenubar)
 {
     short newMenubar = mbarRegular;
-    WindowRef win = FrontWindow();
+    WindowRef win = FrontGameWindow(); /* skip the floating overview */
     short i;
 
     /* determine the new menubar state */
@@ -902,6 +903,8 @@ AdjustMenus(short dimMenubar)
                 SetItemMark(MHND_GAME, menuGameTileMode,
                             macmap_get_mode(_am_map) ? checkMark : noMark);
             }
+            SetItemMark(MHND_GAME, menuGameOverview,
+                        macmap_overview_visible() ? checkMark : noMark);
 
             /* Play Mode submenu: checkmark on the current mode; Explore is
                the only actionable item (one-way, regular mode only) */
@@ -982,6 +985,18 @@ DoMenuEvt(long menuEntry)
 
         case menuGameSavePositions:
             mac_save_window_positions();
+            break;
+
+        case menuGameOverview:
+            if (macmap_overview_visible()) {
+                macmap_overview_hide();
+                macprefs_note_overview(FALSE);
+            } else {
+                macmap_overview_show();
+                macprefs_note_overview(TRUE);
+            }
+            SetItemMark(MHND_GAME, menuGameOverview,
+                        macmap_overview_visible() ? checkMark : noMark);
             break;
 
         case menuGameTileMode: {
@@ -1333,4 +1348,8 @@ mactile_menu_refresh(void)
         DisableItem(MHND_GAME, menuGameTileMode);
     SetItemMark(MHND_GAME, menuGameTileMode,
                 macmap_get_mode(map) ? checkMark : noMark);
+    /* same deferred-sync path re-syncs the Overview mark when the
+       windoid is dismissed via its close box */
+    SetItemMark(MHND_GAME, menuGameOverview,
+                macmap_overview_visible() ? checkMark : noMark);
 }

--- a/sys/mac68k/macmenu.c
+++ b/sys/mac68k/macmenu.c
@@ -992,9 +992,9 @@ DoMenuEvt(long menuEntry)
             SetItemMark(MHND_GAME, menuGameTileMode,
                         newOn ? checkMark : noMark);
             iflags.wc_tiled_map = newOn;
-            /* queue ^R: synchronous redraw from menu-handler context doesn't
-               take; command-loop redraw re-emits print_glyph for the new mode */
-            AddToKeyQueue('R' & 0x1f, 1);
+            /* no ^R needed: print_glyph keeps both caches, so set_mode's
+               repaint_full_viewport + InvalWindowRect already redrew the
+               map; a queued redraw would repaint every cell a second time */
             break;
         }
         }

--- a/sys/mac68k/macmenu.c
+++ b/sys/mac68k/macmenu.c
@@ -104,6 +104,7 @@ enum {
     menuGameRedraw = 1,
     menuGamePrevMsg,
     menuGameReposition,
+    menuGameSavePositions,
     menuGameTileMode,
     ____Game___1,
     menuGamePlayMode,
@@ -977,6 +978,10 @@ DoMenuEvt(long menuEntry)
             /* queue ^R: synchronous redraw from menu-handler context doesn't
                take (window port unsettled), so redraw in the command loop */
             AddToKeyQueue('R' & 0x1f, 1);
+            break;
+
+        case menuGameSavePositions:
+            mac_save_window_positions();
             break;
 
         case menuGameTileMode: {

--- a/sys/mac68k/macprefs.c
+++ b/sys/mac68k/macprefs.c
@@ -2,7 +2,7 @@
 /* NetHack may be freely redistributed.  See license for details. */
 
 /* Preferences dialog: UI settings (map mode, hitpointbar, statuslines,
- * per-window fonts/sizes) persisted in the "NetHack Preferences" file
+ * sound, per-window fonts/sizes) persisted in the "NetHack Preferences" file
  * alongside the window positions (maccurs.c).  Applied at startup after
  * initoptions(), so a saved record overrides the NetHack Defaults file;
  * "Forget Settings" clears the record and the config file rules again.
@@ -11,6 +11,7 @@
 
 #include "hack.h"
 #include "macwin.h"
+#include "macmap.h" /* overview windoid show/hide */
 
 #include <Dialogs.h>
 #include <Menus.h>
@@ -37,7 +38,10 @@ enum {
     /* 18..22 labels, 23 note */
     prefMenuTiles = 24,
     prefDefaultRing = 25, /* bold outline around the Save button */
-    prefSeparator = 26    /* gray rule above the button row */
+    prefSeparator = 26,   /* gray rule above the button row */
+    /* 27: "Status lines:" label */
+    prefSound = 28,
+    prefRule2 = 29 /* gray rule between the checkbox group and fonts */
 };
 
 #define PREFS_SIZE_MENU 6101 /* transient size popup, built per click */
@@ -107,6 +111,8 @@ seed_current(UiPrefs *up)
     up->hitpointbar = iflags.wc2_hitpointbar ? 1 : 0;
     up->statuslines = (iflags.wc2_statuslines == 3) ? 3 : 2;
     up->menutiles = iflags.use_menu_glyphs ? 1 : 0;
+    up->sounds = iflags.sounds ? 1 : 0;
+    up->overview_open = macmap_overview_visible() ? 1 : 0;
     up->sizes[uiFontMap] = iflags.wc_fontsiz_map;
     up->sizes[uiFontStatus] = iflags.wc_fontsiz_status;
     up->sizes[uiFontMessage] = iflags.wc_fontsiz_message;
@@ -129,6 +135,22 @@ macprefs_note_perminv(Boolean open)
     if (up.perminv_open == (open ? 1 : 0))
         return; /* unchanged; skip the file write */
     up.perminv_open = open ? 1 : 0;
+    StoreUiPrefs(&up);
+}
+
+/* same, for the map overview windoid's open/closed state */
+void
+macprefs_note_overview(Boolean open)
+{
+    UiPrefs up;
+
+    if (!RetrieveUiPrefs(&up)) {
+        seed_current(&up);
+        up.valid = 1;
+    }
+    if (up.overview_open == (open ? 1 : 0))
+        return; /* unchanged; skip the file write */
+    up.overview_open = open ? 1 : 0;
     StoreUiPrefs(&up);
 }
 
@@ -203,7 +225,7 @@ pref_redraw(DialogRef dlog, DialogItemIndex item)
         PenSize(1, 1);
         return;
     }
-    if (item == prefSeparator) {
+    if (item == prefSeparator || item == prefRule2) {
         GetDialogItem(dlog, item, &type, &h, &r);
         PenPat(&qd.gray);
         MoveTo(r.left, r.top);
@@ -369,6 +391,7 @@ macprefs_dialog(void)
     set_check(dlog, prefTiles, up.tiled_map);
     set_check(dlog, prefHPbar, up.hitpointbar);
     set_check(dlog, prefMenuTiles, up.menutiles);
+    set_check(dlog, prefSound, up.sounds);
     set_check(dlog, prefLines2, up.statuslines != 3);
     set_check(dlog, prefLines3, up.statuslines == 3);
     for (i = 0; i < UIPREFS_NFONTS; i++) {
@@ -394,6 +417,8 @@ macprefs_dialog(void)
     SetDialogItem(dlog, prefDefaultRing, type, (Handle) redraw, &r);
     GetDialogItem(dlog, prefSeparator, &type, &h, &r);
     SetDialogItem(dlog, prefSeparator, type, (Handle) redraw, &r);
+    GetDialogItem(dlog, prefRule2, &type, &h, &r);
+    SetDialogItem(dlog, prefRule2, type, (Handle) redraw, &r);
     /* the initial GetNewDialog draw ran before the user-item procs were
        installed; repaint so the font popups aren't blank */
     GetWindowPortBounds(GetDialogWindow(dlog), &r);
@@ -402,7 +427,7 @@ macprefs_dialog(void)
     do {
         ModalDialog(filter, &item);
         if (item == prefTiles || item == prefHPbar
-            || item == prefMenuTiles) {
+            || item == prefMenuTiles || item == prefSound) {
             set_check(dlog, item, !get_check(dlog, item));
         } else if (item == prefLines2 || item == prefLines3) {
             set_check(dlog, prefLines2, item == prefLines2);
@@ -433,6 +458,10 @@ macprefs_dialog(void)
         up.tiled_map = get_check(dlog, prefTiles) ? 1 : 0;
         up.hitpointbar = get_check(dlog, prefHPbar) ? 1 : 0;
         up.menutiles = get_check(dlog, prefMenuTiles) ? 1 : 0;
+        up.sounds = get_check(dlog, prefSound) ? 1 : 0;
+        /* not a dialog item: the Game menu toggles it live; carry the
+           live state so Save doesn't clobber it */
+        up.overview_open = macmap_overview_visible() ? 1 : 0;
         up.statuslines = get_check(dlog, prefLines3) ? 3 : 2;
         for (i = 0; i < UIPREFS_NFONTS; i++) {
             if (fontSel[i] > 1) {
@@ -476,6 +505,7 @@ macprefs_apply_startup(void)
     iflags.wc2_hitpointbar = up.hitpointbar ? TRUE : FALSE;
     iflags.wc2_statuslines = (up.statuslines == 3) ? 3 : 2;
     iflags.use_menu_glyphs = up.menutiles ? TRUE : FALSE;
+    iflags.sounds = up.sounds ? TRUE : FALSE;
     for (i = 0; i < UIPREFS_NFONTS; i++) {
         if (up.fonts[i][0]) {
             fnum = 0;

--- a/sys/mac68k/macprefs.c
+++ b/sys/mac68k/macprefs.c
@@ -96,6 +96,42 @@ menu_item_for_font(const unsigned char *name)
     return 1;
 }
 
+/* fill a zeroed UiPrefs from the currently effective settings (dialog
+   opened with no saved record, or a windoid open/close needs a record
+   to write its flag into) */
+static void
+seed_current(UiPrefs *up)
+{
+    memset(up, 0, sizeof *up);
+    up->tiled_map = iflags.wc_tiled_map ? 1 : 0;
+    up->hitpointbar = iflags.wc2_hitpointbar ? 1 : 0;
+    up->statuslines = (iflags.wc2_statuslines == 3) ? 3 : 2;
+    up->menutiles = iflags.use_menu_glyphs ? 1 : 0;
+    up->sizes[uiFontMap] = iflags.wc_fontsiz_map;
+    up->sizes[uiFontStatus] = iflags.wc_fontsiz_status;
+    up->sizes[uiFontMessage] = iflags.wc_fontsiz_message;
+    up->sizes[uiFontMenu] = iflags.wc_fontsiz_menu;
+    up->sizes[uiFontText] = iflags.wc_fontsiz_text;
+}
+
+/* persist the windoid's open/closed state so the next launch can
+   restore it; creates the settings record on first use (seeded from
+   the effective values, so nothing else changes) */
+void
+macprefs_note_perminv(Boolean open)
+{
+    UiPrefs up;
+
+    if (!RetrieveUiPrefs(&up)) {
+        seed_current(&up);
+        up.valid = 1;
+    }
+    if (up.perminv_open == (open ? 1 : 0))
+        return; /* unchanged; skip the file write */
+    up.perminv_open = open ? 1 : 0;
+    StoreUiPrefs(&up);
+}
+
 /* point size a row currently resolves to: config value, else the live
    window's font size, else the port fallback -- used to seed the size
    popups so they show the real size instead of "(default)" */
@@ -303,19 +339,8 @@ macprefs_dialog(void)
     UserItemUPP redraw;
     ModalFilterUPP filter;
 
-    if (!RetrieveUiPrefs(&up)) {
-        /* no saved record: seed from the currently effective settings */
-        memset(&up, 0, sizeof up);
-        up.tiled_map = iflags.wc_tiled_map ? 1 : 0;
-        up.hitpointbar = iflags.wc2_hitpointbar ? 1 : 0;
-        up.statuslines = (iflags.wc2_statuslines == 3) ? 3 : 2;
-        up.menutiles = iflags.use_menu_glyphs ? 1 : 0;
-        up.sizes[uiFontMap] = iflags.wc_fontsiz_map;
-        up.sizes[uiFontStatus] = iflags.wc_fontsiz_status;
-        up.sizes[uiFontMessage] = iflags.wc_fontsiz_message;
-        up.sizes[uiFontMenu] = iflags.wc_fontsiz_menu;
-        up.sizes[uiFontText] = iflags.wc_fontsiz_text;
-    }
+    if (!RetrieveUiPrefs(&up))
+        seed_current(&up); /* no saved record: current effective values */
 
     fontMenu = NewMenu(PREFS_FONT_MENU, P_STRING_CONV("Fonts"));
     if (!fontMenu)

--- a/sys/mac68k/macstat.c
+++ b/sys/mac68k/macstat.c
@@ -216,6 +216,25 @@ macstat_redraw(void)
     }
     TextFace(normal);
     ForeColor(blackColor);
+    if (!small_screen) {
+        /* resize affordance: the window is a documentProc (growable);
+           clip to the corner so DrawGrowIcon's scrollbar frame lines
+           don't cross the status text */
+        RgnHandle oc = NewRgn();
+
+        if (oc) {
+            Rect gr;
+
+            GetClip(oc);
+            GetWindowPortBounds(_mt_window, &gr);
+            gr.left = gr.right - 15;
+            gr.top = gr.bottom - 15;
+            ClipRect(&gr);
+            DrawGrowIcon(_mt_window);
+            SetClip(oc);
+            DisposeRgn(oc);
+        }
+    }
     SetPort(savePort);
 }
 

--- a/sys/mac68k/macwin.c
+++ b/sys/mac68k/macwin.c
@@ -621,11 +621,17 @@ SanePositions(void)
             }
         }
 
+        /* Vertical gap between stacked windows: the frame line plus the
+           1px drop shadow extend 2px below the content, and the next
+           title bar needs its full title_h above -- 2px used to leave
+           the shadow lying ON the title (1px overlap) */
+        short vgap = small_screen ? 2 : 6;
+
         /* Fit the map into the space left by menu bar, message+status windows,
            and title bars; macmap_fit resizes the map window + viewport/backing */
         msg_top = y + title_h;
-        map_top = msg_top + msg_h + 2 + title_h;
-        avail_map_h = screenArea.bottom - map_top - (title_h + stat_h + 2);
+        map_top = msg_top + msg_h + vgap + title_h;
+        avail_map_h = screenArea.bottom - map_top - (title_h + stat_h + vgap);
         avail_map_w = screenArea.right - 4 - inv_w;
         macmap_fit(avail_map_w, avail_map_h, honor);
 
@@ -683,7 +689,7 @@ SanePositions(void)
                     stat_w = screenArea.right - 4;
             }
         }
-        stat_top = map_top + map_h + 2 + title_h;
+        stat_top = map_top + map_h + vgap + title_h;
         if (stat_top + stat_h > screenArea.bottom)
             stat_top = screenArea.bottom - stat_h - 2;
         if (stat_top < mbar_height + 2)
@@ -721,10 +727,11 @@ SanePositions(void)
         }
     }
 
-    /* Handle other windows (NHW_MENU / NHW_TEXT) */
+    /* Handle other windows (NHW_MENU / NHW_TEXT); the inventory windoid
+       is not a stray menu -- the strip placement above owns it */
     for (ix = 0; ix < NUM_MACWINDOWS; ix++) {
         if (ix != WIN_STATUS && ix != WIN_MESSAGE && ix != WIN_MAP
-            && ix != BASE_WINDOW) {
+            && ix != BASE_WINDOW && ix != WIN_INVEN) {
             theWindow = theWindows[ix].its_window;
             if (theWindow && ((WindowPeek) theWindow)->visible) {
                 int shift;
@@ -2430,10 +2437,35 @@ mac_curs(winid win, int x, int y)
     aWin->y_curs = y;
 }
 
+/* One-shot at the first input wait inside the moveloop: reopen the
+   inventory windoid if the preferences file says it was open when the
+   last session ended.  Shown via the select_menu intercept, so no
+   SelectWindow -- the map keeps the focus. */
+static void
+perminv_restore_check(void)
+{
+    static Boolean checked = false;
+    UiPrefs up;
+
+    if (checked || !program_state.in_moveloop)
+        return;
+    checked = true;
+    if (WIN_INVEN == WIN_ERR || !theWindows[WIN_INVEN].its_window
+        || IsWindowVisible(theWindows[WIN_INVEN].its_window))
+        return;
+    if (RetrieveUiPrefs(&up) && up.perminv_open)
+        repopulate_perminvent();
+}
+
 int
 mac_nh_poskey(coordxy *a, coordxy *b, int *c)
 {
-    int ch = mac_nhgetch();
+    int ch;
+
+    perminv_restore_check(); /* one-shot: reopen the inventory windoid
+        if it was open last session; here rather than update_inventory
+        because a quiet game start never triggers an inventory update */
+    ch = mac_nhgetch();
     *a = clicked_pos.h;
     *b = clicked_pos.v;
     *c = clicked_mod;
@@ -2640,18 +2672,36 @@ mac_select_menu(winid win, int how, menu_item **selected_list)
 
             if (!IsWindowVisible(theWin)) {
                 short top, left, sh, sw;
+                Boolean have_pos, have_size;
 
+                have_pos = RetrievePosition(kInvenWindow, &top, &left);
+                have_size = have_pos
+                            && RetrieveSize(kInvenWindow, top, left,
+                                            &sh, &sw);
                 adjust_window_pos(aWin, aWin->x_size + SBARWIDTH + 1,
                                   aWin->y_size * aWin->row_height);
-                /* adjust_window_pos treats the current width as a
-                   MINIMUM and sizes from the content; a size the user
-                   gave the windoid must win over that */
-                if (RetrievePosition(kInvenWindow, &top, &left)
-                    && RetrieveSize(kInvenWindow, top, left, &sh, &sw)) {
+                /* adjust_window_pos sizes from the content (current
+                   width as minimum) and clamps the position against
+                   that width -- restore the user's size, then re-apply
+                   the saved position the clamp may have shifted */
+                if (have_size)
                     SizeWindow(theWin, sw, sh, 1);
-                    if (aWin->scrollBar)
-                        DrawScrollbar(aWin); /* follow the new right edge */
+                if (have_pos) {
+                    MoveWindow(theWin, left, top, 0);
+                } else {
+                    /* never dragged: default to the right-hand strip
+                       that Reposition uses, not the creation spot */
+                    Rect scr = qd.screenBits.bounds, ir;
+
+                    OffsetRect(&scr, -scr.left, -scr.top);
+                    GetWindowPortBounds(theWin, &ir);
+                    left = scr.right - (ir.right - ir.left) - 4;
+                    if (left < 0)
+                        left = 0;
+                    MoveWindow(theWin, left, GetMBarHeight() + 24, 0);
                 }
+                if (have_size && aWin->scrollBar)
+                    DrawScrollbar(aWin); /* follow the new right edge */
             }
             ShowWindow(theWin);
             SetPortWindowPort(theWin);
@@ -2871,23 +2921,11 @@ mac_update_inventory(int arg)
         return;
     /* arg != 0: explicit #perminv ('|') -- open the windoid; arg == 0:
        inventory changed -- refresh only while it's visible (closed
-       window = no updates, that's the toggle) */
-    if (!arg && !IsWindowVisible(theWindows[WIN_INVEN].its_window)) {
-        /* one-shot: reopen at launch if it was open last session (the
-           first update fires right after the game enters the moveloop);
-           shown without SelectWindow so the map keeps the focus */
-        static Boolean perminv_restored = false;
-        UiPrefs up;
-
-        if (!perminv_restored) {
-            perminv_restored = true;
-            if (RetrieveUiPrefs(&up) && up.perminv_open) {
-                repopulate_perminvent();
-                return;
-            }
-        }
+       window = no updates, that's the toggle; the reopen-at-launch
+       one-shot lives in perminv_restore_check, called from the input
+       wait -- update_inventory may not fire at all on a quiet start) */
+    if (!arg && !IsWindowVisible(theWindows[WIN_INVEN].its_window))
         return;
-    }
     repopulate_perminvent();
     if (arg && IsWindowVisible(theWindows[WIN_INVEN].its_window)) {
         SelectWindow(theWindows[WIN_INVEN].its_window); /* an explicit

--- a/sys/mac68k/macwin.c
+++ b/sys/mac68k/macwin.c
@@ -2437,6 +2437,43 @@ mac_curs(winid win, int x, int y)
     aWin->y_curs = y;
 }
 
+/* Game > Save Window Positions: snapshot the position and size of
+   every standing game window into the preferences file.  Dragging
+   and growing save as you go; this is the explicit "keep this whole
+   arrangement", including layouts produced by Reposition, which
+   moves windows programmatically and saves nothing itself. */
+void
+mac_save_window_positions(void)
+{
+    WindowPtr w;
+    Rect b;
+
+    if (WIN_MAP != WIN_ERR && (w = theWindows[WIN_MAP].its_window) != 0
+        && IsWindowVisible(w)) {
+        SaveWindowPos(w); /* position lives in kMapWindow */
+        GetWindowPortBounds(w, &b);
+        /* size is per display mode (text vs tile) */
+        SaveSizeForKind(theWindows[WIN_MAP].tile_mode ? kMapTileWindow
+                                                      : kMapWindow,
+                        b.bottom - b.top, b.right - b.left);
+    }
+    if (WIN_MESSAGE != WIN_ERR
+        && (w = theWindows[WIN_MESSAGE].its_window) != 0
+        && IsWindowVisible(w)) {
+        SaveWindowPos(w);
+        SaveWindowSize(w);
+    }
+    if (_mt_window && IsWindowVisible(_mt_window)) { /* status */
+        SaveWindowPos(_mt_window);
+        SaveWindowSize(_mt_window);
+    }
+    if (WIN_INVEN != WIN_ERR && (w = theWindows[WIN_INVEN].its_window) != 0
+        && IsWindowVisible(w)) {
+        SaveWindowPos(w);
+        SaveWindowSize(w);
+    }
+}
+
 /* One-shot at the first input wait inside the moveloop: reopen the
    inventory windoid if the preferences file says it was open when the
    last session ended.  Shown via the select_menu intercept, so no

--- a/sys/mac68k/macwin.c
+++ b/sys/mac68k/macwin.c
@@ -1970,8 +1970,9 @@ WindowGoAway(EventRecord *theEvent, WindowPtr theWindow)
         } else {
             HideWindow(theWindow);
             if (WIN_INVEN != WIN_ERR && aWin - theWindows == WIN_INVEN) {
-                ; /* inventory windoid: hidden is all -- updates stop
-                     while it's closed; 'i' (#perminv) reopens it */
+                /* inventory windoid: hidden is all -- updates stop
+                   while it's closed; '|' (#perminv) reopens it */
+                macprefs_note_perminv(FALSE);
             } else if (aWin - theWindows != inSelect)
                 mac_destroy_nhwindow(aWin - theWindows);
             else /* if this IS the inSelect window put a close char */
@@ -2382,6 +2383,11 @@ mac_start_menu(winid win, unsigned long mbehavior)
     if (win != WIN_INVEN)
         HideWindow(theWindows[win].its_window); /* the inventory windoid
                                                    stays up through refills */
+    else
+        theWindows[win].drawn = TRUE; /* multi-item pickups refill
+            back-to-back with no update event between; drawn would still
+            be FALSE and mac_clear_nhwindow's early-out would skip the
+            menu-state reset, so add_menu APPENDS duplicate items */
     mac_clear_nhwindow(win);
 }
 
@@ -2569,9 +2575,21 @@ mac_select_menu(winid win, int how, menu_item **selected_list)
         if (theWin) {
             Rect rr;
 
-            if (!IsWindowVisible(theWin))
+            if (!IsWindowVisible(theWin)) {
+                short top, left, sh, sw;
+
                 adjust_window_pos(aWin, aWin->x_size + SBARWIDTH + 1,
                                   aWin->y_size * aWin->row_height);
+                /* adjust_window_pos treats the current width as a
+                   MINIMUM and sizes from the content; a size the user
+                   gave the windoid must win over that */
+                if (RetrievePosition(kInvenWindow, &top, &left)
+                    && RetrieveSize(kInvenWindow, top, left, &sh, &sw)) {
+                    SizeWindow(theWin, sw, sh, 1);
+                    if (aWin->scrollBar)
+                        DrawScrollbar(aWin); /* follow the new right edge */
+                }
+            }
             ShowWindow(theWin);
             SetPortWindowPort(theWin);
             GetWindowPortBounds(theWin, &rr);
@@ -2791,12 +2809,28 @@ mac_update_inventory(int arg)
     /* arg != 0: explicit #perminv ('|') -- open the windoid; arg == 0:
        inventory changed -- refresh only while it's visible (closed
        window = no updates, that's the toggle) */
-    if (!arg && !IsWindowVisible(theWindows[WIN_INVEN].its_window))
+    if (!arg && !IsWindowVisible(theWindows[WIN_INVEN].its_window)) {
+        /* one-shot: reopen at launch if it was open last session (the
+           first update fires right after the game enters the moveloop);
+           shown without SelectWindow so the map keeps the focus */
+        static Boolean perminv_restored = false;
+        UiPrefs up;
+
+        if (!perminv_restored) {
+            perminv_restored = true;
+            if (RetrieveUiPrefs(&up) && up.perminv_open) {
+                repopulate_perminvent();
+                return;
+            }
+        }
         return;
+    }
     repopulate_perminvent();
-    if (arg && IsWindowVisible(theWindows[WIN_INVEN].its_window))
+    if (arg && IsWindowVisible(theWindows[WIN_INVEN].its_window)) {
         SelectWindow(theWindows[WIN_INVEN].its_window); /* an explicit
             open must come up in FRONT of the map, not behind it */
+        macprefs_note_perminv(TRUE);
+    }
 }
 
 static win_request_info *

--- a/sys/mac68k/macwin.c
+++ b/sys/mac68k/macwin.c
@@ -118,6 +118,8 @@ static Boolean cursor_locked = false;
 
 static ControlActionUPP
     MoveScrollUPP; /* scrolling callback, init'ed in InitMac */
+static ControlActionUPP
+    MoveHScrollUPP; /* horizontal (perm-invent) variant */
 
 /* called from getpos.c during farlook; the flag is recorded but nothing
    reads it yet (cursor shaping during farlook is on the UI punch list) */
@@ -198,6 +200,8 @@ static int filter_scroll_key(const int, NhWindow *);
 
 static void DoScrollBar(Point, short, ControlHandle, NhWindow *);
 static pascal void MoveScrollBar(ControlHandle, short);
+static pascal void MoveHScrollBar(ControlHandle, short);
+static void DrawHScrollbar(NhWindow *);
 
 typedef void (*CbFunc)(EventRecord *, WindowPtr);
 typedef short (*CbUpFunc)(EventRecord *, WindowPtr);
@@ -371,6 +375,9 @@ InitMac(void)
     MoveScrollUPP = NewControlActionUPP(MoveScrollBar);
     if (!MoveScrollUPP)
         error("InitMac: NewControlActionUPP failed");
+    MoveHScrollUPP = NewControlActionUPP(MoveHScrollBar);
+    if (!MoveHScrollUPP)
+        error("InitMac: NewControlActionUPP failed");
 
     /* Set up base fonts for all window types */
     GetFNum(P_STRING_CONV("HackFont"), &i);
@@ -516,6 +523,72 @@ DrawScrollbar(NhWindow *aWin)
     }
 }
 
+/* pixel width of the widest menu line, incl. tile indent and margins */
+static short
+menw_content_width(NhWindow *aWin)
+{
+    return aWin->x_size + (aWin->menuTiles ? MACTILE_DIM + 2 : 0) + 8;
+}
+
+/* Horizontal scrollbar for the perm-invent windoid: its column is
+   narrow (overview width), so long item lines clip on the right.
+   Created lazily -- WIN_INVEN isn't known yet at cre_win time. */
+static void
+DrawHScrollbar(NhWindow *aWin)
+{
+    Rect wrect;
+    short viewW, maxpix;
+
+    if (WIN_INVEN == WIN_ERR || aWin != theWindows + WIN_INVEN
+        || !aWin->its_window)
+        return;
+    GetWindowPortBounds(aWin->its_window, &wrect);
+    OffsetRect(&wrect, -wrect.left, -wrect.top);
+    if (!aWin->hScrollBar) {
+        Rect r = wrect;
+
+        r.top = r.bottom - SBARHEIGHT;
+        r.bottom += 1;
+        r.left = -1;
+        r.right -= SBARWIDTH - 1; /* leave the grow corner */
+        aWin->hScrollBar = NewControl(aWin->its_window, &r, P_EMPTY_STRING,
+                                      true, 0, 0, 0, 16, 0L);
+        aWin->hScrollPos = 0;
+        if (!aWin->hScrollBar)
+            return;
+    }
+    /* Compare before every control call: MoveControl and friends
+       hide+show the control, which invalidates it, and an invalidate
+       from inside an update handler spawns another update event. */
+    {
+        Rect crect = (**aWin->hScrollBar).contrlRect;
+
+        if (crect.left != -1 || crect.top != wrect.bottom - SBARHEIGHT)
+            MoveControl(aWin->hScrollBar, -1, wrect.bottom - SBARHEIGHT);
+        crect = (**aWin->hScrollBar).contrlRect;
+        if (crect.right != wrect.right - SBARWIDTH + 1
+            || crect.bottom != wrect.bottom + 1)
+            SizeControl(aWin->hScrollBar, wrect.right - SBARWIDTH + 2,
+                        SBARHEIGHT + 1);
+    }
+    viewW = wrect.right - SBARWIDTH;
+    maxpix = menw_content_width(aWin) - viewW;
+    if (maxpix < 0)
+        maxpix = 0;
+    if (aWin->hScrollPos > maxpix)
+        aWin->hScrollPos = maxpix;
+    if (GetControlMaximum(aWin->hScrollBar) != maxpix)
+        SetControlMaximum(aWin->hScrollBar, maxpix);
+    if (GetControlValue(aWin->hScrollBar) != aWin->hScrollPos)
+        SetControlValue(aWin->hScrollBar, aWin->hScrollPos);
+    {
+        short want = maxpix ? 0 : 255;
+
+        if ((**aWin->hScrollBar).contrlHilite != want)
+            HiliteControl(aWin->hScrollBar, want);
+    }
+}
+
 #define MIN_HEIGHT 50
 
 /* One-shot: when set, the next SanePositions() ignores saved positions and
@@ -523,6 +596,33 @@ DrawScrollbar(NhWindow *aWin)
    it at startup to RESTORE saved positions, the "Reposition Windows" menu
    command (via ResetWindowPositions) calls it to RESET to defaults. */
 static Boolean gResetToDefault = FALSE;
+
+/* Real window-decoration metrics, measured from the visible window's
+   structure vs content regions (borderless windows yield 0); fall back
+   to the classic guesses while the window is hidden (regions unset). */
+static short
+win_title_height(WindowPtr w, short fallback)
+{
+    WindowPeek p = (WindowPeek) w;
+
+    if (p && p->visible && p->strucRgn && p->contRgn
+        && !EmptyRgn(p->strucRgn))
+        return (short) ((**p->contRgn).rgnBBox.top
+                        - (**p->strucRgn).rgnBBox.top);
+    return fallback;
+}
+
+static short
+win_bottom_extra(WindowPtr w, short fallback)
+{
+    WindowPeek p = (WindowPeek) w;
+
+    if (p && p->visible && p->strucRgn && p->contRgn
+        && !EmptyRgn(p->strucRgn))
+        return (short) ((**p->strucRgn).rgnBBox.bottom
+                        - (**p->contRgn).rgnBBox.bottom);
+    return fallback;
+}
 
 /* "Reposition Windows" menu command: lay out the default stack regardless of
    any saved positions. */
@@ -557,7 +657,9 @@ SanePositions(void)
     stat_h = statr.bottom - statr.top;
 
     {
-        short title_h = small_screen ? 0 : 20;   /* title bar + small gap */
+        /* measured title bar; falls back to 19 while the message
+           window is still hidden */
+        short title_h = small_screen ? 0 : win_title_height(msgw, 19);
         short y = mbar_height + (small_screen ? 2 : 4);
         short msg_top, map_top, stat_top, avail_map_h, avail_map_w;
         /* Large screens restore saved positions; "Reposition Windows" sets
@@ -566,6 +668,9 @@ SanePositions(void)
         Boolean honor = !small_screen && !gResetToDefault;
 
         short msg_w = 0; /* 0 => use content_w (default stack width) */
+        Boolean msg_saved = FALSE;
+        /* minimal message height; the default layout grows it to
+           swallow whatever the map and status don't need */
         msg_h = 4 * theWindows[WIN_MESSAGE].row_height + 4;   /* ~4 lines */
         /* keep the big-screen bar past DrawScrollbar's auto-hide threshold */
         if (!small_screen
@@ -579,14 +684,27 @@ SanePositions(void)
             if (RetrievePosition(kMessageWindow, &mt, &ml)
                 && RetrieveSize(kMessageWindow, mt, ml, &sh, &sw)) {
                 if (sh > 0)
-                    msg_h = sh;
+                    msg_h = sh, msg_saved = TRUE;
                 if (sw > 0)
                     msg_w = sw;
             }
         }
 
-        /* Persistent inventory open (or due to reopen at launch):
-           reserve a right-hand strip for it, stack the rest on the left */
+        /* overview windoid open, or due to reopen at the first map flush */
+        Boolean ov_open = macmap_overview_visible();
+        if (!ov_open) {
+            UiPrefs up;
+
+            if (RetrieveUiPrefs(&up) && up.overview_open)
+                ov_open = TRUE;
+        }
+
+        /* Right column: reserved only while the persistent inventory is
+           open (or due to reopen at launch).  The column is exactly as
+           wide as the overview windoid and the inventory fills it
+           vertically (overview above it when open).  A lone overview
+           doesn't reserve map width -- it sits beside the message
+           window instead. */
         short inv_w = 0;
         WindowPtr invw = (WIN_INVEN != WIN_ERR)
                              ? theWindows[WIN_INVEN].its_window
@@ -601,34 +719,55 @@ SanePositions(void)
                     inv_open = TRUE; /* reopens at the first update */
             }
             if (inv_open) {
-                short it2, il2, ih2, iw2;
+                short colw = macmap_overview_width();
 
-                if (IsWindowVisible(invw)) {
-                    Rect ir;
+                /* restoring a saved arrangement: the inventory keeps its
+                   saved (possibly wider) size, so the reserved column
+                   must match it or the stack runs underneath */
+                if (honor) {
+                    short it2, il2, ih2, iw2;
 
-                    GetWindowPortBounds(invw, &ir);
-                    inv_w = ir.right - ir.left;
-                } else if (RetrievePosition(kInvenWindow, &it2, &il2)
-                           && RetrieveSize(kInvenWindow, it2, il2, &ih2,
-                                           &iw2)) {
-                    inv_w = iw2;
-                } else {
-                    inv_w = 200;
+                    if (IsWindowVisible(invw)) {
+                        Rect ir;
+
+                        GetWindowPortBounds(invw, &ir);
+                        if (ir.right - ir.left > colw)
+                            colw = ir.right - ir.left;
+                    } else if (RetrievePosition(kInvenWindow, &it2, &il2)
+                               && RetrieveSize(kInvenWindow, it2, il2,
+                                               &ih2, &iw2)
+                               && iw2 > colw) {
+                        colw = iw2;
+                    }
                 }
-                inv_w += 6; /* gap to the stack */
+                inv_w = colw + 6; /* gap to the stack */
                 if (inv_w > screenArea.right / 2)
                     inv_w = screenArea.right / 2; /* don't starve the map */
             }
         }
 
-        /* Vertical gap between stacked windows: the frame line plus the
-           1px drop shadow extend 2px below the content, and the next
-           title bar needs its full title_h above -- 2px used to leave
-           the shadow lying ON the title (1px overlap) */
-        short vgap = small_screen ? 2 : 6;
+        /* Vertical gap between stacked windows: the measured frame +
+           drop shadow below the content, minus one: the shadow's last
+           pixel lies on the next title bar, so the frames abut and no
+           desktop shows through the seams */
+        short vgap = small_screen ? 2 : (win_bottom_extra(msgw, 2) - 1);
 
-        /* Fit the map into the space left by menu bar, message+status windows,
-           and title bars; macmap_fit resizes the map window + viewport/backing */
+        if (vgap < 1)
+            vgap = 1;
+
+        /* the overview sits beside the message window when there's no
+           inventory column: never let the message row be shorter than
+           the overview windoid, or it overlaps the map's title bar */
+        if (!inv_w && ov_open && !msg_saved) {
+            short need = macmap_overview_height() + 2;
+
+            if (msg_h < need)
+                msg_h = need;
+        }
+
+        /* Fit the map into the space left by menu bar, the (minimal)
+           message window and status; macmap_fit resizes the map window +
+           viewport/backing */
         msg_top = y + title_h;
         map_top = msg_top + msg_h + vgap + title_h;
         avail_map_h = screenArea.bottom - map_top - (title_h + stat_h + vgap);
@@ -640,6 +779,18 @@ SanePositions(void)
         GetWindowPortBounds(mapw, &mr);
         map_h = mr.bottom - mr.top;
         content_w = mr.right - mr.left;
+        /* the map took what it needed: grow the message window by the
+           leftover so the stack fills the whole screen (unless the user
+           saved an explicit message size) */
+        if (!msg_saved) {
+            short spare = screenArea.bottom
+                          - (msg_top + msg_h + vgap + title_h + map_h
+                             + vgap + title_h + stat_h + 2);
+
+            if (spare > 0)
+                msg_h += spare;
+        }
+        map_top = msg_top + msg_h + vgap + title_h;
         content_left = (screenArea.right - inv_w - content_w) / 2;
         if (content_left < 0) content_left = 0;
 
@@ -648,7 +799,21 @@ SanePositions(void)
             top = msg_top; left = content_left;
         }
         MoveWindow(msgw, left, top, 1);
-        SizeWindow(msgw, msg_w ? msg_w : content_w, msg_h, 1);
+        {
+            short mw = msg_w ? msg_w : content_w;
+
+            /* no inventory column: the overview sits beside the message
+               in the top-right corner; shrink the default width so they
+               don't overlap (the map below keeps the full width) */
+            if (!msg_w && !inv_w && ov_open) {
+                short avail = screenArea.right - 4
+                              - (macmap_overview_width() + 6) - left;
+
+                if (avail > 100 && mw > avail)
+                    mw = avail;
+            }
+            SizeWindow(msgw, mw, msg_h, 1);
+        }
         if (theWindows[WIN_MESSAGE].scrollBar)
             DrawScrollbar(&theWindows[WIN_MESSAGE]);
 
@@ -713,17 +878,54 @@ SanePositions(void)
             InvalWindowRect(statw, &sfull);
         }
 
-        /* inventory windoid in the reserved right-hand strip */
+        /* overview windoid: pin to the screen's top-right corner; the
+           inventory windoid (below) starts under it */
+        short ov_gap = 0;
+        {
+            WindowPtr ovw = macmap_overview_window();
+
+            if (ovw && IsWindowVisible(ovw)
+                && !(honor && RetrievePosition(kOverviewWindow, &top,
+                                               &left))) {
+                Rect ovr;
+
+                GetWindowPortBounds(ovw, &ovr);
+                top = msg_top;
+                left = screenArea.right - (ovr.right - ovr.left) - 4;
+                if (left < 0)
+                    left = 0;
+                MoveWindow(ovw, left, top, 0);
+                /* content height + its shadow + the inventory windoid's
+                   title bar, shadow overlapping the title by 1px so the
+                   windoids abut seamlessly, same as the main stack */
+                ov_gap = (ovr.bottom - ovr.top) + win_bottom_extra(ovw, 2)
+                         + win_title_height(invw, 19) - 1;
+            }
+        }
+
+        /* inventory windoid: the right column -- overview width, filling
+           the screen below the overview (or from the top when the
+           overview is closed) */
         if (inv_w && invw && IsWindowVisible(invw)
             && !(honor && RetrievePosition(kInvenWindow, &top, &left))) {
-            Rect ir;
+            short cw = macmap_overview_width();
 
-            GetWindowPortBounds(invw, &ir);
-            top = msg_top;
-            left = screenArea.right - (ir.right - ir.left) - 4;
+            top = msg_top + ov_gap;
+            left = screenArea.right - cw - 4;
             if (left < 0)
                 left = 0;
             MoveWindow(invw, left, top, 0);
+            SizeWindow(invw, cw, screenArea.bottom - top - 2, 1);
+            SetPortWindowPort(invw);
+            {
+                Rect ifull;
+
+                GetWindowPortBounds(invw, &ifull);
+                InvalWindowRect(invw, &ifull);
+            }
+            if (theWindows[WIN_INVEN].scrollBar)
+                DrawScrollbar(&theWindows[WIN_INVEN]);
+            DrawHScrollbar(&theWindows[WIN_INVEN]);
         }
     }
 
@@ -864,6 +1066,8 @@ got1:
     aWin = &theWindows[i];
     aWin->windowTextLen = 0L;
     aWin->scrollBar = (ControlHandle) 0;
+    aWin->hScrollBar = (ControlHandle) 0;
+    aWin->hScrollPos = 0;
     aWin->menuInfo = 0;
     aWin->menuSelected = 0;
     aWin->menuCounts = 0;
@@ -1161,6 +1365,9 @@ mac_clear_nhwindow(winid win)
     case NHW_MENU:
         dispose_menu_handles(aWin);
         menw_clear_pending(aWin);
+        aWin->hScrollPos = 0; /* fresh content: back to the left edge */
+        if (aWin->hScrollBar)
+            SetControlValue(aWin->hScrollBar, 0);
         aWin->menuChar = 'a';
         aWin->miSelLen = 0;
         aWin->miLen = 0;
@@ -1817,8 +2024,13 @@ ToggleMenuSelect(NhWindow *aWin, int line)
 {
     Rect r;
 
+    /* absolute origin, so this is right both from MenwUpdate (already
+       shifted) and from direct selection clicks (unshifted) */
+    if (aWin->hScrollPos)
+        SetOrigin(aWin->hScrollPos, 0);
     GetWindowPortBounds(aWin->its_window, &r);
-    OffsetRect(&r, -r.left, -r.top);
+    r.left = 0; /* content x; right edge stays the visible window edge */
+    r.top = 0;
     if (aWin->scrollBar)
         r.right -= SBARWIDTH;
     r.top = line * aWin->row_height;
@@ -1826,6 +2038,8 @@ ToggleMenuSelect(NhWindow *aWin, int line)
 
     LMSetHiliteMode((UInt8)(LMGetHiliteMode() & 0x7F));
     InvertRect(&r);
+    if (aWin->hScrollPos)
+        SetOrigin(0, 0);
 }
 
 /*
@@ -1952,6 +2166,62 @@ MoveScrollBar(ControlHandle theBar, short part)
     DisposeRgn(rgn);
 }
 
+/* horizontal (perm-invent) scroll action: pixel units, arrows 16px,
+   pages a view width; redraw is a full menu repaint (small window) */
+static pascal void
+MoveHScrollBar(ControlHandle theBar, short part)
+{
+    WindowPtr theWin;
+    NhWindow *w;
+    Rect r;
+    int now, amt, bound;
+
+    if (!part)
+        return;
+    theWin = (**theBar).contrlOwner;
+    w = (NhWindow *) GetWRefCon(theWin);
+    if (!w || w < theWindows || w >= &theWindows[NUM_MACWINDOWS])
+        return;
+    GetWindowPortBounds(theWin, &r);
+    OffsetRect(&r, -r.left, -r.top);
+    now = GetControlValue(theBar);
+    if (part == kControlPageUpPart || part == kControlPageDownPart) {
+        amt = (r.right - r.left) - SBARWIDTH - 16;
+        if (amt < 1) /* window narrower than one page */
+            amt = 1;
+    } else {
+        amt = 16;
+    }
+    if (part == kControlPageUpPart || part == kControlUpButtonPart) {
+        bound = GetControlMinimum(theBar);
+        if (now - bound < amt)
+            amt = now - bound;
+        amt = -amt;
+    } else {
+        bound = GetControlMaximum(theBar);
+        if (bound - now < amt)
+            amt = bound - now;
+    }
+    if (!amt)
+        return;
+    SetControlValue(theBar, (short) (now + amt));
+    w->hScrollPos = (short) (now + amt);
+    /* same shape as MoveScrollBar: shift the pixels, invalidate only
+       the exposed strip -- a full MenwUpdate here would redraw the
+       controls mid-TrackControl (violent flicker) */
+    r.right -= SBARWIDTH;
+    r.bottom -= SBARHEIGHT; /* keep the h-bar itself out of the shift */
+    {
+        RgnHandle rgn = NewRgn();
+
+        if (!rgn)
+            return;
+        ScrollRect(&r, -amt, 0, rgn);
+        InvalWindowRgn(theWin, rgn);
+        DisposeRgn(rgn);
+    }
+}
+
 static void
 DoScrollBar(Point p, short code, ControlHandle theBar, NhWindow *aWin)
 {
@@ -2032,7 +2302,19 @@ draw_growicon_vert_only(WindowPtr wind)
 static void
 WindowGoAway(EventRecord *theEvent, WindowPtr theWindow)
 {
-    NhWindow *aWin = GetNhWin(theWindow);
+    NhWindow *aWin;
+
+    if (GetWRefCon(theWindow) == MACOVERVIEW_REFCON) {
+        /* overview windoid (not an NhWindow): hide and remember */
+        if (!theEvent || TrackGoAway(theWindow, theEvent->where)) {
+            macmap_overview_hide();
+            macprefs_note_overview(FALSE);
+            gTileMenuNeedsUpdate = 1; /* re-sync the Game menu checkmark
+                                         on the next idle pass */
+        }
+        return;
+    }
+    aWin = GetNhWin(theWindow);
 
     if (!theEvent || TrackGoAway(theWindow, theEvent->where)) {
         if (aWin - theWindows == BASE_WINDOW && !iflags.window_inited) {
@@ -2470,6 +2752,8 @@ mac_save_window_positions(void)
         SaveWindowPos(w);
         SaveWindowSize(w);
     }
+    if ((w = macmap_overview_window()) != 0 && IsWindowVisible(w))
+        SaveWindowPos(w); /* fixed size; position only */
 }
 
 /* One-shot at the first input wait inside the moveloop: reopen the
@@ -3702,6 +3986,22 @@ MenwDrawStyled(NhWindow *wind)
     draw_growicon_vert_only(wind->its_window);
     DrawControls(wind->its_window);
 
+    /* Horizontal scroll (perm-invent): shift the port origin so the text
+       below renders scrolled left.  The controls above already drew
+       unshifted.  r2 (the scrollbar clip) follows into shifted coords,
+       but r.left stays 0 because the text and tile x anchor is a content
+       coordinate; its right edge still tracks the visible edge so the
+       inverse row boxes end at the window edge.  MenwUpdate restores the
+       origin. */
+    if (wind->hScrollPos) {
+        SetOrigin(wind->hScrollPos, 0);
+        GetWindowPortBounds(wind->its_window, &r);
+        r2 = r;
+        r2.left = r2.right - SBARWIDTH;
+        r2.right += 1;
+        r2.top -= 1;
+        r.left = 0;
+    }
     if (vis)
         h = clip_exclude_scrollbar(&r2);
 
@@ -3827,9 +4127,14 @@ MenwUpdate(NhWindow *wind)
     int i, line;
     MacMHMenuItem *mi;
 
-    MenwDrawStyled(wind);
-    if (!wind->menuInfo || !wind->menuSelected || wind->miSelLen <= 0)
+    DrawHScrollbar(wind); /* no-op except for WIN_INVEN: keep the range
+                             in sync with the current content width */
+    MenwDrawStyled(wind); /* leaves the origin h-shifted (perm-invent) */
+    if (!wind->menuInfo || !wind->menuSelected || wind->miSelLen <= 0) {
+        if (wind->hScrollPos)
+            SetOrigin(0, 0);
         return;
+    }
     HLock((Handle) wind->menuInfo);
     HLock((Handle) wind->menuSelected);
     /* typed-count display: "x N" right-aligned in each selected row that
@@ -3877,6 +4182,8 @@ MenwUpdate(NhWindow *wind)
     }
     HUnlock((Handle) wind->menuInfo);
     HUnlock((Handle) wind->menuSelected);
+    if (wind->hScrollPos)
+        SetOrigin(0, 0);
     return;
 }
 
@@ -3897,13 +4204,30 @@ click_in_scrollbar(EventRecord *theEvent, WindowPtr theWindow,
     Point p;
     ControlHandle theBar;
 
-    if (!aWin->scrollBar || (**aWin->scrollBar).contrlVis == 0)
+    if ((!aWin->scrollBar || (**aWin->scrollBar).contrlVis == 0)
+        && !aWin->hScrollBar)
         return false;
     p = theEvent->where;
     GlobalToLocal(&p);
     code = FindControl(p, theWindow, &theBar);
     if (!code)
         return false;
+    if (aWin->hScrollBar && theBar == aWin->hScrollBar) {
+        if (code == kControlIndicatorPart) {
+            (void) TrackControl(theBar, p, (ControlActionUPP) 0);
+            if (aWin->hScrollPos != GetControlValue(theBar)) {
+                Rect r;
+
+                aWin->hScrollPos = GetControlValue(theBar);
+                GetWindowPortBounds(theWindow, &r);
+                OffsetRect(&r, -r.left, -r.top);
+                InvalWindowRect(theWindow, &r);
+            }
+        } else {
+            (void) TrackControl(theBar, p, MoveHScrollUPP);
+        }
+        return true;
+    }
     DoScrollBar(p, code, theBar, aWin);
     return true;
 }
@@ -4032,10 +4356,28 @@ GeneralKey(EventRecord *theEvent, WindowPtr theWindow)
     AddToKeyQueue(topl_resp_key(ch), TRUE);
 }
 
+/* Frontmost window for input/menubar purposes: the overview windoid
+   floats above everything but must never own the keyboard or drive
+   the menubar state -- skip it. */
+WindowPtr
+FrontGameWindow(void)
+{
+    WindowPtr w = FrontWindow();
+
+    if (w && GetWRefCon(w) == MACOVERVIEW_REFCON) {
+        WindowPeek p = ((WindowPeek) w)->nextWindow;
+
+        while (p && !p->visible)
+            p = p->nextWindow;
+        w = (WindowPtr) p;
+    }
+    return w;
+}
+
 static void
 HandleKey(EventRecord *theEvent)
 {
-    WindowPtr theWindow = FrontWindow();
+    WindowPtr theWindow = FrontGameWindow();
 
     if (theEvent->modifiers & cmdKey) {
         if ((theEvent->message & 0xff) == '.') {
@@ -4080,7 +4422,10 @@ HandleClick(EventRecord *theEvent)
     case inContent:
         if (not_inSelect) {
             int kind = GetWindowKind(theWindow) - WIN_BASE_KIND;
-            if (kind >= 0 && kind < NUM_FUNCS) {
+            /* the overview floats on top already; SelectWindow would
+               only deactivate the game window */
+            if (GetWRefCon(theWindow) != MACOVERVIEW_REFCON
+                && kind >= 0 && kind < NUM_FUNCS) {
                 winCursorFuncs[kind](theEvent, theWindow, gMouseRgn);
                 SelectWindow(theWindow);
                 SetPortWindowPort(theWindow);
@@ -4125,6 +4470,7 @@ HandleClick(EventRecord *theEvent)
                     if (aWin->scrollBar) {
                         DrawScrollbar(aWin);
                     }
+                    DrawHScrollbar(aWin); /* no-op except WIN_INVEN */
                 }
             }
         } else {
@@ -4175,6 +4521,12 @@ HandleUpdate(EventRecord *theEvent)
         if (WIN_MAP != WIN_ERR && theWindows[WIN_MAP].its_window == theWindow) {
             BeginUpdate(theWindow);
             macmap_update_event(&theWindows[WIN_MAP]);
+            EndUpdate(theWindow);
+            return;
+        }
+        if (GetWRefCon(theWindow) == MACOVERVIEW_REFCON) {
+            BeginUpdate(theWindow);
+            macmap_overview_update_event(theWindow);
             EndUpdate(theWindow);
             return;
         }
@@ -4329,6 +4681,9 @@ HandleEvent(EventRecord *theEvent)
         mactile_menu_refresh();
         break;
     }
+    /* the overview windoid floats: put it back on top if any of the
+       above (SelectWindow, new window) got in front of it */
+    macmap_overview_float();
 }
 
 /**********************************************************************

--- a/sys/mac68k/macwin.c
+++ b/sys/mac68k/macwin.c
@@ -3960,6 +3960,20 @@ HandleUpdate(EventRecord *theEvent)
         existing_update_region =
             (get_invalid_region(theWindow, &rect) == noErr);
     }
+    /* Message window: scrollPos/save_lin can advance between paints
+       (prompt and --more-- paths), so repainting only the damaged
+       region leaves the undamaged part showing the old frame -- most
+       visibly the dotted last-message divider, which then appears at
+       two different heights.  Widen any damage to the whole window so
+       the repaint is coherent. */
+    if (aWin && theWindow != _mt_window
+        && GetWindowKind(theWindow) - WIN_BASE_KIND == NHW_MESSAGE) {
+        Rect fr;
+
+        GetWindowPortBounds(theWindow, &fr);
+        OffsetRect(&fr, -fr.left, -fr.top);
+        InvalWindowRect(theWindow, &fr);
+    }
     BeginUpdate(theWindow);
     SetPortWindowPort(theWindow);
     GetWindowPortBounds(theWindow, &r);

--- a/sys/mac68k/macwin.c
+++ b/sys/mac68k/macwin.c
@@ -580,7 +580,7 @@ SanePositions(void)
         map_top = msg_top + msg_h + 2 + title_h;
         avail_map_h = screenArea.bottom - map_top - (title_h + stat_h + 2);
         avail_map_w = screenArea.right - 4;
-        macmap_fit(avail_map_w, avail_map_h);
+        macmap_fit(avail_map_w, avail_map_h, honor);
 
         /* Re-read the fitted map size; center the stack on its width. */
         GetWindowPortBounds(mapw, &mr);

--- a/sys/mac68k/macwin.c
+++ b/sys/mac68k/macwin.c
@@ -1183,15 +1183,21 @@ leave_topl_mode(char *answer) /* answer must have room for BUFSZ bytes */
     if (ans_len >= BUFSZ)
         ans_len = BUFSZ - 1;
 
-    /* remove unprintables from the answer */
+    /* remove unprintables from the answer -- except a leading ESC, the
+       cancel marker topl_key_body plants; getlin callers test for "\033" */
     HLock((*top_line)->hText);
-    for (ap = *(*top_line)->hText + topl_query_len, bp = answer; ans_len > 0;
-         ans_len--, ap++) {
-        if (*ap >= ' ' && *ap < 128) {
-            *bp++ = *ap;
+    ap = *(*top_line)->hText + topl_query_len;
+    if (ans_len > 0 && *ap == CHAR_ESC) {
+        answer[0] = CHAR_ESC;
+        answer[1] = 0;
+    } else {
+        for (bp = answer; ans_len > 0; ans_len--, ap++) {
+            if (*ap >= ' ' && *ap < 128) {
+                *bp++ = *ap;
+            }
         }
+        *bp = 0;
     }
-    *bp = 0;
     HUnlock((*top_line)->hText);
 
     if (aWin->windowTextLen
@@ -1199,7 +1205,7 @@ leave_topl_mode(char *answer) /* answer must have room for BUFSZ bytes */
         --aWin->windowTextLen;
         --aWin->y_size;
     }
-    putstr(WIN_MESSAGE, ATR_BOLD, answer);
+    putstr(WIN_MESSAGE, ATR_BOLD, answer[0] == CHAR_ESC ? "" : answer);
 
     /* Invalidate the button area so stale buttons get erased */
     if (topl_resp[0])

--- a/sys/mac68k/macwin.c
+++ b/sys/mac68k/macwin.c
@@ -2437,11 +2437,9 @@ mac_curs(winid win, int x, int y)
     aWin->y_curs = y;
 }
 
-/* Game > Save Window Positions: snapshot the position and size of
-   every standing game window into the preferences file.  Dragging
-   and growing save as you go; this is the explicit "keep this whole
-   arrangement", including layouts produced by Reposition, which
-   moves windows programmatically and saves nothing itself. */
+/* Game > Save Window Positions: snapshot the position and size of every
+   standing game window into the preferences file.  This is the only
+   thing that writes them; dragging and growing do not. */
 void
 mac_save_window_positions(void)
 {
@@ -4097,7 +4095,7 @@ HandleClick(EventRecord *theEvent)
         if (not_inSelect) {
             SetCursor(&qdarrow);
             DragWindow(theWindow, theEvent->where, &r);
-            SaveWindowPos(theWindow); /* into the prefs file */
+            /* position persists via Save Window Positions only */
         } else {
             nhbell();
         }
@@ -4119,7 +4117,7 @@ HandleClick(EventRecord *theEvent)
                 l = GrowWindow(theWindow, theEvent->where, &r);
                 if (l) { /* 0 = no size change; don't collapse to 0x0 */
                     SizeWindow(theWindow, l & 0xffff, l >> 16, FALSE);
-                    SaveWindowSize(theWindow);
+                    /* size persists via Save Window Positions only */
                     SetPortWindowPort(theWindow);
                     GetWindowPortBounds(theWindow, &r);
                     OffsetRect(&r, -r.left, -r.top);

--- a/sys/mac68k/macwin.c
+++ b/sys/mac68k/macwin.c
@@ -1540,10 +1540,11 @@ topl_resp_key_body(char ch)
             }
         }
 
-        if (loc) {
+        /* --more-- (CHAR_ANY) continues on any key: no button flash,
+           and nothing typed into the message line */
+        if (loc && *loc != CHAR_ANY) {
             topl_flash_resp(loc - topl_resp);
-            if (*loc != CHAR_ANY)
-                ch = *loc;
+            ch = *loc;
             TEKey(ch, top_line);
         }
     }
@@ -1656,7 +1657,9 @@ mac_display_nhwindow(winid win, boolean f)
         inSelect = win;
         do {
             ch = mac_nhgetch();
-        } while (!ClosingWindowChar(ch));
+            /* --more-- accepts any key; text/menu windows keep the
+               explicit dismiss keys */
+        } while (win == WIN_MESSAGE ? !ch : !ClosingWindowChar(ch));
         inSelect = WIN_ERR;
         UndimMenuBar();
 

--- a/sys/mac68k/macwin.c
+++ b/sys/mac68k/macwin.c
@@ -605,18 +605,37 @@ SanePositions(void)
         MoveWindow(mapw, left, top, 1);
 
         /* Status on the bottom; keep it on-screen. */
+        {
+        short stat_w = content_w;
+
+        /* match map width so the status' right edge aligns -- but never
+           narrower than a full 80-column status line, which would clip
+           the right-hand fields when the map window is small */
+        if (!small_screen) {
+            short stat_min_w;
+            SetPortWindowPort(statw);
+            TextFont(theWindows[WIN_STATUS].font_number);
+            TextSize(theWindows[WIN_STATUS].font_size);
+            stat_min_w = 80 * CharWidth('m') + 2;
+            if (stat_min_w > screenArea.right - 4)
+                stat_min_w = screenArea.right - 4;
+            if (stat_w < stat_min_w)
+                stat_w = stat_min_w;
+        }
         stat_top = map_top + map_h + 2 + title_h;
         if (stat_top + stat_h > screenArea.bottom)
             stat_top = screenArea.bottom - stat_h - 2;
         if (stat_top < mbar_height + 2)
             stat_top = mbar_height + 2;
         if (!(honor && RetrievePosition(kStatusWindow, &top, &left))) {
-            top = stat_top; left = content_left;
+            top = stat_top;
+            left = (screenArea.right - stat_w) / 2;
+            if (left < 0) left = 0;
         }
         MoveWindow(statw, left, top, 1);
-        /* match map width so the status' right edge aligns; stat_h already
-           carries the +2 frame allowance from creation */
-        SizeWindow(statw, content_w, stat_h, 1);
+        /* stat_h already carries the +2 frame allowance from creation */
+        SizeWindow(statw, stat_w, stat_h, 1);
+        }
         /* MoveWindow reset the port origin; restore the 1px frame inset and
            repaint so the status rows stay visible */
         SetPortWindowPort(statw);

--- a/sys/mac68k/macwin.c
+++ b/sys/mac68k/macwin.c
@@ -585,19 +585,56 @@ SanePositions(void)
             }
         }
 
+        /* Persistent inventory open (or due to reopen at launch):
+           reserve a right-hand strip for it, stack the rest on the left */
+        short inv_w = 0;
+        WindowPtr invw = (WIN_INVEN != WIN_ERR)
+                             ? theWindows[WIN_INVEN].its_window
+                             : (WindowPtr) 0;
+        {
+            Boolean inv_open = (invw && IsWindowVisible(invw));
+
+            if (!inv_open && invw) {
+                UiPrefs up;
+
+                if (RetrieveUiPrefs(&up) && up.perminv_open)
+                    inv_open = TRUE; /* reopens at the first update */
+            }
+            if (inv_open) {
+                short it2, il2, ih2, iw2;
+
+                if (IsWindowVisible(invw)) {
+                    Rect ir;
+
+                    GetWindowPortBounds(invw, &ir);
+                    inv_w = ir.right - ir.left;
+                } else if (RetrievePosition(kInvenWindow, &it2, &il2)
+                           && RetrieveSize(kInvenWindow, it2, il2, &ih2,
+                                           &iw2)) {
+                    inv_w = iw2;
+                } else {
+                    inv_w = 200;
+                }
+                inv_w += 6; /* gap to the stack */
+                if (inv_w > screenArea.right / 2)
+                    inv_w = screenArea.right / 2; /* don't starve the map */
+            }
+        }
+
         /* Fit the map into the space left by menu bar, message+status windows,
            and title bars; macmap_fit resizes the map window + viewport/backing */
         msg_top = y + title_h;
         map_top = msg_top + msg_h + 2 + title_h;
         avail_map_h = screenArea.bottom - map_top - (title_h + stat_h + 2);
-        avail_map_w = screenArea.right - 4;
+        avail_map_w = screenArea.right - 4 - inv_w;
         macmap_fit(avail_map_w, avail_map_h, honor);
 
-        /* Re-read the fitted map size; center the stack on its width. */
+        /* Re-read the fitted map size; center the stack on its width
+           (within the region left of the inventory strip). */
         GetWindowPortBounds(mapw, &mr);
         map_h = mr.bottom - mr.top;
         content_w = mr.right - mr.left;
-        content_left = (screenArea.right - content_w) / 2;
+        content_left = (screenArea.right - inv_w - content_w) / 2;
         if (content_left < 0) content_left = 0;
 
         /* Messages on top (honor a saved position on large screens). */
@@ -633,6 +670,19 @@ SanePositions(void)
             if (stat_w < stat_min_w)
                 stat_w = stat_min_w;
         }
+        /* a manually resized status keeps its width across launches
+           (Reposition = clean stack, so only on the honor path) */
+        if (honor) {
+            short st2, sl2, sh2, sw2;
+
+            if (RetrievePosition(kStatusWindow, &st2, &sl2)
+                && RetrieveSize(kStatusWindow, st2, sl2, &sh2, &sw2)
+                && sw2 > 0) {
+                stat_w = sw2;
+                if (stat_w > screenArea.right - 4)
+                    stat_w = screenArea.right - 4;
+            }
+        }
         stat_top = map_top + map_h + 2 + title_h;
         if (stat_top + stat_h > screenArea.bottom)
             stat_top = screenArea.bottom - stat_h - 2;
@@ -640,7 +690,7 @@ SanePositions(void)
             stat_top = mbar_height + 2;
         if (!(honor && RetrievePosition(kStatusWindow, &top, &left))) {
             top = stat_top;
-            left = (screenArea.right - stat_w) / 2;
+            left = (screenArea.right - inv_w - stat_w) / 2;
             if (left < 0) left = 0;
         }
         MoveWindow(statw, left, top, 1);
@@ -655,6 +705,19 @@ SanePositions(void)
             Rect sfull;
             GetWindowPortBounds(statw, &sfull);
             InvalWindowRect(statw, &sfull);
+        }
+
+        /* inventory windoid in the reserved right-hand strip */
+        if (inv_w && invw && IsWindowVisible(invw)
+            && !(honor && RetrievePosition(kInvenWindow, &top, &left))) {
+            Rect ir;
+
+            GetWindowPortBounds(invw, &ir);
+            top = msg_top;
+            left = screenArea.right - (ir.right - ir.left) - 4;
+            if (left < 0)
+                left = 0;
+            MoveWindow(invw, left, top, 0);
         }
     }
 

--- a/sys/mac68k/macwin.c
+++ b/sys/mac68k/macwin.c
@@ -92,6 +92,17 @@ static short gLastTransientLines = 0; /* rows the last transient stored */
  */
 static winid inSelect = WIN_ERR;
 
+/* Persistent inventory windoid: the core creates WIN_INVEN at startup
+   and repopulate_perminvent() refills it through the normal menu
+   windowprocs (start/add/end/select with PICK_NONE, no destroy).  The
+   port treats WIN_INVEN specially everywhere: start_menu doesn't hide
+   it, select_menu shows it non-modally and returns at once, the close
+   box just hides it.  Its visibility is the whole state: #perminv
+   (bound to 'i' in the shipped NetHack Defaults) opens it, inventory
+   changes refresh it only while it's showing, closing it stops the
+   updates.  Display-only: clicks don't select (PICK_NONE outside
+   inSelect is already inert). */
+
 /*
  * The key queue ring buffer where Read is where to take from,
  * Write is where next char goes and count is queue depth.
@@ -1958,7 +1969,10 @@ WindowGoAway(EventRecord *theEvent, WindowPtr theWindow)
             AddToKeyQueue('\033', 1);
         } else {
             HideWindow(theWindow);
-            if (aWin - theWindows != inSelect)
+            if (WIN_INVEN != WIN_ERR && aWin - theWindows == WIN_INVEN) {
+                ; /* inventory windoid: hidden is all -- updates stop
+                     while it's closed; 'i' (#perminv) reopens it */
+            } else if (aWin - theWindows != inSelect)
                 mac_destroy_nhwindow(aWin - theWindows);
             else /* if this IS the inSelect window put a close char */
                 AddToKeyQueue(CHAR_CR,
@@ -2365,7 +2379,9 @@ mac_nh_poskey(coordxy *a, coordxy *b, int *c)
 void
 mac_start_menu(winid win, unsigned long mbehavior)
 {
-    HideWindow(theWindows[win].its_window);
+    if (win != WIN_INVEN)
+        HideWindow(theWindows[win].its_window); /* the inventory windoid
+                                                   stays up through refills */
     mac_clear_nhwindow(win);
 }
 
@@ -2491,6 +2507,8 @@ mac_end_menu(winid win, const char *morestr)
     Str255 buf;
     NhWindow *aWin = &theWindows[win];
 
+    if (win == WIN_INVEN && (!morestr || !*morestr))
+        morestr = "Inventory"; /* windoid gets a proper title */
     buf[0] = 0;
     if (morestr)
         C2P(morestr, buf);
@@ -2543,6 +2561,32 @@ mac_select_menu(winid win, int how, menu_item **selected_list)
     int c;
     NhWindow *aWin = &theWindows[win];
     WindowPtr theWin = aWin->its_window;
+
+    /* inventory windoid: show/refresh and return immediately -- no
+       modal loop, no SelectWindow (it must not steal the focus) */
+    if (win == WIN_INVEN && how == PICK_NONE) {
+        *selected_list = (menu_item *) 0;
+        if (theWin) {
+            Rect rr;
+
+            if (!IsWindowVisible(theWin))
+                adjust_window_pos(aWin, aWin->x_size + SBARWIDTH + 1,
+                                  aWin->y_size * aWin->row_height);
+            ShowWindow(theWin);
+            SetPortWindowPort(theWin);
+            GetWindowPortBounds(theWin, &rr);
+            OffsetRect(&rr, -rr.left, -rr.top);
+            InvalWindowRect(theWin, &rr);
+            if (aWin->scrollBar) {
+                short vis = (rr.bottom - rr.top) / aWin->row_height;
+                short max = aWin->y_size - vis;
+
+                SetControlMaximum(aWin->scrollBar, max > 0 ? max : 0);
+                SetControlValue(aWin->scrollBar, aWin->scrollPos);
+            }
+        }
+        return 0;
+    }
 
     inSelect = win;
     aWin->how = (short) how;
@@ -2737,9 +2781,22 @@ mac_print_glyph(winid win, coordxy x, coordxy y,
 }
 
 static void
-mac_update_inventory(int arg UNUSED)
+mac_update_inventory(int arg)
 {
-    /* stub - could trigger inventory window redraw */
+    if (WIN_INVEN == WIN_ERR || !theWindows[WIN_INVEN].its_window)
+        return;
+    /* skip inventory updating during character initialization */
+    if (!program_state.in_moveloop && !program_state.gameover)
+        return;
+    /* arg != 0: explicit #perminv ('|') -- open the windoid; arg == 0:
+       inventory changed -- refresh only while it's visible (closed
+       window = no updates, that's the toggle) */
+    if (!arg && !IsWindowVisible(theWindows[WIN_INVEN].its_window))
+        return;
+    repopulate_perminvent();
+    if (arg && IsWindowVisible(theWindows[WIN_INVEN].its_window))
+        SelectWindow(theWindows[WIN_INVEN].its_window); /* an explicit
+            open must come up in FRONT of the map, not behind it */
 }
 
 static win_request_info *
@@ -4119,7 +4176,7 @@ struct window_procs mac_procs = {
     WC_COLOR | WC_HILITE_PET | WC_FONT_MAP | WC_FONT_MENU | WC_FONT_MESSAGE
         | WC_FONT_STATUS | WC_FONT_TEXT | WC_FONTSIZ_MAP | WC_FONTSIZ_MENU
         | WC_FONTSIZ_MESSAGE | WC_FONTSIZ_STATUS | WC_FONTSIZ_TEXT
-        | WC_TILED_MAP,
+        | WC_TILED_MAP | WC_PERM_INVENT,
     WC2_SUPPRESS_HIST    /* honor ATR_NOHISTORY: transient msgs (e.g. farlook
                             descriptions) replace the line instead of logging */
         | WC2_HILITE_STATUS | WC2_FLUSH_STATUS | WC2_HITPOINTBAR

--- a/sys/mac68k/nhmenus.r
+++ b/sys/mac68k/nhmenus.r
@@ -215,6 +215,7 @@ resource 'MENU' (138) {
         "Redraw", noIcon, "R", noMark, plain,
         "Previous Message", noIcon, "P", noMark, plain,
         "Reposition Windows", noIcon, "N", noMark, plain,
+        "Save Window Positions", noIcon, noKey, noMark, plain,
         "Tile Mode", noIcon, "T", noMark, plain,
         "-", noIcon, noKey, noMark, plain,
         "Play Mode", noIcon, "\0x1B" /* hierarchicalMenu */, "\0xCA", plain

--- a/sys/mac68k/nhmenus.r
+++ b/sys/mac68k/nhmenus.r
@@ -217,6 +217,7 @@ resource 'MENU' (138) {
         "Reposition Windows", noIcon, "N", noMark, plain,
         "Save Window Positions", noIcon, noKey, noMark, plain,
         "Tile Mode", noIcon, "T", noMark, plain,
+        "Overview Window", noIcon, noKey, noMark, plain,
         "-", noIcon, noKey, noMark, plain,
         "Play Mode", noIcon, "\0x1B" /* hierarchicalMenu */, "\0xCA", plain
     }
@@ -435,7 +436,7 @@ resource 'STR#' (201, "current") {
  * font popups (8-12) and size popups (13-17) are contiguous runs in
  * uiprefs_fonts order (map, status, message, menu, text). */
 resource 'DLOG' (6100, "Preferences") {
-    {24, 56, 320, 456},
+    {24, 56, 312, 456},
     movableDBoxProc, /* System 7 movable modal (titled; drag handled in
                         pref_filter -- ModalDialog won't track it) */
     visible,
@@ -448,33 +449,36 @@ resource 'DLOG' (6100, "Preferences") {
 
 resource 'DITL' (6100) {
     {
-        {264, 310, 284, 384}, Button { enabled, "Save" },          /* 1 */
-        {264, 228, 284, 292}, Button { enabled, "Cancel" },        /* 2 */
-        {264, 16, 284, 140},  Button { enabled, "Forget Settings" }, /* 3 */
-        {12, 16, 30, 190},    CheckBox { enabled, "Tiled map" },   /* 4 */
-        {36, 16, 54, 190},    CheckBox { enabled, "Hit-point bar" }, /* 5 */
-        {12, 210, 30, 384},   RadioButton { enabled, "2 status lines" }, /* 6 */
-        {36, 210, 54, 384},   RadioButton { enabled, "3 status lines" }, /* 7 */
-        {78, 100, 98, 300},   UserItem { enabled },                /* 8 map font */
-        {106, 100, 126, 300}, UserItem { enabled },                /* 9 status */
+        {258, 310, 278, 384}, Button { enabled, "Save" },          /* 1 */
+        {258, 228, 278, 292}, Button { enabled, "Cancel" },        /* 2 */
+        {258, 16, 278, 140},  Button { enabled, "Forget Settings" }, /* 3 */
+        {8, 16, 26, 190},     CheckBox { enabled, "Tiled map" },   /* 4 */
+        {30, 16, 48, 190},    CheckBox { enabled, "Hit-point bar" }, /* 5 */
+        {52, 116, 70, 154},   RadioButton { enabled, "2" }, /* 6 */
+        {52, 158, 70, 196},   RadioButton { enabled, "3" }, /* 7 */
+        {82, 100, 102, 300},  UserItem { enabled },                /* 8 map font */
+        {108, 100, 128, 300}, UserItem { enabled },                /* 9 status */
         {134, 100, 154, 300}, UserItem { enabled },                /* 10 message */
-        {162, 100, 182, 300}, UserItem { enabled },                /* 11 menu */
-        {190, 100, 210, 300}, UserItem { enabled },                /* 12 text */
-        {78, 312, 98, 388},   UserItem { enabled },                /* 13 map size */
-        {106, 312, 126, 388}, UserItem { enabled },                /* 14 status */
+        {160, 100, 180, 300}, UserItem { enabled },                /* 11 menu */
+        {186, 100, 206, 300}, UserItem { enabled },                /* 12 text */
+        {82, 312, 102, 388},  UserItem { enabled },                /* 13 map size */
+        {108, 312, 128, 388}, UserItem { enabled },                /* 14 status */
         {134, 312, 154, 388}, UserItem { enabled },                /* 15 message */
-        {162, 312, 182, 388}, UserItem { enabled },                /* 16 menu */
-        {190, 312, 210, 388}, UserItem { enabled },                /* 17 text */
-        {80, 16, 96, 96},     StaticText { disabled, "Map:" },     /* 18 */
-        {108, 16, 124, 96},   StaticText { disabled, "Status:" },  /* 19 */
+        {160, 312, 180, 388}, UserItem { enabled },                /* 16 menu */
+        {186, 312, 206, 388}, UserItem { enabled },                /* 17 text */
+        {84, 16, 100, 96},    StaticText { disabled, "Map:" },     /* 18 */
+        {110, 16, 126, 96},   StaticText { disabled, "Status:" },  /* 19 */
         {136, 16, 152, 96},   StaticText { disabled, "Message:" }, /* 20 */
-        {164, 16, 180, 96},   StaticText { disabled, "Menu:" },    /* 21 */
-        {192, 16, 208, 96},   StaticText { disabled, "Text:" },    /* 22 */
-        {222, 16, 254, 384},  StaticText { disabled,
+        {162, 16, 178, 96},   StaticText { disabled, "Menu:" },    /* 21 */
+        {188, 16, 204, 96},   StaticText { disabled, "Text:" },    /* 22 */
+        {214, 16, 246, 384},  StaticText { disabled,
             "Changes take effect at the next launch." },           /* 23 */
-        {56, 210, 74, 384},   CheckBox { enabled, "Tiles in menus" }, /* 24 */
-        {260, 306, 288, 388}, UserItem { disabled },  /* 25 default ring */
-        {257, 16, 258, 388},  UserItem { disabled }   /* 26 separator */
+        {8, 210, 26, 384},    CheckBox { enabled, "Tiles in menus" }, /* 24 */
+        {254, 306, 282, 388}, UserItem { disabled },  /* 25 default ring */
+        {251, 16, 252, 388},  UserItem { disabled },  /* 26 separator */
+        {55, 16, 71, 112},    StaticText { disabled, "Status lines:" }, /* 27 */
+        {30, 210, 48, 384},   CheckBox { enabled, "Sound" }, /* 28 */
+        {76, 16, 77, 388},    UserItem { disabled }   /* 29 rule above fonts */
     }
 };
 
@@ -491,6 +495,18 @@ resource 'DLOG' (6200, "About NetHack") {
     6200,
     "About NetHack",
     centerMainScreen
+};
+
+/* Dialog color table: content background = the title PICT's teal
+ * (RGB 71,108,108), so the artwork blends into the whole dialog.
+ * Raw data (no dctb Rez template in the Retro68 RIncludes):
+ * ctSeed, ctFlags, ctSize=0 (one entry), part 0 = wContentColor, RGB.
+ * GetNewDialog picks it up by matching resource ID; ignored on 1-bit
+ * screens, where the dialog stays white (the PICT isn't drawn there
+ * either). */
+data 'dctb' (6200, "About NetHack", purgeable) {
+    $"00000000 0000 0000"
+    $"0000 4747 6C6C 6C6C"
 };
 
 resource 'DITL' (6200) {


### PR DESCRIPTION
- two new optional windows: perminv and map overview (3x3 pixel per tile) for low display resolutions
- "rearrange windows" improved for new windows
- "Game -> Save Window Positions" for explicitly persisting a window arrangement, no constant saving anymore
- misc UI fixes