### PR TITLE
Qt: use idClicked(); buttonClicked(int) is gone in Qt 6

### DIFF
--- a/win/Qt/qt_plsel.cpp
+++ b/win/Qt/qt_plsel.cpp
@@ -358,8 +358,13 @@ NetHackQtPlayerSelector::NetHackQtPlayerSelector(
 	genderbox->layout()->addWidget(gender[i]);
 	gendergroup->addButton(gender[i], i);
     }
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    connect(gendergroup, SIGNAL(idClicked(int)),
+            this, SLOT(selectGender(int)));
+#else
     connect(gendergroup, SIGNAL(buttonClicked(int)),
             this, SLOT(selectGender(int)));
+#endif
 
     QLabel *alignlabel = new QLabel("Alignment");
     alignbox->layout()->addWidget(alignlabel);
@@ -369,8 +374,13 @@ NetHackQtPlayerSelector::NetHackQtPlayerSelector(
 	alignbox->layout()->addWidget(alignment[i]);
 	aligngroup->addButton(alignment[i], i);
     }
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    connect(aligngroup, SIGNAL(idClicked(int)),
+            this, SLOT(selectAlignment(int)));
+#else
     connect(aligngroup, SIGNAL(buttonClicked(int)),
             this, SLOT(selectAlignment(int)));
+#endif
 
     l->addWidget(rand_btn, 4, 2);
     connect(rand_btn, SIGNAL(clicked()), this, SLOT(Randomize()));

--- a/win/Qt/qt_yndlg.cpp
+++ b/win/Qt/qt_yndlg.cpp
@@ -292,7 +292,13 @@ char NetHackQtYnDialog::Exec()
 	    bgroup->addButton(button, i);
 	}
 
-        connect(bgroup, SIGNAL(buttonClicked(int)), this, SLOT(doneItem(int)));
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+        connect(bgroup, SIGNAL(idClicked(int)), this,
+                SLOT(doneItem(int)));
+#else
+        connect(bgroup, SIGNAL(buttonClicked(int)), this,
+                SLOT(doneItem(int)));
+#endif
 
         QLabel *lb = 0;
         if (allow_count) {


### PR DESCRIPTION
**What you see without this fix (Qt 6 builds):** in the player selection dialog, clicking a Gender or Alignment radio button visibly selects it but the choice isn't registered — roles and races that the new choice should allow stay greyed out, with no indication why. In yes/no dialogs, clicking a button does nothing; only the keyboard works.

### `QButtonGroup::buttonClicked(int)` does not exist in Qt 6

`buttonClicked(int)` was deprecated in Qt 5.15 and removed in Qt 6, replaced by
`idClicked(int)`. Three `connect()` calls still use the old name, so on Qt 6 they
fail at runtime:

```
QObject::connect: No such signal QButtonGroup::buttonClicked(int) in ../win/Qt/qt_plsel.cpp:361
QObject::connect: No such signal QButtonGroup::buttonClicked(int) in ../win/Qt/qt_plsel.cpp:372
```

Because these use the string-based `SIGNAL()` macro the failure is only a runtime
warning, and the buttons still *look* like they respond — `QRadioButton` handles its
own check state — so nothing signals to the player that the click was dropped.

Consequences:

| Site | Effect |
|---|---|
| `qt_plsel.cpp:361` | Gender radio buttons never reach `selectGender()` |
| `qt_plsel.cpp:372` | Alignment radio buttons never reach `selectAlignment()` |
| `qt_yndlg.cpp:295` | Clicking a button in a yn dialog does nothing (keyboard still works) |

The player-selection case is the damaging one. `chosen_gend` and `chosen_align` stay at
whatever `Randomize()` set at construction, and `populate_roles()` / `populate_races()`
filter the role and race columns against those stale values:

```c
v = ((ra < 0 || validrace(i, ra))
     && (gn < 0 || validgend(i, (ra >= 0) ? ra : hu, gn))
     && (al < 0 || validalign(i, (ra >= 0) ? ra : hu, al)));
item->setFlags(v ? Qt::ItemIsEnabled | Qt::ItemIsSelectable : Qt::NoItemFlags);
```

So a player who clicks "chaotic" sees the radio button move, but every chaotic-only role
stays greyed out and cannot be selected, with no indication why.

The port already handles the identical `buttonPressed(int)` → `idPressed(int)` rename
this way in `qt_svsel.cpp:98` and `qt_xcmd.cpp:338` (#913, applied 2022-10-27); this
covers the three `buttonClicked(int)` sites that change missed. This commit uses the same
`QT_VERSION_CHECK(5, 15, 0)` guard for consistency, so Qt 5.14 and earlier are unaffected.

### Testing

Built and run on macOS 26 (Tahoe), x86_64, clang, Qt 6.11.1, with
`WANT_WIN_TTY=1 WANT_WIN_CURSES=1 WANT_WIN_QT6=1`, against the 5.0.0 release;
rebased onto current `NetHack-5.0` and compile-checked there. After the patch the
`No such signal` warnings are gone and the role/race columns track the selected
gender and alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Reviewed by human Crissman)

https://claude.ai/code/session_01WJwWF29Bgj7KvkVqPrVr5M
