### PR TITLE
X11: Combine XLoadFont and XQueryFont calls, avoiding crash when loading Unicode font

### DIFF
--- a/win/X11/winX.c
+++ b/win/X11/winX.c
@@ -3125,8 +3125,7 @@ X11_unicode_font(Display *display, XFontStruct *font)
     strcpy(unicode_font + len, "iso10646-1");
     font_name = unicode_font;
 
-    Font font_id = XLoadFont(display, font_name);
-    XFontStruct *unifont = XQueryFont(display, font_id);
+    XFontStruct *unifont = XLoadQueryFont(display, font_name);
     return unifont;
 }
 #endif /* ENHANCED_SYMBOLS */


### PR DESCRIPTION
The separate calls crash if the font does not exist; the combined call returns NULL, as the caller expects.

Resolves #1508 and possibly #569.