### PR TITLE
Fix: first INSURANCE checkpoint is never written.

### DIFF
--- a/src/allmain.c
+++ b/src/allmain.c
@@ -872,10 +872,10 @@ newgame(void)
 
     urealtime.realtime = 0L;
     urealtime.start_timing = getnow();
+    program_state.something_worth_saving++; /* useful data now exists */
 #ifdef INSURANCE
     save_currentstate();
 #endif
-    program_state.something_worth_saving++; /* useful data now exists */
 
     /* Success! */
     welcome(TRUE);

--- a/src/do.c
+++ b/src/do.c
@@ -1385,8 +1385,10 @@ save_currentstate(void)
     if (flags.ins_chkpt) {
         /* write out just-attained level, with pets and everything */
         nhfp = currentlevel_rewrite();
-        if (!nhfp)
+        if (!nhfp) {
+            program_state.in_checkpoint--;
             return;
+        }
         if (nhfp->structlevel)
             bufon(nhfp->fd);
         nhfp->mode = WRITING;

--- a/src/restore.c
+++ b/src/restore.c
@@ -843,9 +843,6 @@ dorecover(NHFILE *nhfp)
     init_oclass_probs(); /* recompute go.oclass_prob_totals[] */
 
     restlevelstate();
-#ifdef INSURANCE
-    savestateinlock();
-#endif
     rtmp = restlevelfile(ledger_no(&u.uz));
     if (rtmp < 2)
         return rtmp; /* dorecover called recursively */
@@ -953,6 +950,12 @@ dorecover(NHFILE *nhfp)
 
     run_timers(); /* expire all timers that have gone off while away */
     program_state.restoring = 0; /* affects bot() so clear before docrt() */
+#ifdef INSURANCE
+    /* first checkpoint of the restored session; every level file has been
+       written and the current level has been read back in, so recover has
+       something to work with even if the player never changes level */
+    save_currentstate();
+#endif
 
     if (ge.early_raw_messages && !program_state.beyond_savefile_load) {
         /*


### PR DESCRIPTION
### The problem:

If a game is killed before the player changes dungeon level for the
first time, `recover` cannot rebuild it. It prints "Checkpointing was
not in effect" and stops. The `<uid><plname>.0` lock file is still only
4 bytes, just the pid that `getlock()` wrote at startup.

`savestateinlock()` returns immediately unless
`program_state.something_worth_saving` is set, and both of the calls
that are supposed to write the first checkpoint run before that flag is
set:

* `newgame()` calls `save_currentstate()` two lines before it
* `dorecover()` calls `savestateinlock()` 73 lines before it, and ahead
  of the pass that writes the level files

So neither call does anything, and the first checkpoint a game gets is
the one from `goto_level()` when the player first takes a staircase.
Until then a `SIGKILL`, an OOM kill, a watchdog or a host reboot loses
everything, and that window covers a long stay on one level as well as
the whole period right after a restore.

This turned up on eu.hardfought.org: a game was killed by a CPU
watchdog after 42 minutes on one level following a restore, and there
was nothing for `recover` to work with. I've seen this before over the
years on both Hardfought and NAO, decided to dig into this and figure
out what was causing some games to recover fine and others not to.

### The fix:

`newgame()`: set the flag before the call.

`dorecover()`: drop the call that does nothing and checkpoint once the
restore has finished instead. Writing it at the old spot would be
worse than not writing it, because none of the level files for the
session exist yet. The new call sits after `program_state.restoring` is
cleared so stairs and traps use the same relative-dlevel encoding a
normal save uses, and it is `save_currentstate()` rather than
`savestateinlock()` so `in_checkpoint` is set while `savegamestate()`
writes `u.ustuck_mid` / `u.usteed_mid`.

The second commit is separate and can be dropped on its own: a failed
`currentlevel_rewrite()` returns from `save_currentstate()` without
undoing its `in_checkpoint` increment, which silently disables every
later checkpoint for the rest of the game.

### Testing:

Built and played (tty, `INSURANCE` on), before and after the fix.

| | before | after |
|---|---|---|
| new game, hero placed, no level change | `.0` is 4 bytes, no level 1 file | `.0` is ~45K, level 1 file written |
| `kill -9` then `recover` | "Checkpointing was not in effect" | rebuilds a save that loads |
| restore, no level change | `.0` still 4 bytes | `.0` rewritten at restore |
| `kill -9` after restore, then `recover` | nothing to recover | rebuilds, restores to the right level |

Level changes still update the checkpoint as before, and normal
save/restore round-trips are unchanged.
