### PR TITLE
Qt and Win32: fix menu columns on some menus

### DIFF
--- a/src/botl.c
+++ b/src/botl.c
@@ -4539,9 +4539,13 @@ status_hilite_menu(void)
 #endif
         any = cg.zeroany;
         any.a_int = fld + 1;
-        Sprintf(buf, "%-18s", initblstats[i].fldname);
+        if (iflags.menu_tab_sep) {
+            Sprintf(buf, "%s\t", initblstats[i].fldname);
+        } else {
+            Sprintf(buf, "%-18s ", initblstats[i].fldname);
+        }
         if (count)
-            Sprintf(eos(buf), " (%d defined)", count);
+            Sprintf(eos(buf), "(%d defined)", count);
         add_menu(tmpwin, &nul_glyphinfo, &any, 0, 0, ATR_NONE,
                  clr, buf, MENU_ITEMFLAGS_NONE);
     }

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -674,10 +674,15 @@ doextlist(void)
                     add_menu_heading(menuwin, buf);
                     menushown[pass] = 1;
                 }
-                /* longest ef_txt at present is "wizrumorcheck" (13 chars);
-                   2nd field will be "    " or " [A]" or " [m]" or "[mA]" */
-                Sprintf(buf, " %-14s %4s %s", efp->ef_txt,
-                        doc_extcmd_flagstr(menuwin, efp), cmd_desc);
+                if (iflags.menu_tab_sep) {
+                    Sprintf(buf, " %s\t%s\t%s", efp->ef_txt,
+                            doc_extcmd_flagstr(menuwin, efp), cmd_desc);
+                } else {
+                    /* longest ef_txt at present is "wizrumorcheck" (13 chars);
+                       2nd field will be "    " or " [A]" or " [m]" or "[mA]" */
+                    Sprintf(buf, " %-14s %4s %s", efp->ef_txt,
+                            doc_extcmd_flagstr(menuwin, efp), cmd_desc);
+                }
                 add_menu_str(menuwin, buf);
                 ++n;
             }

--- a/src/options.c
+++ b/src/options.c
@@ -5703,8 +5703,13 @@ handler_disclose(void)
     start_menu(tmpwin, MENU_BEHAVE_STANDARD);
     any = cg.zeroany;
     for (i = 0; i < NUM_DISCLOSURE_OPTIONS; i++) {
-        Sprintf(buf, "%-12s[%c%c]", disclosure_names[i],
-                flags.end_disclose[i], disclosure_options[i]);
+        if (iflags.menu_tab_sep) {
+            Sprintf(buf, "%s\t[%c%c]", disclosure_names[i],
+                    flags.end_disclose[i], disclosure_options[i]);
+        } else {
+            Sprintf(buf, "%-12s[%c%c]", disclosure_names[i],
+                    flags.end_disclose[i], disclosure_options[i]);
+        }
         any.a_int = i + 1;
         add_menu(tmpwin, &nul_glyphinfo, &any, disclosure_options[i],
                  0, ATR_NONE, clr, buf, MENU_ITEMFLAGS_NONE);

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -979,8 +979,6 @@ symparse_find(const void *bstr_, const void *rec_)
     return 0;
 }
 
-DISABLE_WARNING_FORMAT_NONLITERAL
-
 /*
  * this is called from options.c to do the symset work.
  */
@@ -994,7 +992,7 @@ do_symset(boolean rogueflag)
     menu_item *symset_pick = (menu_item *) 0;
     boolean ready_to_switch = FALSE,
             nothing_to_do = FALSE;
-    char *symset_name, fmtstr[20];
+    char *symset_name;
     struct symsetentry *sl;
     int res, which_set, setcount = 0, chosen = -2, defindx = 0;
     int clr = NO_COLOR;
@@ -1041,7 +1039,6 @@ do_symset(boolean rogueflag)
             return TRUE;
         }
 
-        Sprintf(fmtstr, "%%-%ds %%s", biggest + 2);
         tmpwin = create_nhwindow(NHW_MENU);
         start_menu(tmpwin, MENU_BEHAVE_STANDARD);
         any = cg.zeroany;
@@ -1072,7 +1069,11 @@ do_symset(boolean rogueflag)
                 any.a_int = sl->idx + 2;
                 if (symset_name && !strcmpi(sl->name, symset_name))
                     defindx = any.a_int;
-                Sprintf(buf, fmtstr, sl->name, sl->desc ? sl->desc : "");
+                if (iflags.menu_tab_sep) {
+                    Sprintf(buf, "%s\t%s", sl->name, sl->desc ? sl->desc : "");
+                } else {
+                    Sprintf(buf, "%-*s %s", biggest + 2, sl->name, sl->desc ? sl->desc : "");
+                }
                 add_menu(tmpwin, &nul_glyphinfo, &any, 0, 0,
                          ATR_NONE, clr, buf,
                          (any.a_int == defindx) ? MENU_ITEMFLAGS_SELECTED
@@ -1176,7 +1177,5 @@ do_symset(boolean rogueflag)
     preference_update("symset");
     return TRUE;
 }
-
-RESTORE_WARNING_FORMAT_NONLITERAL
 
 /*symbols.c*/

--- a/win/Qt/qt_menu.cpp
+++ b/win/Qt/qt_menu.cpp
@@ -165,7 +165,7 @@ NetHackQtMenuWindow::NetHackQtMenuWindow(QWidget *parent) :
 {
     // setFont() was in SelectMenu(), in time to be rendered but too late
     // when measuring the width and height that will be needed
-    QFont tablefont(qt_settings->normalFixedFont());
+    QFont tablefont(qt_settings->normalFont());
     table->setFont(tablefont);
 
     QGridLayout *grid = new QGridLayout();
@@ -400,9 +400,8 @@ void NetHackQtMenuWindow::PadMenuColumns(bool split_descr)
                 continue;
             // determine column widths of sub-fields within description
             QStringList columns = itemlist[row].str.split("\t");
-            for (int fld = 0; fld < (int) columns.size(); ++fld) {
-                bool lastcol = (fld == (int) columns.size() - 1);
-                int w = fm.QFM_WIDTH(columns[fld] + (lastcol ? "" : "  "));
+            for (int fld = 0; fld < (int) columns.size() - 1; ++fld) {
+                int w = fm.QFM_WIDTH(columns[fld] + "  ");
                 if (fld >= (int) col_widths.size()) {
                     col_widths.push_back(w); // add another element
                 } else if (col_widths[fld] < w) {
@@ -432,12 +431,21 @@ void NetHackQtMenuWindow::PadMenuColumns(bool split_descr)
             continue;
         QString text = twi->text();
         if (split_descr) {
+            static const QChar u_200A(0x200A); // U+200A HAIR SPACE
             QStringList columns = text.split("\t");
+            int spc0020_width = fm.QFM_WIDTH(" ");
+            int spc200A_width = fm.QFM_WIDTH(u_200A);
+            // Track errors in column widths and adjust subsequent columns so
+            // that these errors do not accumulate across a row
+            int error = 0;
             for (int fld = 0; fld < (int) columns.size() - 1; ++fld) {
                 //columns[fld] += "\t"; /* (used to pad with tabs) */
                 int width = col_widths[fld];
-                while (fm.QFM_WIDTH(columns[fld]) < width)
+                while (fm.QFM_WIDTH(columns[fld]) + error + spc0020_width <= width)
                     columns[fld] += " "; //"\t";
+                while (fm.QFM_WIDTH(columns[fld]) + error + spc200A_width/2 < width)
+                    columns[fld] += u_200A;
+                error += fm.QFM_WIDTH(columns[fld]) - width;
             }
             text = columns.join("");
             twi->setText(text);

--- a/win/X11/NetHack.ad
+++ b/win/X11/NetHack.ad
@@ -31,7 +31,7 @@ NetHack*text*borderWidth:  0
 ! These correspond to the .nethackrc settings font_map, font_menu,
 ! font_message, font_status and font_text
 NetHack.font_map:     mono-10
-NetHack.font_menu:    mono-10
+NetHack.font_menu:    sans-10
 NetHack.font_message: sans-10
 NetHack.font_status:  sans-10
 NetHack.font_text:    mono-10

--- a/win/X11/winX.c
+++ b/win/X11/winX.c
@@ -1571,7 +1571,7 @@ static XtResource resources[] = {
     { nhStr("font_map"), nhStr("Font_map"), XtRString, sizeof(String),
       XtOffset(AppResources *, font_map), XtRString, nhStr("mono-10") },
     { nhStr("font_menu"), nhStr("Font_menu"), XtRString, sizeof(String),
-      XtOffset(AppResources *, font_menu), XtRString, nhStr("mono-10") },
+      XtOffset(AppResources *, font_menu), XtRString, nhStr("sans-10") },
     { nhStr("font_message"), nhStr("Font_message"), XtRString, sizeof(String),
       XtOffset(AppResources *, font_message), XtRString, nhStr("sans-10") },
     { nhStr("font_status"), nhStr("Font_status"), XtRString, sizeof(String),

--- a/win/win32/mhmenu.c
+++ b/win/win32/mhmenu.c
@@ -684,11 +684,16 @@ onMSNHCommand(HWND hWnd, WPARAM wParam, LPARAM lParam)
                 DrawText(hDC, NH_A2W(p1, wbuf, BUFSZ), strlen(p1), &drawRect,
                          DT_CALCRECT | DT_LEFT | DT_VCENTER | DT_EXPANDTABS
                              | DT_SINGLELINE);
-                data->menui.menu.tab_stop_size[column] =
-                    max(data->menui.menu.tab_stop_size[column],
-                        drawRect.right - drawRect.left);
-
-                menuitemwidth += data->menui.menu.tab_stop_size[column];
+                int width = drawRect.right - drawRect.left;
+                /* The last column overhangs any subsequent columns in other
+                   lines */
+                if (p != NULL) {
+                    data->menui.menu.tab_stop_size[column] =
+                        max(data->menui.menu.tab_stop_size[column], width);
+                    menuitemwidth += data->menui.menu.tab_stop_size[column];
+                } else {
+                    menuitemwidth += width;
+                }
 
                 if (p != NULL)
                     *p = '\t';
@@ -1182,7 +1187,8 @@ onDrawItem(HWND hWnd, WPARAM wParam, LPARAM lParam)
     p = strchr(item->str, '\t');
     column = 0;
     SetRect(&drawRect, x, lpdis->rcItem.top,
-            min(x + data->menui.menu.tab_stop_size[0], lpdis->rcItem.right),
+            p != NULL ? x + data->menui.menu.tab_stop_size[0]
+                      : lpdis->rcItem.right,
             lpdis->rcItem.bottom);
     for (;;) {
         TCHAR wbuf2[BUFSZ];
@@ -1199,8 +1205,8 @@ onDrawItem(HWND hWnd, WPARAM wParam, LPARAM lParam)
         p = strchr(p1, '\t');
         drawRect.left = drawRect.right + TAB_SEPARATION;
         ++column;
-        drawRect.right = min(drawRect.left + data->menui.menu.tab_stop_size[column],
-                             lpdis->rcItem.right);
+        drawRect.right = p != NULL ? drawRect.left + data->menui.menu.tab_stop_size[column]
+                                   : lpdis->rcItem.right;
     }
 
     /* draw focused item */


### PR DESCRIPTION
In the core: add tabs to these menus:
- extended command list
- status hilites
- disclose option
- symset selection

Qt and Win32: revise the column width algorithm so that the last column of a line can overhang subsequent columns of other lines.

Qt: change the menu font to proportional and improve the column padding algorithm as follows:
- pad with U+200A HAIR SPACE for finer control of padding
- account for any imprecision in padding width when padding subsequent columns, so that errors cancel and the last column is accurately placed