### PR TITLE
X11: Implement all attributes for fancy status and menus, and add all statuses

### DIFF
--- a/include/botl.h
+++ b/include/botl.h
@@ -238,14 +238,14 @@ extern int cond_idx[CONDITION_COUNT];
 #define BL_TH_ALWAYS_HILITE 105  /* highlight regardless of value */
 #define BL_TH_CRITICALHP 106     /* highlight critically low HP */
 
-#define HL_ATTCLR_NONE    CLR_MAX + 1
-#define HL_ATTCLR_BOLD    CLR_MAX + 2
-#define HL_ATTCLR_DIM     CLR_MAX + 3
-#define HL_ATTCLR_ITALIC  CLR_MAX + 4
-#define HL_ATTCLR_ULINE   CLR_MAX + 5
-#define HL_ATTCLR_BLINK   CLR_MAX + 6
-#define HL_ATTCLR_INVERSE CLR_MAX + 7
-#define BL_ATTCLR_MAX     CLR_MAX + 8
+#define HL_ATTCLR_NONE    (CLR_MAX + 1)
+#define HL_ATTCLR_BOLD    (CLR_MAX + 2)
+#define HL_ATTCLR_DIM     (CLR_MAX + 3)
+#define HL_ATTCLR_ITALIC  (CLR_MAX + 4)
+#define HL_ATTCLR_ULINE   (CLR_MAX + 5)
+#define HL_ATTCLR_BLINK   (CLR_MAX + 6)
+#define HL_ATTCLR_INVERSE (CLR_MAX + 7)
+#define BL_ATTCLR_MAX     (CLR_MAX + 8)
 
 enum hlattribs {
     HL_UNDEF   = 0x00,

--- a/include/winX.h
+++ b/include/winX.h
@@ -331,6 +331,9 @@ extern void (*input_func)(Widget, XEvent *, String *, Cardinal *);
 
 extern struct window_procs X11_procs;
 
+/* Flag maintained by the blink callback */
+extern boolean X11_blink;
+
 /* Check for an invalid window id. */
 #define check_winid(window) \
     do {                                                        \
@@ -424,6 +427,9 @@ extern void destroy_status_window(struct xwindow *);
 extern void adjust_status(struct xwindow *, const char *);
 extern void null_out_status(void);
 extern void check_turn_events(void);
+#ifdef STATUS_HILITES
+extern void X11_tty_status_blink(void);
+#endif
 
 /* ### wintext.c ### */
 extern void delete_text(Widget, XEvent *, String *, Cardinal *);
@@ -519,11 +525,13 @@ extern XFontStruct *X11_italic_font(Display *, XFontStruct *);
 extern XFontStruct *X11_unicode_font(Display *, XFontStruct *);
 #endif
 
+/* ### winlabel.c ### */
 /* Functions for management of enhanced labels */
 extern void X11_wrap_widget(Widget);
 extern void X11_update_label(Widget);
 extern void X11_set_attrs(Widget, unsigned);
 extern void X11_set_highlight(Widget, boolean);
 extern void X11_set_percent(Widget, unsigned, Pixel);
+extern void X11_blink_labels(void);
 
 #endif /* WINX_H */

--- a/include/winX.h
+++ b/include/winX.h
@@ -523,5 +523,7 @@ extern XFontStruct *X11_unicode_font(Display *, XFontStruct *);
 /* Functions for management of enhanced labels */
 extern void X11_wrap_widget(Widget);
 extern void X11_update_label(Widget);
+extern void X11_set_attrs(Widget, unsigned);
+extern void X11_set_percent(Widget, unsigned, Pixel);
 
 #endif /* WINX_H */

--- a/include/winX.h
+++ b/include/winX.h
@@ -454,7 +454,6 @@ extern int get_name_width(Widget);
 extern Widget get_value_widget(Widget);
 extern void set_value_width(Widget, int);
 extern int get_value_width(Widget);
-extern void hilight_value(Widget);
 extern void swap_fg_bg(Widget);
 extern void set_value(Widget w, const char *new_value);
 /* external declarations */
@@ -524,6 +523,7 @@ extern XFontStruct *X11_unicode_font(Display *, XFontStruct *);
 extern void X11_wrap_widget(Widget);
 extern void X11_update_label(Widget);
 extern void X11_set_attrs(Widget, unsigned);
+extern void X11_set_highlight(Widget, boolean);
 extern void X11_set_percent(Widget, unsigned, Pixel);
 
 #endif /* WINX_H */

--- a/include/winX.h
+++ b/include/winX.h
@@ -514,9 +514,14 @@ extern void X11_preference_update(const char *);
 extern void X11_update_inventory(int);
 extern win_request_info *X11_ctrl_nhwindow(winid, int, win_request_info *);
 extern X11_map_symbol X11_glyph_char(const glyph_info *);
+extern XFontStruct *X11_bold_font(Display *, XFontStruct *);
 extern XFontStruct *X11_italic_font(Display *, XFontStruct *);
 #ifdef ENHANCED_SYMBOLS
 extern XFontStruct *X11_unicode_font(Display *, XFontStruct *);
 #endif
+
+/* Functions for management of enhanced labels */
+extern void X11_wrap_widget(Widget);
+extern void X11_update_label(Widget);
 
 #endif /* WINX_H */

--- a/sys/unix/Makefile.src
+++ b/sys/unix/Makefile.src
@@ -259,11 +259,11 @@ WINCURSESOBJ ?= $(TARGETPFX)cursmain.o $(TARGETPFX)curswins.o \
 WINX11SRC ?= ../win/X11/Window.c ../win/X11/dialogs.c ../win/X11/winX.c \
 	../win/X11/winmap.c  ../win/X11/winmenu.c ../win/X11/winmesg.c \
 	../win/X11/winmisc.c ../win/X11/winstat.c ../win/X11/wintext.c \
-	../win/X11/winval.c $(GENTILECFILE)
+	../win/X11/winval.c ../win/X11/winlabel.c $(GENTILECFILE)
 WINX11OBJ ?= $(TARGETPFX)Window.o $(TARGETPFX)dialogs.o $(TARGETPFX)winX.o \
 	$(TARGETPFX)winmap.o $(TARGETPFX)winmenu.o $(TARGETPFX)winmesg.o \
 	$(TARGETPFX)winmisc.o $(TARGETPFX)winstat.o $(TARGETPFX)wintext.o \
-	$(TARGETPFX)winval.o
+	$(TARGETPFX)winval.o $(TARGETPFX)winlabel.o
 #
 # Files for a Qt 3 interface (renamed since nethack 3.6.x)
 #
@@ -1080,6 +1080,8 @@ $(TARGETPFX)winX.o: ../win/X11/winX.c $(HACK_H) ../include/dlb.h \
 		../include/winX.h ../include/xwindow.h ../win/X11/nh32icon \
 		../win/X11/nh56icon ../win/X11/nh72icon
 	$(TARGET_CC) $(TARGET_CFLAGS) $(X11CFLAGS) -c -o $@ ../win/X11/winX.c
+$(TARGETPFX)winlabel.o: ../win/X11/winlabel.c $(HACK_H)
+	$(TARGET_CC) $(TARGET_CFLAGS) $(X11CFLAGS) -c -o $@ ../win/X11/winlabel.c
 $(TARGETPFX)winmap.o: ../win/X11/winmap.c $(HACK_H) ../include/dlb.h \
 		../include/tile2x11.h ../include/winX.h ../include/xwindow.h
 	$(TARGET_CC) $(TARGET_CFLAGS) $(X11CFLAGS) -c -o $@ ../win/X11/winmap.c

--- a/win/X11/winX.c
+++ b/win/X11/winX.c
@@ -3005,6 +3005,27 @@ X11_glyph_char(const glyph_info *glyphinfo)
 #endif
 }
 
+/* Given an XFontStruct, return a corresponding bold font */
+XFontStruct *
+X11_bold_font(Display *display, XFontStruct *font)
+{
+    Atom font_atom;
+    if (!XGetFontProperty(font, XA_FONT, &font_atom)) {
+        return NULL;
+    }
+
+    const char *font_name = XGetAtomName(display, font_atom);
+    if (font_name == NULL) {
+        return NULL;
+    }
+
+    char *bold_font = fontname_boldify(font_name);
+    XFontStruct *font2 = XLoadQueryFont(display, bold_font);
+    free(bold_font);
+
+    return font2;
+}
+
 /* Given an XFontStruct, return a corresponding italic font */
 XFontStruct *
 X11_italic_font(Display *display, XFontStruct *font)

--- a/win/X11/winX.c
+++ b/win/X11/winX.c
@@ -3021,7 +3021,6 @@ X11_bold_font(Display *display, XFontStruct *font)
 
     char *bold_font = fontname_boldify(font_name);
     XFontStruct *font2 = XLoadQueryFont(display, bold_font);
-    free(bold_font);
 
     return font2;
 }

--- a/win/X11/winX.c
+++ b/win/X11/winX.c
@@ -112,6 +112,9 @@ static void X11_error_handler(String) __attribute__((noreturn));
 ATTRNORETURN static XtErrorHandler X11_error_handler(String);
 #endif
 
+boolean X11_blink;
+static unsigned blink_interval = 500; /* milliseconds */
+
 static int X11_io_error_handler(Display *);
 
 static int (*old_error_handler)(Display *, XErrorEvent *);
@@ -200,6 +203,7 @@ static void release_yn_widgets(void);
 static int input_event(int);
 static void win_visible(Widget, XtPointer, XEvent *, Boolean *);
 static void init_standard_windows(void);
+static void blink_callback(XtPointer client_data, XtIntervalId *timer);
 
 /*
  * Local variables.
@@ -1611,6 +1615,7 @@ X11_init_nhwindows(int *argcp, char **argv)
                                (ArgList) args, num_args);
     XtOverrideTranslations(toplevel,
               XtParseTranslationTable("<Message>WM_PROTOCOLS: X11_hangup()"));
+    XtAppAddTimeOut(app_context, blink_interval, blink_callback, NULL);
 
     /* We don't need to realize the top level widget. */
 
@@ -1665,6 +1670,20 @@ X11_init_nhwindows(int *argcp, char **argv)
     /* Display the startup banner in the message window. */
     for (i = 1; i <= 4 + 2; ++i) /* (values beyond 4 yield blank lines) */
         X11_putstr(WIN_MESSAGE, 0, copyright_banner_line(i));
+}
+
+static void
+blink_callback(XtPointer client_data, XtIntervalId *timer)
+{
+    nhUse(timer);
+#ifdef STATUS_HILITES
+    X11_tty_status_blink();
+#endif
+    X11_blink_labels();
+
+    X11_blink = !X11_blink;
+    /* Do it again */
+    XtAppAddTimeOut(app_context, blink_interval, blink_callback, client_data);
 }
 
 /*

--- a/win/X11/winlabel.c
+++ b/win/X11/winlabel.c
@@ -85,8 +85,6 @@ X11_wrap_widget(Widget w)
 
     /* Create the pixmap for the first time */
     update_label(w, data);
-
-    return w;
 }
 
 /* Callback when the widget is deleted */
@@ -124,8 +122,29 @@ check_label(Widget w)
 void
 X11_update_label(Widget w)
 {
-    if (check_label(w)) {
-        WidgetData *data = get_widget_data(w);
+    WidgetData *data = get_widget_data(w);
+    if (data != NULL) {
+        update_label(w, data);
+    }
+}
+
+void
+X11_set_attrs(Widget w, unsigned attrs)
+{
+    WidgetData *data = get_widget_data(w);
+    if (data != NULL) {
+        data->attrs = attrs;
+        update_label(w, data);
+    }
+}
+
+void
+X11_set_percent(Widget w, unsigned percent, Pixel color)
+{
+    WidgetData *data = get_widget_data(w);
+    if (data != NULL) {
+        data->percent = percent;
+        data->bar_color = color;
         update_label(w, data);
     }
 }
@@ -215,6 +234,15 @@ update_label(Widget w, WidgetData *data)
     }
     width = max(width, 1);
     height = max(height, 1);
+
+    /* Use the full width of the widget if a percentage bar is set */
+    if (data->percent != 0) {
+        Dimension wwidth;
+        num_args = 0;
+        XtSetArg(args[num_args], XtNwidth, &wwidth); num_args++;
+        XtGetValues(w, args, num_args);
+        width = max(width, wwidth);
+    }
 
     /* Create the pixmap */
     new_pixmap = XCreatePixmap(display, RootWindowOfScreen(screen),

--- a/win/X11/winlabel.c
+++ b/win/X11/winlabel.c
@@ -1,0 +1,445 @@
+/* NetHack 5.0	winlabel.c	$NHDT-Date: 1781973110 2026/06/20 16:31:50 $  $NHDT-Branch: NetHack-5.0 $:$NHDT-Revision: 1.50 $ */
+/* Copyright (c) Ray Chason, 2026                                 */
+/* NetHack may be freely redistributed.  See license for details. */
+
+#include <X11/Intrinsic.h>
+#include <X11/StringDefs.h>
+#include <X11/Xaw/Label.h>
+
+#include <inttypes.h>
+
+#ifdef PRESERVE_NO_SYSV
+#ifdef SYSV
+#undef SYSV
+#endif
+#undef PRESERVE_NO_SYSV
+#endif
+
+#include "hack.h"
+#include "winX.h"
+
+/* Data attached to a wrapped widget */
+typedef struct WidgetData {
+    /* Displayed text */
+    Pixmap pixmap;
+
+    /* Attributes */
+    unsigned attrs;
+
+    /* Fonts for italic, bold and bold-italic */
+    XFontStruct *font[4]; /* To use the fonts */
+    XFontStruct *font_ptr[4]; /* To free the fonts */
+
+    /* Percentage bar */
+    unsigned percent;
+    Pixel bar_color;
+} WidgetData;
+
+/* Bits for WidgetData::font */
+enum { font_bold = 1, font_italic = 2 };
+
+static boolean check_label(Widget);
+static void delete_callback(Widget, XtPointer, XtPointer);
+static void update_label(Widget, WidgetData *);
+static void allocate_font(Widget, WidgetData *, unsigned);
+static void free_fonts(Widget, WidgetData *);
+
+static WidgetData *add_widget(Widget w);
+static void delete_widget(Widget w);
+static WidgetData *get_widget_data(Widget w);
+
+/*
+ * Create a wrapper for labelWidgetClass and its descendant classes.
+ *
+ * A table is maintained to associate each widget with a data block.
+ * The block contains additional fonts for italic, bold and bold-italic,
+ * attribute flags and a percentage bar.
+ */
+void
+X11_wrap_widget(Widget w)
+{
+    /* We shouldn't use this for anything other than labels and subclasses
+       of labels */
+    if (!check_label(w)) {
+        impossible("Widget is not a Label or of a class derived from Label");
+        return;
+    }
+
+    /* Only wrap once */
+    if (get_widget_data(w)) {
+        impossible("Tried to wrap a widget twice");
+        return;
+    }
+
+    /* Attach a destroy callback to reclaim resources attached to the widget */
+    XtAddCallback(w, XtNdestroyCallback, delete_callback, NULL);
+
+    /* Create the structure with its initial settings */
+    WidgetData *data = add_widget(w);
+
+    /* Copy resources from the created widget */
+    Cardinal num_args2 = 0;
+    Arg args2[1];
+    XtSetArg(args2[num_args2], XtNfont,  &data->font[0]); num_args2++;
+    XtGetValues(w, args2, num_args2);
+
+    /* Create the pixmap for the first time */
+    update_label(w, data);
+
+    return w;
+}
+
+/* Callback when the widget is deleted */
+static void
+delete_callback(Widget w, XtPointer client_data, XtPointer call_data)
+{
+    nhUse(client_data);
+    nhUse(call_data);
+
+    /*
+     * We shouldn't get here with any widget for which check_label returns
+     * false, because such widgets will not have this callback set
+     */
+    WidgetData *data = get_widget_data(w);
+    if (data != NULL) {
+        Display *display = XtDisplay(w);
+        if (data->pixmap != 0) {
+            XFreePixmap(display, data->pixmap);
+        }
+        free_fonts(w, data);
+        free(data);
+    }
+
+    delete_widget(w);
+}
+
+/* Return true if the widget is a Label or of a class derived from Label */
+static boolean
+check_label(Widget w)
+{
+    return XtIsSubclass(w, labelWidgetClass);
+}
+
+/* Update the label's pixmap */
+void
+X11_update_label(Widget w)
+{
+    if (check_label(w)) {
+        WidgetData *data = get_widget_data(w);
+        update_label(w, data);
+    }
+}
+
+/* Update the label's pixmap */
+/* This is called from functions that have altered the data block, and already
+   have a pointer to it */
+static void
+update_label(Widget w, WidgetData *data)
+{
+    Display *display = XtDisplay(w);
+    Screen *screen = DefaultScreenOfDisplay(display);
+    int depth = DefaultDepthOfScreen(screen);
+
+    Pixmap new_pixmap = 0;
+    Cardinal num_args;
+    Arg args[10];
+
+    /* Select the font */
+    unsigned font_idx = 0;
+    if (data->attrs & HL_BOLD) {
+        font_idx |= font_bold;
+        allocate_font(w, data, font_idx);
+    }
+    if (data->attrs & HL_ITALIC) {
+        font_idx |= font_italic;
+        allocate_font(w, data, font_idx);
+    }
+    XFontStruct *font = data->font[font_idx];
+
+    String label;
+    Boolean sens;       /* Make dim if not sensitive */
+    XtJustify justify;  /* Left, center, right */
+    Pixel fgpixel;      /* Colors for the first pass */
+    Pixel bgpixel;
+    Boolean resize;     /* Resizable? */
+    num_args = 0;
+    XtSetArg(args[num_args], XtNlabel, &label); num_args++;
+    XtSetArg(args[num_args], XtNsensitive, &sens); num_args++;
+    XtSetArg(args[num_args], XtNjustify, &justify); num_args++;
+    XtSetArg(args[num_args], XtNforeground, &fgpixel); num_args++;
+    XtSetArg(args[num_args], XtNbackground, &bgpixel); num_args++;
+    XtSetArg(args[num_args], XtNresize, &resize); num_args++;
+    XtGetValues(w, args, num_args);
+    unsigned attrs = data->attrs;
+    if (!sens) {
+        attrs |= HL_DIM;
+    }
+
+    /* Dimensions of pixmap */
+    Dimension width;
+    Dimension height;
+    if (resize) {
+        /* Render the widest width and the total height of the lines */
+        size_t i = 0;
+        width = 0;
+        height = 0;
+        while (label[i] != '\0') {
+            size_t line1 = strcspn(label + i, "\n");
+            size_t line2 = line1;
+            /* Exclude \r from the rendering */
+            if (line2 != 0 && label[i + line2 - 1] == '\r') {
+                --line2;
+            }
+
+            /* Get the width of the line */
+            int lwidth = XTextWidth(font, label + i, line2);
+
+            /* Update pixmap dimensions */
+            width = max(lwidth, width);
+            height += font->ascent + font->descent;
+
+            /* Advance to next line */
+            i += line1;
+            if (label[i] == '\n') {
+                ++i;
+            }
+        }
+
+        /* Always size for at least one line */
+        height = max(height, font->ascent + font->descent);
+    } else {
+        num_args = 0;
+        XtSetArg(args[num_args], XtNwidth, &width); num_args++;
+        XtSetArg(args[num_args], XtNheight, &height); num_args++;
+        XtGetValues(w, args, num_args);
+    }
+    width = max(width, 1);
+    height = max(height, 1);
+
+    /* Create the pixmap */
+    new_pixmap = XCreatePixmap(display, RootWindowOfScreen(screen),
+                               width, height, depth);
+
+    /* If a percent bar is specified, make two passes over the text and render
+       the percent bar in the second pass */
+    for (unsigned pass = 0; pass < 2; ++pass) {
+        XGCValues values;
+
+        if (attrs & HL_INVERSE) {
+            values.foreground = bgpixel;
+            values.background = fgpixel;
+        } else {
+            values.foreground = fgpixel;
+            values.background = bgpixel;
+        }
+        if (attrs & HL_DIM) {
+            values.foreground = (values.foreground & 0xFEFEFE) >> 1;
+            values.background = (values.background & 0xFEFEFE) >> 1;
+        }
+        values.font = font->fid;
+        values.function = GXcopy;
+        GC ggc = XtGetGC(w,
+                         GCFunction | GCForeground | GCBackground | GCFont,
+                         &values);
+        if (pass == 1) {
+            /* Percent bar will occupy this area */
+            XRectangle clip = {
+                .x = 0,
+                .y = 0,
+                .width = width * data->percent / 100,
+                .height = height
+            };
+            XSetClipRectangles(display, ggc, 0, 0, &clip, 1, Unsorted);
+        }
+
+        XSetForeground(display, ggc, values.background);
+        XFillRectangle(display, new_pixmap, ggc, 0, 0, width, height);
+        XSetForeground(display, ggc, values.foreground);
+
+        int y = font->max_bounds.ascent;
+        size_t i = 0;
+        while (label[i] != '\0') {
+            size_t line1 = strcspn(label + i, "\n");
+            size_t line2 = line1;
+            /* Exclude \r from the rendering */
+            if (line2 != 0 && label[i + line2 - 1] == '\r') {
+                --line2;
+            }
+
+            /* Get the width of the line */
+            int lwidth = XTextWidth(font, label + i, line2);
+
+            /* Place the line horizontally */
+            int x = 0;
+            switch (justify) {
+                case XtJustifyLeft:
+                    x = 0;
+                    break;
+
+                case XtJustifyCenter:
+                    x = (width - lwidth) / 2;
+                    break;
+
+                case XtJustifyRight:
+                    x = width - lwidth;
+                    break;
+            }
+
+            /* Render the line */
+            XDrawString(display, new_pixmap, ggc,
+                        x, y,
+                        label + i, line2);
+
+            y += font->ascent + font->descent;
+
+            /* Advance to next line */
+            i += line1;
+            if (label[i] == '\n') {
+                ++i;
+            }
+        }
+
+        XtReleaseGC(w, ggc);
+
+        /* Set up to display the percent bar on the second pass */
+        if (data->percent == 0) {
+            break;
+        }
+        fgpixel = bgpixel;
+        bgpixel = data->bar_color;
+    }
+
+    /* Update the pixmap */
+    num_args = 0;
+    XtSetArg(args[num_args], XtNbitmap, new_pixmap); num_args++;
+    //XtSetArg(args[num_args], XtNwidth, width); num_args++;
+    //XtSetArg(args[num_args], XtNheight, height); num_args++;
+    XtSetValues(w, args, num_args);
+    if (data->pixmap != 0) {
+        XFreePixmap(display, data->pixmap);
+    }
+    data->pixmap = new_pixmap;
+}
+
+/* Allocate a bold or italic font */
+static void
+allocate_font(Widget w, WidgetData *data, unsigned font_idx)
+{
+    Display *display = XtDisplay(w);
+
+    XFontStruct *font1 = (font_idx == (font_bold | font_italic))
+                       ? data->font[font_bold]
+                       : data->font[0];
+    data->font_ptr[font_idx] = (font_idx == font_bold)
+                             ? X11_bold_font(display, font1)
+                             : X11_italic_font(display, font1);
+    data->font[font_idx] = data->font_ptr[font_idx]
+                         ? data->font_ptr[font_idx]
+                         : font1;
+}
+
+/* Free any allocated fonts */
+static void
+free_fonts(Widget w, WidgetData *data)
+{
+    Display *display = XtDisplay(w);
+    for (unsigned i = 0; i < 4; ++i) {
+        XFreeFont(display, data->font_ptr[i]);
+        data->font[i] = NULL;
+        data->font_ptr[i] = NULL;
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//                 A table of widgets and their data blocks                 //
+//////////////////////////////////////////////////////////////////////////////
+
+typedef struct WidgetBucket {
+    Widget w;
+    WidgetData *data;
+} WidgetBucket;
+
+#define MAX_WIDGETS 1024
+static WidgetBucket widget_table[MAX_WIDGETS];
+static unsigned num_widgets;
+
+/* bsearch compare function to search widget-table */
+static int
+widget_compare(const void *key_, const void *value_)
+{
+    const Widget *key = key_;
+    const WidgetBucket *value = value_;
+
+    if ((uintptr_t)key < (uintptr_t)value->w) {
+        return -1;
+    }
+    if ((uintptr_t)key > (uintptr_t)value->w) {
+        return +1;
+    }
+    return 0;
+}
+
+/* Given the widget, return the entry in widget_table, or NULL if not found */
+static WidgetBucket *
+find_widget_bucket(Widget w)
+{
+    WidgetBucket *bucket =
+            bsearch(w, widget_table, num_widgets, sizeof(WidgetBucket),
+                    widget_compare);
+    return bucket;
+}
+
+/* Given the widget, return the WidgetData structure, or NULL if not found */
+static WidgetData *
+get_widget_data(Widget w)
+{
+    WidgetBucket *bucket = find_widget_bucket(w);
+    return (bucket != NULL) ? bucket->data : NULL;
+}
+
+/* Add a widget to the table, set its normal and bold fonts and provide for
+   its removal from the table */
+static WidgetData *
+add_widget(Widget w)
+{
+    /* Panic rather than overflow the array */
+    if (num_widgets >= MAX_WIDGETS) {
+        panic("Widget table is full\n");
+    }
+
+    /* Insert the widget into the table, maintaining its order */
+    unsigned i;
+    for (i = num_widgets;
+         i != 0 && (uintptr_t)widget_table[i-1].w > (uintptr_t)w;
+         --i) {
+        widget_table[i] = widget_table[i-1];
+    }
+    ++num_widgets;
+    widget_table[i].w = w;
+
+    /* Create the data block */
+    WidgetData *data = (WidgetData *)alloc(sizeof(*data));
+    memset(data, 0, sizeof(*data));
+    widget_table[i].data = data;
+
+    return data;
+}
+
+/* Remove the widget from the table */
+static void
+delete_widget(Widget w)
+{
+    /* Find its location in the table */
+    WidgetBucket *bucket = find_widget_bucket(w);
+    if (bucket == NULL) {
+        return;
+    }
+
+    /* Remove the widget from the table */
+    for (unsigned i = (unsigned)(bucket - widget_table);
+         i + 1 < MAX_WIDGETS;
+         ++i) {
+        widget_table[i] = widget_table[i+1];
+    }
+    --num_widgets;
+}

--- a/win/X11/winlabel.c
+++ b/win/X11/winlabel.c
@@ -25,6 +25,7 @@ typedef struct WidgetData {
 
     /* Attributes */
     unsigned attrs;
+    boolean highlight;
 
     /* Fonts for italic, bold and bold-italic */
     XFontStruct *font[4]; /* To use the fonts */
@@ -139,6 +140,16 @@ X11_set_attrs(Widget w, unsigned attrs)
 }
 
 void
+X11_set_highlight(Widget w, boolean highlight)
+{
+    WidgetData *data = get_widget_data(w);
+    if (data != NULL) {
+        data->highlight = highlight;
+        update_label(w, data);
+    }
+}
+
+void
 X11_set_percent(Widget w, unsigned percent, Pixel color)
 {
     WidgetData *data = get_widget_data(w);
@@ -232,16 +243,23 @@ update_label(Widget w, WidgetData *data)
         XtSetArg(args[num_args], XtNheight, &height); num_args++;
         XtGetValues(w, args, num_args);
     }
-    width = max(width, 1);
-    height = max(height, 1);
+    if (width < 2 || height < 2) {
+        /* Pixmap must not have zero size, or a crash will ensue;
+           minimum size 2 simplifies border logic */
+        width = max(width, 2);
+        height = max(height, 2);
+        fgpixel = bgpixel;
+    }
 
-    /* Use the full width of the widget if a percentage bar is set */
-    if (data->percent != 0) {
-        Dimension wwidth;
+    /* Use the full width of the widget if a percentage bar is set or inverse
+       is in effect */
+    if (data->percent != 0 || (attrs & HL_INVERSE) != 0 || data->highlight) {
+        Dimension wwidth, iwidth;
         num_args = 0;
         XtSetArg(args[num_args], XtNwidth, &wwidth); num_args++;
+        XtSetArg(args[num_args], XtNinternalWidth, &iwidth); num_args++;
         XtGetValues(w, args, num_args);
-        width = max(width, wwidth);
+        width = max(width, wwidth - iwidth*2);
     }
 
     /* Create the pixmap */
@@ -253,7 +271,7 @@ update_label(Widget w, WidgetData *data)
     for (unsigned pass = 0; pass < 2; ++pass) {
         XGCValues values;
 
-        if (attrs & HL_INVERSE) {
+        if (!!(attrs & HL_INVERSE) ^ !!data->highlight) {
             values.foreground = bgpixel;
             values.background = fgpixel;
         } else {
@@ -280,7 +298,11 @@ update_label(Widget w, WidgetData *data)
             XSetClipRectangles(display, ggc, 0, 0, &clip, 1, Unsorted);
         }
 
-        XSetForeground(display, ggc, values.background);
+        /* Draw a border for inverse and highlight together */
+        /* Otherwise, fill with the background color */
+        if (!((attrs & HL_INVERSE) && data->highlight)) {
+            XSetForeground(display, ggc, values.background);
+        }
         XFillRectangle(display, new_pixmap, ggc, 0, 0, width, height);
         XSetForeground(display, ggc, values.foreground);
 
@@ -314,9 +336,16 @@ update_label(Widget w, WidgetData *data)
             }
 
             /* Render the line */
-            XDrawString(display, new_pixmap, ggc,
-                        x, y,
-                        label + i, line2);
+            XDrawImageString(display, new_pixmap, ggc,
+                             x, y,
+                             label + i, line2);
+
+            /* Draw the underline if requested */
+            if (attrs & HL_ULINE) {
+                XDrawLine(display, new_pixmap, ggc,
+                          x, y,
+                          x + lwidth - 1, y);
+            }
 
             y += font->ascent + font->descent;
 
@@ -325,6 +354,11 @@ update_label(Widget w, WidgetData *data)
             if (label[i] == '\n') {
                 ++i;
             }
+        }
+
+        /* Ensure a one-pixel border if both inverse and highlight */
+        if ((attrs & HL_INVERSE) && data->highlight) {
+            XDrawRectangle(display, new_pixmap, ggc, 0, 0, width-1, height-1);
         }
 
         XtReleaseGC(w, ggc);

--- a/win/X11/winlabel.c
+++ b/win/X11/winlabel.c
@@ -282,6 +282,9 @@ update_label(Widget w, WidgetData *data)
             values.foreground = (values.foreground & 0xFEFEFE) >> 1;
             values.background = (values.background & 0xFEFEFE) >> 1;
         }
+        if ((attrs & HL_BLINK) && X11_blink) {
+            values.foreground = values.background;
+        }
         values.font = font->fid;
         values.function = GXcopy;
         GC ggc = XtGetGC(w,
@@ -504,4 +507,18 @@ delete_widget(Widget w)
         widget_table[i] = widget_table[i+1];
     }
     --num_widgets;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+/* Call every time the blink flag changes */
+void
+X11_blink_labels(void)
+{
+    for (unsigned i = 0; i < num_widgets; ++i) {
+        WidgetBucket *bucket = &widget_table[i];
+        if (bucket->data->attrs & HL_BLINK) {
+            update_label(bucket->w, bucket->data);
+        }
+    }
 }

--- a/win/X11/winlabel.c
+++ b/win/X11/winlabel.c
@@ -409,7 +409,9 @@ free_fonts(Widget w, WidgetData *data)
 {
     Display *display = XtDisplay(w);
     for (unsigned i = 0; i < 4; ++i) {
-        XFreeFont(display, data->font_ptr[i]);
+        if (data->font_ptr[i] != NULL) {
+            XFreeFont(display, data->font_ptr[i]);
+        }
         data->font[i] = NULL;
         data->font_ptr[i] = NULL;
     }

--- a/win/X11/winmenu.c
+++ b/win/X11/winmenu.c
@@ -168,6 +168,7 @@ menu_select(Widget w, XtPointer client_data, XtPointer call_data)
 
     XtSetArg(args[0], nhStr(XtNlabel), curr->str);
     XtSetValues(w, args, ONE);
+    X11_update_label(w);
 
     if (menu_info->how == PICK_ONE)
         menu_popdown(wp);
@@ -214,6 +215,7 @@ invert_line(struct xwindow *wp, x11_menu_item *curr, int which, long how_many)
         XtSetValues(curr->w, args, ONE);
         curr->pick_count = -1L;
     }
+    X11_update_label(curr->w);
 }
 
 static XEvent fake_perminv_event;
@@ -1350,14 +1352,8 @@ menu_create_entries(struct xwindow *wp, struct menu *curr_menu)
                                                        ? commandWidgetClass
                                                        : labelWidgetClass,
                                                      wp->w, args, num_args);
-
-        if (attr == ATR_BOLD) {
-            load_boldfont(wp, curr->w);
-            num_args = 0;
-            XtSetArg(args[num_args], nhStr(XtNfont),
-                     wp->boldfs); num_args++;
-            XtSetValues(curr->w, args, num_args);
-        }
+        X11_wrap_widget(curr->w);
+        X11_set_attrs(curr->w, 0x1 << attr);
 
         if (canpick)
             XtAddCallback(linewidget, XtNcallback, menu_select,

--- a/win/X11/winmenu.c
+++ b/win/X11/winmenu.c
@@ -258,10 +258,14 @@ menu_key(Widget w, XEvent *event, String *params, Cardinal *num_params)
            overridden if it happens to duplicate a mapped menu command (':'
            to look inside a container vs ':' to select via search string);
            check for group accelerator match too */
-        for (curr = menu_info->curr_menu.base; curr; curr = curr->next)
-            if (curr->identifier.a_void != 0
-                && (curr->selector == ch || curr->gselector == ch))
-                goto make_selection;
+        for (curr = menu_info->curr_menu.base; curr; curr = curr->next) {
+            if (curr->identifier.a_void != 0) {
+                if (curr->selector == ch)
+                    goto make_selection;
+                if (curr->gselector == ch)
+                    goto group_accel;
+            }
+        }
 
         ch = map_menu_cmd(ch);
         if (ch == '\033') { /* quit */

--- a/win/X11/winstat.c
+++ b/win/X11/winstat.c
@@ -94,13 +94,28 @@
 #define F_HALLU    40
 
 #define F_VERS     41 /* version info */
-#define NUM_STATS  42
+
+#define F_WEAPON   42
+#define F_ARMOR    43
+#define F_TERRAIN  44
+#define F_BAREH    45
+#define F_GLOWHANDS 46
+#define F_ICY      47
+#define F_BUSY     48
+#define F_PARALYZED 49
+#define F_SLEEPING 50
+#define F_UNCONSCIOUS 51
+#define F_IRON     52
+#define F_SLIPPERY 53
+#define F_SUBMERGED 54
+#define F_WOUNDEDL 55
+#define NUM_STATS  56
 
 static int condcolor(long, unsigned long *);
 static int condattr(long, unsigned long *);
 static Widget create_tty_status(Widget, Widget);
 static void stat_resized(Widget, XtPointer, XtPointer);
-static void update_fancy_status_field(int, int, int);
+static void update_fancy_status_field(int, const char *, int, int);
 static void update_fancy_status(boolean);
 static Widget create_fancy_status(Widget, Widget);
 static void destroy_fancy_status(struct xwindow *);
@@ -412,6 +427,9 @@ X11_status_update_fancy(
         { BL_HPMAX, F_MAXHP },
         { BL_LEVELDESC, F_DLEVEL },
         { BL_VERS, F_VERS },
+        { BL_WEAPON, F_WEAPON },
+        { BL_ARMOR, F_ARMOR },
+        { BL_TERRAIN, F_TERRAIN },
         { BL_EXP, F_EXP_PTS }
     };
     static const struct mask_to_ff {
@@ -436,6 +454,17 @@ X11_status_update_fancy(
         { BL_MASK_TETHERED, F_TETHERED },
         { BL_MASK_LEV, F_LEV },
         { BL_MASK_FLY, F_FLY },
+        { BL_MASK_BAREH, F_BAREH },
+        { BL_MASK_GLOWHANDS, F_GLOWHANDS },
+        { BL_MASK_ICY, F_ICY },
+        { BL_MASK_BUSY, F_BUSY },
+        { BL_MASK_PARLYZ, F_PARALYZED },
+        { BL_MASK_SLEEPING, F_SLEEPING },
+        { BL_MASK_UNCONSC, F_UNCONSCIOUS },
+        { BL_MASK_ELF_IRON, F_IRON },
+        { BL_MASK_SLIPPERY, F_SLIPPERY },
+        { BL_MASK_SUBMERGED, F_SUBMERGED },
+        { BL_MASK_WOUNDEDL, F_WOUNDEDL },
         { BL_MASK_RIDE, F_RIDE }
     };
     int i;
@@ -457,6 +486,7 @@ X11_status_update_fancy(
             for (i = 0; i < SIZE(mask_to_fancyfield); i++)
                 if ((changed_bits & mask_to_fancyfield[i].mask) != 0L)
                     update_fancy_status_field(mask_to_fancyfield[i].ff,
+                            NULL,
                             condcolor(mask_to_fancyfield[i].mask, colormasks),
                             condattr(mask_to_fancyfield[i].mask, colormasks));
             old_condition_bits = X11_condition_bits; /* remember 'On' bits */
@@ -471,7 +501,8 @@ X11_status_update_fancy(
 
         for (i = 0; i < SIZE(bl_to_fancyfield); i++)
             if (bl_to_fancyfield[i].bl == fld) {
-                update_fancy_status_field(bl_to_fancyfield[i].ff, colr, attr);
+                update_fancy_status_field(bl_to_fancyfield[i].ff,
+                                          (const char *) ptr, colr, attr);
                 break;
             }
 
@@ -1205,7 +1236,7 @@ struct f_overload {
 
 static const struct f_overload *ff_ovld_from_mask(unsigned long);
 static const struct f_overload *ff_ovld_from_indx(int);
-static void update_val(struct X_status_value *, long);
+static void update_val(struct X_status_value *, long, const char *);
 static void skip_cond_val(struct X_status_value *);
 static void update_color(struct X_status_value *, int);
 static Pixel color_to_pixel(Widget, int);
@@ -1293,6 +1324,20 @@ static struct X_status_value shown_stats[NUM_STATS] = {
     { "Hallucinat",   SV_NAME,  W0,   0L, 0, FALSE, TRUE,  FALSE, P0, 0, 0 },
     /* F_VERS; optionally shown, generally treated as a pseudo-condition */
     { "Version 1.2.3", SV_LABEL, W0,  0L, 0, FALSE, FALSE, FALSE, P0, 0, 0 },
+    { "Weapon",       SV_NAME,  W0,  -1L, 0, FALSE, FALSE, FALSE, P0, 0, 0 },
+    { "Armor",        SV_NAME,  W0,  -1L, 0, FALSE, FALSE, FALSE, P0, 0, 0 },
+    { "Terrain",      SV_NAME,  W0,  -1L, 0, FALSE, FALSE, FALSE, P0, 0, 0 },
+    { "BareHands",    SV_NAME,  W0,   0L, 0, FALSE, TRUE,  FALSE, P0, 0, 0 },
+    { "GlowHands",    SV_NAME,  W0,   0L, 0, FALSE, TRUE,  FALSE, P0, 0, 0 },
+    { "Icy",          SV_NAME,  W0,   0L, 0, FALSE, TRUE,  FALSE, P0, 0, 0 },
+    { "Busy",         SV_NAME,  W0,   0L, 0, FALSE, TRUE,  FALSE, P0, 0, 0 },
+    { "Paralyzed",    SV_NAME,  W0,   0L, 0, FALSE, TRUE,  FALSE, P0, 0, 0 },
+    { "Sleeping",     SV_NAME,  W0,   0L, 0, FALSE, TRUE,  FALSE, P0, 0, 0 },
+    { "Unconsc",      SV_NAME,  W0,   0L, 0, FALSE, TRUE,  FALSE, P0, 0, 0 },
+    { "ElfIron",      SV_NAME,  W0,   0L, 0, FALSE, TRUE,  FALSE, P0, 0, 0 },
+    { "Slippery",     SV_NAME,  W0,   0L, 0, FALSE, TRUE,  FALSE, P0, 0, 0 },
+    { "Submerged",    SV_NAME,  W0,   0L, 0, FALSE, TRUE,  FALSE, P0, 0, 0 },
+    { "HurtLegs",     SV_NAME,  W0,   0L, 0, FALSE, TRUE,  FALSE, P0, 0, 0 },
 };
 #undef W0
 #undef P0
@@ -1325,14 +1370,12 @@ static const struct f_overload cond_ovl[] = {
       { { BL_MASK_HELD, F_HELD },
         { BL_MASK_HOLDING, F_HOLDING } },
     },
-#if 0   /* not yet implemented */
-    { (BL_MASK_BUSY | BL_MASK_PARALYZ | BL_MASK_SLEEPING | BL_MASK_UNCONSC),
+    { (BL_MASK_BUSY | BL_MASK_PARLYZ | BL_MASK_SLEEPING | BL_MASK_UNCONSC),
       { { BL_MASK_BUSY, F_BUSY }, /* can't move but none of the below... */
-        { BL_MASK_PARALYZ, F_PARALYZED }
-        { BL_MASK_SLEEPING, F_SLEEPING }
+        { BL_MASK_PARLYZ, F_PARALYZED },
+        { BL_MASK_SLEEPING, F_SLEEPING },
         { BL_MASK_UNCONSC, F_UNCONSCIOUS } },
     },
-#endif
 };
 
 static const struct f_overload *
@@ -1398,7 +1441,7 @@ null_out_status(void)
 DISABLE_WARNING_FORMAT_NONLITERAL
 
 static void
-update_val(struct X_status_value *attr_rec, long new_value)
+update_val(struct X_status_value *attr_rec, long new_value, const char *new_valuestr)
 {
     static boolean Exp_shown = TRUE, time_shown = TRUE, score_shown = TRUE,
                    Xp_was_HD = FALSE;
@@ -1452,7 +1495,10 @@ update_val(struct X_status_value *attr_rec, long new_value)
         X11_update_label(attr_rec->w);
 
     } else if (attr_rec->type == SV_NAME) {
-        if (attr_rec->last_value == new_value)
+        boolean direct = attr_rec == &shown_stats[F_ARMOR]
+                      || attr_rec == &shown_stats[F_WEAPON]
+                      || attr_rec == &shown_stats[F_TERRAIN];
+        if (!direct && attr_rec->last_value == new_value)
             return; /* no change */
 
         attr_rec->last_value = new_value;
@@ -1465,6 +1511,11 @@ update_val(struct X_status_value *attr_rec, long new_value)
             Strcpy(buf, enc_stat[new_value]);
         } else if (new_value) {
             Strcpy(buf, attr_rec->name); /* condition name On */
+        /* Special cases: weapon, armor and terrain */
+        } else if (direct) {
+            if (new_valuestr == NULL)
+                return;
+            Strcpy(buf, new_valuestr);
         } else {
             *buf = '\0'; /* condition name Off */
         }
@@ -1537,7 +1588,7 @@ update_val(struct X_status_value *attr_rec, long new_value)
             /* core won't call status_update() for Exp when it hasn't changed
                so do so ourselves (to get Exp_shown flag to match display) */
             if (force_update)
-                update_fancy_status_field(F_EXP_PTS, NO_COLOR, HL_UNDEF);
+                update_fancy_status_field(F_EXP_PTS, NULL, NO_COLOR, HL_UNDEF);
         }
 
         if (attr_rec->last_value == new_value && !force_update) /* same */
@@ -1598,6 +1649,7 @@ update_val(struct X_status_value *attr_rec, long new_value)
            already highlighted and being set to blank */
         if (attr_rec != &shown_stats[F_TIME]
             && attr_rec != &shown_stats[F_VERS]
+            && attr_rec != &shown_stats[F_TERRAIN]
             && !attr_rec->set ^ !*buf) {
             if (attr_rec->type == SV_VALUE)
                 X11_set_highlight(get_value_widget(attr_rec->w), TRUE);
@@ -1716,7 +1768,7 @@ set_percent(int index, int percent, int color)
  * [***] version is optional, right-justified after conditions
  */
 static void
-update_fancy_status_field(int i, int color, int attributes)
+update_fancy_status_field(int i, const char *valstr, int color, int attributes)
 {
     struct X_status_value *sv = &shown_stats[i];
     unsigned long condmask = 0L;
@@ -1816,6 +1868,39 @@ update_fancy_status_field(int i, int color, int attributes)
         case F_HALLU:
             condmask = BL_MASK_HALLU;
             break;
+        case F_BAREH:
+            condmask = BL_MASK_BAREH;
+            break;
+        case F_GLOWHANDS:
+            condmask = BL_MASK_GLOWHANDS;
+            break;
+        case F_ICY:
+            condmask = BL_MASK_ICY;
+            break;
+        case F_BUSY:
+            condmask = BL_MASK_BUSY;
+            break;
+        case F_PARALYZED:
+            condmask = BL_MASK_PARLYZ;
+            break;
+        case F_SLEEPING:
+            condmask = BL_MASK_SLEEPING;
+            break;
+        case F_UNCONSCIOUS:
+            condmask = BL_MASK_UNCONSC;
+            break;
+        case F_IRON:
+            condmask = BL_MASK_ELF_IRON;
+            break;
+        case F_SLIPPERY:
+            condmask = BL_MASK_SLIPPERY;
+            break;
+        case F_SUBMERGED:
+            condmask = BL_MASK_SUBMERGED;
+            break;
+        case F_WOUNDEDL:
+            condmask = BL_MASK_WOUNDEDL;
+            break;
 
         /* pseudo-condition */
         case F_VERS:
@@ -1867,6 +1952,11 @@ update_fancy_status_field(int i, int color, int attributes)
             val = 0L;
 #endif
             break;
+        case F_WEAPON:
+        case F_ARMOR:
+        case F_TERRAIN:
+            /* valstr is the value */
+            break;
         default: {
             /*
              * There is a possible infinite loop that occurs with:
@@ -1900,7 +1990,7 @@ update_fancy_status_field(int i, int color, int attributes)
             return;
         }
     }
-    update_val(sv, val);
+    update_val(sv, val, valstr);
     if (color != sv->colr)
         update_color(sv, color);
     if (attributes != sv->attr)
@@ -1928,7 +2018,7 @@ update_fancy_status(boolean force_update)
            the no longer displayed field; we're a bit more conservative
            than that and do this when toggling on as well as off */
         for (i = 0; i < NUM_STATS; i++)
-            update_fancy_status_field(i, NO_COLOR, HL_UNDEF);
+            update_fancy_status_field(i, NULL, NO_COLOR, HL_UNDEF);
         old_condition_bits = X11_condition_bits;
 
         old_upolyd = Upolyd;
@@ -2010,6 +2100,17 @@ width_string(int sv_index)
     case F_STUN:
     case F_CONF:
     case F_HALLU:
+    case F_BAREH:
+    case F_GLOWHANDS:
+    case F_BUSY:
+    case F_PARALYZED:
+    case F_SLEEPING:
+    case F_UNCONSCIOUS:
+    case F_IRON:
+    case F_SLIPPERY:
+    case F_SUBMERGED:
+    case F_WOUNDEDL:
+    case F_ICY:
         return shown_stats[sv_index].name;
 
     case F_NAME:
@@ -2035,6 +2136,12 @@ width_string(int sv_index)
         return "123456789"; /* a tenth digit will still fit legibly */
     case F_ALIGN:
         return "Neutral";
+    case F_WEAPON:
+        return "Dual+joust";
+    case F_ARMOR:
+        return "GCAUHBS";
+    case F_TERRAIN:
+        return "Portcullis";
     }
     impossible("width_string: unknown index %d\n", sv_index);
     return "";
@@ -2224,32 +2331,36 @@ init_column(
  * two columns and might expand to more if 'hitpointbar' is implemented.
  * Version is optional, right justified, and much wider than the others.
  *
- Title ("Plname the Rank")   <>            <>           <>          <>
- Dungeon-Branch-and-Level    <>           Hunger       Grabbed     Held
- Hit-points    Max-HP       Strength      Encumbrance  Petrifying  Blind
- Power-points  Max-Power    Dexterity     Trapped      Slimed      Deaf
- Armor-class   Alignment    Constitution  Levitation   Strangled   Stunned
- Xp-level     [Exp-points]  Intelligence  Flying       Food-Pois   Confused
- Gold         [Score]       Wisdom        Riding       Term-Ill    Hallucinat
-  <>          [Time]        Charisma       <>          Sinking         Version
+ Title ("Plname the Rank")   <>            <>       <>           <>          <>
+ Dungeon-Branch-and-Level    <>           Weapon   Hunger       Grabbed     Held
+ Hit-points    Max-HP       Strength      Armor    Encumbrance  Petrifying  Blind
+ Power-points  Max-Power    Dexterity     Terrain  Trapped      Slimed      Deaf
+ Armor-class   Alignment    Constitution   <>      Levitation   Strangled   Stunned
+ Xp-level     [Exp-points]  Intelligence   <>      Flying       Food-Pois   Confused
+ Gold         [Score]       Wisdom         <>      Riding       Term-Ill    Hallucinat
+  <>          [Time]        Charisma       <>       <>          Sinking         Version
  *
- * A seventh column is going to be needed to fit in more conditions.
+ * An eighth column is going to be needed to fit in more conditions.
  */
 
-/* including F_DUMMY makes the three status condition columns evenly
+/* including F_DUMMY makes the status condition columns evenly
    spaced with regard to the adjacent characteristics (Str,Dex,&c) column;
    we lose track of the Widget pointer for F_DUMMY, each use clobbering the
    one before, leaving the one from leftover_indices[]; since they're never
    updated, that shouldn't matter */
-static int status_indices[3][11] = {
+static int status_indices[][11] = {
+    { F_DUMMY, F_WEAPON, F_ARMOR, F_TERRAIN,
+      F_BAREH, F_GLOWHANDS, F_ICY, F_DUMMY, -1, 0, 0 },
     { F_DUMMY, F_HUNGER, F_ENCUMBER, F_TRAPPED,
       F_LEV, F_FLY, F_RIDE, F_DUMMY, -1, 0, 0 },
     { F_DUMMY, F_GRABBED, F_STONE, F_SLIME, F_STRNGL,
       F_FOODPOIS, F_TERMILL, F_IN_LAVA, -1, 0, 0 },
     { F_DUMMY, F_HELD, F_BLIND, F_DEAF, F_STUN,
-      F_CONF, F_HALLU, F_VERS, -1, 0, 0 },
+      F_CONF, F_HALLU, F_DUMMY, -1, 0, 0 },
+    { F_DUMMY, F_BUSY, F_IRON, F_SLIPPERY,
+      F_SUBMERGED, F_WOUNDEDL, F_DUMMY, F_VERS, -1, 0, 0 }
 };
-/* used to fill up the empty space to right of 3rd status condition column */
+/* used to fill up the empty space to right of last status condition column */
 static int leftover_indices[] = { F_DUMMY, -1, 0, 0 };
 /* -2: top two rows of these columns are reserved for title and location */
 static int col1_indices[11 - 2] = {
@@ -2335,7 +2446,7 @@ init_info_form(Widget parent, Widget top, Widget left)
     return form;
 }
 
-/* give the three status condition columns the same width */
+/* give the status condition columns the same width */
 static void
 fixup_cond_widths(void)
 {
@@ -2343,7 +2454,7 @@ fixup_cond_widths(void)
 
     w1 = w2 = 0;
     for (pass = 1; pass <= 2; ++pass) { /* two passes... */
-        for (i = 0; i < 3; i++) { /* three columns */
+        for (i = 0; i < SIZE(status_indices); i++) {
             for (ip = status_indices[i]; *ip != -1; ++ip) { /* X fields */
                 /* pass 1: find -1;  pass 2: update field widths, find -1 */
                 if (pass == 2)
@@ -2373,11 +2484,11 @@ fixup_cond_widths(void)
         Dimension vers_width = 0;
         struct X_status_value *sv = &shown_stats[F_VERS];
 
-        if (sv) {
+        if (sv->w) {
             XtSetArg(args[0], XtNwidth, &vers_width);
             XtGetValues(sv->w, args, ONE);
             if (vers_width) {
-                vers_width *= 3;
+                vers_width *= 2;
                 XtSetArg(args[0], XtNwidth, vers_width);
                 XtSetArg(args[1], nhStr(XtNjustify), XtJustifyRight);
                 XtSetValues(sv->w, args, TWO);
@@ -2416,15 +2527,15 @@ create_fancy_status(Widget parent, Widget top)
     w = init_column("status_characteristics", form, (Widget) 0, w,
                     characteristics_indices, 15);
 #endif
-    for (i = 0; i < 3; i++) {
+    for (i = 0; i < SIZE(status_indices); i++) {
         Sprintf(buf, "status_condition%d", i + 1);
         w = init_column(buf, form, (Widget) 0, w, status_indices[i], 0);
     }
-    fixup_cond_widths(); /* make all 3 status_conditionN columns same width
+    fixup_cond_widths(); /* make all status_conditionN columns same width
                           * (actually, the slot for F_VERS is much wider) */
     /* TODO:
      * Calculate and set the width of the F_VERS widjet to be from the
-     * start of the third condition column through the right edge and
+     * start of the last condition column through the right edge and
      * get rid of the dummy column.
      */
 

--- a/win/X11/winstat.c
+++ b/win/X11/winstat.c
@@ -1223,12 +1223,10 @@ struct f_overload {
 
 static const struct f_overload *ff_ovld_from_mask(unsigned long);
 static const struct f_overload *ff_ovld_from_indx(int);
-static void hilight_label(Widget);
 static void update_val(struct X_status_value *, long);
 static void skip_cond_val(struct X_status_value *);
 static void update_color(struct X_status_value *, int);
 static Pixel color_to_pixel(Widget, int);
-static boolean name_widget_has_label(struct X_status_value *);
 static void apply_hilite_attributes(struct X_status_value *, int);
 static const char *width_string(int);
 static void create_widget(Widget, struct X_status_value *, int);
@@ -1413,18 +1411,6 @@ null_out_status(void)
             break;
         }
     }
-}
-
-/* this is almost an exact duplicate of hilight_value() */
-static void
-hilight_label(Widget w) /* label widget */
-{
-    /*
-     * This predates STATUS_HILITES.
-     * It is used to show any changed item in inverse and gets
-     * reset on the next turn.
-     */
-    swap_fg_bg(w);
 }
 
 DISABLE_WARNING_FORMAT_NONLITERAL
@@ -1631,14 +1617,10 @@ update_val(struct X_status_value *attr_rec, long new_value)
         if (attr_rec != &shown_stats[F_TIME]
             && attr_rec != &shown_stats[F_VERS]
             && !attr_rec->set ^ !*buf) {
-            /* But don't hilite if inverted from status_hilite since
-               it will already be hilited by apply_hilite_attributes(). */
-            if (!attr_rec->inverted_hilite) {
-                if (attr_rec->type == SV_VALUE)
-                    hilight_value(attr_rec->w);
-                else
-                    hilight_label(attr_rec->w);
-            }
+            if (attr_rec->type == SV_VALUE)
+                X11_set_highlight(get_value_widget(attr_rec->w), TRUE);
+            else
+                X11_set_highlight(attr_rec->w, TRUE);
             attr_rec->set = !attr_rec->set;
         }
         attr_rec->turn_count = 0;
@@ -1664,7 +1646,7 @@ skip_cond_val(struct X_status_value *sv)
            also requested to be highlighted, it used its own copy of
            'set' but the same widget so the highlighting got toggled
            off; this will turn in back on in that exceptional case */
-        hilight_label(sv->w);
+        X11_set_highlight(sv->w, FALSE);
         sv->set = FALSE;
     }
 }
@@ -1686,10 +1668,7 @@ update_color(struct X_status_value *sv, int color)
         sv->colr = color;
     }
     if (pixel != 0) {
-        char *arg_name = (sv->set || sv->inverted_hilite) ? XtNbackground
-                         : XtNforeground;
-
-        XtSetArg(args[0], arg_name, pixel);
+        XtSetArg(args[0], XtNforeground, pixel);
         XtSetValues(w, args, ONE);
         X11_update_label(w);
     }
@@ -1719,38 +1698,14 @@ color_to_pixel(Widget w, int color)
     return pixel;
 }
 
-static boolean
-name_widget_has_label(struct X_status_value *sv)
-{
-    Arg args[1];
-    const char *label;
-
-    XtSetArg(args[0], XtNlabel, &label);
-    XtGetValues(sv->w, args, ONE);
-    return (*label != '\0');
-}
-
 static void
 apply_hilite_attributes(struct X_status_value *sv, int attributes)
 {
-    boolean attr_inversion = ((HL_INVERSE & attributes)
-                              && (sv->type != SV_NAME
-                                  || name_widget_has_label(sv)));
-
-    if (sv->inverted_hilite != attr_inversion) {
-        sv->inverted_hilite = attr_inversion;
-        if (!sv->set) {
-            if (sv->type == SV_VALUE)
-                hilight_value(sv->w);
-            else
-                hilight_label(sv->w);
-        }
+    Widget w = sv->w;
+    if (sv->type == SV_VALUE) {
+        w = get_value_widget(w);
     }
-    sv->attr = attributes;
-    /* Could possibly add more attributes here: HL_ATTCLR_DIM,
-       HL_ATTCLR_BLINK, HL_ATTCLR_ULINE, and HL_ATTCLR_BOLD. If so,
-       extract the above into its own function apply_hilite_inverse()
-       and each other attribute into its own to keep the code clean. */
+    X11_set_attrs(w, attributes);
 }
 
 static void
@@ -2021,14 +1976,10 @@ check_turn_events(void)
             continue;
 
         if (sv->turn_count++ >= hilight_time) {
-            /* unhighlights by toggling a highlighted item back off again,
-               unless forced inverted by a status_hilite rule */
-            if (!sv->inverted_hilite) {
-                if (sv->type == SV_VALUE)
-                    hilight_value(sv->w);
-                else
-                    hilight_label(sv->w);
-            }
+            if (sv->type == SV_VALUE)
+                X11_set_highlight(get_value_widget(sv->w), FALSE);
+            else
+                X11_set_highlight(sv->w, FALSE);
             sv->set = FALSE;
         }
     }

--- a/win/X11/winstat.c
+++ b/win/X11/winstat.c
@@ -1398,6 +1398,7 @@ null_out_status(void)
         case SV_NAME:
             XtSetArg(args[0], XtNlabel, "");
             XtSetValues(sv->w, args, ONE);
+            X11_update_label(sv->w);
             break;
 
         default:
@@ -1473,6 +1474,7 @@ update_val(struct X_status_value *attr_rec, long new_value)
         Strcpy((char *) attr_rec->name, buf);
         XtSetArg(args[0], XtNlabel, buf);
         XtSetValues(attr_rec->w, args, ONE);
+        X11_update_label(attr_rec->w);
 
     } else if (attr_rec->type == SV_NAME) {
         if (attr_rec->last_value == new_value)
@@ -1494,6 +1496,7 @@ update_val(struct X_status_value *attr_rec, long new_value)
 
         XtSetArg(args[0], XtNlabel, buf);
         XtSetValues(attr_rec->w, args, ONE);
+        X11_update_label(attr_rec->w);
 
     } else { /* a value pair */
         boolean force_update = FALSE;
@@ -1687,6 +1690,7 @@ update_color(struct X_status_value *sv, int color)
 
         XtSetArg(args[0], arg_name, pixel);
         XtSetValues(w, args, ONE);
+        X11_update_label(w);
     }
 }
 
@@ -2096,6 +2100,7 @@ create_widget(Widget parent, struct X_status_value *sv, int sv_index)
                                          : "dlevel",
                                       labelWidgetClass, parent,
                                       args, num_args);
+        X11_wrap_widget(sv->w);
         break;
     case SV_NAME: {
         char buf[BUFSZ];
@@ -2132,6 +2137,7 @@ create_widget(Widget parent, struct X_status_value *sv, int sv_index)
         XtSetArg(args[num_args], XtNinternalHeight, 0); num_args++;
         sv->w = XtCreateManagedWidget(sv->name, labelWidgetClass, parent,
                                       args, num_args);
+        X11_wrap_widget(sv->w);
         break;
     }
     default:

--- a/win/X11/winstat.c
+++ b/win/X11/winstat.c
@@ -112,9 +112,6 @@ static void adjust_status_fancy(struct xwindow *, const char *);
 static void adjust_status_tty(struct xwindow *, const char *);
 static void set_percent(int, int, int);
 static void tty_status_exposed(Widget, XtPointer, XtPointer);
-#ifdef STATUS_HILITES
-static void tty_status_blink(XtPointer client_data, XtIntervalId *timer);
-#endif
 static void tty_status_redraw(Widget);
 static int tty_render_field(Widget, int, int, enum statusfields);
 static void tty_status_colors(Widget, int, int, Pixel *, Pixel *);
@@ -207,10 +204,6 @@ struct tty_cond_field {
 static Widget X11_status_widget;
 static struct tty_status_field X11_status_labels[MAXBLSTATS];
 static struct tty_cond_field X11_cond_labels[32]; /* Ugh */
-#ifdef STATUS_HILITES
-static boolean blink;
-static const unsigned long blink_interval = 500; /* milliseconds */
-#endif
 
 static struct xwindow *xw_status_win;
 
@@ -361,7 +354,7 @@ X11_status_update_tty(
                 for (unsigned j = 0; j < SIZE(tt_condorder); ++j) {
                     if ((mask & tt_condorder[j].mask) != 0) {
                         struct tty_cond_field *fldp = &X11_cond_labels[j];
-                        fldp->attrs |= 0x1 << (i - CLR_MAX);
+                        fldp->attrs |= 0x1 << (i - HL_ATTCLR_NONE);
                     }
                 }
             }
@@ -542,10 +535,6 @@ create_tty_status(Widget parent, Widget top)
 
     XtAddCallback(X11_status_widget, XtNexposeCallback, tty_status_exposed,
                   (XtPointer) 0);
-#ifdef STATUS_HILITES
-    XtAppAddTimeOut(app_context, blink_interval, tty_status_blink,
-                    (XtPointer) X11_status_widget);
-#endif
 
     return X11_status_widget;
 }
@@ -564,12 +553,9 @@ tty_status_exposed(Widget w, XtPointer client_data, /* unused */
 }
 
 #ifdef STATUS_HILITES
-static void
-tty_status_blink(XtPointer client_data, XtIntervalId *timer)
+void
+X11_tty_status_blink(void)
 {
-    Widget w = (Widget) client_data;
-    nhUse(timer);
-
     /* Do we have any active blink attributes? */
     boolean have_blink = FALSE;
     for (unsigned i = 0; i < SIZE(X11_status_labels) && !have_blink; ++i) {
@@ -580,12 +566,8 @@ tty_status_blink(XtPointer client_data, XtIntervalId *timer)
     }
 
     if (have_blink) {
-        tty_status_redraw(w);
-        blink = !blink;
+        tty_status_redraw(X11_status_widget);
     }
-
-    /* Do it again */
-    XtAppAddTimeOut(app_context, blink_interval, tty_status_blink, client_data);
 }
 #endif /* STATUS_HILITES */
 
@@ -933,7 +915,7 @@ tty_status_colors(Widget w, int color, int attr, Pixel *fgpixel, Pixel *bgpixel)
     }
 
     /* Implement blink */
-    if ((attr & HL_BLINK) && blink) {
+    if ((attr & HL_BLINK) && X11_blink) {
         *fgpixel = *bgpixel;
     }
 

--- a/win/X11/winstat.c
+++ b/win/X11/winstat.c
@@ -1633,8 +1633,10 @@ update_val(struct X_status_value *attr_rec, long new_value)
         }
         attr_rec->turn_count = 0;
     } else {
+        Widget w = (attr_rec->type == SV_LABEL || attr_rec->type == SV_NAME) ? attr_rec->w
+                   : get_value_widget(attr_rec->w);
         XtSetArg(args[0], XtNforeground, &attr_rec->default_fg);
-        XtGetValues(attr_rec->w, args, ONE);
+        XtGetValues(w, args, ONE);
         attr_rec->after_init = TRUE;
     }
 }

--- a/win/X11/winstat.c
+++ b/win/X11/winstat.c
@@ -110,6 +110,7 @@ static void destroy_status_window_fancy(struct xwindow *);
 static void destroy_status_window_tty(struct xwindow *);
 static void adjust_status_fancy(struct xwindow *, const char *);
 static void adjust_status_tty(struct xwindow *, const char *);
+static void set_percent(int, int, int);
 static void tty_status_exposed(Widget, XtPointer, XtPointer);
 #ifdef STATUS_HILITES
 static void tty_status_blink(XtPointer client_data, XtIntervalId *timer);
@@ -390,7 +391,7 @@ static void
 X11_status_update_fancy(
     int fld,
     genericptr_t ptr,
-    int chg UNUSED, int percent UNUSED,
+    int chg UNUSED, int percent,
     int colrattr,
     unsigned long *colormasks UNUSED)
 {
@@ -480,6 +481,11 @@ X11_status_update_fancy(
                 update_fancy_status_field(bl_to_fancyfield[i].ff, colr, attr);
                 break;
             }
+
+        /* Hit point bar */
+        if (fld == BL_HP) {
+            set_percent(F_NAME, iflags.wc2_hitpointbar ? percent : 0, colr);
+        }
     }
 }
 
@@ -1221,6 +1227,7 @@ static void hilight_label(Widget);
 static void update_val(struct X_status_value *, long);
 static void skip_cond_val(struct X_status_value *);
 static void update_color(struct X_status_value *, int);
+static Pixel color_to_pixel(Widget, int);
 static boolean name_widget_has_label(struct X_status_value *);
 static void apply_hilite_attributes(struct X_status_value *, int);
 static const char *width_string(int);
@@ -1667,8 +1674,6 @@ update_color(struct X_status_value *sv, int color)
 {
     Pixel pixel = 0;
     Arg args[1];
-    XrmValue source;
-    XrmValue dest;
     Widget w = (sv->type == SV_LABEL || sv->type == SV_NAME) ? sv->w
                : get_value_widget(sv->w);
 
@@ -1677,12 +1682,8 @@ update_color(struct X_status_value *sv, int color)
             pixel = sv->default_fg;
         sv->colr = NO_COLOR;
     } else {
-        source.addr = (XPointer) fancy_status_hilite_colors[color];
-        source.size = (unsigned int) strlen((const char *) source.addr) + 1;
-        dest.size = (unsigned int) sizeof (Pixel);
-        dest.addr = (XPointer) &pixel;
-        if (XtConvertAndStore(w, XtRString, &source, XtRPixel, &dest))
-            sv->colr = color;
+        pixel = color_to_pixel(w, color);
+        sv->colr = color;
     }
     if (pixel != 0) {
         char *arg_name = (sv->set || sv->inverted_hilite) ? XtNbackground
@@ -1692,6 +1693,30 @@ update_color(struct X_status_value *sv, int color)
         XtSetValues(w, args, ONE);
         X11_update_label(w);
     }
+}
+
+static Pixel
+color_to_pixel(Widget w, int color)
+{
+    Pixel pixel;
+
+    if (fancy_status_hilite_colors[color][0] != '\0') {
+        XrmValue source;
+        XrmValue dest;
+        source.addr = (XPointer) fancy_status_hilite_colors[color];
+        source.size = (unsigned int) strlen((const char *) source.addr) + 1;
+        dest.size = (unsigned int) sizeof (Pixel);
+        dest.addr = (XPointer) &pixel;
+        if (XtConvertAndStore(w, XtRString, &source, XtRPixel, &dest)) {
+            return pixel;
+        }
+    }
+
+    pixel = 0xFFFFFF;
+    Arg args[1];
+    XtSetArg(args[0], XtNforeground, &pixel);
+    XtGetValues(toplevel, args, ONE);
+    return pixel;
 }
 
 static boolean
@@ -1726,6 +1751,13 @@ apply_hilite_attributes(struct X_status_value *sv, int attributes)
        HL_ATTCLR_BLINK, HL_ATTCLR_ULINE, and HL_ATTCLR_BOLD. If so,
        extract the above into its own function apply_hilite_inverse()
        and each other attribute into its own to keep the code clean. */
+}
+
+static void
+set_percent(int index, int percent, int color)
+{
+    Widget w = shown_stats[index].w;
+    X11_set_percent(w, percent, color_to_pixel(w, color));
 }
 
 /*

--- a/win/X11/winstat.c
+++ b/win/X11/winstat.c
@@ -1513,8 +1513,9 @@ update_val(struct X_status_value *attr_rec, long new_value, const char *new_valu
             Strcpy(buf, attr_rec->name); /* condition name On */
         /* Special cases: weapon, armor and terrain */
         } else if (direct) {
-            if (new_valuestr == NULL)
+            if (new_valuestr == NULL) {
                 return;
+            }
             Strcpy(buf, new_valuestr);
         } else {
             *buf = '\0'; /* condition name Off */
@@ -2331,16 +2332,19 @@ init_column(
  * two columns and might expand to more if 'hitpointbar' is implemented.
  * Version is optional, right justified, and much wider than the others.
  *
- Title ("Plname the Rank")   <>            <>       <>           <>          <>
- Dungeon-Branch-and-Level    <>           Weapon   Hunger       Grabbed     Held
- Hit-points    Max-HP       Strength      Armor    Encumbrance  Petrifying  Blind
- Power-points  Max-Power    Dexterity     Terrain  Trapped      Slimed      Deaf
- Armor-class   Alignment    Constitution   <>      Levitation   Strangled   Stunned
- Xp-level     [Exp-points]  Intelligence   <>      Flying       Food-Pois   Confused
- Gold         [Score]       Wisdom         <>      Riding       Term-Ill    Hallucinat
-  <>          [Time]        Charisma       <>       <>          Sinking         Version
+ Title ("Plname the Rank")   <>            <>           <>          <>
+ Dungeon-Branch-and-Level    <>            <>           <>          <>
+ Hit-points    Max-HP       Strength      Hunger       Grabbed     Held
+ Power-points  Max-Power    Dexterity     Encumbrance  Petrifying  Blind
+ Armor-class   Alignment    Constitution  Trapped      Slimed      Deaf
+ Xp-level     [Exp-points]  Intelligence  Levitation   Strangled   Stunned
+ Gold         [Score]       Wisdom        Flying       Food-Pois   Confused
+  <>          [Time]        Charisma      Riding       Term-Ill    Hallucinat
+ BareHands     <>            <>           HurtLegs     Sinking     GlowHands
+ Weapon       Armor         Terrain       Elf-Iron     Busy        Icy
+  <>           <>            <>           Slippery     Submerged       Version
  *
- * An eighth column is going to be needed to fit in more conditions.
+ * A seventh column is going to be needed to fit in more conditions.
  */
 
 /* including F_DUMMY makes the status condition columns evenly
@@ -2348,29 +2352,34 @@ init_column(
    we lose track of the Widget pointer for F_DUMMY, each use clobbering the
    one before, leaving the one from leftover_indices[]; since they're never
    updated, that shouldn't matter */
-static int status_indices[][11] = {
-    { F_DUMMY, F_WEAPON, F_ARMOR, F_TERRAIN,
-      F_BAREH, F_GLOWHANDS, F_ICY, F_DUMMY, -1, 0, 0 },
+static int status_indices[][13] = {
     { F_DUMMY, F_HUNGER, F_ENCUMBER, F_TRAPPED,
-      F_LEV, F_FLY, F_RIDE, F_DUMMY, -1, 0, 0 },
+      F_LEV, F_FLY, F_RIDE, F_WOUNDEDL, F_IRON, F_SLIPPERY,
+      -1, 0, 0 },
     { F_DUMMY, F_GRABBED, F_STONE, F_SLIME, F_STRNGL,
-      F_FOODPOIS, F_TERMILL, F_IN_LAVA, -1, 0, 0 },
+      F_FOODPOIS, F_TERMILL, F_IN_LAVA, F_BUSY, F_SUBMERGED,
+      -1, 0, 0 },
     { F_DUMMY, F_HELD, F_BLIND, F_DEAF, F_STUN,
-      F_CONF, F_HALLU, F_DUMMY, -1, 0, 0 },
-    { F_DUMMY, F_BUSY, F_IRON, F_SLIPPERY,
-      F_SUBMERGED, F_WOUNDEDL, F_DUMMY, F_VERS, -1, 0, 0 }
+      F_CONF, F_HALLU, F_GLOWHANDS, F_ICY, F_VERS,
+      -1, 0, 0 },
 };
 /* used to fill up the empty space to right of last status condition column */
 static int leftover_indices[] = { F_DUMMY, -1, 0, 0 };
 /* -2: top two rows of these columns are reserved for title and location */
-static int col1_indices[11 - 2] = {
-    F_HP,    F_POWER,    F_AC,    F_XP_LEVL, F_GOLD,  F_DUMMY,  -1, 0, 0
+static int col1_indices[13 - 2] = {
+    F_HP,    F_POWER,    F_AC,    F_XP_LEVL, F_GOLD,  F_DUMMY,
+    F_BAREH, F_WEAPON, F_DUMMY,
+    -1, 0, 0
 };
-static int col2_indices[11 - 2] = {
-    F_MAXHP, F_MAXPOWER, F_ALIGN, F_EXP_PTS, F_SCORE, F_TIME,   -1, 0, 0
+static int col2_indices[13 - 2] = {
+    F_MAXHP, F_MAXPOWER, F_ALIGN, F_EXP_PTS, F_SCORE, F_TIME,
+    F_DUMMY, F_ARMOR, F_DUMMY,
+    -1, 0, 0
 };
-static int characteristics_indices[11 - 2] = {
-    F_STR, F_DEX, F_CON, F_INT, F_WIS, F_CHA, -1, 0, 0
+static int characteristics_indices[13 - 2] = {
+    F_STR, F_DEX, F_CON, F_INT, F_WIS, F_CHA,
+    F_DUMMY, F_TERRAIN, F_DUMMY,
+    -1, 0, 0
 };
 
 /*
@@ -2378,10 +2387,10 @@ static int characteristics_indices[11 - 2] = {
  *
  *                title
  *               location
- * col1_indices[0]      col2_indices[0]      col3_indices[0]
- * col1_indices[1]      col2_indices[1]      col3_indices[1]
- *    ...                  ...                  ...
- * col1_indices[5]      col2_indices[5]      col3_indices[5]
+ * col1_indices[0]      col2_indices[0]      col3_indices[0]      col4_indices[0]
+ * col1_indices[1]      col2_indices[1]      col3_indices[1]      col4_indices[1]
+ *    ...                  ...                  ...                  ...
+ * col1_indices[5]      col2_indices[5]      col3_indices[5]      col4_indices[5]
  *
  * The status conditions are managed separately and appear to the right
  * of this form.
@@ -2420,7 +2429,7 @@ init_info_form(Widget parent, Widget top, Widget left)
     XtSetArg(args[num_args], nhStr(XtNfromVert), sv_name->w); num_args++;
     XtSetValues(sv_dlevel->w, args, num_args);
 
-    /* there are 3 columns beneath but top 2 rows are centered over first 2 */
+    /* there are 4 columns beneath but top 2 rows are centered over first 2 */
     col1 = init_column("name_col1", form, sv_dlevel->w, (Widget) 0,
                        col1_indices, 0);
     col2 = init_column("name_col2", form, sv_dlevel->w, col1,
@@ -2488,7 +2497,7 @@ fixup_cond_widths(void)
             XtSetArg(args[0], XtNwidth, &vers_width);
             XtGetValues(sv->w, args, ONE);
             if (vers_width) {
-                vers_width *= 2;
+                vers_width *= 3;
                 XtSetArg(args[0], XtNwidth, vers_width);
                 XtSetArg(args[1], nhStr(XtNjustify), XtJustifyRight);
                 XtSetValues(sv->w, args, TWO);

--- a/win/X11/winval.c
+++ b/win/X11/winval.c
@@ -152,14 +152,6 @@ get_value_width(Widget w)
     return (int) width;
 }
 
-/* Swap foreground and background colors (this is the best I can do with */
-/* a label widget, unless I can get some init hook in there).            */
-void
-hilight_value(Widget w)
-{
-    swap_fg_bg(get_value_widget(w));
-}
-
 /* Swap the foreground and background colors of the given widget */
 void
 swap_fg_bg(Widget w)

--- a/win/X11/winval.c
+++ b/win/X11/winval.c
@@ -57,6 +57,7 @@ create_value(Widget parent, const char *name_value)
     num_args++;
     name =
         XtCreateManagedWidget(WNAME, labelWidgetClass, form, args, num_args);
+    X11_wrap_widget(name);
 
     num_args = 0;
     XtSetArg(args[num_args], XtNjustify, XtJustifyRight);
@@ -67,8 +68,9 @@ create_value(Widget parent, const char *name_value)
     num_args++;
     XtSetArg(args[num_args], XtNinternalHeight, 0);
     num_args++;
-    (void) XtCreateManagedWidget(WVALUE, labelWidgetClass, form, args,
-                                 num_args);
+    Widget value = XtCreateManagedWidget(WVALUE, labelWidgetClass, form, args,
+                                         num_args);
+    X11_wrap_widget(value);
     return form;
 }
 
@@ -81,6 +83,7 @@ set_name(Widget w, const char *new_label)
     name = XtNameToWidget(w, WNAME);
     XtSetArg(args[0], XtNlabel, new_label);
     XtSetValues(name, args, ONE);
+    X11_update_label(name);
 }
 
 void
@@ -122,6 +125,7 @@ set_value(Widget w, const char *new_value)
     val = get_value_widget(w);
     XtSetArg(args[0], XtNlabel, new_value);
     XtSetValues(val, args, ONE);
+    X11_update_label(val);
 }
 
 void
@@ -170,4 +174,5 @@ swap_fg_bg(Widget w)
     XtSetArg(args[0], XtNforeground, bg);
     XtSetArg(args[1], XtNbackground, fg);
     XtSetValues(w, args, TWO);
+    X11_update_label(w);
 }


### PR DESCRIPTION
New features:
* All attributes implemented for fancy status and menus: bold, italic, dim, underline, blink, inverse
* Fancy status now displays all possible status types

Bugs fixed:
* Changes to fancy status values now time out correctly
* Menu group accelerators now reach all matches in the menu