### PR TITLE
Qt: fix use-after-free reading the player name

### DIFF
--- a/win/Qt/qt_plsel.cpp
+++ b/win/Qt/qt_plsel.cpp
@@ -559,7 +559,10 @@ void NetHackQtPlayerSelector::plnamePlayVsQuit()
 // the line edit widget for the name field has received input
 void NetHackQtPlayerSelector::selectName(const QString& n)
 {
-    const char *name_str = n.toLatin1().constData();
+    // the QByteArray has to outlive name_str; calling constData() on
+    // the temporary returned by toLatin1() leaves it dangling
+    QByteArray name_bytes = n.toLatin1();
+    const char *name_str = name_bytes.constData();
     // skip any leading spaces
     // (it would be better to set up a validator that rejects leading spaces)
     while (*name_str == ' ')


### PR DESCRIPTION
**What you see without this fix (observed with Qt 6.11.1 on macOS):** in the player selection dialog the **Play** button stays greyed out no matter what name you type, so a game can't be started from the dialog at all.

### Use-after-free reading the player name field

`selectName()` did:

```cpp
const char *name_str = n.toLatin1().constData();
```

`toLatin1()` returns a temporary `QByteArray`, destroyed at the end of the full
expression, so `name_str` dangles before it is ever read. Both the leading-space loop and
the `str_copy()` into `svp.plname` operate on freed memory.

In practice `svp.plname` comes out empty. `plnamePlayVsQuit()` only enables `[Play]` when
`*svp.plname` is non-zero, so the button stays greyed out no matter what the player types
and there is no way to start a game from the dialog.

Being undefined behaviour it will not reproduce everywhere. It is reliable here with
Qt 6.11.1 on macOS. Reduced to a standalone program against the same Qt:

```
shipped code : plname=""        Play button=GREYED OUT
patched code : plname="Splart"  Play button=ENABLED
```

This is the same mistake as #996 (use-after-free when saving Qt message history), at a
site that fix did not cover. It is the only remaining instance in `win/Qt` — the other
five `toLatin1().constData()` uses pass the pointer directly as a call argument, where
the temporary survives to the end of the full expression.

### Reproducer

Standalone program with the shipped and patched code side by side (Qt 6.11.1,
macOS x86_64, clang, `-O0`):

```
shipped code : plname=""            Play button=GREYED OUT
patched code : plname="Splarticus"  Play button=ENABLED
```

Under AddressSanitizer the shipped version reports
`heap-use-after-free ... READ of size 1` at the `while (*name_str == ' ')`
line, with the free coming from the `QByteArray` temporary's destructor on
the line before.

### Testing

Built and run on macOS 26 (Tahoe), x86_64, clang, Qt 6.11.1, against the 5.0.0
release; rebased onto current `NetHack-5.0` and compile-checked there. Independent of
#1670 (the `idClicked` fix); both are needed for the dialog to be usable on Qt 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Reviewed by human Crissman)

https://claude.ai/code/session_01WJwWF29Bgj7KvkVqPrVr5M
