### PR TITLE
Bugfix: do not ask for confirmation for unambiguous char combos

### DIFF
--- a/src/role.c
+++ b/src/role.c
@@ -2219,8 +2219,8 @@ genl_player_setup(int screenheight)
     /* Used to avoid "Is this ok?" if player has already specified all
      * four facets of role.
      * Note that rigid_role_checks might force any unspecified facets to
-     * have a specific value, but that will still require confirmation;
-     * player can specify the forced ones if avoiding that is demanded.
+     * have a specific value, but that would still require confirmation,
+     * except later we re-compute this check, after rigid_role_checks.
      */
     picksomething = (ROLE == ROLE_NONE || RACE == ROLE_NONE
                      || GEND == ROLE_NONE || ALGN == ROLE_NONE);
@@ -2241,6 +2241,10 @@ genl_player_setup(int screenheight)
     /* prevent unnecessary prompting if role forces race (samurai) or gender
        (valkyrie) or alignment (rogue), or race forces alignment (orc), &c */
     rigid_role_checks();
+
+    /* re-compute picksomething to avoid confirm on force role combinations. */
+    picksomething = (ROLE == ROLE_NONE || RACE == ROLE_NONE
+                     || GEND == ROLE_NONE || ALGN == ROLE_NONE);
 
     if (ROLE == ROLE_NONE || RACE == ROLE_NONE
         || GEND == ROLE_NONE || ALGN == ROLE_NONE) {


### PR DESCRIPTION
It seems that the game will always ask "are you sure you want to play $combo? y/n" on start
in cases where, due to role or race restrictions, only one combination of race/role/align/gender is possible,
but the full combination has not been explicitly set in the rcfile.

Examples that will prompt (one or more property constrained implicitly):
OPTIONS=race:dwarf,role:valkyrie,gender:female
OPTIONS=race:dwarf,role:valkyrie,align:lawful
OPTIONS=race:dwarf,role:valkyrie
OPTIONS=race:gnome,role:wizard,gender:female

Examples that will not prompt:
OPTIONS=race:dwarf,role:valkyrie,gender:female,align:lawful
OPTIONS=race:gnome,role:wizard,gender:female,align:neutral

A possible fix for this is to re-compute `picksomething` in `src/role.c` after `rigid_role_checks();`