### PR TITLE
Clamp negative monster movement on restore

### DIFF
--- a/src/restore.c
+++ b/src/restore.c
@@ -1219,6 +1219,12 @@ getlev(NHFILE *nhfp, int pid, xint8 lev)
         if (ghostly) {
             mtmp->movement = 0;
         }
+        /* movement is a short; a monster that banked movement points for
+           a long time (5.0.0 steeds could, see "off-map monsters banking
+           turns") can arrive from an older save with a wrapped-around
+           negative value and then be unable to act for hundreds of turns */
+        if (mtmp->movement < 0)
+            mtmp->movement = 0;
         if (mtmp->m_id == u.usteed_mid) {
             /* steed is kept on fmon list but off the map */
             u.usteed = mtmp;


### PR DESCRIPTION
**What you see without this fix:** after restoring a save, a pet (in my case a
warhorse that had just lost its saddle to a nymph) never moves again, for
hundreds of turns, although farlook shows nothing wrong with it.

`monst.movement` is a `short`. A monster that accumulates movement points
without spending them for long enough wraps around to a large negative value.
5.0.0 could do that to a ridden steed: after a level change the steed kept
`MON_STILL_ARRIVING` (fixed in c0f06ac4f) and, being treated as off the map,
banked its allocation every turn (fixed in 9f7a9d2c8). Both fixes stop new
damage, but a save written by 5.0.0 can still carry the wrapped value — my
warhorse restored with `movement = -11428` and needed about 600 turns to earn
that back.

This resets negative movement to 0 when a level is restored, next to the
existing bones-file sanitizing in the same loop. Verified with the affected
save: before the change the horse showed `movement=-11428`, after it `0`, and
it was moving again within a few turns.

### Reproduction on 5.0.0 (release code)

Wizard mode, tame saddled pony, readout of `u.usteed->movement` added to farlook:

```
before level change:             movement=24, stays 24 (spent every turn)
level teleport:                  mstate=0x100 (MON_STILL_ARRIVING), movement=24
 +308 turns ridden:              movement=5076
 +605 turns:                     movement=9852
 +977 turns:                     movement=15852
+1477 turns:                     movement=23892
+1775 turns:                     movement=28716
+2076 turns:                     movement=-32164   <- short wrapped
```

About 2,000 ridden turns after any staircase is enough. The steed stays
unaffected while ridden (the hero uses `mcalcmove(u.usteed)` directly), so the
damage is invisible until the player dismounts or the saddle is removed.

Rebased onto current `NetHack-5.0` and compile-checked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJwWF29Bgj7KvkVqPrVr5M

