### PR TITLE
X11: Render text with Xft

### DIFF
--- a/include/winX.h
+++ b/include/winX.h
@@ -11,6 +11,9 @@
 
 #ifdef USE_XFT
 #include <X11/Xft/Xft.h>
+typedef XftFont X11_Font;
+#else
+typedef XFontStruct X11_Font;
 #endif
 
 #ifndef COLOR_H
@@ -529,6 +532,7 @@ extern void X11_set_attrs(Widget, unsigned);
 extern void X11_set_highlight(Widget, boolean);
 extern void X11_set_percent(Widget, unsigned, Pixel);
 extern void X11_blink_labels(void);
+extern int X11_font_height(X11_Font *);
 
 /*
  * These are for widgets that use the enhanced label services only for text

--- a/include/winX.h
+++ b/include/winX.h
@@ -382,7 +382,7 @@ extern Boolean nhCvtStringToPixel(Display *, XrmValuePtr, Cardinal *,
 extern void get_window_frame_extents(Widget, long *, long *, long *, long *);
 extern void get_widget_window_geometry(Widget, int *, int *, int *, int *);
 extern char *fontname_boldify(const char *);
-extern Dimension nhFontHeight(Widget);
+extern Dimension nhFontHeight(Widget, int);
 extern char key_event_to_char(XKeyEvent *);
 extern void msgkey(Widget, XtPointer, XEvent *, Boolean *);
 extern void highlight_yn(boolean);

--- a/include/winX.h
+++ b/include/winX.h
@@ -84,7 +84,7 @@ struct text_map_info_t {
         square_ascent, /*   placement of changes.        */
         square_lbearing;
 
-#ifdef ENHANCED_SYMBOLS
+#if defined(ENHANCED_SYMBOLS) && !defined(USE_XFT)
     XFontStruct *font;
 #endif
 };
@@ -131,7 +131,12 @@ struct line_element {
 };
 
 struct mesg_info_t {
+#ifdef USE_XFT
+    Pixel fgpixel;   /* Color for text drawing */
+#else
+    GC gc;           /* GC for text drawing */
     XFontStruct *fs;                 /* Font for the window. */
+#endif
     int num_lines;                   /* line count */
     struct line_element *head;       /* head of circular line queue */
     struct line_element *line_here;  /* current drawn line position */
@@ -139,11 +144,6 @@ struct mesg_info_t {
                                      /*     bottom of screen             */
     struct line_element *last_pause_head; /* pointer to head of previous */
                                           /* turn                        */
-#ifdef USE_XFT
-    Pixel fgpixel;   /* Color for text drawing */
-#else
-    GC gc;           /* GC for text drawing */
-#endif
     int char_width,  /* Saved font information so we can  */
         char_height, /*   calculate the correct placement */
         char_ascent, /*   of changes.                     */
@@ -161,7 +161,9 @@ struct mesg_info_t {
 struct status_info_t {
     struct text_buffer text; /* Just a text buffer. */
     Pixel fg, bg;          /* foreground and background */
+#ifndef USE_XFT
     XFontStruct *fs;       /* Status window font structure. */
+#endif
     Dimension spacew;      /* width of one space */
     Position x, y[3];      /* x coord (not used), y for up to three lines */
     Dimension wd, ht;      /* width (not used), height (same for all lines) */
@@ -202,7 +204,9 @@ struct menu_info_t {
     struct menu curr_menu; /* Menu being displayed. */
     struct menu new_menu;  /* New menu being built. */
 
+#ifndef USE_XFT
     XFontStruct *fs;           /* Font for the window. */
+#endif
     long menu_count;           /* number entered by user */
     Dimension line_height;     /* Total height of a line of text. */
     Dimension internal_height; /* Internal height between widget & border */
@@ -225,10 +229,6 @@ struct menu_info_t {
  */
 struct text_info_t {
     struct text_buffer text;
-    XFontStruct *fs;        /* Font for the text window. */
-    int max_width;          /* Width of widest line so far. */
-    int extra_width,        /* Sum of left and right border widths. */
-        extra_height;       /* Sum of top and bottom border widths. */
     boolean blocked;        /*  */
     boolean destroy_on_ack; /* Destroy this window when acknowledged. */
 #ifdef GRAPHIC_TOMBSTONE
@@ -250,8 +250,10 @@ struct xwindow {
 
     boolean nh_colors_inited;
     XColor nh_colors[CLR_MAX];
+#ifndef USE_XFT
     XFontStruct *boldfs;       /* Bold font */
     Display *boldfs_dpy;       /* Bold font display */
+#endif
     char *title;
 
     union {
@@ -361,8 +363,10 @@ extern boolean X11_blink;
     } while (0)
 
 /* ### Window.c ### */
+#ifndef USE_XFT
 extern Font WindowFont(Widget);
 extern XFontStruct *WindowFontStruct(Widget);
+#endif
 
 /* ### dialogs.c ### */
 extern Widget CreateDialog(Widget, String, XtCallbackProc, XtCallbackProc);

--- a/include/winX.h
+++ b/include/winX.h
@@ -544,7 +544,7 @@ extern XFontStruct *X11_unicode_font(Display *, XFontStruct *);
 #endif
 
 #ifdef USE_XFT
-extern XftFont *X11_new_font(Widget w, boolean bold, int win_type);
+extern XftFont *X11_new_font(Widget w, unsigned attrs, int win_type);
 extern void X11_release_font(Widget w, XftFont *font);
 extern void X11_new_color(Widget w, Pixel pixel, XftColor *color);
 #endif

--- a/include/winX.h
+++ b/include/winX.h
@@ -374,23 +374,15 @@ extern void positionpopup(Widget, boolean);
 /* ### winX.c ### */
 extern struct xwindow *find_widget(Widget);
 extern XColor get_nhcolor(struct xwindow *, int);
-extern void init_menu_nhcolors(struct xwindow *);
 extern void load_boldfont(struct xwindow *, Widget);
-extern Boolean nhApproxColor(Screen *, Colormap, char *, XColor *);
-extern Boolean nhCvtStringToPixel(Display *, XrmValuePtr, Cardinal *,
-                                  XrmValuePtr, XrmValuePtr, XtPointer *);
-extern void get_window_frame_extents(Widget, long *, long *, long *, long *);
 extern void get_widget_window_geometry(Widget, int *, int *, int *, int *);
-extern char *fontname_boldify(const char *);
 extern Dimension nhFontHeight(Widget, int);
 extern char key_event_to_char(XKeyEvent *);
-extern void msgkey(Widget, XtPointer, XEvent *, Boolean *);
 extern void highlight_yn(boolean);
 extern void nh_XtPopup(Widget, int, Widget);
 extern void nh_XtPopdown(Widget);
 extern void win_X11_init(int);
 extern void find_scrollbars(Widget, Widget, Widget *, Widget *);
-extern void nh_keyscroll(Widget, XEvent *, String *, Cardinal *);
 
 /* ### winmesg.c ### */
 extern void set_message_slider(struct xwindow *);
@@ -420,8 +412,6 @@ extern void create_menu_window(struct xwindow *);
 extern void destroy_menu_window(struct xwindow *);
 
 /* ### winmisc.c ### */
-extern XtPointer i2xtp(int);
-extern int xtp2i(XtPointer);
 extern void ps_key(Widget, XEvent *, String *,
                    Cardinal *); /* player selection action */
 extern void race_key(Widget, XEvent *, String *,
@@ -442,7 +432,9 @@ extern void release_extended_cmds(void);
 /* ### winstatus.c ### */
 extern void create_status_window(struct xwindow *, boolean, Widget);
 extern void destroy_status_window(struct xwindow *);
+#ifndef STATUS_HILITES
 extern void adjust_status(struct xwindow *, const char *);
+#endif
 extern void null_out_status(void);
 extern void check_turn_events(void);
 #ifdef STATUS_HILITES
@@ -465,7 +457,6 @@ extern void append_text_buffer(struct text_buffer *, const char *,
                                boolean); /* text buffer routines */
 extern void init_text_buffer(struct text_buffer *);
 extern void clear_text_buffer(struct text_buffer *);
-extern void free_text_buffer(struct text_buffer *);
 #ifdef GRAPHIC_TOMBSTONE
 extern void calculate_rip_text(int, time_t);
 #endif
@@ -481,64 +472,41 @@ extern int get_value_width(Widget);
 extern void swap_fg_bg(Widget);
 extern void set_value(Widget w, const char *new_value);
 /* external declarations */
-extern char *X11_getmsghistory(boolean);
-extern void X11_putmsghistory(const char *, boolean);
-extern void X11_init_nhwindows(int *, char **);
 extern void X11_player_selection(void);
-extern void X11_askname(void);
-extern void X11_get_nh_event(void);
 extern void X11_exit_nhwindows(const char *);
-extern void X11_suspend_nhwindows(const char *);
-extern void X11_resume_nhwindows(void);
 extern winid X11_create_nhwindow(int);
-extern void X11_clear_nhwindow(winid);
-extern void X11_display_nhwindow(winid, boolean);
 extern void X11_destroy_nhwindow(winid);
-extern void X11_curs(winid, int, int);
-extern void X11_putstr(winid, int, const char *);
-extern void X11_display_file(const char *, boolean);
 extern void X11_start_menu(winid, unsigned long);
 extern void X11_add_menu(winid, const glyph_info *, const ANY_P *, char,
                          char, int, int, const char *, unsigned int);
 extern void X11_end_menu(winid, const char *);
 extern int X11_select_menu(winid, int, MENU_ITEM_P **);
-extern void X11_mark_synch(void);
-extern void X11_wait_synch(void);
 #ifdef CLIPPING
 extern void X11_cliparound(int, int);
 #endif
 extern void X11_print_glyph(winid, coordxy, coordxy, const glyph_info *,
                             const glyph_info *);
 extern void X11_raw_print(const char *);
-extern void X11_raw_print_bold(const char *);
-extern int X11_nhgetch(void);
-extern int X11_nh_poskey(coordxy *, coordxy *, int *);
 extern void X11_nhbell(void);
-extern int X11_doprev_message(void);
 extern char X11_yn_function_core(const char *, const char *, char, unsigned);
-extern char X11_yn_function(const char *, const char *, char);
 extern void X11_getlin(const char *, char *);
 extern int X11_get_ext_cmd(void);
-extern void X11_number_pad(int);
-extern void X11_delay_output(void);
 extern void X11_status_init(void);
 extern void X11_status_finish(void);
 extern void X11_status_enablefield(int, const char *, const char *, boolean);
 extern void X11_status_update(int, genericptr_t, int, int, int,
                               unsigned long *);
 
-#ifdef GRAPHIC_TOMBSTONE
-extern void X11_outrip(winid, int, time_t);
-#else
+#ifndef GRAPHIC_TOMBSTONE
 extern void genl_outrip(winid, int, time_t);
 #endif
 
-extern void X11_preference_update(const char *);
 extern void X11_update_inventory(int);
-extern win_request_info *X11_ctrl_nhwindow(winid, int, win_request_info *);
 extern X11_map_symbol X11_glyph_char(const glyph_info *);
+#ifndef USE_XFT
 extern XFontStruct *X11_bold_font(Display *, XFontStruct *);
 extern XFontStruct *X11_italic_font(Display *, XFontStruct *);
+#endif /* !USE_XFT */
 #ifdef ENHANCED_SYMBOLS
 extern XFontStruct *X11_unicode_font(Display *, XFontStruct *);
 #endif

--- a/include/winX.h
+++ b/include/winX.h
@@ -139,7 +139,11 @@ struct mesg_info_t {
                                      /*     bottom of screen             */
     struct line_element *last_pause_head; /* pointer to head of previous */
                                           /* turn                        */
+#ifdef USE_XFT
+    Pixel fgpixel;   /* Color for text drawing */
+#else
     GC gc;           /* GC for text drawing */
+#endif
     int char_width,  /* Saved font information so we can  */
         char_height, /*   calculate the correct placement */
         char_ascent, /*   of changes.                     */

--- a/include/winX.h
+++ b/include/winX.h
@@ -9,6 +9,10 @@
 #ifndef WINX_H
 #define WINX_H
 
+#ifdef USE_XFT
+#include <X11/Xft/Xft.h>
+#endif
+
 #ifndef COLOR_H
 #include "color.h"      /* CLR_MAX */
 #endif
@@ -317,6 +321,16 @@ typedef struct {
     Pixel pet_mark_color;     /* color of pet mark */
     String pilemark_bitmap;   /* X11 bitmap file used to mark item piles */
     Pixel pilemark_color;     /* color of item pile mark */
+#ifdef USE_XFT
+    String font_map;          /* font for the map */
+    String font_menu;         /* font for menus */
+    String font_message;      /* font for the message window */
+    String font_status;       /* font for the status window */
+    String font_text;         /* font for text windows */
+#ifdef GRAPHIC_TOMBSTONE
+    String font_rip;          /* font for tombstone */
+#endif
+#endif
 #ifdef GRAPHIC_TOMBSTONE
     String tombstone; /* name of XPM file for tombstone */
     int tombtext_x;   /* x-coord of center of first tombstone text */
@@ -523,6 +537,12 @@ extern XFontStruct *X11_bold_font(Display *, XFontStruct *);
 extern XFontStruct *X11_italic_font(Display *, XFontStruct *);
 #ifdef ENHANCED_SYMBOLS
 extern XFontStruct *X11_unicode_font(Display *, XFontStruct *);
+#endif
+
+#ifdef USE_XFT
+extern XftFont *X11_new_font(Widget w, boolean bold, int win_type);
+extern void X11_release_font(Widget w, XftFont *font);
+extern void X11_new_color(Widget w, Pixel pixel, XftColor *color);
 #endif
 
 /* ### winlabel.c ### */

--- a/include/winX.h
+++ b/include/winX.h
@@ -558,4 +558,36 @@ extern void X11_set_highlight(Widget, boolean);
 extern void X11_set_percent(Widget, unsigned, Pixel);
 extern void X11_blink_labels(void);
 
+/*
+ * These are for widgets that use the enhanced label services only for text
+ * rendering; not for percentage bars, underlines and such. They only need
+ * these services if XFT is in use.
+ */
+#ifdef USE_XFT
+static inline void
+X11_wrap_widget_if_Xft(Widget w, int win_type)
+{
+    X11_wrap_widget(w, win_type);
+}
+
+static inline void
+X11_update_label_if_Xft(Widget w)
+{
+    X11_update_label(w);
+}
+#else /* !USE_XFT */
+static inline void
+X11_wrap_widget_if_Xft(Widget w, int win_type)
+{
+    nhUse(w);
+    nhUse(win_type);
+}
+
+static inline void
+X11_update_label_if_Xft(Widget w)
+{
+    nhUse(w);
+}
+#endif /* ?USE_XFT */
+
 #endif /* WINX_H */

--- a/include/winX.h
+++ b/include/winX.h
@@ -551,7 +551,7 @@ extern void X11_new_color(Widget w, Pixel pixel, XftColor *color);
 
 /* ### winlabel.c ### */
 /* Functions for management of enhanced labels */
-extern void X11_wrap_widget(Widget);
+extern void X11_wrap_widget(Widget, int);
 extern void X11_update_label(Widget);
 extern void X11_set_attrs(Widget, unsigned);
 extern void X11_set_highlight(Widget, boolean);

--- a/src/mdlib.c
+++ b/src/mdlib.c
@@ -576,6 +576,9 @@ static const char *const build_opts[] = {
 #ifdef USE_XPM
     "tiles file in XPM format",
 #endif
+#ifdef USE_XFT
+    "font rendering with Xft",
+#endif
 #ifdef GRAPHIC_TOMBSTONE
     "graphical RIP screen",
 #endif

--- a/sys/unix/Makefile.src
+++ b/sys/unix/Makefile.src
@@ -1080,7 +1080,7 @@ $(TARGETPFX)winX.o: ../win/X11/winX.c $(HACK_H) ../include/dlb.h \
 		../include/winX.h ../include/xwindow.h ../win/X11/nh32icon \
 		../win/X11/nh56icon ../win/X11/nh72icon
 	$(TARGET_CC) $(TARGET_CFLAGS) $(X11CFLAGS) -c -o $@ ../win/X11/winX.c
-$(TARGETPFX)winlabel.o: ../win/X11/winlabel.c $(HACK_H)
+$(TARGETPFX)winlabel.o: ../win/X11/winlabel.c $(HACK_H) ../include/winX.h
 	$(TARGET_CC) $(TARGET_CFLAGS) $(X11CFLAGS) -c -o $@ ../win/X11/winlabel.c
 $(TARGETPFX)winmap.o: ../win/X11/winmap.c $(HACK_H) ../include/dlb.h \
 		../include/tile2x11.h ../include/winX.h ../include/xwindow.h

--- a/sys/unix/NewInstall.unx
+++ b/sys/unix/NewInstall.unx
@@ -98,6 +98,9 @@ additional interfaces. See below.
 |          |       |                 |                                      |
 |          |       |                 | One possible way:                    |
 |          |       |                 |    brew install xquartz              |
+|          |       |                 |    brew install libxft               |
+|          |       |                 |    brew install fontconfig           |
+|          |       |                 |    brew install freetype             |
 |----------+-------+-----------------+--------------------------------------|
 | MacOS    | Qt    | WANT_WIN_QT     | You will need to obtain and          |
 |          |       |                 | install Qt if you want Qt            |

--- a/sys/unix/hints/linux.500
+++ b/sys/unix/hints/linux.500
@@ -410,7 +410,8 @@ X11CFLAGS = -I/opt/X11/include
 # avoid repeated complaints about _X_NONNULL(args...) in <X11/Xfuncproto.h>
 X11CFLAGS += -Wno-variadic-macros
 ifdef USE_XFT
-X11CFLAGS += -DUSE_XFT $(shell pkg-config --cflags xft fontconfig)
+CFLAGS += -DUSE_XFT
+X11CFLAGS += $(shell pkg-config --cflags xft fontconfig)
 WINX11LIB += $(shell pkg-config --libs xft fontconfig)
 endif
 ifdef USE_XPM

--- a/sys/unix/hints/linux.500
+++ b/sys/unix/hints/linux.500
@@ -397,6 +397,7 @@ endif   # MAKEFILE_SRC
 
 ifdef WANT_WIN_X11
 USE_XPM=1
+USE_XFT=1
 WINX11LIB = -lXaw -lXmu -lXext -lXt -lX11
 VARDATND0 += x11tiles NetHack.ad pet_mark.xbm pilemark.xbm
 ifndef CROSSCOMPILE
@@ -408,6 +409,10 @@ POSTINSTALL += bdftopcf win/X11/nh10.bdf > $(HACKDIR)/nh10.pcf; ( cd $(HACKDIR);
 X11CFLAGS = -I/opt/X11/include
 # avoid repeated complaints about _X_NONNULL(args...) in <X11/Xfuncproto.h>
 X11CFLAGS += -Wno-variadic-macros
+ifdef USE_XFT
+X11CFLAGS += -DUSE_XFT $(shell pkg-config --cflags xft fontconfig)
+WINX11LIB += $(shell pkg-config --libs xft fontconfig)
+endif
 ifdef USE_XPM
 CFLAGS += -DUSE_XPM
 WINX11LIB += -lXpm

--- a/sys/unix/hints/macOS.500
+++ b/sys/unix/hints/macOS.500
@@ -289,7 +289,8 @@ X11CFLAGS = -I/opt/X11/include
 # avoid repeated complaints about _X_NONNULL(args...) in <X11/Xfuncproto.h>
 X11CFLAGS += -Wno-variadic-macros
 ifdef USE_XFT
-X11CFLAGS += -DUSE_XFT $(shell pkg-config --cflags xft fontconfig)
+CFLAGS += -DUSE_XFT
+X11CFLAGS += $(shell pkg-config --cflags xft fontconfig)
 WINX11LIB += $(shell pkg-config --libs xft fontconfig)
 endif
 ifdef USE_XPM

--- a/sys/unix/hints/macOS.500
+++ b/sys/unix/hints/macOS.500
@@ -277,6 +277,7 @@ HINTOBJ=$(CHAINOBJ)
 endif # WANT_WIN_CHAIN
 
 ifdef WANT_WIN_X11
+USE_XFT=1
 USE_XPM=1
 WINX11LIB = -lXaw -lXmu -lXext -lXt -lX11
 VARDATND0 += x11tiles NetHack.ad pet_mark.xbm pilemark.xbm
@@ -287,6 +288,10 @@ POSTINSTALL += bdftopcf win/X11/nh10.bdf > $(HACKDIR)/nh10.pcf; ( cd $(HACKDIR);
 X11CFLAGS = -I/opt/X11/include
 # avoid repeated complaints about _X_NONNULL(args...) in <X11/Xfuncproto.h>
 X11CFLAGS += -Wno-variadic-macros
+ifdef USE_XFT
+X11CFLAGS += -DUSE_XFT $(shell pkg-config --cflags xft fontconfig)
+WINX11LIB += $(shell pkg-config --libs xft fontconfig)
+endif
 ifdef USE_XPM
 CFLAGS += -DUSE_XPM
 WINX11LIB += -lXpm

--- a/sys/unix/hints/macOS.500
+++ b/sys/unix/hints/macOS.500
@@ -290,8 +290,8 @@ X11CFLAGS = -I/opt/X11/include
 X11CFLAGS += -Wno-variadic-macros
 ifdef USE_XFT
 CFLAGS += -DUSE_XFT
-X11CFLAGS += $(shell pkg-config --cflags xft fontconfig)
-WINX11LIB += $(shell pkg-config --libs xft fontconfig)
+X11CFLAGS += $(shell pkg-config --cflags xft fontconfig freetype2)
+WINX11LIB += $(shell pkg-config --libs xft fontconfig freetype2)
 endif
 ifdef USE_XPM
 CFLAGS += -DUSE_XPM

--- a/win/X11/NetHack.ad
+++ b/win/X11/NetHack.ad
@@ -27,6 +27,18 @@ NetHack*tombstone*font:    NETHACK_FONT
 NetHack*text*rip*font:     -*-times-medium-r-*-*-12-*-*-*-*-*-*-*
 NetHack*text*borderWidth:  0
 
+! Vector font to be used if Xft support is enabled
+! These correspond to the .nethackrc settings font_map, font_menu,
+! font_message, font_status and font_text
+NetHack.font_map:     mono-10
+NetHack.font_menu:    mono-10
+NetHack.font_message: sans-10
+NetHack.font_status:  sans-10
+NetHack.font_text:    mono-10
+
+! No .nethackrc setting for this, but it gets the right size
+NetHack.font_rip:     sans-9
+
 ! tile_file names a file containing full-color tiles for the map.
 ! If you use a 100dpi (or greater) monitor you may wish to double the
 ! tile size so you can see the figures.  If NetHack was compiled to

--- a/win/X11/Window.c
+++ b/win/X11/Window.c
@@ -168,6 +168,7 @@ WindowClassRec windowClassRec = {
 
 WidgetClass windowWidgetClass = (WidgetClass) &windowClassRec;
 
+#ifndef USE_XFT
 Font
 WindowFont(Widget w)
 {
@@ -179,3 +180,4 @@ WindowFontStruct(Widget w)
 {
     return ((WindowWidget) w)->window.font;
 }
+#endif

--- a/win/X11/dialogs.c
+++ b/win/X11/dialogs.c
@@ -132,6 +132,7 @@ CreateDialog(Widget parent, String name, XtCallbackProc okay_callback,
     XtSetArg(args[num_args], nhStr(XtNborderWidth), 0); num_args++;
     prompt = XtCreateManagedWidget("prompt", labelWidgetClass, form,
                                    args, num_args);
+    X11_wrap_widget_if_Xft(prompt, NHW_MENU);
 
     num_args = 0;
 #ifdef SPECIAL_CMAP
@@ -169,6 +170,7 @@ CreateDialog(Widget parent, String name, XtCallbackProc okay_callback,
              XtParseAcceleratorTable(okay_accelerators)); num_args++;
     okay = XtCreateManagedWidget("okay", commandWidgetClass, form,
                                  args, num_args);
+    X11_wrap_widget_if_Xft(okay, NHW_MENU);
     XtAddCallback(okay, XtNcallback, okay_callback, form);
     XtSetArg(args[0], XtNwidth, &owidth);
     XtGetValues(okay, args, ONE);
@@ -193,6 +195,7 @@ CreateDialog(Widget parent, String name, XtCallbackProc okay_callback,
                  XtParseAcceleratorTable(cancel_accelerators)); num_args++;
         cancel = XtCreateManagedWidget("cancel", commandWidgetClass, form,
                                        args, num_args);
+        X11_wrap_widget_if_Xft(cancel, NHW_MENU);
         XtAddCallback(cancel, XtNcallback, cancel_callback, form);
         XtInstallAccelerators(response, cancel);
         XtSetArg(args[0], XtNwidth, &cwidth);
@@ -241,6 +244,7 @@ SetDialogPrompt(Widget w, String newprompt)
     label = XtNameToWidget(w, "prompt");
     XtSetArg(args[0], nhStr(XtNlabel), newprompt);
     XtSetValues(label, args, ONE);
+    X11_update_label_if_Xft(label);
 }
 
 /* get what the user typed; caller must free the response */

--- a/win/X11/winX.c
+++ b/win/X11/winX.c
@@ -98,7 +98,7 @@ void (*input_func)(Widget, XEvent *, String *, Cardinal *);
 int click_x, click_y, click_button; /* Click position on a map window
                                      * (filled by set_button_values()). */
 int updated_inventory; /* used to indicate perm_invent updating */
-color_attr X11_menu_promptstyle = { NO_COLOR, ATR_NONE };
+static color_attr X11_menu_promptstyle = { NO_COLOR, ATR_NONE };
 
 /* X11/Intrinsic.h prototype has an issue if [[NORETURN]] is used
  * rather than the old __attribute((noreturn)) under c23 */
@@ -127,6 +127,41 @@ static XtSignalId X11_sig_id;
 #endif
 #endif
 #endif
+
+static void init_menu_nhcolors(struct xwindow *);
+static Boolean nhApproxColor(Screen *, Colormap, char *, XColor *);
+static Boolean nhCvtStringToPixel(Display *, XrmValuePtr, Cardinal *,
+                                  XrmValuePtr, XrmValuePtr, XtPointer *);
+static void get_window_frame_extents(Widget, long *, long *, long *, long *);
+#ifndef USE_XFT
+static char *fontname_boldify(const char *);
+#endif
+static void msgkey(Widget, XtPointer, XEvent *, Boolean *);
+static void nh_keyscroll(Widget, XEvent *, String *, Cardinal *);
+static char *X11_getmsghistory(boolean);
+static void X11_putmsghistory(const char *, boolean);
+static void X11_init_nhwindows(int *, char **);
+static void X11_askname(void);
+static void X11_get_nh_event(void);
+static void X11_suspend_nhwindows(const char *);
+static void X11_resume_nhwindows(void);
+static void X11_clear_nhwindow(winid);
+static void X11_display_nhwindow(winid, boolean);
+static void X11_curs(winid, int, int);
+static void X11_putstr(winid, int, const char *);
+static void X11_display_file(const char *, boolean);
+static void X11_mark_synch(void);
+static void X11_wait_synch(void);
+static void X11_raw_print_bold(const char *);
+static int X11_nhgetch(void);
+static int X11_nh_poskey(coordxy *, coordxy *, int *);
+static int X11_doprev_message(void);
+static char X11_yn_function(const char *, const char *, char);
+static void X11_number_pad(int);
+static void X11_delay_output(void);
+static void X11_outrip(winid, int, time_t);
+static void X11_preference_update(const char *);
+static win_request_info *X11_ctrl_nhwindow(winid, int, win_request_info *);
 
 /* Interface definition, for windows.c */
 struct window_procs X11_procs = {
@@ -214,7 +249,7 @@ static winid message_win = WIN_ERR, /* These are the winids of the message, */
              status_win = WIN_ERR;  /*   are created in init_windows().     */
 static Pixmap icon_pixmap = None;   /* Pixmap for icon.                     */
 
-void
+static void
 X11_putmsghistory(const char *msg, boolean is_restoring)
 {
     if (WIN_MESSAGE != WIN_ERR) {
@@ -225,7 +260,7 @@ X11_putmsghistory(const char *msg, boolean is_restoring)
     }
 }
 
-char *
+static char *
 X11_getmsghistory(boolean init)
 {
     if (WIN_MESSAGE != WIN_ERR) {
@@ -308,7 +343,7 @@ get_nhcolor(struct xwindow *wp, int clr)
     return wp->nh_colors[0];
 }
 
-void
+static void
 init_menu_nhcolors(struct xwindow *wp)
 {
     static const char *mapCLR_to_res[CLR_MAX] = {
@@ -392,7 +427,7 @@ init_menu_nhcolors(struct xwindow *wp)
  * allocate the exact color, they puke and give you something stupid.
  * This is an attempt to find some close readonly cell and use it.
  */
-XtConvertArgRec const nhcolorConvertArgs[] = {
+static XtConvertArgRec const nhcolorConvertArgs[] = {
     { XtWidgetBaseOffset,
       (XtPointer) (ptrdiff_t) XtOffset(Widget, core.screen),
       sizeof (Screen *) },
@@ -425,7 +460,7 @@ XtConvertArgRec const nhcolorConvertArgs[] = {
  * The approximate color found is returned in color as well.
  * Return True if something close was found.
  */
-Boolean
+static Boolean
 nhApproxColor(
     Screen *screen,    /* screen to use */
     Colormap colormap, /* the colormap to use */
@@ -501,7 +536,7 @@ nhApproxColor(
     return True;
 }
 
-Boolean
+static Boolean
 nhCvtStringToPixel(
     Display *dpy,
     XrmValuePtr args, Cardinal *num_args,
@@ -594,7 +629,7 @@ nhCvtStringToPixel(
 }
 
 /* Ask the WM for window frame size */
-void
+static void
 get_window_frame_extents(
     Widget w,
     long *top, long *bottom,
@@ -670,8 +705,9 @@ get_widget_window_geometry(
     *y -= top;
 }
 
+#ifndef USE_XFT
 /* Change the full font name string so the weight is "bold" */
-char *
+static char *
 fontname_boldify(const char *fontname)
 {
     static char buf[BUFSZ];
@@ -719,6 +755,7 @@ load_boldfont(struct xwindow *wp, Widget w)
     fontname = fontname_boldify(XGetAtomName(dpy, (Atom)ret));
     wp->boldfs = XLoadQueryFont(dpy, fontname);
 }
+#endif /* !USE_XFT */
 
 /* ARGSUSED */
 static void
@@ -960,13 +997,13 @@ X11_raw_print(const char *str)
     (void) puts(str);
 }
 
-void
+static void
 X11_raw_print_bold(const char *str)
 {
     (void) puts(str);
 }
 
-void
+static void
 X11_curs(winid window, int x, int y)
 {
     check_winid(window);
@@ -984,7 +1021,7 @@ X11_curs(winid window, int x, int y)
     window_list[window].cursy = y;
 }
 
-void
+static void
 X11_putstr(winid window, int attr, const char *str)
 {
     winid new_win;
@@ -1032,19 +1069,19 @@ X11_putstr(winid window, int attr, const char *str)
 }
 
 /* We do event processing as a callback, so this is a null routine. */
-void
+static void
 X11_get_nh_event(void)
 {
     return;
 }
 
-int
+static int
 X11_nhgetch(void)
 {
     return input_event(EXIT_ON_KEY_PRESS);
 }
 
-int
+static int
 X11_nh_poskey(coordxy *x, coordxy *y, int *mod)
 {
     int val = input_event(EXIT_ON_KEY_OR_BUTTON_PRESS);
@@ -1151,7 +1188,7 @@ X11_create_nhwindow(int type)
     return window;
 }
 
-void
+static void
 X11_clear_nhwindow(winid window)
 {
     struct xwindow *wp;
@@ -1177,7 +1214,7 @@ X11_clear_nhwindow(winid window)
     }
 }
 
-void
+static void
 X11_display_nhwindow(winid window, boolean blocking)
 {
     struct xwindow *wp;
@@ -1328,7 +1365,7 @@ X11_update_inventory(int arg)
     return;
 }
 
-win_request_info *
+static win_request_info *
 X11_ctrl_nhwindow(
     winid window UNUSED,
     int request UNUSED,
@@ -1351,7 +1388,7 @@ X11_ctrl_nhwindow(
 }
 
 /* The current implementation has all of the saved lines on the screen. */
-int
+static int
 X11_doprev_message(void)
 {
     return 0;
@@ -1374,7 +1411,7 @@ X11_nhbell(void)
     }
 }
 
-void
+static void
 X11_mark_synch(void)
 {
     if (x_inited) {
@@ -1391,7 +1428,7 @@ X11_mark_synch(void)
     }
 }
 
-void
+static void
 X11_wait_synch(void)
 {
     if (x_inited) {
@@ -1401,13 +1438,13 @@ X11_wait_synch(void)
 }
 
 /* Both resume_ and suspend_ are called from ioctl.c and unixunix.c. */
-void
+static void
 X11_resume_nhwindows(void)
 {
     return;
 }
 /* ARGSUSED */
-void
+static void
 X11_suspend_nhwindows(const char *str)
 {
     nhUse(str);
@@ -1417,7 +1454,7 @@ X11_suspend_nhwindows(const char *str)
 
 /* Under X, we don't need to initialize the number pad. */
 /* ARGSUSED */
-void
+static void
 X11_number_pad(int state) /* called from options.c */
 {
     nhUse(state);
@@ -1426,7 +1463,7 @@ X11_number_pad(int state) /* called from options.c */
 }
 
 #ifdef GRAPHIC_TOMBSTONE
-void
+static void
 X11_outrip(winid window, int how, time_t when)
 {
     struct xwindow *wp;
@@ -1597,7 +1634,7 @@ X11_io_error_handler(Display *display)
     return 0;
 }
 
-void
+static void
 X11_init_nhwindows(int *argcp, char **argv)
 {
     int i;
@@ -1812,7 +1849,7 @@ d_timeout(XtPointer client_data, XtIntervalId *id)
  * function will send an event to the map window which will be waiting
  * for a sent event.
  */
-void
+static void
 X11_delay_output(void)
 {
     if (!x_inited)
@@ -1902,7 +1939,7 @@ askname_done(Widget w, XtPointer client_data, XtPointer call_data)
 
 /* ask player for character's name to replace generic name "player" (or other
    values; see config.h) after 'nethack -u player' or OPTIONS=name:player */
-void
+static void
 X11_askname(void)
 {
     Widget popup, dialog;
@@ -2120,7 +2157,7 @@ X11_getlin(
 
 /* uses a menu (with no selectors specified) rather than a text window
    to allow previous_page and first_menu actions to move backwards */
-void
+static void
 X11_display_file(const char *str, boolean complain)
 {
     dlb *fp;
@@ -2518,7 +2555,7 @@ X11_yn_function_core(
 
 /* X11-specific edition of yn_function(), the routine called by the core
    to show a prompt and get a single key answer, often 'y' vs 'n' */
-char
+static char
 X11_yn_function(
     const char *ques,     /* prompt text */
     const char *choices,  /* allowed response chars; any char if Null */
@@ -2531,7 +2568,7 @@ X11_yn_function(
 
 /* used when processing window-capability-specific run-time options;
    we support toggling tiles on and off via iflags.wc_tiled_map */
-void
+static void
 X11_preference_update(const char *pref)
 {
     if (!strcmp(pref, "tiled_map")) {
@@ -2562,7 +2599,7 @@ input_event(int exit_condition)
 }
 
 /*ARGSUSED*/
-void
+static void
 msgkey(Widget w, XtPointer data, XEvent *event, Boolean *continue_to_dispatch)
 {
     Cardinal num = 0;
@@ -2893,7 +2930,7 @@ find_scrollbars(
  * Scroll a viewport, using standard NH 1,2,3,4,6,7,8,9 directions.
  */
 /*ARGSUSED*/
-void
+static void
 nh_keyscroll(Widget viewport, XEvent *event, String *params,
              Cardinal *num_params)
 {
@@ -3058,6 +3095,7 @@ X11_glyph_char(const glyph_info *glyphinfo)
 #endif
 }
 
+#ifndef USE_XFT
 /* Given an XFontStruct, return a corresponding bold font */
 XFontStruct *
 X11_bold_font(Display *display, XFontStruct *font)
@@ -3120,6 +3158,7 @@ X11_italic_font(Display *display, XFontStruct *font)
 
     return font2;
 }
+#endif /* !USE_XFT */
 
 #ifdef ENHANCED_SYMBOLS
 /* Given an XFontStruct, return a corresponding font that supports Unicode */

--- a/win/X11/winX.c
+++ b/win/X11/winX.c
@@ -1161,8 +1161,10 @@ X11_create_nhwindow(int type)
         wp->pixel_height = 0;
     wp->keep_window = FALSE;
     wp->nh_colors_inited = FALSE;
+#ifndef USE_XFT
     wp->boldfs = (XFontStruct *) 0;
     wp->boldfs_dpy = (Display *) 0;
+#endif
     wp->title = (char *) 0;
 
     switch (type) {
@@ -1304,11 +1306,13 @@ X11_destroy_nhwindow(winid window)
         WIN_INVEN = WIN_ERR;
     }
 
+#ifndef USE_XFT
     if (wp->boldfs) {
         XFreeFont(wp->boldfs_dpy, wp->boldfs);
         wp->boldfs = (XFontStruct *) 0;
         wp->boldfs_dpy = (Display *) 0;
     }
+#endif
 
     if (wp->title) {
         free(wp->title);
@@ -3158,7 +3162,6 @@ X11_italic_font(Display *display, XFontStruct *font)
 
     return font2;
 }
-#endif /* !USE_XFT */
 
 #ifdef ENHANCED_SYMBOLS
 /* Given an XFontStruct, return a corresponding font that supports Unicode */
@@ -3203,6 +3206,7 @@ X11_unicode_font(Display *display, XFontStruct *font)
     return unifont;
 }
 #endif /* ENHANCED_SYMBOLS */
+#endif /* !USE_XFT */
 
 #ifdef USE_XFT
 

--- a/win/X11/winX.c
+++ b/win/X11/winX.c
@@ -794,7 +794,7 @@ nhFontHeight(Widget w, int win_type)
 #ifdef USE_XFT
 
     XftFont *font = X11_new_font(w, 0, win_type);
-    Dimension height = font->height;
+    Dimension height = X11_font_height(font);
     X11_release_font(w, font);
     return height;
 

--- a/win/X11/winX.c
+++ b/win/X11/winX.c
@@ -3165,7 +3165,7 @@ X11_unicode_font(Display *display, XFontStruct *font)
 /* Open a vector font for the given widget */
 
 extern XftFont *
-X11_new_font(Widget w, boolean bold, int win_type)
+X11_new_font(Widget w, unsigned attrs, int win_type)
 {
     const char *font_name = NULL;
     const char *iflags_font_name = NULL;
@@ -3248,9 +3248,10 @@ X11_new_font(Widget w, boolean bold, int win_type)
     /* Set reasonable bounds on the font size */
     font_size = min(max(font_size, 6), 50);
 
-    Snprintf(name, sizeof(name), "%.*s-%d:%s",
+    Snprintf(name, sizeof(name), "%.*s-%d%s%s",
             (int) name_len, font_name, font_size,
-            bold ? "bold" : "medium");
+            (attrs & HL_BOLD) ? ":bold" : "",
+            (attrs & HL_ITALIC) ? ":italic" : "");
 
     Display *display = XtDisplay(w);
     XftFont *font = XftFontOpenName(display, DefaultScreen(display), name);

--- a/win/X11/winX.c
+++ b/win/X11/winX.c
@@ -1513,6 +1513,22 @@ static XtResource resources[] = {
     { nhStr("pilemark_color"), nhStr("Pilemark_color"), XtRPixel,
       sizeof(XtRPixel), XtOffset(AppResources *, pilemark_color), XtRString,
       nhStr("Green") },
+#ifdef USE_XFT
+    { nhStr("font_map"), nhStr("Font_map"), XtRString, sizeof(String),
+      XtOffset(AppResources *, font_map), XtRString, nhStr("mono-10") },
+    { nhStr("font_menu"), nhStr("Font_menu"), XtRString, sizeof(String),
+      XtOffset(AppResources *, font_menu), XtRString, nhStr("mono-10") },
+    { nhStr("font_message"), nhStr("Font_message"), XtRString, sizeof(String),
+      XtOffset(AppResources *, font_message), XtRString, nhStr("sans-10") },
+    { nhStr("font_status"), nhStr("Font_status"), XtRString, sizeof(String),
+      XtOffset(AppResources *, font_status), XtRString, nhStr("sans-10") },
+    { nhStr("font_text"), nhStr("Font_text"), XtRString, sizeof(String),
+      XtOffset(AppResources *, font_text), XtRString, nhStr("mono-10") },
+#ifdef GRAPHIC_TOMBSTONE
+    { nhStr("font_rip"), nhStr("Font_rip"), XtRString, sizeof(String),
+      XtOffset(AppResources *, font_rip), XtRString, nhStr("sans-9") },
+#endif
+#endif
 #ifdef GRAPHIC_TOMBSTONE
     { nhStr("tombstone"), nhStr("Tombstone"), XtRString, sizeof(String),
       XtOffset(AppResources *, tombstone), XtRString, nhStr("rip.xpm") },
@@ -3130,5 +3146,133 @@ X11_unicode_font(Display *display, XFontStruct *font)
     return unifont;
 }
 #endif /* ENHANCED_SYMBOLS */
+
+#ifdef USE_XFT
+
+/* Open a vector font for the given widget */
+
+extern XftFont *
+X11_new_font(Widget w, boolean bold, int win_type)
+{
+    const char *font_name = NULL;
+    const char *iflags_font_name = NULL;
+    int font_size = 0;
+    char name[512];
+
+    switch (win_type) {
+    case NHW_MESSAGE:
+        font_name = appResources.font_message;
+        iflags_font_name = iflags.wc_font_message;
+        font_size = iflags.wc_fontsiz_message;
+        break;
+
+    case NHW_STATUS:
+        font_name = appResources.font_status;
+        iflags_font_name = iflags.wc_font_status;
+        font_size = iflags.wc_fontsiz_status;
+        break;
+
+    case NHW_MAP:
+        font_name = appResources.font_map;
+        iflags_font_name = iflags.wc_font_map;
+        font_size = iflags.wc_fontsiz_map;
+        break;
+
+    case NHW_MENU:
+    case NHW_PERMINVENT:
+        font_name = appResources.font_menu;
+        iflags_font_name = iflags.wc_font_menu;
+        font_size = iflags.wc_fontsiz_menu;
+        break;
+
+    case NHW_TEXT:
+        font_name = appResources.font_text;
+        iflags_font_name = iflags.wc_font_text;
+        font_size = iflags.wc_fontsiz_text;
+        break;
+
+    default:
+        break;
+    }
+
+    if (font_name == NULL) {
+        font_name = "mono-10";
+    }
+
+    /* Override the font name if specified in the configuration file */
+    if (iflags_font_name != NULL) {
+        font_name = iflags_font_name;
+    }
+
+    /*
+     * Specify font size as follows:
+     * * Use any font size specified in the configuration file
+     * * If no such size is specified, use the one in the font name;
+     *   e.g., "Courier-14" specifies 14 points
+     * * If still no size, use 10 points
+     */
+    size_t name_len = strlen(font_name);
+    const char *dash = strrchr(font_name, '-');
+    if (dash) {
+        char *end;
+        long size = strtol(dash + 1, &end, 10);
+        if (*end == '\0') {
+            /* The name ends in a size */
+            name_len = (size_t) (dash - font_name);
+            /* Use font_size if specified;
+               else use the size from font_name */
+            if (font_size <= 0) {
+                font_size = (int) size;
+            }
+        }
+    }
+
+    /* Use 10 if no size specified */
+    if (font_size <= 0) {
+        font_size = 10;
+    }
+
+    /* Set reasonable bounds on the font size */
+    font_size = min(max(font_size, 6), 50);
+
+    Snprintf(name, sizeof(name), "%.*s-%d:%s",
+            (int) name_len, font_name, font_size,
+            bold ? "bold" : "medium");
+
+    Display *display = XtDisplay(w);
+    XftFont *font = XftFontOpenName(display, DefaultScreen(display), name);
+
+    return font;
+}
+
+/* Free the font returned by X11_new_font */
+
+void
+X11_release_font(Widget w, XftFont *font)
+{
+    Display *display = XtDisplay(w);
+    XftFontClose(display,  font);
+}
+
+/* Assign a new color having the given RGB components */
+
+void
+X11_new_color(Widget w, Pixel pixel, XftColor *color)
+{
+    XRenderColor rcolor;
+    rcolor.red   = ((pixel >> 16) & 0xFF) * 0x0101;
+    rcolor.green = ((pixel >>  8) & 0xFF) * 0x0101;
+    rcolor.blue  = ((pixel >>  0) & 0xFF) * 0x0101;
+    rcolor.alpha = 0xFFFF;
+
+    Display *display = XtDisplay(w);
+    Screen *screen = DefaultScreenOfDisplay(display);
+    Visual *visual = DefaultVisualOfScreen(screen);
+    Colormap cmap = DefaultColormapOfScreen(screen);
+
+    XftColorAllocValue(display, visual, cmap, &rcolor, color);
+}
+
+#endif /* USE_XFT */
 
 /*winX.c*/

--- a/win/X11/winX.c
+++ b/win/X11/winX.c
@@ -2446,6 +2446,7 @@ X11_yn_function_core(
             (void) memset(buf2, 'X', 25), buf2[25] = '\0'; /* 25 'X's */
             yn_minwidth = (Dimension) XTextWidth(yn_font, buf2,
                                                  (int) strlen(buf2));
+            X11_wrap_widget_if_Xft(yn_label, NHW_MESSAGE);
         }
     }
 
@@ -2454,6 +2455,7 @@ X11_yn_function_core(
     num_args = 0;
     XtSetArg(args[num_args], XtNlabel, buf); num_args++;
     XtSetValues(yn_label, args, num_args);
+    X11_update_label_if_Xft(yn_label);
 
     /* for !slow, pop up the prompt+response widget */
     if (!appResources.slow) {
@@ -2497,6 +2499,7 @@ X11_yn_function_core(
         num_args = 0;
         XtSetArg(args[num_args], XtNlabel, " "); num_args++;
         XtSetValues(yn_label, args, num_args);
+        X11_update_label_if_Xft(yn_label);
 
         input_func = 0; /* keystrokes now belong to the map */
         highlight_yn(FALSE); /* disguise yn_label as part of map */
@@ -2620,6 +2623,7 @@ highlight_yn(boolean init)
             XtSetArg(args[0], XtNforeground, vals.foreground);
             XtSetArg(args[1], XtNbackground, vals.background);
             XtSetValues(yn_label, args, TWO);
+            X11_update_label_if_Xft(yn_label);
         }
     } else
         swap_fg_bg(yn_label);
@@ -2687,6 +2691,7 @@ init_standard_windows(void)
         XtSetArg(args[num_args], nhStr(XtNresizable), True); num_args++;
         XtSetArg(args[num_args], nhStr(XtNlabel), " "); num_args++;
         XtSetValues(yn_label, args, num_args);
+        X11_wrap_widget_if_Xft(yn_label, NHW_MESSAGE);
     }
 
     /*

--- a/win/X11/winX.c
+++ b/win/X11/winX.c
@@ -752,10 +752,21 @@ nhFreePixel(
  * assumption of ascent + descent is not always valid.
  */
 Dimension
-nhFontHeight(Widget w)
+nhFontHeight(Widget w, int win_type)
 {
+#ifdef USE_XFT
+
+    XftFont *font = X11_new_font(w, 0, win_type);
+    Dimension height = font->height;
+    X11_release_font(w, font);
+    return height;
+
+#else /* !USE_XFT */
+
     Arg args[1];
     XFontStruct *fs;
+
+    nhUse(win_type);
 
 #ifdef _XawTextSink_h
     Widget sink = NULL;
@@ -776,6 +787,8 @@ nhFontHeight(Widget w)
 
     /* Assume font height is ascent + descent. */
     return fs->ascent + fs->descent;
+
+#endif /* ?USE_XFT */
 }
 
 static String *default_resource_data = 0, /* NULL-terminated arrays */

--- a/win/X11/winlabel.c
+++ b/win/X11/winlabel.c
@@ -28,8 +28,13 @@ typedef struct WidgetData {
     boolean highlight;
 
     /* Fonts for italic, bold and bold-italic */
+#ifdef USE_XFT
+    int win_type;
+    XftFont *vfont[4];
+#else /* !USE_XFT */
     XFontStruct *font[4]; /* To use the fonts */
     XFontStruct *font_ptr[4]; /* To free the fonts */
+#endif /* ?USE_XFT */
 
     /* Percentage bar */
     unsigned percent;
@@ -57,7 +62,7 @@ static WidgetData *get_widget_data(Widget w);
  * attribute flags and a percentage bar.
  */
 void
-X11_wrap_widget(Widget w)
+X11_wrap_widget(Widget w, int win_type)
 {
     /* We shouldn't use this for anything other than labels and subclasses
        of labels */
@@ -79,10 +84,16 @@ X11_wrap_widget(Widget w)
     WidgetData *data = add_widget(w);
 
     /* Copy resources from the created widget */
+#ifdef USE_XFT
+    data->win_type = win_type;
+    allocate_font(w, data, 0);
+#else /* !USE_XFT */
     Cardinal num_args2 = 0;
     Arg args2[1];
     XtSetArg(args2[num_args2], XtNfont,  &data->font[0]); num_args2++;
     XtGetValues(w, args2, num_args2);
+    nhUse(win_type);
+#endif /* ?USE_XFT */
 
     /* Create the pixmap for the first time */
     update_label(w, data);
@@ -184,7 +195,11 @@ update_label(Widget w, WidgetData *data)
         font_idx |= font_italic;
         allocate_font(w, data, font_idx);
     }
+#ifdef USE_XFT
+    XftFont *vfont = data->vfont[font_idx];
+#else
     XFontStruct *font = data->font[font_idx];
+#endif
 
     String label;
     Boolean sens;       /* Make dim if not sensitive */
@@ -222,11 +237,17 @@ update_label(Widget w, WidgetData *data)
             }
 
             /* Get the width of the line */
+#ifdef USE_XFT
+            XGlyphInfo extents;
+            XftTextExtents8(display, vfont, (const FcChar8*) (label + i), line2, &extents);
+            int lwidth = extents.width - extents.x;
+#else
             int lwidth = XTextWidth(font, label + i, line2);
+#endif
 
             /* Update pixmap dimensions */
             width = max(lwidth, width);
-            height += font->ascent + font->descent;
+            ++height;
 
             /* Advance to next line */
             i += line1;
@@ -236,7 +257,14 @@ update_label(Widget w, WidgetData *data)
         }
 
         /* Always size for at least one line */
-        height = max(height, font->ascent + font->descent);
+        height = max(height, 1);
+
+        /* Convert height to pixels */
+#ifdef USE_XFT
+        height *= vfont->height;
+#else
+        height *= font->ascent + font->descent;
+#endif
     } else {
         num_args = 0;
         XtSetArg(args[num_args], XtNwidth, &width); num_args++;
@@ -285,11 +313,20 @@ update_label(Widget w, WidgetData *data)
         if ((attrs & HL_BLINK) && X11_blink) {
             values.foreground = values.background;
         }
+#ifdef USE_XFT
+        Visual *visual = DefaultVisualOfScreen(screen);
+        Colormap cmap = DefaultColormapOfScreen(screen);
+        XftDraw *draw = XftDrawCreate(display, new_pixmap, visual, cmap);
+        XftColor fgcolor, bgcolor;
+        X11_new_color(w, values.foreground, &fgcolor);
+        X11_new_color(w, values.background, &bgcolor);
+#else /* !USE_XFT */
         values.font = font->fid;
         values.function = GXcopy;
         GC ggc = XtGetGC(w,
                          GCFunction | GCForeground | GCBackground | GCFont,
                          &values);
+#endif /* ?USE_XFT */
         if (pass == 1) {
             /* Percent bar will occupy this area */
             XRectangle clip = {
@@ -298,18 +335,34 @@ update_label(Widget w, WidgetData *data)
                 .width = width * data->percent / 100,
                 .height = height
             };
+#ifdef USE_XFT
+            XftDrawSetClipRectangles(draw, 0, 0, &clip, 1);
+#else /* !USE_XFT */
             XSetClipRectangles(display, ggc, 0, 0, &clip, 1, Unsorted);
+#endif /* ?USE_XFT */
         }
 
         /* Draw a border for inverse and highlight together */
         /* Otherwise, fill with the background color */
+#ifdef USE_XFT
+        if (!((attrs & HL_INVERSE) && data->highlight)) {
+            XftDrawRect(draw, &bgcolor, 0, 0, width, height);
+        } else {
+            XftDrawRect(draw, &fgcolor, 0, 0, width, height);
+        }
+#else /* !USE_XFT */
         if (!((attrs & HL_INVERSE) && data->highlight)) {
             XSetForeground(display, ggc, values.background);
         }
         XFillRectangle(display, new_pixmap, ggc, 0, 0, width, height);
         XSetForeground(display, ggc, values.foreground);
+#endif /* ?USE_XFT */
 
+#ifdef USE_XFT
+        int y = vfont->ascent;
+#else /* !USE_XFT */
         int y = font->max_bounds.ascent;
+#endif /* ?USE_XFT */
         size_t i = 0;
         while (label[i] != '\0') {
             size_t line1 = strcspn(label + i, "\n");
@@ -320,7 +373,13 @@ update_label(Widget w, WidgetData *data)
             }
 
             /* Get the width of the line */
+#ifdef USE_XFT
+            XGlyphInfo extents;
+            XftTextExtents8(display, vfont, (const FcChar8*) (label + i), line2, &extents);
+            int lwidth = extents.width - extents.x;
+#else
             int lwidth = XTextWidth(font, label + i, line2);
+#endif
 
             /* Place the line horizontally */
             int x = 0;
@@ -339,18 +398,32 @@ update_label(Widget w, WidgetData *data)
             }
 
             /* Render the line */
+#ifdef USE_XFT
+            XftDrawRect(draw, &bgcolor, x, y - vfont->ascent, lwidth, vfont->height);
+            XftDrawString8(draw, &fgcolor, vfont, x, y,
+                           (const FcChar8 *) (label + i), line2);
+#else
             XDrawImageString(display, new_pixmap, ggc,
                              x, y,
                              label + i, line2);
+#endif
 
             /* Draw the underline if requested */
             if (attrs & HL_ULINE) {
+#ifdef USE_XFT
+                XftDrawRect(draw, &fgcolor, x, y, lwidth, 1);
+#else
                 XDrawLine(display, new_pixmap, ggc,
                           x, y,
                           x + lwidth - 1, y);
+#endif
             }
 
+#ifdef USE_XFT
+            y += vfont->height;
+#else
             y += font->ascent + font->descent;
+#endif
 
             /* Advance to next line */
             i += line1;
@@ -361,10 +434,23 @@ update_label(Widget w, WidgetData *data)
 
         /* Ensure a one-pixel border if both inverse and highlight */
         if ((attrs & HL_INVERSE) && data->highlight) {
+#ifdef USE_XFT
+            XftDrawRect(draw, &fgcolor, 0, 0,        width, 1);
+            XftDrawRect(draw, &fgcolor, 0, height-1, width, 1);
+            XftDrawRect(draw, &fgcolor, 0, 0,        1,     height);
+            XftDrawRect(draw, &fgcolor, 0, height-1, 1,     height);
+#else
             XDrawRectangle(display, new_pixmap, ggc, 0, 0, width-1, height-1);
+#endif
         }
 
+#ifdef USE_XFT
+        XftColorFree(display, visual, cmap, &fgcolor);
+        XftColorFree(display, visual, cmap, &bgcolor);
+        XftDrawDestroy(draw);
+#else
         XtReleaseGC(w, ggc);
+#endif
 
         /* Set up to display the percent bar on the second pass */
         if (data->percent == 0) {
@@ -377,8 +463,6 @@ update_label(Widget w, WidgetData *data)
     /* Update the pixmap */
     num_args = 0;
     XtSetArg(args[num_args], XtNbitmap, new_pixmap); num_args++;
-    //XtSetArg(args[num_args], XtNwidth, width); num_args++;
-    //XtSetArg(args[num_args], XtNheight, height); num_args++;
     XtSetValues(w, args, num_args);
     if (data->pixmap != 0) {
         XFreePixmap(display, data->pixmap);
@@ -390,8 +474,13 @@ update_label(Widget w, WidgetData *data)
 static void
 allocate_font(Widget w, WidgetData *data, unsigned font_idx)
 {
+#ifdef USE_XFT
+    static const unsigned attrs[4] = {
+        0, HL_BOLD, HL_ITALIC, HL_BOLD | HL_ITALIC
+    };
+    data->vfont[font_idx] = X11_new_font(w, attrs[font_idx], data->win_type);
+#else
     Display *display = XtDisplay(w);
-
     XFontStruct *font1 = (font_idx == (font_bold | font_italic))
                        ? data->font[font_bold]
                        : data->font[0];
@@ -401,6 +490,7 @@ allocate_font(Widget w, WidgetData *data, unsigned font_idx)
     data->font[font_idx] = data->font_ptr[font_idx]
                          ? data->font_ptr[font_idx]
                          : font1;
+#endif
 }
 
 /* Free any allocated fonts */
@@ -409,11 +499,18 @@ free_fonts(Widget w, WidgetData *data)
 {
     Display *display = XtDisplay(w);
     for (unsigned i = 0; i < 4; ++i) {
+#ifdef USE_XFT
+        if (data->vfont[i] != NULL) {
+            XftFontClose(display, data->vfont[i]);
+        }
+        data->vfont[i] = NULL;
+#else
         if (data->font_ptr[i] != NULL) {
             XFreeFont(display, data->font_ptr[i]);
         }
         data->font[i] = NULL;
         data->font_ptr[i] = NULL;
+#endif
     }
 }
 

--- a/win/X11/winlabel.c
+++ b/win/X11/winlabel.c
@@ -418,7 +418,7 @@ update_label(Widget w, WidgetData *data)
             XftDrawRect(draw, &fgcolor, 0, 0,        width, 1);
             XftDrawRect(draw, &fgcolor, 0, height-1, width, 1);
             XftDrawRect(draw, &fgcolor, 0, 0,        1,     height);
-            XftDrawRect(draw, &fgcolor, 0, height-1, 1,     height);
+            XftDrawRect(draw, &fgcolor, width-1, 0,  1,     height);
 #else
             XDrawRectangle(display, new_pixmap, ggc, 0, 0, width-1, height-1);
 #endif

--- a/win/X11/winlabel.c
+++ b/win/X11/winlabel.c
@@ -18,6 +18,15 @@
 #include "hack.h"
 #include "winX.h"
 
+/* Declarations depending on Xft support or none */
+#ifdef USE_XFT
+typedef XftFont X11_Font;
+#else
+typedef XFontStruct X11_Font;
+#endif
+static int X11_text_width(Display *, X11_Font *, const char *, size_t);
+static int X11_font_height(X11_Font *);
+
 /* Data attached to a wrapped widget */
 typedef struct WidgetData {
     /* Displayed text */
@@ -28,12 +37,11 @@ typedef struct WidgetData {
     boolean highlight;
 
     /* Fonts for italic, bold and bold-italic */
+    X11_Font *font[4]; /* To use the fonts */
 #ifdef USE_XFT
     int win_type;
-    XftFont *vfont[4];
 #else /* !USE_XFT */
-    XFontStruct *font[4]; /* To use the fonts */
-    XFontStruct *font_ptr[4]; /* To free the fonts */
+    X11_Font *font_ptr[4]; /* To free the fonts */
 #endif /* ?USE_XFT */
 
     /* Percentage bar */
@@ -195,11 +203,7 @@ update_label(Widget w, WidgetData *data)
         font_idx |= font_italic;
         allocate_font(w, data, font_idx);
     }
-#ifdef USE_XFT
-    XftFont *vfont = data->vfont[font_idx];
-#else
-    XFontStruct *font = data->font[font_idx];
-#endif
+    X11_Font *font = data->font[font_idx];
 
     String label;
     Boolean sens;       /* Make dim if not sensitive */
@@ -237,13 +241,7 @@ update_label(Widget w, WidgetData *data)
             }
 
             /* Get the width of the line */
-#ifdef USE_XFT
-            XGlyphInfo extents;
-            XftTextExtents8(display, vfont, (const FcChar8*) (label + i), line2, &extents);
-            int lwidth = extents.width - extents.x;
-#else
-            int lwidth = XTextWidth(font, label + i, line2);
-#endif
+            int lwidth = X11_text_width(display, font, label + i, line2);
 
             /* Update pixmap dimensions */
             width = max(lwidth, width);
@@ -260,11 +258,7 @@ update_label(Widget w, WidgetData *data)
         height = max(height, 1);
 
         /* Convert height to pixels */
-#ifdef USE_XFT
-        height *= vfont->height;
-#else
-        height *= font->ascent + font->descent;
-#endif
+        height *= X11_font_height(font);
     } else {
         num_args = 0;
         XtSetArg(args[num_args], XtNwidth, &width); num_args++;
@@ -358,11 +352,7 @@ update_label(Widget w, WidgetData *data)
         XSetForeground(display, ggc, values.foreground);
 #endif /* ?USE_XFT */
 
-#ifdef USE_XFT
-        int y = vfont->ascent;
-#else /* !USE_XFT */
-        int y = font->max_bounds.ascent;
-#endif /* ?USE_XFT */
+        int y = font->ascent;
         size_t i = 0;
         while (label[i] != '\0') {
             size_t line1 = strcspn(label + i, "\n");
@@ -373,13 +363,7 @@ update_label(Widget w, WidgetData *data)
             }
 
             /* Get the width of the line */
-#ifdef USE_XFT
-            XGlyphInfo extents;
-            XftTextExtents8(display, vfont, (const FcChar8*) (label + i), line2, &extents);
-            int lwidth = extents.width - extents.x;
-#else
-            int lwidth = XTextWidth(font, label + i, line2);
-#endif
+            int lwidth = X11_text_width(display, font, label + i, line2);
 
             /* Place the line horizontally */
             int x = 0;
@@ -399,8 +383,8 @@ update_label(Widget w, WidgetData *data)
 
             /* Render the line */
 #ifdef USE_XFT
-            XftDrawRect(draw, &bgcolor, x, y - vfont->ascent, lwidth, vfont->height);
-            XftDrawString8(draw, &fgcolor, vfont, x, y,
+            XftDrawRect(draw, &bgcolor, x, y - font->ascent, lwidth, font->height);
+            XftDrawString8(draw, &fgcolor, font, x, y,
                            (const FcChar8 *) (label + i), line2);
 #else
             XDrawImageString(display, new_pixmap, ggc,
@@ -419,11 +403,7 @@ update_label(Widget w, WidgetData *data)
 #endif
             }
 
-#ifdef USE_XFT
-            y += vfont->height;
-#else
-            y += font->ascent + font->descent;
-#endif
+            y += X11_font_height(font);
 
             /* Advance to next line */
             i += line1;
@@ -478,10 +458,10 @@ allocate_font(Widget w, WidgetData *data, unsigned font_idx)
     static const unsigned attrs[4] = {
         0, HL_BOLD, HL_ITALIC, HL_BOLD | HL_ITALIC
     };
-    data->vfont[font_idx] = X11_new_font(w, attrs[font_idx], data->win_type);
+    data->font[font_idx] = X11_new_font(w, attrs[font_idx], data->win_type);
 #else
     Display *display = XtDisplay(w);
-    XFontStruct *font1 = (font_idx == (font_bold | font_italic))
+    X11_Font *font1 = (font_idx == (font_bold | font_italic))
                        ? data->font[font_bold]
                        : data->font[0];
     data->font_ptr[font_idx] = (font_idx == font_bold)
@@ -500,10 +480,10 @@ free_fonts(Widget w, WidgetData *data)
     Display *display = XtDisplay(w);
     for (unsigned i = 0; i < 4; ++i) {
 #ifdef USE_XFT
-        if (data->vfont[i] != NULL) {
-            XftFontClose(display, data->vfont[i]);
+        if (data->font[i] != NULL) {
+            XftFontClose(display, data->font[i]);
         }
-        data->vfont[i] = NULL;
+        data->font[i] = NULL;
 #else
         if (data->font_ptr[i] != NULL) {
             XFreeFont(display, data->font_ptr[i]);
@@ -513,6 +493,39 @@ free_fonts(Widget w, WidgetData *data)
 #endif
     }
 }
+
+//////////////////////////////////////////////////////////////////////////////
+//             Functions that depend on the font rendering API              //
+//////////////////////////////////////////////////////////////////////////////
+
+#ifdef USE_XFT
+static int
+X11_text_width(Display *display, X11_Font *font, const char *text, size_t length)
+{
+    XGlyphInfo extents;
+    XftTextExtents8(display, font, (const FcChar8*) text, length, &extents);
+    return extents.width - extents.x;
+}
+
+static int
+X11_font_height(X11_Font *font)
+{
+    return font->height;
+}
+#else /* !USE_XFT */
+static int
+X11_text_width(Display *display, X11_Font *font, const char *text, size_t length)
+{
+    nhUse(display);
+    return XTextWidth(font, text, length);
+}
+
+static int
+X11_font_height(X11_Font *font)
+{
+    return font->ascent + font->descent;
+}
+#endif /* !USE_XFT */
 
 //////////////////////////////////////////////////////////////////////////////
 //                 A table of widgets and their data blocks                 //

--- a/win/X11/winlabel.c
+++ b/win/X11/winlabel.c
@@ -19,13 +19,7 @@
 #include "winX.h"
 
 /* Declarations depending on Xft support or none */
-#ifdef USE_XFT
-typedef XftFont X11_Font;
-#else
-typedef XFontStruct X11_Font;
-#endif
 static int X11_text_width(Display *, X11_Font *, const char *, size_t);
-static int X11_font_height(X11_Font *);
 
 /* Data attached to a wrapped widget */
 typedef struct WidgetData {
@@ -383,7 +377,7 @@ update_label(Widget w, WidgetData *data)
 
             /* Render the line */
 #ifdef USE_XFT
-            XftDrawRect(draw, &bgcolor, x, y - font->ascent, lwidth, font->height);
+            XftDrawRect(draw, &bgcolor, x, y - font->ascent, lwidth, X11_font_height(font));
             XftDrawString8(draw, &fgcolor, font, x, y,
                            (const FcChar8 *) (label + i), line2);
 #else
@@ -507,10 +501,10 @@ X11_text_width(Display *display, X11_Font *font, const char *text, size_t length
     return extents.width - extents.x;
 }
 
-static int
+int
 X11_font_height(X11_Font *font)
 {
-    return font->height;
+    return max(font->height, font->ascent + font->descent);
 }
 #else /* !USE_XFT */
 static int
@@ -520,7 +514,7 @@ X11_text_width(Display *display, X11_Font *font, const char *text, size_t length
     return XTextWidth(font, text, length);
 }
 
-static int
+int
 X11_font_height(X11_Font *font)
 {
     return font->ascent + font->descent;

--- a/win/X11/winmap.c
+++ b/win/X11/winmap.c
@@ -1048,7 +1048,7 @@ get_char_info(struct xwindow *wp)
     struct text_map_info_t *text_map = &map_info->text_map;
     XftFont *font = X11_new_font(wp->w, 0, NHW_MAP);
     text_map->square_width = font->max_advance_width;
-    text_map->square_height = font->height;
+    text_map->square_height = X11_font_height(font);
     text_map->square_ascent = 0;
     text_map->square_lbearing = 0;
     X11_release_font(wp->w, font);
@@ -1546,7 +1546,7 @@ X11_draw_image_string(
 {
     XftDrawRect(draw, bgcolor, x, y,
                 length * font->max_advance_width,
-                font->height);
+                X11_font_height(font));
 
     int xt = x;
     int yt = y + font->ascent;

--- a/win/X11/winmap.c
+++ b/win/X11/winmap.c
@@ -72,12 +72,15 @@ static void X11_free_gc(struct xwindow *wp, GC gc, X11_color color);
 static void X11_draw_image_string(Display *display, Drawable d,
                                   GC ggc, int x, int y,
                                   const X11_map_symbol *string, int length);
-#endif /* ?USE_XFT */
 #ifdef ENHANCED_SYMBOLS
 static void X11_set_map_font(struct xwindow *wp);
 #endif
+#endif /* ?USE_XFT */
 static Font X11_get_map_font(struct xwindow *wp);
+#ifndef USE_XFT
 static XFontStruct *X11_get_map_font_struct(struct xwindow *wp);
+#endif
+static void get_text_gc(struct xwindow *, Font);
 static boolean init_tiles(struct xwindow *);
 static void set_button_values(Widget, int, int, unsigned);
 static void map_check_size_change(struct xwindow *);
@@ -85,7 +88,6 @@ static void map_update(struct xwindow *, int, int, int, int, boolean);
 static void init_text(struct xwindow *);
 static void map_exposed(Widget, XtPointer, XtPointer);
 static void set_gc(Widget, Font, const char *, Pixel, GC *, GC *);
-static void get_text_gc(struct xwindow *, Font);
 static void map_all_unexplored(struct map_info_t *);
 static void get_char_info(struct xwindow *);
 static void display_cursor(struct xwindow *);
@@ -844,7 +846,11 @@ set_gc(
     GC *regular, GC *inverse)
 {
     XGCValues values;
+#ifdef USE_XFT
+    XtGCMask mask = GCFunction | GCForeground | GCBackground;
+#else
     XtGCMask mask = GCFunction | GCForeground | GCBackground | GCFont;
+#endif
     Pixel curpixel;
     Arg arg[1];
 
@@ -1587,10 +1593,16 @@ X11_make_gc(
                 values.background = bgpixel;
             }
             values.function = GXcopy;
+#ifdef USE_XFT
+            ggc = XtGetGC(wp->w,
+                         GCFunction | GCForeground | GCBackground,
+                         &values);
+#else
             values.font = X11_get_map_font(wp);
             ggc = XtGetGC(wp->w,
                          GCFunction | GCForeground | GCBackground | GCFont,
                          &values);
+#endif
         } else {
             ggc = (cur_inv ? text_map->inv_copy_gc : text_map->copy_gc);
         }
@@ -1784,7 +1796,7 @@ create_map_window(
 
     map_info = wp->map_information =
         (struct map_info_t *) alloc(sizeof (struct map_info_t));
-#ifdef ENHANCED_SYMBOLS
+#if defined(ENHANCED_SYMBOLS) && !defined(USE_XFT)
     X11_set_map_font(wp);
 #endif
 
@@ -1835,7 +1847,7 @@ create_map_window(
     map_all_unexplored(map_info);
 }
 
-#ifdef ENHANCED_SYMBOLS
+#if defined(ENHANCED_SYMBOLS) && !defined(USE_XFT)
 static void
 X11_set_map_font(struct xwindow *wp)
 {
@@ -1853,14 +1865,20 @@ X11_set_map_font(struct xwindow *wp)
         map_info->text_map.font = fs;
     }
 }
-#endif
+#endif /* ENHANCED_SYMBOLS && !USE_XFT */
 
 static Font
 X11_get_map_font(struct xwindow *wp)
 {
+#ifdef USE_XFT
+    nhUse(wp);
+    return 0;
+#else /* !USE_XFT */
     return X11_get_map_font_struct(wp)->fid;
+#endif /* ?USE_XFT */
 }
 
+#ifndef USE_XFT
 static XFontStruct *
 X11_get_map_font_struct(struct xwindow *wp)
 {
@@ -1876,6 +1894,7 @@ X11_get_map_font_struct(struct xwindow *wp)
     return WindowFontStruct(wp->w);
 #endif
 }
+#endif /* USE_XFT */
 
 /*
  * Destroy this map window.
@@ -1900,7 +1919,7 @@ destroy_map_window(struct xwindow *wp)
         }
 
         /* Free the font structure if we allocated one */
-#ifdef ENHANCED_SYMBOLS
+#if defined(ENHANCED_SYMBOLS) && !defined(USE_XFT)
         XFreeFont(XtDisplay(wp->w), text_map->font);
 #endif
 

--- a/win/X11/winmap.c
+++ b/win/X11/winmap.c
@@ -1040,7 +1040,7 @@ get_char_info(struct xwindow *wp)
 #ifdef USE_XFT
     struct map_info_t *map_info = wp->map_information;
     struct text_map_info_t *text_map = &map_info->text_map;
-    XftFont *font = X11_new_font(wp->w, FALSE, NHW_MAP);
+    XftFont *font = X11_new_font(wp->w, 0, NHW_MAP);
     text_map->square_width = font->max_advance_width;
     text_map->square_height = font->height;
     text_map->square_ascent = 0;
@@ -1430,7 +1430,7 @@ map_update(struct xwindow *wp, int start_row, int stop_row, int start_col, int s
         XtGetValues(wp->w, arg, 1);
 
         XftDraw *draw = XftDrawCreate(display, XtWindow(wp->w), visual, cmap);
-        XftFont *font = X11_new_font(wp->w, FALSE, NHW_MAP);
+        XftFont *font = X11_new_font(wp->w, 0, NHW_MAP);
         XftColor bgcolor;
         X11_new_color(wp->w, bgpixel, &bgcolor);
 #endif /* USE_XFT */

--- a/win/X11/winmap.c
+++ b/win/X11/winmap.c
@@ -59,17 +59,23 @@ extern int total_tiles_used, Tile_corr;
 #define NH_INVERSE_COLOR  0x40000000
 #define NH_ENHANCED_COLOR 0x80000000
 
+#ifdef USE_XFT
+static void X11_get_color(struct xwindow *wp, X11_color nhcolor, XftColor *color);
+static void X11_draw_image_string(XftDraw *draw, XftFont *font,
+                                  XftColor *fgcolor, XftColor *bgcolor,
+                                  int x, int y,
+                                  const X11_map_symbol *string, int length);
+#else /* !USE_XFT */
 static GC X11_make_gc(struct xwindow *wp, struct text_map_info_t *text_map,
                       X11_color color, boolean inverted);
-#ifdef ENHANCED_SYMBOLS
 static void X11_free_gc(struct xwindow *wp, GC gc, X11_color color);
-#endif
-#ifdef ENHANCED_SYMBOLS
-static void X11_set_map_font(struct xwindow *wp);
-#endif
 static void X11_draw_image_string(Display *display, Drawable d,
                                   GC ggc, int x, int y,
                                   const X11_map_symbol *string, int length);
+#endif /* ?USE_XFT */
+#ifdef ENHANCED_SYMBOLS
+static void X11_set_map_font(struct xwindow *wp);
+#endif
 static Font X11_get_map_font(struct xwindow *wp);
 static XFontStruct *X11_get_map_font_struct(struct xwindow *wp);
 static boolean init_tiles(struct xwindow *);
@@ -1031,6 +1037,16 @@ clear_map_window(struct xwindow *wp)
 static void
 get_char_info(struct xwindow *wp)
 {
+#ifdef USE_XFT
+    struct map_info_t *map_info = wp->map_information;
+    struct text_map_info_t *text_map = &map_info->text_map;
+    XftFont *font = X11_new_font(wp->w, FALSE, NHW_MAP);
+    text_map->square_width = font->max_advance_width;
+    text_map->square_height = font->height;
+    text_map->square_ascent = 0;
+    text_map->square_lbearing = 0;
+    X11_release_font(wp->w, font);
+#else /* !USE_XFT */
     XFontStruct *fs;
     struct map_info_t *map_info = wp->map_information;
     struct text_map_info_t *text_map = &map_info->text_map;
@@ -1062,6 +1078,7 @@ get_char_info(struct xwindow *wp)
 
     if (fs->min_bounds.width != fs->max_bounds.width)
         X11_raw_print("Warning:  map font is not monospaced!");
+#endif /* ?USE_XFT */
 }
 
 /*
@@ -1400,47 +1417,141 @@ map_update(struct xwindow *wp, int start_row, int stop_row, int start_col, int s
     } else {
         struct text_map_info_t *text_map = &map_info->text_map;
 
-        {
-            X11_color *c_ptr;
-            X11_map_symbol *t_ptr;
-            int cur_col, win_ystart;
-            X11_color color;
-            GC ggc;
+#ifdef USE_XFT
+        /* Set up font and background color */
+        Display *display = XtDisplay(wp->w);
+        Screen *screen = DefaultScreenOfDisplay(display);
+        Visual *visual = DefaultVisualOfScreen(screen);
+        Colormap cmap = DefaultColormapOfScreen(screen);
 
-            for (row = start_row; row <= stop_row; row++) {
-                win_ystart =
-                    text_map->square_ascent + (row * text_map->square_height);
+        Pixel bgpixel;
+        Arg arg[1];
+        XtSetArg(arg[0], XtNbackground, &bgpixel);
+        XtGetValues(wp->w, arg, 1);
 
-                t_ptr = &(text_map->text[row][start_col]);
-                c_ptr = &(text_map->colors[row][start_col]);
-                cur_col = start_col;
-                while (cur_col <= stop_col) {
-                    color = *c_ptr++;
-                    count = 1;
-                    while ((cur_col + count) <= stop_col && *c_ptr == color) {
-                        count++;
-                        c_ptr++;
-                    }
+        XftDraw *draw = XftDrawCreate(display, XtWindow(wp->w), visual, cmap);
+        XftFont *font = X11_new_font(wp->w, FALSE, NHW_MAP);
+        XftColor bgcolor;
+        X11_new_color(wp->w, bgpixel, &bgcolor);
+#endif /* USE_XFT */
 
-                    ggc = X11_make_gc(wp, text_map, color, inverted);
-                    X11_draw_image_string(XtDisplay(wp->w), XtWindow(wp->w),
-                                          ggc,
-                                          text_map->square_lbearing
-                                              + (text_map->square_width
-                                                 * (cur_col - COL0_OFFSET)),
-                                          win_ystart, t_ptr, count);
-#ifdef ENHANCED_SYMBOLS
-                    X11_free_gc(wp, ggc, color);
-#endif
+        for (row = start_row; row <= stop_row; row++) {
+            int win_ystart =
+                text_map->square_ascent + (row * text_map->square_height);
 
-                    /* move text pointer and column count */
-                    t_ptr += count;
-                    cur_col += count;
-                } /* col loop */
-            }     /* row loop */
-        }
+            X11_map_symbol *t_ptr = &(text_map->text[row][start_col]);
+            X11_color *c_ptr = &(text_map->colors[row][start_col]);
+            int cur_col = start_col;
+            while (cur_col <= stop_col) {
+                X11_color color = *c_ptr++;
+                count = 1;
+                while ((cur_col + count) <= stop_col && *c_ptr == color) {
+                    count++;
+                    c_ptr++;
+                }
+
+#ifdef USE_XFT
+                XftColor fgcolor;
+                X11_get_color(wp, color, &fgcolor);
+                boolean cur_inv = !!inverted ^ ((color & NH_INVERSE_COLOR) != 0);
+                X11_draw_image_string(draw, font,
+                                      cur_inv ? &bgcolor : &fgcolor,
+                                      cur_inv ? &fgcolor : &bgcolor,
+                                      text_map->square_lbearing
+                                          + (text_map->square_width
+                                             * (cur_col - COL0_OFFSET)),
+                                      win_ystart, t_ptr, count);
+                XftColorFree(display, visual, cmap, &fgcolor);
+#else /* !USE_XFT */
+                GC ggc = X11_make_gc(wp, text_map, color, inverted);
+                X11_draw_image_string(XtDisplay(wp->w), XtWindow(wp->w),
+                                      ggc,
+                                      text_map->square_lbearing
+                                          + (text_map->square_width
+                                             * (cur_col - COL0_OFFSET)),
+                                      win_ystart, t_ptr, count);
+                X11_free_gc(wp, ggc, color);
+#endif /* ?USE_XFT */
+
+                /* move text pointer and column count */
+                t_ptr += count;
+                cur_col += count;
+            } /* col loop */
+        }     /* row loop */
+
+#ifdef USE_XFT
+        /* Free resources from Xft */
+        XftColorFree(display, visual, cmap, &bgcolor);
+        X11_release_font(wp->w, font);
+        XftDrawDestroy(draw);
+#endif /* USE_XFT */
     }
 }
+
+#ifdef USE_XFT
+static void
+X11_get_color(struct xwindow *wp, X11_color nhcolor, XftColor *color)
+{
+    Pixel pixel;
+
+    if ((nhcolor & NH_ENHANCED_COLOR) != 0) {
+        pixel = COLORVAL(nhcolor);
+    } else {
+        static struct {
+            const char *name;
+            Pixel rgb;
+        } map_colors[] = {
+            { XtNblack,          0xFFFFFFFF }, /* CLR_BLACK */
+            { XtNred,            0xFFFFFFFF }, /* CLR_RED */
+            { XtNgreen,          0xFFFFFFFF }, /* CLR_GREEN */
+            { XtNbrown,          0xFFFFFFFF }, /* CLR_BROWN */
+            { XtNblue,           0xFFFFFFFF }, /* CLR_BLUE */
+            { XtNmagenta,        0xFFFFFFFF }, /* CLR_MAGENTA */
+            { XtNcyan,           0xFFFFFFFF }, /* CLR_CYAN */
+            { XtNgray,           0xFFFFFFFF }, /* CLR_GRAY */
+            { XtNforeground,     0xFFFFFFFF }, /* NO_COLOR */
+            { XtNorange,         0xFFFFFFFF }, /* CLR_ORANGE */
+            { XtNbright_green,   0xFFFFFFFF }, /* CLR_BRIGHT_GREEN */
+            { XtNyellow,         0xFFFFFFFF }, /* CLR_YELLOW */
+            { XtNbright_blue,    0xFFFFFFFF }, /* CLR_BRIGHT_BLUE */
+            { XtNbright_magenta, 0xFFFFFFFF }, /* CLR_BRIGHT_MAGENTA */
+            { XtNbright_cyan,    0xFFFFFFFF }, /* CLR_BRIGHT_CYAN */
+            { XtNwhite,          0xFFFFFFFF }, /* CLR_WHITE */
+        };
+        pixel = map_colors[nhcolor & 0xF].rgb;
+        if (pixel == 0xFFFFFFFF) {
+            /* Retrieve resource */
+            Arg arg[1];
+            XtSetArg(arg[0], (char *) map_colors[nhcolor & 0xF].name, &pixel);
+            XtGetValues(wp->w, arg, 1);
+            map_colors[nhcolor & 0xF].rgb = pixel;
+        }
+    }
+
+    X11_new_color(wp->w, pixel, color);
+}
+
+static void
+X11_draw_image_string(
+    XftDraw *draw, XftFont *font,
+    XftColor *fgcolor, XftColor *bgcolor,
+    int x, int y,
+    const X11_map_symbol *string, int length)
+{
+    XftDrawRect(draw, bgcolor, x, y,
+                length * font->max_advance_width,
+                font->height);
+
+    int xt = x;
+    int yt = y + font->ascent;
+#ifdef ENHANCED_SYMBOLS
+    XftDrawString32(draw, fgcolor, font, xt, yt, string, length);
+#else /* !ENHANCED_SYMBOLS */
+    XftDrawString8(draw, fgcolor, font, xt, yt, string, length);
+#endif /* ?ENHANCED_SYMBOLS */
+}
+
+#else /* !USE_XFT */
 
 static GC
 X11_make_gc(
@@ -1503,16 +1614,16 @@ X11_make_gc(
     return ggc;
 }
 
-#ifdef ENHANCED_SYMBOLS
 static void
 X11_free_gc(struct xwindow *wp, GC ggc, X11_color color)
 {
+#ifdef ENHANCED_SYMBOLS
     if ((color & NH_ENHANCED_COLOR) != 0 && iflags.use_color) {
         /* X11_make_gc allocated a new GC */
         XtReleaseGC(wp->w, ggc);
     }
-}
 #endif
+}
 
 static void
 X11_draw_image_string(
@@ -1545,6 +1656,8 @@ X11_draw_image_string(
     XDrawImageString(display, d, ggc, x, y, (char *) string, length);
 #endif /* ?ENHANCED_SYMBOLS */
 }
+
+#endif /* ?USE_XFT */
 
 /* Adjust the number of rows and columns on the given map window */
 void

--- a/win/X11/winmenu.c
+++ b/win/X11/winmenu.c
@@ -1366,13 +1366,17 @@ menu_create_entries(struct xwindow *wp, struct menu *curr_menu)
 
         menulineidx++;
         Sprintf(tmpbuf, "menuline_%s", (canpick) ? "command" : "label");
-        curr->w = linewidget = XtCreateManagedWidget(tmpbuf,
-                                                     canpick
-                                                       ? commandWidgetClass
-                                                       : labelWidgetClass,
-                                                     wp->w, args, num_args);
+        /* Need to create the widget unmanaged, set up the pixmap, and then
+           manage it, or else items in the inventory window get the wrong
+           size */
+        curr->w = linewidget = XtCreateWidget(tmpbuf,
+                                              canpick
+                                                ? commandWidgetClass
+                                                : labelWidgetClass,
+                                              wp->w, args, num_args);
         X11_wrap_widget(curr->w, NHW_MENU);
         X11_set_attrs(curr->w, 0x1 << attr);
+        XtManageChild(curr->w);
 
         if (canpick)
             XtAddCallback(linewidget, XtNcallback, menu_select,

--- a/win/X11/winmenu.c
+++ b/win/X11/winmenu.c
@@ -1025,6 +1025,9 @@ X11_select_menu(winid window, int how, menu_item **menu_list)
                                                 labelWidgetClass, form,
                                                 args, num_args)
                         : (Widget) 0;
+        if (label) {
+            X11_wrap_widget_if_Xft(label, NHW_MENU);
+        }
 
         all = menu_create_buttons(wp, form, label);
 
@@ -1194,6 +1197,7 @@ menu_create_buttons(struct xwindow *wp, Widget form, Widget under)
     XtSetArg(args[num_args], nhStr(XtNright), XtChainLeft); num_args++;
     ok = XtCreateManagedWidget("OK", commandWidgetClass, form,
                                args, num_args);
+    X11_wrap_widget_if_Xft(ok, NHW_MENU);
     XtAddCallback(ok, XtNcallback, menu_ok, (XtPointer) wp);
     XtSetArg(args[0], XtNwidth, &lblwidth[0]);
     XtGetValues(lblwidget[0] = ok, args, ONE);
@@ -1212,6 +1216,7 @@ menu_create_buttons(struct xwindow *wp, Widget form, Widget under)
     XtSetArg(args[num_args], nhStr(XtNright), XtChainLeft); num_args++;
     cancel = XtCreateManagedWidget("cancel", commandWidgetClass, form,
                                    args, num_args);
+    X11_wrap_widget_if_Xft(cancel, NHW_MENU);
     XtAddCallback(cancel, XtNcallback, menu_cancel, (XtPointer) wp);
     XtSetArg(args[0], XtNwidth, &lblwidth[1]);
     XtGetValues(lblwidget[1] = cancel, args, ONE);
@@ -1229,6 +1234,7 @@ menu_create_buttons(struct xwindow *wp, Widget form, Widget under)
     XtSetArg(args[num_args], nhStr(XtNright), XtChainLeft); num_args++;
     all = XtCreateManagedWidget("all", commandWidgetClass, form,
                                 args, num_args);
+    X11_wrap_widget_if_Xft(all, NHW_MENU);
     XtAddCallback(all, XtNcallback, menu_all, (XtPointer) wp);
     XtSetArg(args[0], XtNwidth, &lblwidth[2]);
     XtGetValues(lblwidget[2] = all, args, ONE);
@@ -1245,6 +1251,7 @@ menu_create_buttons(struct xwindow *wp, Widget form, Widget under)
     XtSetArg(args[num_args], nhStr(XtNright), XtChainLeft); num_args++;
     none = XtCreateManagedWidget("none", commandWidgetClass, form,
                                  args, num_args);
+    X11_wrap_widget_if_Xft(none, NHW_MENU);
     XtAddCallback(none, XtNcallback, menu_none, (XtPointer) wp);
     XtSetArg(args[0], XtNwidth, &lblwidth[3]);
     XtGetValues(lblwidget[3] = none, args, ONE);
@@ -1261,6 +1268,7 @@ menu_create_buttons(struct xwindow *wp, Widget form, Widget under)
     XtSetArg(args[num_args], nhStr(XtNright), XtChainLeft); num_args++;
     invert = XtCreateManagedWidget("invert", commandWidgetClass, form,
                                    args, num_args);
+    X11_wrap_widget_if_Xft(invert, NHW_MENU);
     XtAddCallback(invert, XtNcallback, menu_invert, (XtPointer) wp);
     XtSetArg(args[0], XtNwidth, &lblwidth[4]);
     XtGetValues(lblwidget[4] = invert, args, ONE);
@@ -1278,6 +1286,7 @@ menu_create_buttons(struct xwindow *wp, Widget form, Widget under)
     XtSetArg(args[num_args], nhStr(XtNright), XtChainLeft); num_args++;
     search = XtCreateManagedWidget("search", commandWidgetClass, form,
                                    args, num_args);
+    X11_wrap_widget_if_Xft(search, NHW_MENU);
     XtAddCallback(search, XtNcallback, menu_search, (XtPointer) wp);
     XtSetArg(args[0], XtNwidth, &lblwidth[5]);
     XtGetValues(lblwidget[5] = search, args, ONE);

--- a/win/X11/winmenu.c
+++ b/win/X11/winmenu.c
@@ -1362,7 +1362,7 @@ menu_create_entries(struct xwindow *wp, struct menu *curr_menu)
                                                        ? commandWidgetClass
                                                        : labelWidgetClass,
                                                      wp->w, args, num_args);
-        X11_wrap_widget(curr->w);
+        X11_wrap_widget(curr->w, NHW_MENU);
         X11_set_attrs(curr->w, 0x1 << attr);
 
         if (canpick)

--- a/win/X11/winmenu.c
+++ b/win/X11/winmenu.c
@@ -89,9 +89,9 @@ static const char menu_entry_translations[] = "#override\n\
      <Btn4Down>: scroll(8)\n\
      <Btn5Down>: scroll(2)";
 
-XtTranslations menu_entry_translation_table = (XtTranslations) 0;
-XtTranslations menu_translation_table = (XtTranslations) 0;
-XtTranslations menu_del_translation_table = (XtTranslations) 0;
+static XtTranslations menu_entry_translation_table = (XtTranslations) 0;
+static XtTranslations menu_translation_table = (XtTranslations) 0;
+static XtTranslations menu_del_translation_table = (XtTranslations) 0;
 
 static void
 create_menu_translation_tables(void)

--- a/win/X11/winmesg.c
+++ b/win/X11/winmesg.c
@@ -158,11 +158,20 @@ create_message_window(struct xwindow *wp, /* window pointer */
     XtGetValues(wp->w, args, num_args);
 
     /* Save character information for fast use later. */
+#ifdef USE_XFT
+    XftFont *font = X11_new_font(wp->w, FALSE, NHW_MESSAGE);
+    mesg_info->char_width = font->max_advance_width;
+    mesg_info->char_height = font->height;
+    mesg_info->char_ascent = font->ascent;
+    mesg_info->char_lbearing = 0;
+    X11_release_font(wp->w, font);
+#else
     mesg_info->char_width = mesg_info->fs->max_bounds.width;
     mesg_info->char_height =
         mesg_info->fs->max_bounds.ascent + mesg_info->fs->max_bounds.descent;
     mesg_info->char_ascent = mesg_info->fs->max_bounds.ascent;
     mesg_info->char_lbearing = -mesg_info->fs->min_bounds.lbearing;
+#endif
 
     get_gc(wp->w, mesg_info);
 
@@ -466,20 +475,50 @@ redraw_message_window(struct xwindow *wp)
     }
 
     /* For now, just update the whole shootn' match. */
+#ifdef USE_XFT
+    Display *display = XtDisplay(wp->w);
+    Screen *screen = DefaultScreenOfDisplay(display);
+    Visual *visual = DefaultVisualOfScreen(screen);
+    Colormap cmap = DefaultColormapOfScreen(screen);
+    XftDraw *draw = XftDrawCreate(display, XtWindow(wp->w), visual, cmap);
+    XftFont *font = X11_new_font(wp->w, FALSE, NHW_MESSAGE);
+    XftColor fgcolor;
+    X11_new_color(wp->w, mesg_info->fgpixel, &fgcolor);
+#endif /* USE_XFT */
+
     for (y_base = row = 0, curr = mesg_info->head; row < mesg_info->num_lines;
          row++, y_base += mesg_info->char_height, curr = curr->next) {
+#ifdef USE_XFT
+        if (curr->line != NULL) {
+            XftDrawString8(draw, &fgcolor, font,
+                        mesg_info->char_lbearing, mesg_info->char_ascent + y_base,
+                        (const FcChar8 *) curr->line, curr->str_length);
+        }
+#else /* !USE_XFT */
         XDrawString(XtDisplay(wp->w), XtWindow(wp->w), mesg_info->gc,
                     mesg_info->char_lbearing, mesg_info->char_ascent + y_base,
                     curr->line, curr->str_length);
+#endif /* ?USE_XFT */
         /*
          * This draws a line at the _top_ of the line of text pointed to by
          * mesg_info->last_pause.
          */
         if (appResources.message_line && curr == mesg_info->line_here) {
+#ifdef USE_XFT
+            XftDrawRect(draw, &fgcolor, 0,
+                        y_base, wp->pixel_width, y_base);
+#else /* !USE_XFT */
             XDrawLine(XtDisplay(wp->w), XtWindow(wp->w), mesg_info->gc, 0,
                       y_base, wp->pixel_width, y_base);
+#endif /* ?USE_XFT */
         }
     }
+
+#ifdef USE_XFT
+    XftColorFree(display, visual, cmap, &fgcolor);
+    XftFontClose(display, font);
+    XftDrawDestroy(draw);
+#endif /* USE_XFT */
 
     mesg_info->dirty = False;
 }
@@ -549,6 +588,12 @@ mesg_exposed(Widget w,
 static void
 get_gc(Widget w, struct mesg_info_t *mesg_info)
 {
+#ifdef USE_XFT
+    Arg arg[1];
+
+    XtSetArg(arg[0], XtNforeground, &mesg_info->fgpixel);
+    XtGetValues(w, arg, ONE);
+#else /* !USE_XFT */
     XGCValues values;
     XtGCMask mask = GCFunction | GCForeground | GCBackground | GCFont;
     Pixel fgpixel, bgpixel;
@@ -563,6 +608,7 @@ get_gc(Widget w, struct mesg_info_t *mesg_info)
     values.function = GXcopy;
     values.font = WindowFont(w);
     mesg_info->gc = XtGetGC(w, mask, &values);
+#endif /* ?USE_XFT */
 }
 
 /*

--- a/win/X11/winmesg.c
+++ b/win/X11/winmesg.c
@@ -159,7 +159,7 @@ create_message_window(struct xwindow *wp, /* window pointer */
 
     /* Save character information for fast use later. */
 #ifdef USE_XFT
-    XftFont *font = X11_new_font(wp->w, FALSE, NHW_MESSAGE);
+    XftFont *font = X11_new_font(wp->w, 0, NHW_MESSAGE);
     mesg_info->char_width = font->max_advance_width;
     mesg_info->char_height = font->height;
     mesg_info->char_ascent = font->ascent;
@@ -481,7 +481,7 @@ redraw_message_window(struct xwindow *wp)
     Visual *visual = DefaultVisualOfScreen(screen);
     Colormap cmap = DefaultColormapOfScreen(screen);
     XftDraw *draw = XftDrawCreate(display, XtWindow(wp->w), visual, cmap);
-    XftFont *font = X11_new_font(wp->w, FALSE, NHW_MESSAGE);
+    XftFont *font = X11_new_font(wp->w, 0, NHW_MESSAGE);
     XftColor fgcolor;
     X11_new_color(wp->w, mesg_info->fgpixel, &fgcolor);
 #endif /* USE_XFT */

--- a/win/X11/winmesg.c
+++ b/win/X11/winmesg.c
@@ -37,7 +37,7 @@
 
 static struct line_element *get_previous(struct line_element *);
 static void set_circle_buf(struct mesg_info_t *, int);
-static char *split(char *, XFontStruct *, Dimension);
+static char *split(char *, struct xwindow *, Dimension);
 static void add_line(struct mesg_info_t *, const char *);
 static void redraw_message_window(struct xwindow *);
 static void mesg_check_size_change(struct xwindow *);
@@ -83,7 +83,9 @@ create_message_window(struct xwindow *wp, /* window pointer */
     wp->mesg_information = mesg_info =
         (struct mesg_info_t *) alloc(sizeof (struct mesg_info_t));
 
+#ifndef USE_XFT
     mesg_info->fs = 0;
+#endif
     mesg_info->num_lines = 0;
     mesg_info->head = mesg_info->line_here = mesg_info->last_pause =
         mesg_info->last_pause_head = (struct line_element *) 0;
@@ -151,26 +153,37 @@ create_message_window(struct xwindow *wp, /* window pointer */
      * is appResources.message_lines high and DEFAULT_MESSAGE_WIDTH wide.
      */
 
+    /* Save character information for fast use later. */
+#ifdef USE_XFT
+    XftFont *font = X11_new_font(wp->w, 0, NHW_MESSAGE);
+    XGlyphInfo extents;
+    mesg_info->char_width = font->max_advance_width;
+    mesg_info->char_height = font->height;
+    mesg_info->char_ascent = font->ascent;
+    mesg_info->char_lbearing = 0;
+    /* Xft seems to offer no direct way to distinguish proportional from
+       monospaced fonts. Assume that "!" will be narrower than maximum. */
+    XftTextExtents8(XtDisplay(wp->w), font, (const FcChar8*) "!", 1, &extents);
+    int min_width = extents.width - extents.x;
+    /* "Maximum" is likely to include things like Chinese characters that
+     * display at double width. Use the width of "M". */
+    XftTextExtents8(XtDisplay(wp->w), font, (const FcChar8*) "M", 1, &extents);
+    int max_width = extents.width - extents.x;
+    X11_release_font(wp->w, font);
+#else
     /* Get the font information. */
     num_args = 0;
     XtSetArg(args[num_args], XtNfont, &mesg_info->fs);
     num_args++;
     XtGetValues(wp->w, args, num_args);
 
-    /* Save character information for fast use later. */
-#ifdef USE_XFT
-    XftFont *font = X11_new_font(wp->w, 0, NHW_MESSAGE);
-    mesg_info->char_width = font->max_advance_width;
-    mesg_info->char_height = font->height;
-    mesg_info->char_ascent = font->ascent;
-    mesg_info->char_lbearing = 0;
-    X11_release_font(wp->w, font);
-#else
     mesg_info->char_width = mesg_info->fs->max_bounds.width;
     mesg_info->char_height =
         mesg_info->fs->max_bounds.ascent + mesg_info->fs->max_bounds.descent;
     mesg_info->char_ascent = mesg_info->fs->max_bounds.ascent;
     mesg_info->char_lbearing = -mesg_info->fs->min_bounds.lbearing;
+    int min_width = mesg_info->fs->min_bounds.width;
+    int max_width = mesg_info->fs->max_bounds.width;
 #endif
 
     get_gc(wp->w, mesg_info);
@@ -178,12 +191,11 @@ create_message_window(struct xwindow *wp, /* window pointer */
     wp->pixel_height = ((int) iflags.msg_history) * mesg_info->char_height;
 
     /* If a variable spaced font, only use 2/3 of the default size */
-    if (mesg_info->fs->min_bounds.width != mesg_info->fs->max_bounds.width) {
+    if (min_width != max_width) {
         wp->pixel_width = ((2 * DEFAULT_MESSAGE_WIDTH) / 3)
-                          * mesg_info->fs->max_bounds.width;
+                          * max_width;
     } else
-        wp->pixel_width =
-            (DEFAULT_MESSAGE_WIDTH * mesg_info->fs->max_bounds.width);
+        wp->pixel_width = (DEFAULT_MESSAGE_WIDTH * max_width);
 
     /* Set the new width and height. */
     num_args = 0;
@@ -259,7 +271,7 @@ append_message(struct xwindow *wp, const char *str)
     remainder = buf;
     do {
         mark = remainder;
-        remainder = split(mark, wp->mesg_information->fs, wp->pixel_width);
+        remainder = split(mark, wp, wp->pixel_width);
         add_line(wp->mesg_information, mark);
     } while (remainder);
 }
@@ -366,10 +378,16 @@ set_circle_buf(struct mesg_info_t *mesg_info, int count)
  * not, back up from the end by words until we find a place to split.
  */
 static char *
-split(char *s,
-      XFontStruct *fs, /* Font for the window. */
+split(
+      char *s,
+      struct xwindow *wp,
       Dimension pixel_width)
 {
+#ifdef USE_XFT
+    XftFont *font = X11_new_font(wp->w, 0, NHW_MESSAGE);
+#else
+    XFontStruct *fs = wp->mesg_information->fs; /* Font for the window. */
+#endif
     char save, *end, *remainder;
 
     save = '\0';
@@ -377,7 +395,18 @@ split(char *s,
     end = eos(s); /* point to null at end of string */
 
     /* assume that if end == s, XXXXXX returns 0) */
-    while ((Dimension) XTextWidth(fs, s, (int) strlen(s)) > pixel_width) {
+    while (TRUE) {
+#ifdef USE_XFT
+        XGlyphInfo extents;
+        XftTextExtents8(XtDisplay(wp->w), font, (const FcChar8*) s, strlen(s), &extents);
+        if (extents.width - extents.x < pixel_width) {
+            break;
+        }
+#else
+        if ((Dimension) XTextWidth(fs, s, (int) strlen(s)) < pixel_width) {
+            break;
+        }
+#endif
         *end-- = save;
         while (*end != ' ') {
             if (end == s)
@@ -388,6 +417,9 @@ split(char *s,
         *end = '\0';
         remainder = end + 1;
     }
+#ifdef USE_XFT
+    X11_release_font(wp->w, font);
+#endif
     return remainder;
 }
 

--- a/win/X11/winmesg.c
+++ b/win/X11/winmesg.c
@@ -158,7 +158,7 @@ create_message_window(struct xwindow *wp, /* window pointer */
     XftFont *font = X11_new_font(wp->w, 0, NHW_MESSAGE);
     XGlyphInfo extents;
     mesg_info->char_width = font->max_advance_width;
-    mesg_info->char_height = font->height;
+    mesg_info->char_height = X11_font_height(font);
     mesg_info->char_ascent = font->ascent;
     mesg_info->char_lbearing = 0;
     /* Xft seems to offer no direct way to distinguish proportional from

--- a/win/X11/winmisc.c
+++ b/win/X11/winmisc.c
@@ -124,13 +124,13 @@ static Widget make_menu(const char *, const char *, const char *, const char *,
                         const char **, Widget **, XtCallbackProc, Widget *);
 
 /* Bad Hack alert. Using integers instead of XtPointers */
-XtPointer
+static XtPointer
 i2xtp(int i)
 {
     return (XtPointer) (ptrdiff_t) i;
 }
 
-int
+static int
 xtp2i(XtPointer x)
 {
     return (int) (ptrdiff_t) x;
@@ -328,15 +328,15 @@ algn_key(Widget w, XEvent *event, String *params, Cardinal *num_params)
     exit_x_event = TRUE;
 }
 
-int plsel_n_races, plsel_n_roles;
-Widget *plsel_race_radios = (Widget *) 0;
-Widget *plsel_role_radios = (Widget *) 0;
-Widget *plsel_gend_radios = (Widget *) 0;
-Widget *plsel_align_radios = (Widget *) 0;
+static int plsel_n_races, plsel_n_roles;
+static Widget *plsel_race_radios = (Widget *) 0;
+static Widget *plsel_role_radios = (Widget *) 0;
+static Widget *plsel_gend_radios = (Widget *) 0;
+static Widget *plsel_align_radios = (Widget *) 0;
 
-Widget plsel_name_input;
+static Widget plsel_name_input;
 
-Widget plsel_btn_play;
+static Widget plsel_btn_play;
 
 static void
 plsel_dialog_acceptvalues(void)

--- a/win/X11/winmisc.c
+++ b/win/X11/winmisc.c
@@ -416,6 +416,7 @@ plsel_set_play_button(boolean state)
 
     XtSetArg(args[0], nhStr(XtNsensitive), !state);
     XtSetValues(plsel_btn_play, args, ONE);
+    X11_update_label_if_Xft(plsel_btn_play);
 }
 
 static void
@@ -441,6 +442,7 @@ plsel_set_sensitivities(boolean setcurr)
             c = j;
         XtSetArg(args[0], nhStr(XtNsensitive), v);
         XtSetValues(plsel_role_radios[j], args, ONE);
+        X11_update_label_if_Xft(plsel_role_radios[j]);
         if (valid < 0 && v)
             valid = j;
     }
@@ -459,6 +461,7 @@ plsel_set_sensitivities(boolean setcurr)
             c = j;
         XtSetArg(args[0], nhStr(XtNsensitive), v);
         XtSetValues(plsel_race_radios[j], args, ONE);
+        X11_update_label_if_Xft(plsel_race_radios[j]);
         if (valid < 0 && v)
             valid = j;
     }
@@ -566,6 +569,7 @@ X11_player_selection_setupOthers(void)
             c = j;
         XtSetArg(args[0], nhStr(XtNsensitive), v);
         XtSetValues(plsel_gend_radios[j], args, ONE);
+        X11_update_label_if_Xft(plsel_gend_radios[j]);
         if (valid < 0 && v)
             valid = j;
     }
@@ -583,6 +587,7 @@ X11_player_selection_setupOthers(void)
             c = j;
         XtSetArg(args[0], nhStr(XtNsensitive), v);
         XtSetValues(plsel_align_radios[j], args, ONE);
+        X11_update_label_if_Xft(plsel_align_radios[j]);
         if (valid < 0 && v)
             valid = j;
     }
@@ -619,6 +624,7 @@ racetoggleCallback(Widget w, XtPointer client, XtPointer call)
             c = j;
         XtSetArg(args[0], nhStr(XtNsensitive), v);
         XtSetValues(plsel_role_radios[j], args, ONE);
+        X11_update_label_if_Xft(plsel_role_radios[j]);
         if (valid < 0 && v)
             valid = j;
     }
@@ -658,6 +664,7 @@ roletoggleCallback(Widget w, XtPointer client, XtPointer call)
             c = j;
         XtSetArg(args[0], nhStr(XtNsensitive), v);
         XtSetValues(plsel_race_radios[j], args, ONE);
+        X11_update_label_if_Xft(plsel_race_radios[j]);
         if (valid < 0 && v)
             valid = j;
     }
@@ -688,6 +695,7 @@ gendertoggleCallback(Widget w, XtPointer client, XtPointer call)
             XtSetArg(args[0], XtNlabel,
                      (r < 1) ? roles[i].name.m : roles[i].name.f);
             XtSetValues(plsel_role_radios[i], args, ONE);
+            X11_update_label_if_Xft(plsel_role_radios[i]);
         }
     }
 }
@@ -770,6 +778,7 @@ X11_create_player_selection_name(Widget form)
     namelabel = XtCreateManagedWidget("name_label",
                                       labelWidgetClass, name_form,
                                       args, num_args);
+    X11_wrap_widget_if_Xft(namelabel, NHW_MENU);
 
     num_args = 0;
     XtSetArg(args[num_args], nhStr(XtNfromVert), namelabel); num_args++;
@@ -899,6 +908,7 @@ X11_player_selection_dialog(void)
     racelabel = XtCreateManagedWidget("race_label",
                                       labelWidgetClass, race_form,
                                       args, num_args);
+    X11_wrap_widget_if_Xft(racelabel, NHW_MENU);
 
     num_args = 0;
     XtSetArg(args[num_args], nhStr(XtNtopMargin), 0); num_args++;
@@ -939,6 +949,7 @@ X11_player_selection_dialog(void)
                                            toggleWidgetClass,
                                            race_form2,
                                            args, num_args);
+        X11_wrap_widget_if_Xft(racewidget, NHW_MENU);
         XtAddCallback(racewidget, XtNcallback, racetoggleCallback, i2xtp(i));
         tmpwidget = racewidget;
         plsel_race_radios[i] = racewidget;
@@ -963,6 +974,7 @@ X11_player_selection_dialog(void)
     XtSetArg(args[num_args], nhStr(XtNlabel), "Role"); num_args++;
     rolelabel = XtCreateManagedWidget("role_label", labelWidgetClass,
                                       role_form, args, num_args);
+    X11_wrap_widget_if_Xft(rolelabel, NHW_MENU);
 
     num_args = 0;
     XtSetArg(args[num_args], nhStr(XtNtopMargin), 0); num_args++;
@@ -998,9 +1010,11 @@ X11_player_selection_dialog(void)
                      plsel_role_radios[0]); num_args++;
         }
         XtSetArg(args[num_args], nhStr(XtNradioData), (i + 1)); num_args++;
+        XtSetArg(args[num_args], nhStr(XtNresizable), True); num_args++;
 
         rolewidget = XtCreateManagedWidget(roles[i].name.m, toggleWidgetClass,
                                            role_form2, args, num_args);
+        X11_wrap_widget_if_Xft(rolewidget, NHW_MENU);
         XtAddCallback(rolewidget, XtNcallback, roletoggleCallback, i2xtp(i));
         tmpwidget = rolewidget;
         plsel_role_radios[i] = rolewidget;
@@ -1027,6 +1041,7 @@ X11_player_selection_dialog(void)
     XtSetArg(args[num_args], nhStr(XtNlabel), "Gender"); num_args++;
     gendlabel = XtCreateManagedWidget("gender_label", labelWidgetClass,
                                       gend_form, args, num_args);
+    X11_wrap_widget_if_Xft(gendlabel, NHW_MENU);
 
     num_args = 0;
     XtSetArg(args[num_args], nhStr(XtNtopMargin), 0); num_args++;
@@ -1048,6 +1063,7 @@ X11_player_selection_dialog(void)
     plsel_gend_radios[0] = gend_radio_m
         =  XtCreateManagedWidget("Male", toggleWidgetClass,
                                  gend_form2, args, num_args);
+    X11_wrap_widget_if_Xft(plsel_gend_radios[0], NHW_MENU);
     num_args = 0;
     XtSetArg(args[num_args], nhStr(XtNfromVert), gend_radio_m); num_args++;
     XtSetArg(args[num_args], XtNwidth, cwid); num_args++;
@@ -1057,6 +1073,7 @@ X11_player_selection_dialog(void)
     plsel_gend_radios[1] = gend_radio_f
         =  XtCreateManagedWidget("Female", toggleWidgetClass,
                                  gend_form2, args, num_args);
+    X11_wrap_widget_if_Xft(plsel_gend_radios[1], NHW_MENU);
 
     XawToggleUnsetCurrent(plsel_gend_radios[0]);
 
@@ -1086,6 +1103,7 @@ X11_player_selection_dialog(void)
     XtSetArg(args[num_args], nhStr(XtNlabel), "Alignment"); num_args++;
     alignlabel = XtCreateManagedWidget("align_label", labelWidgetClass,
                                        align_form, args, num_args);
+    X11_wrap_widget_if_Xft(alignlabel, NHW_MENU);
 
     num_args = 0;
     XtSetArg(args[num_args], nhStr(XtNtopMargin), 0); num_args++;
@@ -1106,6 +1124,7 @@ X11_player_selection_dialog(void)
     plsel_align_radios[0] = align_radio_l
         =  XtCreateManagedWidget("Lawful", toggleWidgetClass,
                                  align_form2, args, num_args);
+    X11_wrap_widget_if_Xft(plsel_align_radios[0], NHW_MENU);
     num_args = 0;
     XtSetArg(args[num_args], nhStr(XtNfromVert), align_radio_l); num_args++;
     XtSetArg(args[num_args], XtNwidth, cwid); num_args++;
@@ -1115,6 +1134,7 @@ X11_player_selection_dialog(void)
     plsel_align_radios[1] = align_radio_n
         = XtCreateManagedWidget("Neutral", toggleWidgetClass,
                                 align_form2, args, num_args);
+    X11_wrap_widget_if_Xft(plsel_align_radios[1], NHW_MENU);
     num_args = 0;
     XtSetArg(args[num_args], nhStr(XtNfromVert), align_radio_n); num_args++;
     XtSetArg(args[num_args], XtNwidth, cwid); num_args++;
@@ -1124,6 +1144,7 @@ X11_player_selection_dialog(void)
     plsel_align_radios[2] = align_radio_c
         =  XtCreateManagedWidget("Chaotic", toggleWidgetClass,
                                  align_form2, args, num_args);
+    X11_wrap_widget_if_Xft(plsel_align_radios[2], NHW_MENU);
 
     XawToggleUnsetCurrent(plsel_align_radios[0]);
 
@@ -1159,10 +1180,13 @@ X11_player_selection_dialog(void)
     XtSetArg(args[num_args], nhStr(XtNtop), XtChainTop); num_args++;
     XtSetArg(args[num_args], nhStr(XtNleft), XtChainLeft); num_args++;
     XtSetArg(args[num_args], nhStr(XtNright), XtChainRight); num_args++;
-    XtSetArg(args[num_args], XtNwidth, cwid); num_args++;
     XtSetArg(args[num_args], nhStr(XtNlabel), "Random"); num_args++;
     random_btn = XtCreateManagedWidget("random", commandWidgetClass, btn_form,
                                        args, num_args);
+    X11_wrap_widget_if_Xft(random_btn, NHW_MENU);
+    num_args = 0;
+    XtSetArg(args[num_args], XtNwidth, cwid); num_args++;
+    XtSetValues(random_btn, args, num_args);
     XtAddCallback(random_btn, XtNcallback, plsel_random_btn_callback, form);
 
     /* "Play" button */
@@ -1171,11 +1195,14 @@ X11_player_selection_dialog(void)
     XtSetArg(args[num_args], nhStr(XtNfromVert), random_btn); num_args++;
     XtSetArg(args[num_args], nhStr(XtNleft), XtChainLeft); num_args++;
     XtSetArg(args[num_args], nhStr(XtNright), XtChainRight); num_args++;
-    XtSetArg(args[num_args], XtNwidth, cwid); num_args++;
     XtSetArg(args[num_args], nhStr(XtNlabel), "Play"); num_args++;
     plsel_btn_play = play_btn
         = XtCreateManagedWidget("play", commandWidgetClass, btn_form,
                                 args, num_args);
+    X11_wrap_widget_if_Xft(play_btn, NHW_MENU);
+    num_args = 0;
+    XtSetArg(args[num_args], XtNwidth, cwid); num_args++;
+    XtSetValues(play_btn, args, num_args);
     XtAddCallback(play_btn, XtNcallback, plsel_play_btn_callback, form);
 
     /* "Quit" button */
@@ -1185,10 +1212,13 @@ X11_player_selection_dialog(void)
     XtSetArg(args[num_args], nhStr(XtNbottom), XtChainBottom); num_args++;
     XtSetArg(args[num_args], nhStr(XtNleft), XtChainLeft); num_args++;
     XtSetArg(args[num_args], nhStr(XtNright), XtChainRight); num_args++;
-    XtSetArg(args[num_args], XtNwidth, cwid); num_args++;
     XtSetArg(args[num_args], nhStr(XtNlabel), "Quit"); num_args++;
     quit_btn = XtCreateManagedWidget("quit", commandWidgetClass, btn_form,
                                      args, num_args);
+    X11_wrap_widget_if_Xft(quit_btn, NHW_MENU);
+    num_args = 0;
+    XtSetArg(args[num_args], XtNwidth, cwid); num_args++;
+    XtSetValues(quit_btn, args, num_args);
     XtAddCallback(quit_btn, XtNcallback, plsel_quit_btn_callback, form);
 
     /********************************************/
@@ -2039,6 +2069,7 @@ make_menu(const char *popup_name, const char *popup_label,
     XtSetArg(args[num_args], XtNborderWidth, 0); num_args++;
     label = XtCreateManagedWidget(popup_label, labelWidgetClass, form, args,
                                   num_args);
+    X11_wrap_widget_if_Xft(label, NHW_MENU);
 
     cumulative_height = 0;
     XtSetArg(args[0], XtNheight, &height);
@@ -2058,6 +2089,7 @@ make_menu(const char *popup_name, const char *popup_label,
     Sprintf(btnname, "btn_%s", left_name);
     left = XtCreateManagedWidget(btnname, commandWidgetClass, form, args,
                                  num_args);
+    X11_wrap_widget_if_Xft(left, NHW_MENU);
     XtAddCallback(left, XtNcallback, left_callback, (XtPointer) 0);
     skip = (distance < 4) ? 8 : 2 * distance;
 
@@ -2081,6 +2113,7 @@ make_menu(const char *popup_name, const char *popup_label,
     Sprintf(btnname, "btn_%s", right_name);
     right = XtCreateManagedWidget(btnname, commandWidgetClass, form, args,
                                   num_args);
+    X11_wrap_widget_if_Xft(right, NHW_MENU);
     XtAddCallback(right, XtNcallback, right_callback, (XtPointer) 0);
 
     XtInstallAccelerators(form, left);
@@ -2106,6 +2139,7 @@ make_menu(const char *popup_name, const char *popup_label,
 
         *curr = XtCreateManagedWidget(widget_names[i], commandWidgetClass,
                                       form, args, num_args);
+        X11_wrap_widget_if_Xft(*curr, NHW_MENU);
         XtAddCallback(*curr, XtNcallback, name_callback,
                       (XtPointer) (ptrdiff_t) i);
         above = *curr++;

--- a/win/X11/winstat.c
+++ b/win/X11/winstat.c
@@ -123,8 +123,10 @@ static void create_status_window_fancy(struct xwindow *, boolean, Widget);
 static void create_status_window_tty(struct xwindow *, boolean, Widget);
 static void destroy_status_window_fancy(struct xwindow *);
 static void destroy_status_window_tty(struct xwindow *);
+#ifndef STATUS_HILITES
 static void adjust_status_fancy(struct xwindow *, const char *);
 static void adjust_status_tty(struct xwindow *, const char *);
+#endif
 static void set_percent(int, int, int);
 static void tty_status_exposed(Widget, XtPointer, XtPointer);
 static void tty_status_redraw(Widget);
@@ -1092,6 +1094,7 @@ destroy_status_window_tty(struct xwindow *wp)
         wp->type = NHW_NONE;
 }
 
+#ifndef STATUS_HILITES
 /*ARGSUSED*/
 void
 adjust_status_tty(struct xwindow *wp UNUSED, const char *str UNUSED)
@@ -1099,6 +1102,7 @@ adjust_status_tty(struct xwindow *wp UNUSED, const char *str UNUSED)
     /* nothing */
     return;
 }
+#endif
 
 void
 create_status_window(
@@ -1162,6 +1166,7 @@ destroy_status_window(struct xwindow *wp)
         destroy_status_window_tty(wp);
 }
 
+#ifndef STATUS_HILITES
 void
 adjust_status(struct xwindow *wp, const char *str)
 {
@@ -1170,6 +1175,7 @@ adjust_status(struct xwindow *wp, const char *str)
     else
         adjust_status_tty(wp, str);
 }
+#endif
 
 void
 create_status_window_fancy(struct xwindow *wp, /* window pointer */
@@ -1270,6 +1276,7 @@ destroy_status_window_fancy(struct xwindow *wp)
         wp->type = NHW_NONE;
 }
 
+#ifndef STATUS_HILITES
 /*
  * This assumes several things:
  *      + Status has only 2 lines
@@ -1300,6 +1307,7 @@ adjust_status_fancy(struct xwindow *wp, const char *str)
              wp->status_information->text.text); num_args++;
     XtSetValues(wp->w, args, num_args);
 }
+#endif
 
 /* Fancy ================================================================== */
 extern const char *const hu_stat[];  /* from eat.c */

--- a/win/X11/winstat.c
+++ b/win/X11/winstat.c
@@ -785,6 +785,7 @@ tty_render_text(Widget w, const XRectangle *clip, int x, int y,
 
     /* Get the font */
     XftFont *font = X11_new_font(w, attr, NHW_STATUS);
+    int height = X11_font_height(font);
 
     /* Get the drawing resources */
     Display *display = XtDisplay(w);
@@ -827,7 +828,7 @@ tty_render_text(Widget w, const XRectangle *clip, int x, int y,
             goldwidth = extents.width - extents.x;
 
             /* Render the gold symbol */
-            XftDrawRect(draw, &bgcolor, x, y, goldwidth, font->height);
+            XftDrawRect(draw, &bgcolor, x, y, goldwidth, height);
 #ifdef ENHANCED_SYMBOLS
             XftDrawString32(draw, &fgcolor, font, x, y + font->ascent, &goldch, 1);
 #else /* !ENHANCED_SYMBOLS */
@@ -857,7 +858,7 @@ tty_render_text(Widget w, const XRectangle *clip, int x, int y,
     }
 
     /* Render the string */
-    XftDrawRect(draw, &bgcolor, x + goldwidth, y, width, font->height);
+    XftDrawRect(draw, &bgcolor, x + goldwidth, y, width, height);
     XftDrawString8(draw, &fgcolor, font,
                    x + goldwidth, y + font->ascent,
                      (const FcChar8 *) text, strlen(text));

--- a/win/X11/winstat.c
+++ b/win/X11/winstat.c
@@ -558,7 +558,7 @@ create_tty_status(Widget parent, Widget top)
     X11_status_widget = XtCreateManagedWidget("status_form", windowWidgetClass,
                                               form, args, num_args);
 
-    int height = nhFontHeight(X11_status_widget) * 3;
+    int height = nhFontHeight(X11_status_widget, NHW_STATUS) * 3;
     num_args = 0;
     XtSetArg(args[num_args], XtNheight, height); num_args++;
     XtSetValues(form, args, num_args);
@@ -618,7 +618,7 @@ tty_status_redraw(Widget w)
     num_args = 0;
     XtSetArg(args[num_args], XtNwidth, &width); num_args++;
     XtGetValues(w, args, num_args);
-    int height = nhFontHeight(w);
+    int height = nhFontHeight(w, NHW_STATUS);
 
     int x = 0;
     int y = 0;
@@ -770,16 +770,115 @@ tty_render_text(Widget w, const XRectangle *clip, int x, int y,
     nhUse(attr);
 #endif
 
-    Arg args[5];
-    Cardinal num_args;
-    XGCValues values;
-    Pixel fgpixel, bgpixel;
-    XFontStruct *font;
-    XFontStruct *font_italic = NULL; /* custodial */
     int goldwidth = 0;
 
     /* Get the colors */
+    Pixel fgpixel, bgpixel;
     tty_status_colors(w, color, attr, &fgpixel, &bgpixel);
+
+#ifdef USE_XPM
+
+    /* Get the font */
+    XftFont *font = X11_new_font(w, (attr & HL_BOLD) != 0, NHW_STATUS);
+
+    /* Get the drawing resources */
+    Display *display = XtDisplay(w);
+    Screen *screen = DefaultScreenOfDisplay(display);
+    Visual *visual = DefaultVisualOfScreen(screen);
+    Colormap cmap = DefaultColormapOfScreen(screen);
+    XftDraw *draw = XftDrawCreate(display, XtWindow(w), visual, cmap);
+
+    /* Convert the colors to Xft form */
+    XftColor fgcolor, bgcolor;
+    X11_new_color(w, fgpixel, &fgcolor);
+    X11_new_color(w, bgpixel, &bgcolor);
+
+    /* If drawing a hitpoint bar, we'll need a clipping rectangle */
+    if (clip != NULL) {
+        XftDrawSetClipRectangles(draw, 0, 0, clip, 1);
+    }
+
+    /* Gold will begin with a glyph string. Convert this to the proper
+       character, which might possibly be Unicode */
+    if (fld == BL_GOLD && memcmp(text, "\\G", 2) == 0) {
+        char *end;
+        unsigned long glyphcode = strtoul(text+2, &end, 16);
+        if ((glyphcode >> 16) == (unsigned) svc.context.rndencode && *end == ':') {
+            /* We have a proper glyph code */
+            glyph_info glyphinfo;
+            glyphcode &= 0xFFFF;
+            map_glyphinfo(0, 0, glyphcode, 0, &glyphinfo);
+            X11_map_symbol goldsym = X11_glyph_char(&glyphinfo);
+
+            /* Get the width of the gold symbol */
+            XGlyphInfo extents;
+#ifdef ENHANCED_SYMBOLS
+            FcChar32 goldch = goldsym;
+            XftTextExtents32(display, font, &goldch, 1, &extents);
+#else /* !ENHANCED_SYMBOLS */
+            FcChar8 goldch = goldsym;
+            XftTextExtents8(display, font, &goldch, 1, &extents);
+#endif /* ?ENHANCED_SYMBOLS */
+            goldwidth = extents.width - extents.x;
+
+            /* Render the gold symbol */
+            XftDrawRect(draw, &bgcolor, x, y, goldwidth, font->height);
+#ifdef ENHANCED_SYMBOLS
+            XftDrawString32(draw, &fgcolor, font, x, y + font->ascent, &goldch, 1);
+#else /* !ENHANCED_SYMBOLS */
+            XftDrawString8(draw, &fgcolor, font, x, y + font->ascent, &goldch, 1);
+#endif /* ?ENHANCED_SYMBOLS */
+
+            text = end;
+        }
+    }
+
+    /* Get the width of the rendered string, not including goldwidth */
+    XGlyphInfo extents;
+    XftTextExtents8(display, font, (const FcChar8 *) text, strlen(text), &extents);
+    int width = extents.width - extents.x;
+
+    /* Place version on the right */
+    if (fld == BL_VERS) {
+        Cardinal num_args = 0;
+        Arg args[1];
+        Dimension wwidth;
+        XtSetArg(args[num_args], XtNwidth, &wwidth); num_args++;
+        XtGetValues(w, args, num_args);
+        int x2 = wwidth - width;
+        if (x2 > x) {
+            x = x2;
+        }
+    }
+
+    /* Render the string */
+    XftDrawRect(draw, &bgcolor, x + goldwidth, y, width, font->height);
+    XftDrawString8(draw, &fgcolor, font,
+                   x + goldwidth, y + font->ascent,
+                     (const FcChar8 *) text, strlen(text));
+    width += goldwidth;
+
+#ifdef STATUS_HILITES
+    /* Implement underline */
+    if (attr & HL_ULINE) {
+        XftDrawRect(draw, &fgcolor, x, y + font->ascent, width, 1);
+    }
+#endif /* STATUS_HILITES */
+
+    /* Release resources */
+
+    XftColorFree(display, visual, cmap, &fgcolor);
+    XftColorFree(display, visual, cmap, &bgcolor);
+    XftDrawDestroy(draw);
+    X11_release_font(w, font);
+
+#else /* !USE_XPM */
+
+    Arg args[5];
+    Cardinal num_args;
+    XGCValues values;
+    XFontStruct *font;
+    XFontStruct *font_italic = NULL; /* custodial */
 
     values.foreground = fgpixel;
     values.background = bgpixel;
@@ -805,6 +904,7 @@ tty_render_text(Widget w, const XRectangle *clip, int x, int y,
         }
     }
 
+    /* Get a graphics context */
     values.font = font->fid;
     values.function = GXcopy;
     GC ggc = XtGetGC(w,
@@ -907,6 +1007,7 @@ tty_render_text(Widget w, const XRectangle *clip, int x, int y,
     if (font_italic != NULL) {
         XFreeFont(XtDisplay(w), font_italic);
     }
+#endif /* ?USE_XPM */
 
     /* Caller will advance x by the width */
     return width;
@@ -1139,7 +1240,7 @@ create_status_window_fancy(struct xwindow *wp, /* window pointer */
              &right_margin); num_args++;
     XtGetValues(wp->w, args, num_args);
 
-    wp->pixel_height = 2 * nhFontHeight(wp->w) + top_margin + bottom_margin;
+    wp->pixel_height = 2 * nhFontHeight(wp->w, NHW_STATUS) + top_margin + bottom_margin;
     wp->pixel_width = COLNO * fs->max_bounds.width
                     + left_margin + right_margin;
 

--- a/win/X11/winstat.c
+++ b/win/X11/winstat.c
@@ -130,7 +130,7 @@ static void adjust_status_tty(struct xwindow *, const char *);
 static void set_percent(int, int, int);
 static void tty_status_exposed(Widget, XtPointer, XtPointer);
 static void tty_status_redraw(Widget);
-static int tty_render_field(Widget, int, int, enum statusfields);
+static int tty_render_field(Widget, int, int, int, enum statusfields);
 static void tty_status_colors(Widget, int, int, Pixel *, Pixel *);
 static int tty_render_text(Widget, const XRectangle *, int, int, const char *,
                            int, int, enum statusfields);
@@ -622,6 +622,9 @@ tty_status_redraw(Widget w)
     XtGetValues(w, args, num_args);
     int height = nhFontHeight(w, NHW_STATUS);
 
+    /* Space between fields. For now, this is equal to one half the height. */
+    int spacing = height/2;
+
     int x = 0;
     int y = 0;
     XClearWindow(XtDisplay(w), XtWindow(w));
@@ -632,7 +635,7 @@ tty_status_redraw(Widget w)
                 if (fld == BL_FLUSH) {
                     break;
                 }
-                int wid = tty_render_field(w, x, y, fld);
+                int wid = tty_render_field(w, x, y, spacing, fld);
                 if (fld == BL_TITLE) {
                     name_x = x;
                     name_y = y;
@@ -650,7 +653,7 @@ tty_status_redraw(Widget w)
                 if (fld == BL_FLUSH) {
                     break;
                 }
-                int wid = tty_render_field(w, x, y, fld);
+                int wid = tty_render_field(w, x, y, spacing, fld);
                 if (fld == BL_TITLE) {
                     name_x = x;
                     name_y = y;
@@ -688,7 +691,7 @@ tty_status_redraw(Widget w)
 
 /* Render one field of the TTY status */
 static int
-tty_render_field(Widget w, int x, int y, enum statusfields fld)
+tty_render_field(Widget w, int x, int y, int spacing, enum statusfields fld)
 {
     static struct stat_fmt {
         const char *pre;
@@ -733,7 +736,7 @@ tty_render_field(Widget w, int x, int y, enum statusfields fld)
         for (unsigned j = 0; j < SIZE(X11_cond_labels); ++j) {
             struct tty_cond_field const *fldp = &X11_cond_labels[j];
             if (fldp->text != NULL) {
-                width += tty_render_text(w, NULL, x + width, y, " ", NO_COLOR, 0, BL_FLUSH);
+                width += spacing;
                 width += tty_render_text(w, NULL, x + width, y, fldp->text, fldp->color, fldp->attrs, BL_FLUSH);
             }
         }
@@ -744,7 +747,7 @@ tty_render_field(Widget w, int x, int y, enum statusfields fld)
             struct tty_status_field const *fldp = &X11_status_labels[fld];
             if (fldp->text != NULL && fldp->text[0] != '\0') {
                 if (x != 0 && (formats[fld].pre == NULL || strchr("(/", formats[fld].pre[0]) == NULL)) {
-                    width += tty_render_text(w, NULL, x + width, y, " ", NO_COLOR, 0, BL_FLUSH);
+                    width += spacing;
                 }
                 if (formats[fld].pre != NULL) {
                     width += tty_render_text(w, NULL, x + width, y, formats[fld].pre, NO_COLOR, 0, BL_FLUSH);

--- a/win/X11/winstat.c
+++ b/win/X11/winstat.c
@@ -2274,7 +2274,7 @@ create_widget(Widget parent, struct X_status_value *sv, int sv_index)
                                          : "dlevel",
                                       labelWidgetClass, parent,
                                       args, num_args);
-        X11_wrap_widget(sv->w);
+        X11_wrap_widget(sv->w, NHW_STATUS);
         break;
     case SV_NAME: {
         char buf[BUFSZ];
@@ -2311,7 +2311,7 @@ create_widget(Widget parent, struct X_status_value *sv, int sv_index)
         XtSetArg(args[num_args], XtNinternalHeight, 0); num_args++;
         sv->w = XtCreateManagedWidget(sv->name, labelWidgetClass, parent,
                                       args, num_args);
-        X11_wrap_widget(sv->w);
+        X11_wrap_widget(sv->w, NHW_STATUS);
         break;
     }
     default:

--- a/win/X11/winstat.c
+++ b/win/X11/winstat.c
@@ -776,7 +776,7 @@ tty_render_text(Widget w, const XRectangle *clip, int x, int y,
     Pixel fgpixel, bgpixel;
     tty_status_colors(w, color, attr, &fgpixel, &bgpixel);
 
-#ifdef USE_XPM
+#ifdef USE_XFT
 
     /* Get the font */
     XftFont *font = X11_new_font(w, attr, NHW_STATUS);
@@ -872,7 +872,7 @@ tty_render_text(Widget w, const XRectangle *clip, int x, int y,
     XftDrawDestroy(draw);
     X11_release_font(w, font);
 
-#else /* !USE_XPM */
+#else /* !USE_XFT */
 
     Arg args[5];
     Cardinal num_args;
@@ -1007,7 +1007,7 @@ tty_render_text(Widget w, const XRectangle *clip, int x, int y,
     if (font_italic != NULL) {
         XFreeFont(XtDisplay(w), font_italic);
     }
-#endif /* ?USE_XPM */
+#endif /* ?USE_XFT */
 
     /* Caller will advance x by the width */
     return width;

--- a/win/X11/winstat.c
+++ b/win/X11/winstat.c
@@ -779,7 +779,7 @@ tty_render_text(Widget w, const XRectangle *clip, int x, int y,
 #ifdef USE_XPM
 
     /* Get the font */
-    XftFont *font = X11_new_font(w, (attr & HL_BOLD) != 0, NHW_STATUS);
+    XftFont *font = X11_new_font(w, attr, NHW_STATUS);
 
     /* Get the drawing resources */
     Display *display = XtDisplay(w);

--- a/win/X11/wintext.c
+++ b/win/X11/wintext.c
@@ -154,7 +154,7 @@ display_text_window(struct xwindow *wp, boolean blocking)
     width = text_info->max_width + text_info->extra_width;
     text_info->blocked = blocking;
     text_info->destroy_on_ack = FALSE;
-    font_height = nhFontHeight(wp->w);
+    font_height = nhFontHeight(wp->w, NHW_TEXT);
 
     /*
      * Calculate the number of lines to use.  First, find the number of

--- a/win/X11/wintext.c
+++ b/win/X11/wintext.c
@@ -59,6 +59,8 @@ static const char rip_translations[] = "#override\n\
 static Widget create_ripout_widget(Widget);
 #endif
 
+static void free_text_buffer(struct text_buffer *);
+
 /*ARGSUSED*/
 void
 delete_text(Widget w, XEvent *event, String *params, Cardinal *num_params)
@@ -388,7 +390,7 @@ clear_text_buffer(struct text_buffer *tb)
 }
 
 /* Free up allocated memory. */
-void
+static void
 free_text_buffer(struct text_buffer *tb)
 {
     free(tb->text);

--- a/win/X11/wintext.c
+++ b/win/X11/wintext.c
@@ -237,6 +237,8 @@ create_text_window(struct xwindow *wp)
     num_args++;
     XtSetArg(args[num_args], XtNallowHoriz, True);
     num_args++;
+    XtSetArg(args[num_args], XtNtranslations,
+             XtParseTranslationTable(text_translations)), num_args++;
     Widget viewport = XtCreateManagedWidget(
         "text_viewport",     /* name */
         viewportWidgetClass, /* widget class from Window.h */

--- a/win/X11/wintext.c
+++ b/win/X11/wintext.c
@@ -506,6 +506,33 @@ rip_exposed(Widget w, XtPointer client_data UNUSED,
 
     x = appResources.tombtext_x;
     y = appResources.tombtext_y;
+#ifdef USE_XFT
+    Display *display = XtDisplay(w);
+    Screen *screen = DefaultScreenOfDisplay(display);
+    Visual *visual = DefaultVisualOfScreen(screen);
+    Colormap cmap = DefaultColormapOfScreen(screen);
+    XftDraw *draw = XftDrawCreate(display, XtWindow(w), visual, cmap);
+    XftFont *font = XftFontOpenName(display, DefaultScreen(display),
+                                    appResources.font_rip);
+    XftColor foreground;
+    X11_new_color(w, values.foreground, &foreground);
+    for (i = 0; i <= YEAR_LINE; i++) {
+        size_t len = strlen(rip_line[i]);
+        XGlyphInfo extents;
+        XftTextExtents8(display, font,
+                        (const FcChar8 *) rip_line[i], len,
+                        &extents);
+        int width = extents.width - extents.x;
+
+        XftDrawString8(draw, &foreground, font, x - width / 2, y,
+                       (const FcChar8 *) rip_line[i], len);
+        x += appResources.tombtext_dx;
+        y += appResources.tombtext_dy;
+    }
+    XftFontClose(display, font);
+    XftDrawDestroy(draw);
+    XftColorFree(display, visual, cmap, &foreground);
+#else /* !USE_XFT */
     for (i = 0; i <= YEAR_LINE; i++) {
         int len = strlen(rip_line[i]);
         XFontStruct *font = WindowFontStruct(w);
@@ -515,6 +542,7 @@ rip_exposed(Widget w, XtPointer client_data UNUSED,
         x += appResources.tombtext_dx;
         y += appResources.tombtext_dy;
     }
+#endif /* ?USE_XFT */
 
     XtReleaseGC(w, ggc);
 }

--- a/win/X11/wintext.c
+++ b/win/X11/wintext.c
@@ -136,16 +136,10 @@ add_to_text_window(struct xwindow *wp, int attr, /* currently unused */
                    const char *str)
 {
     struct text_info_t *text_info = wp->text_information;
-    int width;
 
     nhUse(attr);
 
     append_text_buffer(&text_info->text, str, FALSE);
-
-    /* Calculate text width and save longest line */
-    width = XTextWidth(text_info->fs, str, (int) strlen(str));
-    if (width > text_info->max_width)
-        text_info->max_width = width;
 }
 
 void
@@ -208,9 +202,6 @@ create_text_window(struct xwindow *wp)
         (struct text_info_t *) alloc(sizeof(struct text_info_t));
 
     init_text_buffer(&text_info->text);
-    text_info->max_width = 0;
-    text_info->extra_width = 0;
-    text_info->extra_height = 0;
     text_info->blocked = FALSE;
     text_info->destroy_on_ack = TRUE; /* Ok to destroy before display */
 #ifdef GRAPHIC_TOMBSTONE
@@ -269,15 +260,6 @@ create_text_window(struct xwindow *wp)
                                   args,      /* set some values */
                                   num_args); /* number of values to set */
     X11_wrap_widget_if_Xft(wp->w, NHW_TEXT);
-
-    /* Get the font and margin information. */
-    num_args = 0;
-    XtSetArg(args[num_args], XtNfont, &text_info->fs);
-    num_args++;
-    XtGetValues(wp->w, args, num_args);
-
-    text_info->extra_width = 0;
-    text_info->extra_height = 0;
 }
 
 void
@@ -495,12 +477,16 @@ rip_exposed(Widget w, XtPointer client_data UNUSED,
         XDestroyImage(rip_image); /* data bytes free'd also */
     }
 
-    mask = GCFunction | GCForeground | GCGraphicsExposures | GCFont;
     values.graphics_exposures = False;
     XtSetArg(args[0], XtNforeground, &values.foreground);
     XtGetValues(w, args, 1);
     values.function = GXcopy;
+#ifdef USE_XFT
+    mask = GCFunction | GCForeground | GCGraphicsExposures;
+#else
+    mask = GCFunction | GCForeground | GCGraphicsExposures | GCFont;
     values.font = WindowFont(w);
+#endif
     ggc = XtGetGC(w, mask, &values);
 
     if (rip_pixmap != None) {

--- a/win/X11/wintext.c
+++ b/win/X11/wintext.c
@@ -17,7 +17,8 @@
 #include <X11/Shell.h>
 #include <X11/Xos.h>
 #include <X11/Xaw/Form.h>
-#include <X11/Xaw/AsciiText.h>
+#include <X11/Xaw/Label.h>
+#include <X11/Xaw/Viewport.h>
 #include <X11/Xaw/Cardinals.h>
 #include <X11/Xatom.h>
 
@@ -43,12 +44,16 @@
                           */
 
 static const char text_translations[] = "#override\n\
-     <BtnDown>: dismiss_text()\n\
+     <Btn1Down>: dismiss_text()\n\
+     <Btn4Down>: scroll(8)\n\
+     <Btn5Down>: scroll(2)\n\
      <Key>: key_dismiss_text()";
 
 #ifdef GRAPHIC_TOMBSTONE
 static const char rip_translations[] = "#override\n\
-     <BtnDown>: rip_dismiss_text()\n\
+     <Btn1Down>: rip_dismiss_text()\n\
+     <Btn4Down>: scroll(8)\n\
+     <Btn5Down>: scroll(2)\n\
      <Key>: rip_dismiss_text()";
 
 static Widget create_ripout_widget(Widget);
@@ -147,41 +152,12 @@ display_text_window(struct xwindow *wp, boolean blocking)
     struct text_info_t *text_info;
     Arg args[8];
     Cardinal num_args;
-    Dimension width, height, font_height;
-    int nlines;
 
     text_info = wp->text_information;
-    width = text_info->max_width + text_info->extra_width;
     text_info->blocked = blocking;
     text_info->destroy_on_ack = FALSE;
-    font_height = nhFontHeight(wp->w, NHW_TEXT);
-
-    /*
-     * Calculate the number of lines to use.  First, find the number of
-     * lines that would fit on the screen.  Next, remove four of these
-     * lines to give room for a possible window manager titlebar (some
-     * wm's put a titlebar on transient windows).  Make sure we have
-     * _some_ lines.  Finally, use the number of lines in the text if
-     * there are fewer than the max.
-     */
-    nlines = (XtScreen(wp->w)->height - text_info->extra_height) / font_height;
-    nlines -= 4;
-
-    if (nlines > text_info->text.num_lines)
-        nlines = text_info->text.num_lines;
-    if (nlines <= 0)
-        nlines = 1;
-
-    height = nlines * font_height + text_info->extra_height;
 
     num_args = 0;
-
-    if (nlines < text_info->text.num_lines) {
-        /* add on width of scrollbar.  Really should look this up,
-         * but can't until the window is realized.  Chicken-and-egg problem.
-         */
-        width += 20;
-    }
 
 #ifdef GRAPHIC_TOMBSTONE
     if (text_info->is_rip) {
@@ -195,18 +171,10 @@ display_text_window(struct xwindow *wp, boolean blocking)
     }
 #endif
 
-    if (width > (Dimension) XtScreen(wp->w)->width) { /* too wide for screen */
-        /* Back off some amount - we really need to back off the scrollbar */
-        /* width plus some extra.                                          */
-        width = XtScreen(wp->w)->width - 20;
-    }
-    XtSetArg(args[num_args], XtNstring, text_info->text.text);
-    num_args++;
-    XtSetArg(args[num_args], XtNwidth, width);
-    num_args++;
-    XtSetArg(args[num_args], XtNheight, height);
+    XtSetArg(args[num_args], XtNlabel, text_info->text.text);
     num_args++;
     XtSetValues(wp->w, args, num_args);
+    X11_update_label_if_Xft(wp->w);
 
 #ifdef TRANSIENT_TEXT
     XtRealizeWidget(wp->popup);
@@ -216,22 +184,6 @@ display_text_window(struct xwindow *wp, boolean blocking)
 #endif
 
     nh_XtPopup(wp->popup, (int) XtGrabNone, wp->w);
-
-    /* Kludge alert.  Scrollbars are not sized correctly by the Text widget */
-    /* if added before the window is displayed, so do it afterward. */
-    num_args = 0;
-    if (nlines < text_info->text.num_lines) { /* add vert scrollbar */
-        XtSetArg(args[num_args], nhStr(XtNscrollVertical),
-                 XawtextScrollAlways);
-        num_args++;
-    }
-    if (width >= (Dimension)(XtScreen(wp->w)->width - 20)) { /* too wide */
-        XtSetArg(args[num_args], nhStr(XtNscrollHorizontal),
-                 XawtextScrollAlways);
-        num_args++;
-    }
-    if (num_args)
-        XtSetValues(wp->w, args, num_args);
 
     /* We want the user to acknowledge. */
     if (blocking) {
@@ -246,7 +198,6 @@ create_text_window(struct xwindow *wp)
     struct text_info_t *text_info;
     Arg args[8];
     Cardinal num_args;
-    Position top_margin, bottom_margin, left_margin, right_margin;
     Widget form;
 
     wp->type = NHW_TEXT;
@@ -280,46 +231,49 @@ create_text_window(struct xwindow *wp)
         wp->popup,
         XtParseTranslationTable("<Message>WM_PROTOCOLS: delete_text()"));
 
+    /* Create the viewport */
+    num_args = 0;
+    XtSetArg(args[num_args], XtNallowVert, True);
+    num_args++;
+    XtSetArg(args[num_args], XtNallowHoriz, True);
+    num_args++;
+    Widget viewport = XtCreateManagedWidget(
+        "text_viewport",     /* name */
+        viewportWidgetClass, /* widget class from Window.h */
+        wp->popup,           /* parent widget */
+        args,                /* set some values */
+        num_args);           /* number of values to set */
+
     num_args = 0;
     XtSetArg(args[num_args], XtNallowShellResize, True), num_args++;
     XtSetArg(args[num_args], XtNtranslations,
              XtParseTranslationTable(text_translations)), num_args++;
-    form = XtCreateManagedWidget("form", formWidgetClass, wp->popup, args,
+    form = XtCreateManagedWidget("form", formWidgetClass, viewport, args,
                                  num_args);
 
     num_args = 0;
-    XtSetArg(args[num_args], nhStr(XtNdisplayCaret), False);
-    num_args++;
-    XtSetArg(args[num_args], XtNresize, XawtextResizeBoth);
-    num_args++;
     XtSetArg(args[num_args], XtNtranslations,
              XtParseTranslationTable(text_translations));
     num_args++;
+    XtSetArg(args[num_args], XtNjustify, XtJustifyLeft); num_args++;
 
     wp->w = XtCreateManagedWidget(svk.killer.name[0] && WIN_MAP == WIN_ERR
                                       ? "tombstone"
                                       : "text_text", /* name */
-                                  asciiTextWidgetClass,
+                                  labelWidgetClass,
                                   form,      /* parent widget */
                                   args,      /* set some values */
                                   num_args); /* number of values to set */
+    X11_wrap_widget_if_Xft(wp->w, NHW_TEXT);
 
     /* Get the font and margin information. */
     num_args = 0;
     XtSetArg(args[num_args], XtNfont, &text_info->fs);
     num_args++;
-    XtSetArg(args[num_args], nhStr(XtNtopMargin), &top_margin);
-    num_args++;
-    XtSetArg(args[num_args], nhStr(XtNbottomMargin), &bottom_margin);
-    num_args++;
-    XtSetArg(args[num_args], nhStr(XtNleftMargin), &left_margin);
-    num_args++;
-    XtSetArg(args[num_args], nhStr(XtNrightMargin), &right_margin);
-    num_args++;
     XtGetValues(wp->w, args, num_args);
 
-    text_info->extra_width = left_margin + right_margin;
-    text_info->extra_height = top_margin + bottom_margin;
+    text_info->extra_width = 0;
+    text_info->extra_height = 0;
 }
 
 void

--- a/win/X11/winval.c
+++ b/win/X11/winval.c
@@ -57,7 +57,7 @@ create_value(Widget parent, const char *name_value)
     num_args++;
     name =
         XtCreateManagedWidget(WNAME, labelWidgetClass, form, args, num_args);
-    X11_wrap_widget(name);
+    X11_wrap_widget(name, NHW_STATUS);
 
     num_args = 0;
     XtSetArg(args[num_args], XtNjustify, XtJustifyRight);
@@ -70,7 +70,7 @@ create_value(Widget parent, const char *name_value)
     num_args++;
     Widget value = XtCreateManagedWidget(WVALUE, labelWidgetClass, form, args,
                                          num_args);
-    X11_wrap_widget(value);
+    X11_wrap_widget(value, NHW_STATUS);
     return form;
 }
 


### PR DESCRIPTION
Adding Xft support gives these advantages:
* Support for TrueType and OpenType fonts. The user can select any font configured on their computer.
* Support for the Unicode supplementary planes.

At this writing, only a few text input widgets still use the bitmap fonts. These are proving to be tough to convert and I'm leaving them for another day.