### PR TITLE
Fix error handling in the fetch-Lua target

### DIFF
--- a/sys/unix/Makefile.top
+++ b/sys/unix/Makefile.top
@@ -422,13 +422,15 @@ fetch-Lua:
 		    CHKSUMS=../submodules/CHKSUMS; \
 		    CHKSUMSTMP=../submodules/CHKSUMS.tmp; \
 		    fgrep $$luafile < $$CHKSUMS > $$CHKSUMSTMP; \
-		    if [ -z $$CHKSUMSTMP ]; then \
+		    if [ ! -s $$CHKSUMSTMP ]; then \
+			rm -f $$CHKSUMSTMP; \
 			echo "Cannot check $$luafile - no checksum known"; \
 			echo "Rerun with 'NOCHKSUM=1' to skip this check"; \
 			exit 1; \
 		    else \
 			echo "Checksum found"; \
 			chksum_or_fail $$luafile; \
+			rm -f $$CHKSUMSTMP; \
 		    fi; \
 		fi; \
                     `: If we can unpack it, we are done.`; \
@@ -436,7 +438,7 @@ fetch-Lua:
 		`: fallthrough to next source `; \
 	    fi; \
 	done; \
-	echo "Unable to find a valid source - STOPPING" \
+	echo "Unable to find a valid source - STOPPING"; \
 	exit 1; \
 	)
 # remove include/nhlua.h in case it was created for some other Lua version


### PR DESCRIPTION
Three small defects in the `fetch-Lua` target in `sys/unix/Makefile.top`. I went looking for the `CHKSUMS.tmp` leftover and found the other two next to it.

### 1. The "no checksum known" branch could never run

```sh
CHKSUMSTMP=../submodules/CHKSUMS.tmp
fgrep $luafile < $CHKSUMS > $CHKSUMSTMP
if [ -z $CHKSUMSTMP ]; then
```

`-z` tests the filename string, which is never empty, so the branch was dead. A tarball with no entry in `submodules/CHKSUMS` fell through to the else branch and was "verified" against an empty checklist.

Building with a Lua version that has no checksum entry, before and after:

```
# before
Searching for known checksum
Checksum found
Checking integrity of lua-5.4.4.tar.gz with /usr/bin/shasum -a 256
shasum: ../submodules/CHKSUMS.tmp: no properly formatted SHA checksum lines found
Integrity check FAILED - STOPPING

# after
Searching for known checksum
Cannot check lua-5.4.4.tar.gz - no checksum known
Rerun with 'NOCHKSUM=1' to skip this check
```

It fails closed either way, so this is not a security issue, but "Integrity check FAILED" points at a corrupted or tampered download when the real cause is a missing entry.

### 2. Exhausting every download source exited 0

```sh
echo "Unable to find a valid source - STOPPING" \
exit 1; \
```

The line continuation makes `exit 1` an argument to `echo`, so the subshell exits 0 and make reports success. The build then fails later with "Please do 'make fetch-lua'", which is the message you just tried to act on.

```
# before
$ make fetch-lua LUA_VERSION=9.9.9; echo "exit=$?"
curl: (22) The requested URL returned error: 404
Unable to find a valid source - STOPPING exit 1
exit=0

# after
$ make fetch-lua LUA_VERSION=9.9.9; echo "exit=$?"
curl: (22) The requested URL returned error: 404
Unable to find a valid source - STOPPING
make: *** [Makefile:2534: fetch-Lua] Error 1
exit=2
```

### 3. CHKSUMS.tmp was never removed

It is now deleted on both exits from the checksum block. Not on the integrity-failure path, where the build has stopped hard and the file is more useful kept than removed.

### Testing

Ubuntu 24.04, gcc, `sys/unix/hints/linux.500`, tty.

- `make fetch-lua` then `make all` and `make install`: unchanged, game builds and runs, `CHKSUMS.tmp` no longer left behind.
- `LUA_VERSION=9.9.9` (no such tarball anywhere): exit 0 before, exit 2 after.
- `LUA_VERSION=5.4.4` (downloads fine, absent from `CHKSUMS`): misleading integrity failure before, accurate message after.
- I have not tested on macOS or BSD, and have not exercised the `NOCHKSUM=1` path.

No `doc/fixes5-0-1.txt` entry, since recent contributor PRs leave that to you. Happy to add one if you would rather have it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
