### PR TITLE
Name the container in loot prompts

### DIFF
--- a/src/invent.c
+++ b/src/invent.c
@@ -1756,7 +1756,7 @@ getobj(
 {
     struct obj *otmp;
     char ilet = 0;
-    char buf[BUFSZ], qbuf[QBUFSZ];
+    char buf[BUFSZ], qbuf[QBUFSZ], contbuf[QBUFSZ];
     char lets[BUFSZ], altlets[BUFSZ];
     int suggested = 0;
     char *bp = buf, *ap = altlets;
@@ -1913,10 +1913,19 @@ getobj(
         You("don't have anything %sto %s.", inaccess ? "else " : "", word);
         return (struct obj *) 0;
     }
+    /* when stashing into a container, name it in the prompt */
+    contbuf[0] = '\0';
+    if (gc.current_container && !strcmp(word, "stash"))
+        (void) safe_qbuf(contbuf, "What do you want to stash in ", "?",
+                         gc.current_container, doname, ansimpleoname,
+                         "it");
     for (;;) {
         cnt = 0L;
         cntgiven = FALSE;
-        Sprintf(qbuf, "What do you want to %s?", word);
+        if (*contbuf)
+            Strcpy(qbuf, contbuf);
+        else
+            Sprintf(qbuf, "What do you want to %s?", word);
         if (gi.in_doagain) {
             ilet = readchar();
         } else if (iflags.force_invmenu) {
@@ -1970,9 +1979,13 @@ getobj(
                 allowed_choices = altlets;
 
             menuquery[0] = qbuf[0] = '\0';
-            if (iflags.force_invmenu)
-                Snprintf(menuquery, sizeof menuquery,
-                         "What do you want to %s?", word);
+            if (iflags.force_invmenu) {
+                if (*contbuf)
+                    Strcpy(menuquery, contbuf);
+                else
+                    Snprintf(menuquery, sizeof menuquery,
+                             "What do you want to %s?", word);
+            }
             if (!allowed_choices || *allowed_choices == HANDS_SYM
                 || *buf == HANDS_SYM)
                 handsbuf = getobj_hands_txt(word, qbuf);

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -3239,6 +3239,7 @@ traditional_loot(boolean put_in)
     int (*actionfunc)(OBJ_P), (*checkfunc)(OBJ_P);
     struct obj **objlist;
     char selection[MAXOCLASSES + 10]; /* +10: room for B,U,C,X plus slop */
+    char actbuf[QBUFSZ];
     const char *action;
     boolean one_by_one, allflag;
     int used = ECMD_OK, menu_on_request = 0;
@@ -3256,7 +3257,10 @@ traditional_loot(boolean put_in)
         gp.pickup_encumbrance = 0; /* used to limit verbosity */
     }
 
-    if (query_classes(selection, &one_by_one, &allflag, action, *objlist,
+    /* prompt names the container; per-item prompts keep the short verb */
+    (void) safe_qbuf(actbuf, put_in ? "put into " : "take out of ", "",
+                     gc.current_container, doname, ansimpleoname, "it");
+    if (query_classes(selection, &one_by_one, &allflag, actbuf, *objlist,
                       FALSE, &menu_on_request)) {
         if (askchain(objlist, (one_by_one ? (char *) 0 : selection), allflag,
                      actionfunc, checkfunc, 0, action))
@@ -3275,7 +3279,6 @@ menu_loot(int retry, boolean put_in)
     boolean all_categories = TRUE, loot_everything = FALSE, autopick = FALSE;
     char buf[BUFSZ];
     boolean loot_justpicked = FALSE;
-    const char *action = put_in ? "Put in" : "Take out";
     struct obj *otmp, *otmp2;
     menu_item *pick_list;
     int mflags, res;
@@ -3287,7 +3290,11 @@ menu_loot(int retry, boolean put_in)
         all_categories = (retry == -2);
     } else if (flags.menu_style == MENU_FULL) {
         all_categories = FALSE;
-        Sprintf(buf, "%s what type of objects?", action);
+        /* name the container so it's clear what is being loaded/unloaded */
+        (void) safe_qbuf(buf, put_in ? "Put what type of objects into "
+                                     : "Take what type of objects out of ",
+                         "?", gc.current_container, doname, ansimpleoname,
+                         "it");
         mflags = (ALL_TYPES | UNPAID_TYPES | BUCX_TYPES | CHOOSE_ALL
                   | JUSTPICKED );
         n = query_category(buf,
@@ -3365,7 +3372,9 @@ menu_loot(int retry, boolean put_in)
             mflags |= JUSTPICKED;
         if (!put_in)
             gc.current_container->cknown = 1;
-        Sprintf(buf, "%s what?", action);
+        (void) safe_qbuf(buf, put_in ? "Put what into " : "Take what out of ",
+                         "?", gc.current_container, doname, ansimpleoname,
+                         "it");
         n = query_objlist(buf,
                           put_in ? &gi.invent : &(gc.current_container->cobj),
                           mflags, &pick_list, PICK_ANY,


### PR DESCRIPTION
When looting a container, the item prompts don't say which container:

    Put in what type of objects?
    Take out what?
    What do you want to stash?

With several containers in inventory it's easy to load the wrong one. I put a bag
of tricks into a bag of holding this way; the "Do what with your bag called
holding?" line scrolls off before the item selection appears.

This names the container in those prompts, using its full description (BUC state and
contents count included):

    Put what type of objects into a blessed bag called holding containing 27 items?
    Take what out of an empty uncursed sack?
    What do you want to stash in a blessed bag called holding containing 27 items?

Implementation: the prompts in `menu_loot()`, `traditional_loot()` (class prompt only —
the per-item `askchain()` prompts keep the short "put in" verb) and `getobj()` (verb
"stash") are built with `safe_qbuf(..., doname, ansimpleoname, ...)`, the same idiom as
the "Pick up <object>?" prompt in `pickup.c`, so a long name falls back to the simple form
instead of overflowing. No new functions. The "Do what with your <container>?" action menu is unchanged. The existing "You cannot fit X into Y" messages are unchanged.

Tested in tty and Qt on macOS with menustyle full and traditional, against the
5.0.0 release; rebased onto current `NetHack-5.0` and compile-checked there.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

🙎‍♂️ Reviewed by human Crissman

https://claude.ai/code/session_01WJwWF29Bgj7KvkVqPrVr5M





