### PR TITLE
Qt: size menu and text windows to their contents

### DIFF
--- a/win/Qt/qt_menu.cpp
+++ b/win/Qt/qt_menu.cpp
@@ -115,20 +115,29 @@ QSize NetHackQtMenuListBox::sizeHint() const
     return QSize(TotalWidth() + vsize, TotalHeight() + hsize);
 }
 
-//
-//  FIXME:
-//      Inventory displays reuse the same menu window and so far this
-//      is not updating the size as intended.  The size of the first
-//      instance persists.
-//
-
 // resize current menu window and the table (rows of entries) inside it
 void NetHackQtMenuWindow::MenuResize()
 {
-    // when this was just 'adjustSize()', our sizeHints() was not
-    // being called so explicitly indicate the table widget
-    table->adjustSize();
-    this->adjustSize();
+    // The layout caches the table's size hint and nothing invalidated
+    // that cache when the contents changed, so a reused window (the
+    // core's WIN_INVEN) kept the size of the first menu shown in it.
+    // Invalidate explicitly, then size from the fresh hint.  Resizing
+    // here instead of via adjustSize() also drops the latter's
+    // two-thirds-of-screen cap, which is too small for a long inventory
+    // in a large font.
+    table->updateGeometry();
+    if (layout())
+        layout()->invalidate();
+    QSize want = sizeHint();
+#if QT_VERSION < 0x060000
+    QRect avail = QApplication::desktop()->availableGeometry(this);
+#else
+    QRect avail = screen()->availableGeometry();
+#endif
+    int maxw = avail.width() * 9 / 10, maxh = avail.height() * 9 / 10;
+    if (want.height() > maxh) // vertical scroll bar will be needed
+        want.rwidth() += table->verticalScrollBar()->sizeHint().width();
+    resize(std::min(want.width(), maxw), std::min(want.height(), maxh));
 
     // Temporary? workaround for scrolling becoming wedged if using
     // all/none/invert removes all counts so we narrow a non-empty
@@ -1126,7 +1135,16 @@ void NetHackQtTextWindow::Display(bool block UNUSED)
         showNormal();
     } else {
 	move(0, 0);
-	adjustSize();
+	// size to content, capped at 90% of the screen rather than
+	// adjustSize()'s two thirds
+	QSize want = sizeHint();
+#if QT_VERSION < 0x060000
+	QRect avail = QApplication::desktop()->availableGeometry(this);
+#else
+	QRect avail = screen()->availableGeometry();
+#endif
+	resize(std::min(want.width(), avail.width() * 9 / 10),
+	       std::min(want.height(), avail.height() * 9 / 10));
 	centerOnMain(this);
 	show();
     }


### PR DESCRIPTION
Menu windows in the Qt interface open far too small — often a few rows of a
long inventory — and the inventory window keeps whatever size it had the first
time it was shown, because the core reuses one window for WIN_INVEN and the
layout's cached size hint was never invalidated. The FIXME/TEMPORARY comments in
`qt_menu.cpp` describe this.

This change:

- invalidates the table's cached size hint on every `MenuResize()` and sizes the
  dialog from the fresh hint, so reused windows track their current contents;
- sizes directly instead of via `adjustSize()`, whose two-thirds-of-screen cap is
  too small for a long inventory in a large font — cap at 90% of the available
  screen instead, adding the vertical scroll bar's width when the list is taller
  than that;
- gives `NetHackQtTextWindow::Display()` the same 90% cap.

Tested on macOS 26, x86_64, Qt 6.11.1: a 21-row inventory in the "Huge" font now
opens at 623×731 with every row visible; shorter menus shrink to fit. Also
compile-checked against current `NetHack-5.0`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Reviewed by human Crissman)

https://claude.ai/code/session_01WJwWF29Bgj7KvkVqPrVr5M

